### PR TITLE
feat: integrate Supabase transaction API

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { supabase } from "./lib/supabase"
-import { listTransactions } from "./lib/api"
+import { supabase } from "./lib/supabase";
+import {
+  listTransactions,
+  addTransaction as apiAdd,
+  updateTransaction as apiUpdate,
+  deleteTransaction as apiDelete,
+} from "./lib/api";
 
 // ==== UTILITAS ==========================================
 const idr = new Intl.NumberFormat("id-ID", { style: "currency", currency: "IDR" });
@@ -38,26 +43,155 @@ export default function App() {
   const [data, setData] = useState(loadInitial); // { txs, cat, budgets, ver }
   const [filter, setFilter] = useState({ type: "all", q: "", month: "all" });
   const [showCat, setShowCat] = useState(false);
+  const [useCloud, setUseCloud] = useState(false);
+  const [sessionUser, setSessionUser] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [cloudAll, setCloudAll] = useState([]); // daftar semua transaksi cloud untuk daftar bulan
+  const [catMap, setCatMap] = useState({}); // nama -> id kategori di Supabase
 
-  useEffect(() => { saveData(data); }, [data]);
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      setSessionUser(data.session?.user || null);
+    });
+    const { data: listener } = supabase.auth.onAuthStateChange((_e, session) => {
+      setSessionUser(session?.user || null);
+    });
+    return () => {
+      listener.subscription.unsubscribe();
+    };
+  }, []);
 
-  const addTx = (tx) => setData((d) => ({ ...d, txs: [{ ...tx, id: uid() }, ...d.txs] }));
-  const removeTx = (id) => setData((d) => ({ ...d, txs: d.txs.filter((t) => t.id !== id) }));
-  const updateTx = (id, patch) => setData((d) => ({ ...d, txs: d.txs.map((t) => (t.id === id ? { ...t, ...patch } : t)) }));
+  useEffect(() => { if (!useCloud || !sessionUser) saveData(data); }, [data, useCloud, sessionUser]);
+
+  useEffect(() => {
+    if (useCloud && sessionUser) {
+      loadCategories();
+    } else {
+      setData(loadInitial());
+      setCloudAll([]);
+    }
+  }, [useCloud, sessionUser]);
+
+  useEffect(() => {
+    if (useCloud && sessionUser) fetchCloud(filter);
+  }, [filter, useCloud, sessionUser]);
+
+  const addTx = async (tx) => {
+    if (useCloud && sessionUser) {
+      setLoading(true); setError("");
+      try {
+        const saved = await apiAdd({
+          date: tx.date,
+          type: tx.type,
+          amount: tx.amount,
+          note: tx.note,
+          category_id: catMap[tx.category] || null,
+        });
+        const res = { ...saved, category: tx.category };
+        setData((d) => ({ ...d, txs: [res, ...d.txs] }));
+        setCloudAll((d) => [res, ...d]);
+      } catch (e) {
+        setError(e.message);
+        alert("Gagal menambah transaksi: " + e.message);
+      } finally {
+        setLoading(false);
+      }
+    } else {
+      setData((d) => ({ ...d, txs: [{ ...tx, id: uid() }, ...d.txs] }));
+    }
+  };
+
+  const removeTx = async (id) => {
+    if (useCloud && sessionUser) {
+      setLoading(true); setError("");
+      try {
+        await apiDelete(id);
+        setData((d) => ({ ...d, txs: d.txs.filter((t) => t.id !== id) }));
+        setCloudAll((d) => d.filter((t) => t.id !== id));
+      } catch (e) {
+        setError(e.message);
+        alert("Gagal menghapus transaksi: " + e.message);
+      } finally {
+        setLoading(false);
+      }
+    } else {
+      setData((d) => ({ ...d, txs: d.txs.filter((t) => t.id !== id) }));
+    }
+  };
+
+  const updateTx = async (id, patch) => {
+    if (useCloud && sessionUser) {
+      setLoading(true); setError("");
+      try {
+        const saved = await apiUpdate(id, {
+          date: patch.date,
+          type: patch.type,
+          note: patch.note,
+          amount: patch.amount,
+          category_id: patch.category ? catMap[patch.category] || null : undefined,
+        });
+        const res = { ...saved, category: patch.category ?? saved.category };
+        setData((d) => ({ ...d, txs: d.txs.map((t) => (t.id === id ? res : t)) }));
+        setCloudAll((d) => d.map((t) => (t.id === id ? res : t)));
+      } catch (e) {
+        setError(e.message);
+        alert("Gagal mengubah transaksi: " + e.message);
+      } finally {
+        setLoading(false);
+      }
+    } else {
+      setData((d) => ({ ...d, txs: d.txs.map((t) => (t.id === id ? { ...t, ...patch } : t)) }));
+    }
+  };
 
   const addBudget = (b) => setData((d) => ({ ...d, budgets: [{ ...b, id: uid() }, ...d.budgets] }));
   const removeBudget = (id) => setData((d) => ({ ...d, budgets: d.budgets.filter((b) => b.id !== id) }));
 
+  async function fetchCloud(filt) {
+    setLoading(true); setError("");
+    try {
+      const { rows } = await listTransactions({ ...filt, pageSize: 1000 });
+      setData((d) => ({ ...d, txs: rows }));
+      if (filt.type === 'all' && filt.month === 'all' && !filt.q) {
+        setCloudAll(rows);
+      }
+    } catch (e) {
+      setError(e.message);
+      alert("Gagal memuat data: " + e.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function loadCategories() {
+    try {
+      const { data: cats, error: err } = await supabase
+        .from('categories')
+        .select('id,name,type');
+      if (err) throw err;
+      const cat = { income: [], expense: [] };
+      const map = {};
+      (cats || []).forEach((c) => {
+        cat[c.type] = [...(cat[c.type] || []), c.name];
+        map[c.name] = c.id;
+      });
+      setData((d) => ({ ...d, cat }));
+      setCatMap(map);
+    } catch (e) {
+      alert("Gagal memuat kategori: " + e.message);
+    }
+  }
+
   const months = useMemo(() => {
-    const m = new Set(
-      data.txs.map((t) => t.date?.slice(0, 7)).filter(Boolean)
-    );
-    // Tambahkan bulan berjalan agar bisa set budget walau belum ada transaksi
+    const source = useCloud && sessionUser ? cloudAll : data.txs;
+    const m = new Set(source.map((t) => t.date?.slice(0, 7)).filter(Boolean));
     m.add(new Date().toISOString().slice(0, 7));
     return ["all", ...Array.from(m).sort().reverse()];
-  }, [data.txs]);
+  }, [data.txs, useCloud, sessionUser, cloudAll]);
 
   const filtered = useMemo(() => {
+    if (useCloud && sessionUser) return data.txs;
     return data.txs.filter((t) => {
       const okType = filter.type === "all" || t.type === filter.type;
       const okMonth = filter.month === "all" || (t.date || "").startsWith(filter.month);
@@ -65,7 +199,7 @@ export default function App() {
       const okQ = !q || [t.category, t.note].join(" ").toLowerCase().includes(q);
       return okType && okMonth && okQ;
     });
-  }, [data.txs, filter]);
+  }, [data.txs, filter, useCloud, sessionUser]);
 
   const stats = useMemo(() => {
     const income = filtered.filter((t) => t.type === "income").reduce((s, t) => s + Number(t.amount || 0), 0);
@@ -131,7 +265,9 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-slate-50 text-slate-800">
-      <TopBar stats={stats} />
+      <TopBar stats={stats} useCloud={useCloud} setUseCloud={setUseCloud} />
+      {loading && <div className="max-w-5xl mx-auto p-4 text-sm">Loading…</div>}
+      {error && <div className="max-w-5xl mx-auto p-4 text-sm text-red-600">{error}</div>}
 
       <main className="max-w-5xl mx-auto p-4">
         <Card>
@@ -188,18 +324,24 @@ export default function App() {
 }
 
 // ==== SUBKOMPONEN =======================================
-function TopBar({ stats }) {
+function TopBar({ stats, useCloud, setUseCloud }) {
   return (
     <header className="bg-white border-b sticky top-0 z-10">
       <div className="max-w-5xl mx-auto p-4 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Logo />
           <h1 className="text-xl font-bold">HematWoi</h1>
-          <span className="text-xs ml-2 px-2 py-1 bg-slate-100 rounded">HW · Local-first</span>
+          <span className="text-xs ml-2 px-2 py-1 bg-slate-100 rounded">{useCloud ? 'Cloud' : 'Local'}</span>
         </div>
-        <div className="text-right">
-          <div className="text-xs text-slate-500">Saldo</div>
-          <div className="text-lg font-semibold">{idr.format(stats.balance)}</div>
+        <div className="flex items-center gap-4">
+          <label className="text-xs flex items-center gap-1">
+            <input type="checkbox" checked={useCloud} onChange={(e)=>setUseCloud(e.target.checked)} />
+            Cloud
+          </label>
+          <div className="text-right">
+            <div className="text-xs text-slate-500">Saldo</div>
+            <div className="text-lg font-semibold">{idr.format(stats.balance)}</div>
+          </div>
         </div>
       </div>
     </header>
@@ -231,7 +373,7 @@ function AddForm({ categories, onAdd }) {
     // Sinkronkan default kategori saat tipe berubah
     const list = form.type === "income" ? categories.income : categories.expense;
     if (!list.includes(form.category)) setForm((f) => ({ ...f, category: list[0] || "Lainnya" }));
-  }, [form.type, categories]);
+  }, [form.type, categories, form.category]);
 
   const submit = (e) => {
     e.preventDefault();
@@ -564,6 +706,7 @@ function Footer() {
 }
 
 // ==== CSS MINI (tanpa Tailwind/Bootstrap) =================
+/* eslint-disable no-useless-escape */
 const css = `
 :root{
   --b:#e5e7eb; --bg:#f8fafc; --tx:#0f172a; --mut:#64748b;
@@ -623,3 +766,4 @@ body{margin:0; background:var(--bg); color:var(--tx); font-family: ui-sans-serif
 .bar .fill{height:100%; background:linear-gradient(90deg, var(--brand), #87c5ff)}
 .bar.over{outline:2px solid #fca5a5}
 `;
+/* eslint-enable no-useless-escape */

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,38 +1,69 @@
-import { supabase } from './supabase'
+import { supabase } from "./supabase";
 
 // SELECT
-export async function listTransactions() {
-  const { data, error } = await supabase
-    .from('transactions')
-    .select('id,date,type,amount,note,category_id, categories:category_id (name,type)')
-    .order('date', { ascending: false })
-  if (error) throw error
-  // opsional: flatten nama kategori
-  return data.map(t => ({ ...t, category: t.categories?.name || null }))
+export async function listTransactions({ type, month, q, page = 1, pageSize = 20 } = {}) {
+  let query = supabase
+    .from("transactions")
+    .select(
+      "id,date,type,amount,note,category_id,categories:category_id (name)",
+      { count: "exact" }
+    )
+    .order("date", { ascending: false });
+
+  if (type) {
+    query = query.eq("type", type);
+  }
+  if (month) {
+    const start = `${month}-01`;
+    const end = new Date(start);
+    end.setMonth(end.getMonth() + 1);
+    query = query.gte("date", start).lt("date", end.toISOString().slice(0, 10));
+  }
+  if (q) {
+    const like = `%${q}%`;
+    query = query.or(`note.ilike.${like},categories.name.ilike.${like}`);
+  }
+
+  const from = (page - 1) * pageSize;
+  const to = from + pageSize - 1;
+
+  const { data, error, count } = await query.range(from, to);
+  if (error) throw error;
+  const rows = (data || []).map((t) => ({ ...t, category: t.categories?.name || null }));
+  return { rows, total: count || 0, page, pageSize };
 }
 
 // INSERT
-export async function addTransaction(tx) {
-  // TRIGGER akan mengisi user_id otomatis
-  const insert = {
-    date: tx.date, type: tx.type,
-    amount: tx.amount, note: tx.note || null,
-    category_id: tx.category_id || null
-  }
-  const { data, error } = await supabase.from('transactions').insert(insert).select().single()
-  if (error) throw error
-  return data
+export async function addTransaction({ date, type, amount, note, category_id }) {
+  const { data, error } = await supabase
+    .from("transactions")
+    .insert({
+      date,
+      type,
+      amount,
+      note: note || null,
+      category_id: category_id || null,
+    })
+    .select("id,date,type,amount,note,category_id,categories:category_id (name)")
+    .single();
+  if (error) throw error;
+  return { ...data, category: data.categories?.name || null };
 }
 
 // UPDATE
 export async function updateTransaction(id, patch) {
-  const { data, error } = await supabase.from('transactions').update(patch).eq('id', id).select().single()
-  if (error) throw error
-  return data
+  const { data, error } = await supabase
+    .from("transactions")
+    .update(patch)
+    .eq("id", id)
+    .select("id,date,type,amount,note,category_id,categories:category_id (name)")
+    .single();
+  if (error) throw error;
+  return { ...data, category: data.categories?.name || null };
 }
 
 // DELETE
 export async function deleteTransaction(id) {
-  const { error } = await supabase.from('transactions').delete().eq('id', id)
-  if (error) throw error
+  const { error } = await supabase.from("transactions").delete().eq("id", id);
+  if (error) throw error;
 }


### PR DESCRIPTION
## Summary
- add API helper for Supabase with filterable CRUD operations
- support cloud/local toggle in app with loading and error handling
- route transaction actions to Supabase when cloud mode is enabled

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6d9fbedb48332a641c8e82f8d3f61