### PR TITLE
feat: add core UI components

### DIFF
--- a/src/components/AddForm.jsx
+++ b/src/components/AddForm.jsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+
+export default function AddForm({ categories, onAdd }) {
+  const today = new Date().toISOString().slice(0, 10);
+  const [date, setDate] = useState(today);
+  const [type, setType] = useState('expense');
+  const [category, setCategory] = useState('');
+  const [note, setNote] = useState('');
+  const [amount, setAmount] = useState('');
+
+  const catList = categories?.[type] || [];
+
+  const submit = (e) => {
+    e.preventDefault();
+    onAdd({ date, type, category, note, amount: Number(amount) });
+    setNote('');
+    setAmount('');
+  };
+
+  return (
+    <form onSubmit={submit} className="card flex flex-col gap-2">
+      <div className="flex flex-col sm:flex-row gap-2">
+        <input
+          type="date"
+          className="w-full rounded-lg border px-3 py-2"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+        />
+        <select
+          className="w-full sm:w-auto rounded-lg border px-3 py-2"
+          value={type}
+          onChange={(e) => {
+            setType(e.target.value);
+            setCategory('');
+          }}
+        >
+          <option value="expense">Pengeluaran</option>
+          <option value="income">Pemasukan</option>
+        </select>
+        <select
+          className="w-full rounded-lg border px-3 py-2"
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+        >
+          <option value="">Kategori</option>
+          {catList.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+      </div>
+      <input
+        type="text"
+        placeholder="Catatan"
+        className="w-full rounded-lg border px-3 py-2"
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+      />
+      <div className="flex items-center gap-2">
+        <input
+          type="number"
+          placeholder="Jumlah"
+          className="w-full rounded-lg border px-3 py-2"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+        />
+        <button className="btn bg-brand border-brand text-white" type="submit">
+          Tambah
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/BudgetSection.jsx
+++ b/src/components/BudgetSection.jsx
@@ -1,0 +1,104 @@
+import { useState, useMemo } from 'react';
+
+function toRupiah(n = 0) {
+  return new Intl.NumberFormat('id-ID', {
+    style: 'currency',
+    currency: 'IDR',
+    minimumFractionDigits: 0,
+  }).format(n);
+}
+
+export default function BudgetSection({ filterMonth, budgets = [], txs = [], categories, onAdd, onRemove }) {
+  const [form, setForm] = useState({ category: '', month: filterMonth || '', amount: '' });
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const submit = (e) => {
+    e.preventDefault();
+    if (!form.category || !form.month || !form.amount) return;
+    onAdd({ category: form.category, month: form.month, amount: Number(form.amount) });
+    setForm({ category: '', month: filterMonth || '', amount: '' });
+  };
+
+  const list = budgets.filter((b) => b.month === filterMonth);
+
+  const spentByCat = useMemo(() => {
+    const map = {};
+    txs.forEach((t) => {
+      const m = t.date.slice(0, 7);
+      if (t.type === 'expense' && m === filterMonth) {
+        map[t.category] = (map[t.category] || 0) + t.amount;
+      }
+    });
+    return map;
+  }, [txs, filterMonth]);
+
+  return (
+    <div className="card">
+      <h2 className="font-semibold mb-2">Anggaran</h2>
+      <form onSubmit={submit} className="flex flex-wrap gap-2 mb-4">
+        <select
+          name="category"
+          className="rounded-lg border px-3 py-2"
+          value={form.category}
+          onChange={handleChange}
+        >
+          <option value="">Kategori</option>
+          {(categories?.expense || []).map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <input
+          type="month"
+          name="month"
+          className="rounded-lg border px-3 py-2"
+          value={form.month}
+          onChange={handleChange}
+        />
+        <input
+          type="number"
+          name="amount"
+          placeholder="Jumlah"
+          className="w-32 rounded-lg border px-3 py-2"
+          value={form.amount}
+          onChange={handleChange}
+        />
+        <button className="btn bg-brand border-brand text-white" type="submit">
+          Tambah
+        </button>
+      </form>
+      <ul className="space-y-2">
+        {list.map((b) => {
+          const used = spentByCat[b.category] || 0;
+          const pct = Math.min(100, Math.round((used / b.amount) * 100));
+          return (
+            <li key={b.id} className="border rounded-lg p-2">
+              <div className="flex justify-between mb-1 text-sm">
+                <span>{b.category}</span>
+                <span>
+                  {toRupiah(used)} / {toRupiah(b.amount)}
+                </span>
+              </div>
+              <div className="w-full h-2 bg-gray-200 rounded">
+                <div
+                  className="h-full bg-brand rounded"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+              <button className="btn mt-2" onClick={() => onRemove(b.id)}>
+                Hapus
+              </button>
+            </li>
+          );
+        })}
+        {!list.length && (
+          <li className="text-sm text-gray-500">Belum ada anggaran bulan ini.</li>
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,0 +1,13 @@
+export default function Card({ title, actions, children }) {
+  return (
+    <div className="card">
+      {(title || actions) && (
+        <div className="flex items-center justify-between mb-2">
+          {title && <h2 className="font-semibold">{title}</h2>}
+          {actions}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/src/components/DataTools.jsx
+++ b/src/components/DataTools.jsx
@@ -1,0 +1,10 @@
+export default function DataTools({ onExport, onImportJSON, onImportCSV, onManageCat }) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <button className="btn" onClick={onExport}>Export JSON</button>
+      <button className="btn" onClick={onImportJSON}>Import JSON</button>
+      <button className="btn" onClick={onImportCSV}>Import CSV</button>
+      <button className="btn" onClick={onManageCat}>Kelola Kategori</button>
+    </div>
+  );
+}

--- a/src/components/Filters.jsx
+++ b/src/components/Filters.jsx
@@ -1,0 +1,40 @@
+function formatMonth(m) {
+  if (!m) return '';
+  const date = new Date(`${m}-01`);
+  return date.toLocaleDateString('id-ID', { month: 'short', year: 'numeric' });
+}
+
+export default function Filters({ months = [], filter, setFilter }) {
+  return (
+    <div className="card flex flex-wrap items-center gap-2">
+      <select
+        className="rounded-lg border px-3 py-2"
+        value={filter.type}
+        onChange={(e) => setFilter({ ...filter, type: e.target.value })}
+      >
+        <option value="all">Semua</option>
+        <option value="income">Pemasukan</option>
+        <option value="expense">Pengeluaran</option>
+      </select>
+      <select
+        className="rounded-lg border px-3 py-2"
+        value={filter.month}
+        onChange={(e) => setFilter({ ...filter, month: e.target.value })}
+      >
+        <option value="all">Semua Bulan</option>
+        {months.map((m) => (
+          <option key={m} value={m}>
+            {formatMonth(m)}
+          </option>
+        ))}
+      </select>
+      <input
+        type="text"
+        placeholder="Cari"
+        className="rounded-lg border px-3 py-2 flex-1 min-w-[120px]"
+        value={filter.q}
+        onChange={(e) => setFilter({ ...filter, q: e.target.value })}
+      />
+    </div>
+  );
+}

--- a/src/components/Logo.jsx
+++ b/src/components/Logo.jsx
@@ -1,0 +1,8 @@
+export default function Logo() {
+  return (
+    <div className="w-10 h-10 flex items-center justify-center bg-brand text-white rounded-lg font-bold">
+      HW
+      <span className="sr-only">HematWoi</span>
+    </div>
+  );
+}

--- a/src/components/ManageCategories.jsx
+++ b/src/components/ManageCategories.jsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+export default function ManageCategories({ cat, onSave }) {
+  const [income, setIncome] = useState((cat?.income || []).join('\n'));
+  const [expense, setExpense] = useState((cat?.expense || []).join('\n'));
+
+  const save = () => {
+    const parse = (str) =>
+      str
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean);
+    onSave({ income: parse(income), expense: parse(expense) });
+  };
+
+  return (
+    <div className="card">
+      <h2 className="font-semibold mb-2">Kelola Kategori</h2>
+      <div className="grid sm:grid-cols-2 gap-4">
+        <div>
+          <h3 className="mb-1 text-sm font-medium">Pemasukan</h3>
+          <textarea
+            className="w-full h-40 rounded-lg border px-3 py-2"
+            value={income}
+            onChange={(e) => setIncome(e.target.value)}
+          />
+        </div>
+        <div>
+          <h3 className="mb-1 text-sm font-medium">Pengeluaran</h3>
+          <textarea
+            className="w-full h-40 rounded-lg border px-3 py-2"
+            value={expense}
+            onChange={(e) => setExpense(e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="mt-4">
+        <button className="btn bg-brand border-brand text-white" onClick={save}>
+          Simpan
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,0 +1,18 @@
+export default function Modal({ open, title, children, onClose }) {
+  if (!open) return null;
+  const stop = (e) => e.stopPropagation();
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div className="bg-white rounded-xl p-4 max-w-lg w-full m-4" onClick={stop}>
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="font-semibold">{title}</h2>
+          <button className="btn" onClick={onClose}>Tutup</button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Row.jsx
+++ b/src/components/Row.jsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+
+function toRupiah(n = 0) {
+  return new Intl.NumberFormat('id-ID', {
+    style: 'currency',
+    currency: 'IDR',
+    minimumFractionDigits: 0,
+  }).format(n);
+}
+
+export default function Row({ item, onRemove, onUpdate }) {
+  const [edit, setEdit] = useState(false);
+  const [note, setNote] = useState(item.note || '');
+  const [amount, setAmount] = useState(item.amount);
+
+  const save = () => {
+    onUpdate(item.id, { note, amount: Number(amount) });
+    setEdit(false);
+  };
+
+  return (
+    <tr>
+      <td className="p-2">
+        {item.category && <span className="badge">{item.category}</span>}
+      </td>
+      <td className="p-2">{item.date}</td>
+      <td className="p-2">
+        {edit ? (
+          <input
+            className="w-full rounded-lg border px-2 py-1"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+          />
+        ) : (
+          item.note || '-'
+        )}
+      </td>
+      <td
+        className={`p-2 text-right ${
+          item.type === 'income' ? 'text-green-600' : 'text-red-600'
+        }`}
+      >
+        {edit ? (
+          <input
+            type="number"
+            className="w-24 rounded-lg border px-2 py-1 text-right"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+          />
+        ) : (
+          toRupiah(item.amount)
+        )}
+      </td>
+      <td className="p-2 text-right">
+        {edit ? (
+          <div className="flex gap-1 justify-end">
+            <button className="btn bg-brand border-brand text-white" onClick={save}>
+              Simpan
+            </button>
+            <button className="btn" onClick={() => setEdit(false)}>
+              Batal
+            </button>
+          </div>
+        ) : (
+          <div className="flex gap-1 justify-end">
+            <button className="btn" onClick={() => setEdit(true)}>
+              Edit
+            </button>
+            <button className="btn" onClick={() => onRemove(item.id)}>
+              Hapus
+            </button>
+          </div>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/src/components/Summary.jsx
+++ b/src/components/Summary.jsx
@@ -1,0 +1,32 @@
+function toRupiah(n = 0) {
+  return new Intl.NumberFormat('id-ID', {
+    style: 'currency',
+    currency: 'IDR',
+    minimumFractionDigits: 0,
+  }).format(n);
+}
+
+export default function Summary({ stats }) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-3">
+      <div className="card text-center">
+        <div className="text-sm">Pemasukan</div>
+        <div className="text-lg font-semibold text-green-600">
+          {toRupiah(stats?.income || 0)}
+        </div>
+      </div>
+      <div className="card text-center">
+        <div className="text-sm">Pengeluaran</div>
+        <div className="text-lg font-semibold text-red-600">
+          {toRupiah(stats?.expense || 0)}
+        </div>
+      </div>
+      <div className="card text-center">
+        <div className="text-sm">Saldo</div>
+        <div className="text-lg font-semibold">
+          {toRupiah(stats?.balance || 0)}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -1,0 +1,32 @@
+import Logo from './Logo';
+
+function toRupiah(n = 0) {
+  return new Intl.NumberFormat('id-ID', {
+    style: 'currency',
+    currency: 'IDR',
+    minimumFractionDigits: 0,
+  }).format(n);
+}
+
+export default function TopBar({ stats, useCloud, setUseCloud }) {
+  return (
+    <div className="max-w-5xl mx-auto p-4 flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        <Logo />
+        <h1 className="font-bold text-lg">HematWoi</h1>
+        <span className="badge">{useCloud ? 'Cloud' : 'Lokal'}</span>
+      </div>
+      <div className="flex items-center gap-4">
+        <label className="flex items-center gap-1 text-sm">
+          <input
+            type="checkbox"
+            checked={useCloud}
+            onChange={(e) => setUseCloud(e.target.checked)}
+          />
+          Cloud
+        </label>
+        <div className="font-semibold">Saldo: {toRupiah(stats?.balance || 0)}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TxTable.jsx
+++ b/src/components/TxTable.jsx
@@ -1,0 +1,24 @@
+import Row from './Row';
+
+export default function TxTable({ items = [], onRemove, onUpdate }) {
+  return (
+    <div className="overflow-auto">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="text-left">
+            <th className="p-2">Kategori</th>
+            <th className="p-2">Tanggal</th>
+            <th className="p-2">Catatan</th>
+            <th className="p-2 text-right">Jumlah</th>
+            <th className="p-2" />
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <Row key={item.id} item={item} onRemove={onRemove} onUpdate={onUpdate} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- build reusable Logo, Card, Modal, and TopBar with cloud toggle and saldo display
- add AddForm, Filters, Summary, and DataTools for transaction management
- implement TxTable with inline Row editing plus Budget and Category management sections

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c6f5b0869c8332b00bf662728dab39