### PR TITLE
feat: add supabase authentication

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -67,6 +67,10 @@ export default function App() {
     return () => sub.subscription.unsubscribe();
   }, []);
 
+  useEffect(() => {
+    if (!sessionUser && useCloud) setUseCloud(false);
+  }, [sessionUser, useCloud]);
+
   // Persist local
   useEffect(() => {
     localStorage.setItem("hematwoi:v3", JSON.stringify(data));

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -6,10 +6,12 @@ export default function Modal({ open, title, children, onClose }) {
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
       onClick={onClose}
     >
-      <div className="bg-white rounded-xl p-4 max-w-lg w-full m-4" onClick={stop}>
+      <div className="card w-full max-w-md m-4" onClick={stop}>
         <div className="flex items-center justify-between mb-2">
           <h2 className="font-semibold">{title}</h2>
-          <button className="btn" onClick={onClose}>Tutup</button>
+          <button className="btn" onClick={onClose}>
+            ✕
+          </button>
         </div>
         {children}
       </div>

--- a/src/components/SignIn.jsx
+++ b/src/components/SignIn.jsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import Modal from "./Modal";
+import { supabase } from "../lib/supabase";
+
+export default function SignIn({ open, onClose }) {
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+  const [cooldown, setCooldown] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setError("");
+    setMessage("");
+    try {
+      const { error } = await supabase.auth.signInWithOtp({
+        email,
+        options: { emailRedirectTo: window.location.origin },
+      });
+      if (error) throw error;
+      setMessage("Cek email untuk link masuk.");
+      setCooldown(true);
+      setTimeout(() => setCooldown(false), 5000);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Modal open={open} title="Masuk HematWoi" onClose={onClose}>
+      {message && <p className="text-green-600 text-sm mb-2">{message}</p>}
+      {error && <p className="text-red-500 text-sm mb-2">{error}</p>}
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input
+          type="email"
+          className="input w-full"
+          placeholder="emailmu@example.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <button
+          type="submit"
+          className="btn btn-primary w-full"
+          disabled={loading || cooldown}
+        >
+          {loading ? "Mengirim..." : "Kirim Link Masuk"}
+        </button>
+      </form>
+    </Modal>
+  );
+}

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -1,32 +1,79 @@
-import Logo from './Logo';
+import { useEffect, useState } from "react";
+import Logo from "./Logo";
+import SignIn from "./SignIn";
+import { supabase } from "../lib/supabase";
 
 function toRupiah(n = 0) {
-  return new Intl.NumberFormat('id-ID', {
-    style: 'currency',
-    currency: 'IDR',
+  return new Intl.NumberFormat("id-ID", {
+    style: "currency",
+    currency: "IDR",
     minimumFractionDigits: 0,
   }).format(n);
 }
 
 export default function TopBar({ stats, useCloud, setUseCloud }) {
+  const [sessionUser, setSessionUser] = useState(null);
+  const [showSignIn, setShowSignIn] = useState(false);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => setSessionUser(data.user ?? null));
+    const { data: sub } = supabase.auth.onAuthStateChange((_ev, session) => {
+      setSessionUser(session?.user ?? null);
+    });
+    return () => sub.subscription.unsubscribe();
+  }, []);
+
+  useEffect(() => {
+    if (sessionUser && showSignIn) setShowSignIn(false);
+  }, [sessionUser, showSignIn]);
+
+  const shortEmail = (email = "") =>
+    email.length > 20 ? email.slice(0, 17) + "..." : email;
+
+  const handleToggle = (e) => {
+    const next = e.target.checked;
+    if (next && !sessionUser) {
+      setShowSignIn(true);
+      setUseCloud(false);
+      return;
+    }
+    setUseCloud(next);
+  };
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+    if (useCloud) setUseCloud(false);
+  };
+
   return (
     <div className="max-w-5xl mx-auto p-4 flex items-center justify-between">
       <div className="flex items-center gap-2">
         <Logo />
         <h1 className="font-bold text-lg">HematWoi</h1>
-        <span className="badge">{useCloud ? 'Cloud' : 'Lokal'}</span>
       </div>
       <div className="flex items-center gap-4">
+        <span className="badge">{useCloud ? "Cloud" : "Local"}</span>
         <label className="flex items-center gap-1 text-sm">
-          <input
-            type="checkbox"
-            checked={useCloud}
-            onChange={(e) => setUseCloud(e.target.checked)}
-          />
+          <input type="checkbox" checked={useCloud} onChange={handleToggle} />
           Cloud
         </label>
-        <div className="font-semibold">Saldo: {toRupiah(stats?.balance || 0)}</div>
+        <div className="font-semibold hidden sm:block">
+          Saldo: {toRupiah(stats?.balance || 0)}
+        </div>
+        {sessionUser ? (
+          <>
+            <span className="badge">{shortEmail(sessionUser.email)}</span>
+            <button className="btn" onClick={handleLogout}>
+              Keluar
+            </button>
+          </>
+        ) : (
+          <button className="btn btn-primary" onClick={() => setShowSignIn(true)}>
+            Masuk
+          </button>
+        )}
       </div>
+      <SignIn open={showSignIn} onClose={() => setShowSignIn(false)} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add email magic link sign-in flow with reusable modal
- show session status and logout in TopBar; gate cloud toggle on auth
- reset cloud mode when session ends

## Testing
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6fef852a0833286deec919af9678c