### PR TITLE
feat: add user settings with dark mode

### DIFF
--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from "react";
+import Modal from "./Modal";
+
+export default function SettingsPanel({ open, onClose, value, onChange }) {
+  const [form, setForm] = useState(value);
+
+  useEffect(() => {
+    setForm(value);
+  }, [value, open]);
+
+  const handleSave = () => {
+    onChange(form);
+    onClose();
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title="Settings">
+      <div className="space-y-4">
+        <div>
+          <h3 className="font-semibold mb-2">Tampilan</h3>
+          <div className="space-y-3">
+            <div>
+              <div className="text-sm mb-1">Theme</div>
+              <div className="flex gap-2">
+                {[
+                  ["system", "System"],
+                  ["light", "Light"],
+                  ["dark", "Dark"],
+                ].map(([val, label]) => (
+                  <label key={val} className="flex items-center gap-1 text-sm">
+                    <input
+                      type="radio"
+                      name="theme"
+                      value={val}
+                      checked={form.theme === val}
+                      onChange={(e) =>
+                        setForm((f) => ({ ...f, theme: e.target.value }))
+                      }
+                    />
+                    {label}
+                  </label>
+                ))}
+              </div>
+            </div>
+            <div>
+              <div className="text-sm mb-1">Density</div>
+              <div className="flex gap-2">
+                {[
+                  ["comfortable", "Comfortable"],
+                  ["compact", "Compact"],
+                ].map(([val, label]) => (
+                  <label key={val} className="flex items-center gap-1 text-sm">
+                    <input
+                      type="radio"
+                      name="density"
+                      value={val}
+                      checked={form.density === val}
+                      onChange={(e) =>
+                        setForm((f) => ({ ...f, density: e.target.value }))
+                      }
+                    />
+                    {label}
+                  </label>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <h3 className="font-semibold mb-2">Preferensi Data</h3>
+          <div className="space-y-3">
+            <label className="block text-sm">
+              <div className="mb-1">Default Bulan</div>
+              <select
+                className="input"
+                value={form.defaultMonth}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, defaultMonth: e.target.value }))
+                }
+              >
+                <option value="current">Current</option>
+                <option value="last">Last</option>
+                <option value="none">None</option>
+              </select>
+            </label>
+            <label className="block text-sm">
+              <div className="mb-1">Format Mata Uang</div>
+              <select
+                className="input"
+                value={form.currency}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, currency: e.target.value }))
+                }
+              >
+                <option value="IDR">IDR</option>
+                <option value="USD">USD</option>
+              </select>
+            </label>
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <button className="btn" onClick={onClose}>
+            Batal
+          </button>
+          <button className="btn btn-primary" onClick={handleSave}>
+            Simpan
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -3,10 +3,12 @@ import Logo from "./Logo";
 import SignIn from "./SignIn";
 import { supabase } from "../lib/supabase";
 
-function toRupiah(n = 0) {
-  return new Intl.NumberFormat("id-ID", {
+function formatCurrency(n = 0) {
+  const pref = window.__hw_prefs?.currency === "USD" ? "USD" : "IDR";
+  const locale = pref === "USD" ? "en-US" : "id-ID";
+  return new Intl.NumberFormat(locale, {
     style: "currency",
-    currency: "IDR",
+    currency: pref,
     minimumFractionDigits: 0,
   }).format(n);
 }
@@ -58,8 +60,16 @@ export default function TopBar({ stats, useCloud, setUseCloud }) {
           Cloud
         </label>
         <div className="font-semibold hidden sm:block">
-          Saldo: {toRupiah(stats?.balance || 0)}
+          Saldo: {formatCurrency(stats?.balance || 0)}
         </div>
+        <button
+          className="btn"
+          onClick={() =>
+            window.dispatchEvent(new CustomEvent("hw:open-settings"))
+          }
+        >
+          ⚙️
+        </button>
         {sessionUser ? (
           <>
             <span className="badge">{shortEmail(sessionUser.email)}</span>

--- a/src/components/TxTable.jsx
+++ b/src/components/TxTable.jsx
@@ -8,6 +8,7 @@ export default function TxTable({ items = [], onRemove, onUpdate }) {
   const start = (page - 1) * pageSize + 1;
   const end = Math.min(page * pageSize, items.length);
   const pageItems = items.slice(start - 1, end);
+  const density = window.__hw_prefs?.density || "comfortable";
 
   useEffect(() => {
     setPage(1);
@@ -17,7 +18,7 @@ export default function TxTable({ items = [], onRemove, onUpdate }) {
 
   return (
     <div className="table-wrap overflow-auto">
-      <table className="min-w-full text-sm">
+      <table className={`min-w-full text-sm ${density === "compact" ? "table-compact" : ""}`}>
         <thead className="bg-white md:sticky md:top-0">
           <tr className="text-left">
             <th className="p-2">Kategori</th>

--- a/src/index.css
+++ b/src/index.css
@@ -2,8 +2,20 @@
 @tailwind components;
 @tailwind utilities;
 
-/* helper opsional—hapus kalau gak perlu */
-.container { @apply mx-auto max-w-5xl px-4; }
-.card { @apply bg-white rounded-xl shadow-sm border p-4; }
 .btn { @apply inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm; }
+.btn-primary { @apply bg-brand border-brand text-white; }
+.card { @apply bg-white rounded-xl shadow-sm border p-4; }
+.input { @apply w-full rounded-lg border px-3 py-2; }
 .badge { @apply inline-block rounded-full border px-2 py-0.5 text-xs; }
+.table-wrap { @apply overflow-auto; }
+
+/* table density */
+.table-compact td { @apply py-1; }
+
+/* dark mode surfaces */
+:root { color-scheme: light dark; }
+.dark body { @apply bg-slate-950 text-slate-100; }
+.dark .card { @apply bg-slate-900 border-slate-800; }
+.dark .input { @apply bg-slate-900 border-slate-700 text-slate-100; }
+.dark .btn { @apply border-slate-700; }
+.dark .badge { @apply border-slate-700; }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,11 +1,10 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: ["./index.html","./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {
-      colors: {
-        brand: "#3898f8",
-      },
+      colors: { brand: "#3898f8" },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- add dark mode support and base styling
- implement SettingsPanel to manage theme and user preferences
- persist preferences locally and to Supabase with global density handling

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c74d1c04a88332bc170bdb914332d9