### PR TITLE
feat: add reporting dashboard with export

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "recharts": "^2.12.7",
+    "jspdf": "^2.5.1",
+    "html2canvas": "^1.4.1",
     "lucide-react": "^0.474.0",
     "clsx": "^2.1.1",
     "@dnd-kit/core": "^6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      html2canvas:
+        specifier: ^1.4.1
+        version: 1.4.1
+      jspdf:
+        specifier: ^2.5.1
+        version: 2.5.1
       lucide-react:
         specifier: ^0.474.0
         version: 0.474.0(react@19.1.1)
@@ -615,6 +621,9 @@ packages:
   '@types/phoenix@1.6.6':
     resolution: {integrity: sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==}
 
+  '@types/raf@3.4.3':
+    resolution: {integrity: sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==}
+
   '@types/react-dom@19.1.9':
     resolution: {integrity: sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==}
     peerDependencies:
@@ -674,6 +683,11 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  atob@2.1.2:
+    resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
+    engines: {node: '>= 4.5.0'}
+    hasBin: true
+
   autoprefixer@10.4.21:
     resolution: {integrity: sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -683,6 +697,10 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
 
   baseline-browser-mapping@2.8.3:
     resolution: {integrity: sha512-mcE+Wr2CAhHNWxXN/DdTI+n4gsPc5QpXpWnyCQWiQYIYZX+ZMJ8juXZgjRa/0/YPJo/NSsgW15/YgmI4nbysYw==}
@@ -707,6 +725,11 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  btoa@1.2.1:
+    resolution: {integrity: sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==}
+    engines: {node: '>= 0.4.0'}
+    hasBin: true
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -717,6 +740,10 @@ packages:
 
   caniuse-lite@1.0.30001741:
     resolution: {integrity: sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==}
+
+  canvg@3.0.11:
+    resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
+    engines: {node: '>=10.0.0'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -747,9 +774,15 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  core-js@3.45.1:
+    resolution: {integrity: sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -830,6 +863,9 @@ packages:
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+
+  dompurify@2.5.8:
+    resolution: {integrity: sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -941,6 +977,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -1006,6 +1045,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1086,6 +1129,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jspdf@2.5.1:
+    resolution: {integrity: sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -1276,6 +1322,9 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1350,6 +1399,9 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  raf@3.4.1:
+    resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
+
   react-dom@19.1.1:
     resolution: {integrity: sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==}
     peerDependencies:
@@ -1398,6 +1450,9 @@ packages:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -1410,6 +1465,10 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rgbcolor@1.0.1:
+    resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
+    engines: {node: '>= 0.8.15'}
 
   rollup@4.50.1:
     resolution: {integrity: sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA==}
@@ -1441,6 +1500,10 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackblur-canvas@2.7.0:
+    resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
+    engines: {node: '>=0.1.14'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -1475,10 +1538,17 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svg-pathdata@6.0.3:
+    resolution: {integrity: sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==}
+    engines: {node: '>=12.0.0'}
+
   tailwindcss@3.4.17:
     resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -1525,6 +1595,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
@@ -2097,6 +2170,9 @@ snapshots:
 
   '@types/phoenix@1.6.6': {}
 
+  '@types/raf@3.4.3':
+    optional: true
+
   '@types/react-dom@19.1.9(@types/react@19.1.13)':
     dependencies:
       '@types/react': 19.1.13
@@ -2155,6 +2231,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  atob@2.1.2: {}
+
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
       browserslist: 4.26.0
@@ -2166,6 +2244,8 @@ snapshots:
       postcss-value-parser: 4.2.0
 
   balanced-match@1.0.2: {}
+
+  base64-arraybuffer@1.0.2: {}
 
   baseline-browser-mapping@2.8.3: {}
 
@@ -2192,11 +2272,25 @@ snapshots:
       node-releases: 2.0.21
       update-browserslist-db: 1.1.3(browserslist@4.26.0)
 
+  btoa@1.2.1: {}
+
   callsites@3.1.0: {}
 
   camelcase-css@2.0.1: {}
 
   caniuse-lite@1.0.30001741: {}
+
+  canvg@3.0.11:
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@types/raf': 3.4.3
+      core-js: 3.45.1
+      raf: 3.4.1
+      regenerator-runtime: 0.13.11
+      rgbcolor: 1.0.1
+      stackblur-canvas: 2.7.0
+      svg-pathdata: 6.0.3
+    optional: true
 
   chalk@4.1.2:
     dependencies:
@@ -2229,11 +2323,18 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  core-js@3.45.1:
+    optional: true
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
 
   cssesc@3.0.0: {}
 
@@ -2296,6 +2397,9 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.4
       csstype: 3.1.3
+
+  dompurify@2.5.8:
+    optional: true
 
   eastasianwidth@0.2.0: {}
 
@@ -2441,6 +2545,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fflate@0.4.8: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -2502,6 +2608,11 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
+
   ignore@5.3.2: {}
 
   import-fresh@3.3.1:
@@ -2559,6 +2670,18 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  jspdf@2.5.1:
+    dependencies:
+      '@babel/runtime': 7.28.4
+      atob: 2.1.2
+      btoa: 1.2.1
+      fflate: 0.4.8
+    optionalDependencies:
+      canvg: 3.0.11
+      core-js: 3.45.1
+      dompurify: 2.5.8
+      html2canvas: 1.4.1
 
   keyv@4.5.4:
     dependencies:
@@ -2714,6 +2837,9 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
+  performance-now@2.1.0:
+    optional: true
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -2773,6 +2899,11 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  raf@3.4.1:
+    dependencies:
+      performance-now: 2.1.0
+    optional: true
+
   react-dom@19.1.1(react@19.1.1):
     dependencies:
       react: 19.1.1
@@ -2828,6 +2959,9 @@ snapshots:
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2
 
+  regenerator-runtime@0.13.11:
+    optional: true
+
   resolve-from@4.0.0: {}
 
   resolve@1.22.10:
@@ -2837,6 +2971,9 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
+
+  rgbcolor@1.0.1:
+    optional: true
 
   rollup@4.50.1:
     dependencies:
@@ -2883,6 +3020,9 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  stackblur-canvas@2.7.0:
+    optional: true
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -2921,6 +3061,9 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svg-pathdata@6.0.3:
+    optional: true
+
   tailwindcss@3.4.17:
     dependencies:
       '@alloc/quick-lru': 5.2.0
@@ -2947,6 +3090,10 @@ snapshots:
       sucrase: 3.35.0
     transitivePeerDependencies:
       - ts-node
+
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
 
   thenify-all@1.6.0:
     dependencies:
@@ -2990,6 +3137,10 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
 
   victory-vendor@36.9.2:
     dependencies:

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,8 @@ import BudgetSection from "./components/BudgetSection";
 import Modal from "./components/Modal";
 import ManageCategories from "./components/ManageCategories";
 import DashboardCharts from "./components/DashboardCharts";
+import ReportFilters from "./components/ReportFilters";
+import Reports from "./components/Reports";
 import Skeleton from "./components/Skeleton";
 import { Table as TableIcon } from "lucide-react";
 import { supabase } from "./lib/supabase";
@@ -57,6 +59,9 @@ function loadInitial() {
 export default function App() {
   const [data, setData] = useState(loadInitial);
   const [filter, setFilter] = useState({ type: "all", q: "", month: "all" });
+  const currentMonth = new Date().toISOString().slice(0, 7);
+  const [reportMonth, setReportMonth] = useState(filter.month === "all" ? currentMonth : filter.month);
+  const [comparePrev, setComparePrev] = useState(false);
   const [showCat, setShowCat] = useState(false);
   const [theme, setTheme] = useState(() => localStorage.getItem('hematwoi:v3:theme') || 'system');
   const [prefs, setPrefs] = useState(() => {
@@ -497,7 +502,6 @@ export default function App() {
     reader.readAsText(file);
   }
 
-  const currentMonth = new Date().toISOString().slice(0, 7);
   const isLoading = useCloud && data.txs.length === 0;
 
   return (
@@ -526,6 +530,21 @@ export default function App() {
             txs={data.txs}
           />
         )}
+
+        <ReportFilters
+          month={reportMonth}
+          months={months}
+          comparePrev={comparePrev}
+          onToggleCompare={setComparePrev}
+          onChange={setReportMonth}
+        />
+        <Reports
+          month={reportMonth}
+          months={months}
+          txs={data.txs}
+          budgets={data.budgets}
+          comparePrevEnabled={comparePrev}
+        />
 
         <BudgetSection
           filterMonth={filter.month === "all" ? currentMonth : filter.month}

--- a/src/components/ExportReport.jsx
+++ b/src/components/ExportReport.jsx
@@ -1,0 +1,82 @@
+import jsPDF from "jspdf";
+import html2canvas from "html2canvas";
+
+export default function ExportReport({
+  month,
+  kpi = {},
+  byCategory = [],
+  byDay = [],
+  budgetsForMonth = [],
+}) {
+  const exportCSV = () => {
+    try {
+      const lines = [];
+      lines.push("KPI");
+      lines.push("Metric,Value");
+      lines.push(`Pemasukan,${kpi.income || 0}`);
+      lines.push(`Pengeluaran,${kpi.expense || 0}`);
+      lines.push(`Saldo,${kpi.balance || 0}`);
+      lines.push(`Savings Rate,${((kpi.savings || 0) * 100).toFixed(2)}%`);
+      lines.push("");
+      lines.push("Per Kategori");
+      lines.push("Kategori,Total");
+      byCategory.forEach((c) => lines.push(`${c.category},${c.total}`));
+      lines.push("");
+      lines.push("Per Hari");
+      lines.push("Tanggal,Pemasukan,Pengeluaran");
+      byDay.forEach((d) => lines.push(`${d.date},${d.income},${d.expense}`));
+      lines.push("");
+      lines.push("Budget");
+      lines.push("Kategori,Limit,Terpakai,Sisa,Progress%");
+      budgetsForMonth.forEach((b) =>
+        lines.push(
+          `${b.category},${b.cap},${b.used},${b.remaining},${Math.round(
+            b.progress * 100
+          )}`
+        )
+      );
+      const blob = new Blob([lines.join("\n")], { type: "text/csv;charset=utf-8;" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `hematwoi-report-${month}.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      alert("Gagal export CSV: " + e.message);
+    }
+  };
+
+  const exportPDF = async () => {
+    try {
+      const el = document.getElementById("report-capture");
+      if (!el) throw new Error("Area laporan tidak ditemukan");
+      const canvas = await html2canvas(el, { scale: 2 });
+      const imgData = canvas.toDataURL("image/png");
+      const pdf = new jsPDF("p", "mm", "a4");
+      const pdfWidth = pdf.internal.pageSize.getWidth();
+      const pdfHeight = (canvas.height * pdfWidth) / canvas.width;
+      pdf.addImage(imgData, "PNG", 0, 0, pdfWidth, pdfHeight);
+      pdf.setFontSize(10);
+      pdf.text(
+        `HematWoi • Laporan ${month} • ${new Date().toLocaleString("id-ID")}`,
+        10,
+        pdf.internal.pageSize.getHeight() - 10
+      );
+      pdf.save(`hematwoi-report-${month}.pdf`);
+    } catch (e) {
+      alert("Gagal export PDF: " + e.message);
+    }
+  };
+
+  return (
+    <div className="flex gap-2">
+      <button className="btn" onClick={exportCSV}>
+        Export CSV
+      </button>
+      <button className="btn" onClick={exportPDF}>
+        Export PDF
+      </button>
+    </div>
+  );
+}

--- a/src/components/KPITiles.jsx
+++ b/src/components/KPITiles.jsx
@@ -1,0 +1,72 @@
+import { ArrowUpRight, ArrowDownRight } from "lucide-react";
+
+function toRupiah(n = 0) {
+  return new Intl.NumberFormat("id-ID", {
+    style: "currency",
+    currency: "IDR",
+    minimumFractionDigits: 0,
+  }).format(n);
+}
+
+function toPercent(n = 0) {
+  return (n || 0).toLocaleString("id-ID", {
+    style: "percent",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  });
+}
+
+export default function KPITiles({ income = 0, expense = 0, prevIncome = 0, prevExpense = 0 }) {
+  const balance = income - expense;
+  const prevBalance = prevIncome - prevExpense;
+  const savings = income > 0 ? balance / income : 0;
+  const prevSavings = prevIncome > 0 ? prevBalance / prevIncome : 0;
+
+  const incomeDelta = prevIncome ? (income - prevIncome) / prevIncome : null;
+  const expenseDelta = prevExpense ? (expense - prevExpense) / prevExpense : null;
+  const balanceDelta = prevBalance ? (balance - prevBalance) / prevBalance : null;
+  const savingsDelta = prevSavings ? (savings - prevSavings) / prevSavings : null;
+
+  const renderDelta = (delta) => {
+    if (delta == null || !isFinite(delta)) return "—";
+    const Arrow = delta >= 0 ? ArrowUpRight : ArrowDownRight;
+    const color = delta >= 0 ? "text-green-600" : "text-red-600";
+    return (
+      <span className={`flex items-center justify-center gap-1 ${color}`}>
+        <Arrow className="h-3 w-3" />
+        {Math.abs(delta).toLocaleString("id-ID", {
+          style: "percent",
+          minimumFractionDigits: 0,
+          maximumFractionDigits: 0,
+        })}
+      </span>
+    );
+  };
+
+  return (
+    <div className="card">
+      <div className="grid gap-4 text-center sm:grid-cols-4">
+        <div>
+          <div className="text-sm">Pemasukan</div>
+          <div className="text-lg font-semibold text-green-600">{toRupiah(income)}</div>
+          <div className="text-xs">{renderDelta(incomeDelta)}</div>
+        </div>
+        <div>
+          <div className="text-sm">Pengeluaran</div>
+          <div className="text-lg font-semibold text-red-600">{toRupiah(expense)}</div>
+          <div className="text-xs">{renderDelta(expenseDelta)}</div>
+        </div>
+        <div>
+          <div className="text-sm">Saldo</div>
+          <div className="text-lg font-semibold text-blue-600">{toRupiah(balance)}</div>
+          <div className="text-xs">{renderDelta(balanceDelta)}</div>
+        </div>
+        <div>
+          <div className="text-sm">Savings Rate</div>
+          <div className="text-lg font-semibold">{toPercent(savings)}</div>
+          <div className="text-xs">{renderDelta(savingsDelta)}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ReportFilters.jsx
+++ b/src/components/ReportFilters.jsx
@@ -1,0 +1,38 @@
+export default function ReportFilters({ month, months = [], onChange, comparePrev, onToggleCompare }) {
+  const currentMonth = new Date().toISOString().slice(0, 7);
+
+  const handleMonthChange = (e) => {
+    const val = e.target.value || currentMonth;
+    onChange(val);
+  };
+
+  return (
+    <div className="card">
+      <div className="grid gap-3 sm:grid-cols-4 items-center">
+        <select className="input" value={month} onChange={handleMonthChange}>
+          <option value="">Pilih bulan…</option>
+          {months.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+        <input type="date" className="input" disabled />
+        <input type="date" className="input" disabled />
+        <div className="flex flex-col gap-2">
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={comparePrev}
+              onChange={(e) => onToggleCompare(e.target.checked)}
+            />
+            <span className="text-sm">Bandingkan dengan bulan sebelumnya</span>
+          </label>
+          <button className="btn" onClick={() => onChange(currentMonth)}>
+            Reset
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Reports.jsx
+++ b/src/components/Reports.jsx
@@ -1,0 +1,325 @@
+import { useMemo } from "react";
+import KPITiles from "./KPITiles";
+import ExportReport from "./ExportReport";
+import {
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  Legend,
+  AreaChart,
+  Area,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  BarChart,
+  Bar,
+} from "recharts";
+
+function toRupiah(n = 0) {
+  return new Intl.NumberFormat("id-ID", {
+    style: "currency",
+    currency: "IDR",
+    minimumFractionDigits: 0,
+  }).format(n);
+}
+
+export default function Reports({
+  month,
+  months = [],
+  txs = [],
+  budgets = [],
+  comparePrevEnabled,
+}) {
+  const filtered = useMemo(
+    () => txs.filter((t) => String(t.date).slice(0, 7) === month),
+    [txs, month]
+  );
+
+  const income = useMemo(
+    () =>
+      filtered
+        .filter((t) => t.type === "income")
+        .reduce((s, t) => s + Number(t.amount || 0), 0),
+    [filtered]
+  );
+  const expense = useMemo(
+    () =>
+      filtered
+        .filter((t) => t.type === "expense")
+        .reduce((s, t) => s + Number(t.amount || 0), 0),
+    [filtered]
+  );
+  const balance = income - expense;
+  const savings = income > 0 ? balance / income : 0;
+
+  const [y, m] = month.split("-").map(Number);
+  const prevDate = new Date(y, m - 2, 1);
+  const prevMonth = `${prevDate.getFullYear()}-${String(
+    prevDate.getMonth() + 1
+  ).padStart(2, "0")}`;
+  const prevMonthExists = months.includes(prevMonth);
+  const prevTxs = useMemo(
+    () =>
+      prevMonthExists
+        ? txs.filter((t) => String(t.date).slice(0, 7) === prevMonth)
+        : [],
+    [txs, prevMonth, prevMonthExists]
+  );
+  const prevIncome = prevTxs
+    .filter((t) => t.type === "income")
+    .reduce((s, t) => s + Number(t.amount || 0), 0);
+  const prevExpense = prevTxs
+    .filter((t) => t.type === "expense")
+    .reduce((s, t) => s + Number(t.amount || 0), 0);
+
+  const catAgg = {};
+  filtered.forEach((t) => {
+    if (t.type === "expense") {
+      const cat = t.category || "Lainnya";
+      catAgg[cat] = (catAgg[cat] || 0) + Number(t.amount || 0);
+    }
+  });
+  const byCategory = Object.entries(catAgg)
+    .map(([category, total]) => ({ category, total }))
+    .sort((a, b) => b.total - a.total)
+    .slice(0, 10);
+  const pieData = byCategory.map((c) => ({ name: c.category, value: c.total }));
+  const COLORS = [
+    "#dc2626",
+    "#fb923c",
+    "#f59e0b",
+    "#eab308",
+    "#84cc16",
+    "#22c55e",
+    "#0ea5e9",
+    "#6366f1",
+    "#a855f7",
+    "#ec4899",
+  ];
+
+  const daysInMonth = new Date(y, m, 0).getDate();
+  const dayMap = {};
+  filtered.forEach((t) => {
+    const d = String(t.date).slice(8, 10);
+    if (!dayMap[d]) dayMap[d] = { day: d, income: 0, expense: 0 };
+    dayMap[d][t.type] += Number(t.amount || 0);
+  });
+  const byDay = Array.from({ length: daysInMonth }, (_, i) => {
+    const d = String(i + 1).padStart(2, "0");
+    return {
+      date: `${month}-${d}`,
+      day: d,
+      income: dayMap[d]?.income || 0,
+      expense: dayMap[d]?.expense || 0,
+    };
+  });
+
+  const budgetsForMonth = budgets
+    .filter((b) => b.month === month)
+    .map((b) => {
+      const cap = Number(b.amount || 0);
+      const used = filtered
+        .filter((t) => t.type === "expense" && t.category === b.category)
+        .reduce((s, t) => s + Number(t.amount || 0), 0);
+      return {
+        category: b.category,
+        cap,
+        used,
+        remaining: cap - used,
+        progress: cap > 0 ? used / cap : 0,
+      };
+    });
+
+  const kpi = { income, expense, balance, savings };
+
+  if (income + expense === 0) {
+    return (
+      <section className="space-y-4">
+        <div id="report-capture" className="space-y-4">
+          <div className="card">
+            <h2 className="font-semibold">Laporan Bulan {month}</h2>
+          </div>
+          <div className="card text-center">Belum ada data pada bulan ini.</div>
+        </div>
+        <ExportReport
+          month={month}
+          kpi={kpi}
+          byCategory={[]}
+          byDay={[]}
+          budgetsForMonth={[]}
+        />
+      </section>
+    );
+  }
+
+  const compareData = [
+    { name: "Pemasukan", thisMonth: income, prevMonth: prevIncome },
+    { name: "Pengeluaran", thisMonth: expense, prevMonth: prevExpense },
+  ];
+
+  const renderPieTooltip = ({ payload }) => {
+    if (!payload?.length) return null;
+    const p = payload[0];
+    return (
+      <div className="rounded bg-white p-2 text-xs shadow">
+        {p.name}: {toRupiah(p.value)}
+      </div>
+    );
+  };
+
+  const renderAreaTooltip = ({ payload, label }) => {
+    if (!payload?.length) return null;
+    return (
+      <div className="rounded bg-white p-2 text-xs shadow">
+        <div>Hari {label}</div>
+        {payload.map((p) => (
+          <div
+            key={p.dataKey}
+            className={p.dataKey === "income" ? "text-green-600" : "text-red-600"}
+          >
+            {p.name}: {toRupiah(p.value)}
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  const renderBarTooltip = ({ payload }) => {
+    if (!payload?.length) return null;
+    const p = payload[0];
+    return (
+      <div className="rounded bg-white p-2 text-xs shadow">
+        {p.payload.name}: {toRupiah(p.value)}
+      </div>
+    );
+  };
+
+  return (
+    <section className="space-y-4">
+      <div id="report-capture" className="space-y-4">
+        <div className="card">
+          <h2 className="font-semibold">Laporan Bulan {month}</h2>
+        </div>
+        <KPITiles
+          income={income}
+          expense={expense}
+          prevIncome={prevIncome}
+          prevExpense={prevExpense}
+        />
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="h-[260px] md:h-[300px]">
+            {pieData.length ? (
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie data={pieData} dataKey="value" innerRadius="50%" outerRadius="80%">
+                    {pieData.map((entry, i) => (
+                      <Cell key={i} fill={COLORS[i % COLORS.length]} />
+                    ))}
+                  </Pie>
+                  <Tooltip content={renderPieTooltip} />
+                  <Legend />
+                </PieChart>
+              </ResponsiveContainer>
+            ) : (
+              <div className="flex h-full items-center justify-center text-sm">
+                Belum ada data kategori.
+              </div>
+            )}
+          </div>
+          <div className="h-[260px] md:h-[300px]">
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart
+                data={byDay}
+                margin={{ top: 10, right: 30, left: 0, bottom: 0 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="day" />
+                <YAxis />
+                <Tooltip content={renderAreaTooltip} />
+                <Legend />
+                <Area
+                  type="monotone"
+                  dataKey="income"
+                  name="Pemasukan"
+                  stroke="#16a34a"
+                  fill="#16a34a"
+                  fillOpacity={0.3}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="expense"
+                  name="Pengeluaran"
+                  stroke="#dc2626"
+                  fill="#dc2626"
+                  fillOpacity={0.3}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
+          {comparePrevEnabled && (
+            <div className="h-[260px] md:h-[300px] md:col-span-2">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={compareData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="name" />
+                  <YAxis />
+                  <Tooltip content={renderBarTooltip} />
+                  <Legend />
+                  <Bar dataKey="thisMonth" name={month} fill="#3898f8" />
+                  <Bar dataKey="prevMonth" name={prevMonth} fill="#94a3b8" />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </div>
+        <div className="card">
+          <h3 className="mb-2 font-semibold">Kepatuhan Budget</h3>
+          {budgetsForMonth.length ? (
+            <div className="table-wrap">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left">
+                    <th className="p-1">Kategori</th>
+                    <th className="p-1">Limit</th>
+                    <th className="p-1">Terpakai</th>
+                    <th className="p-1">Sisa</th>
+                    <th className="p-1">Progres</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {budgetsForMonth.map((b) => (
+                    <tr key={b.category} className="align-top">
+                      <td className="p-1">{b.category}</td>
+                      <td className="p-1">{toRupiah(b.cap)}</td>
+                      <td className="p-1">{toRupiah(b.used)}</td>
+                      <td className="p-1">{toRupiah(b.remaining)}</td>
+                      <td className="p-1 w-32">
+                        <div className="h-2 rounded-full bg-slate-200">
+                          <div
+                            className="h-2 rounded-full bg-brand"
+                            style={{ width: `${Math.min(100, b.progress * 100)}%` }}
+                          />
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <div className="text-sm">Belum ada budget bulan ini.</div>
+          )}
+        </div>
+      </div>
+      <ExportReport
+        month={month}
+        kpi={kpi}
+        byCategory={byCategory}
+        byDay={byDay}
+        budgetsForMonth={budgetsForMonth}
+      />
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add report filters with month picker and comparison toggle
- display KPI tiles and charts for selected month
- export report data to CSV or PDF

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c74f6dffc48332b1342075881abba4