### PR TITLE
feat: add toast notifications and recurring reminders

### DIFF
--- a/src/components/AddForm.jsx
+++ b/src/components/AddForm.jsx
@@ -7,14 +7,36 @@ export default function AddForm({ categories, onAdd }) {
   const [category, setCategory] = useState('');
   const [note, setNote] = useState('');
   const [amount, setAmount] = useState('');
+  const [recurring, setRecurring] = useState(false);
+  const [period, setPeriod] = useState('monthly');
 
   const catList = categories?.[type] || [];
 
   const submit = (e) => {
     e.preventDefault();
-    onAdd({ date, type, category, note, amount: Number(amount) });
+    const tx = { date, type, category, note, amount: Number(amount) };
+    onAdd(tx);
+    if (recurring) {
+      try {
+        const raw = localStorage.getItem('hematwoi:recurrings');
+        const arr = raw ? JSON.parse(raw) : [];
+        arr.push({
+          category,
+          note,
+          amount: Number(amount),
+          type,
+          period,
+          last: new Date().toISOString(),
+        });
+        localStorage.setItem('hematwoi:recurrings', JSON.stringify(arr));
+      } catch {
+        // ignore
+      }
+    }
     setNote('');
     setAmount('');
+    setRecurring(false);
+    setPeriod('monthly');
   };
 
   return (
@@ -57,6 +79,28 @@ export default function AddForm({ categories, onAdd }) {
         value={note}
         onChange={(e) => setNote(e.target.value)}
       />
+      <div className="flex items-center gap-2">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            className="h-4 w-4"
+            checked={recurring}
+            onChange={(e) => setRecurring(e.target.checked)}
+          />
+          <span className="text-sm">Recurring</span>
+        </label>
+        {recurring && (
+          <select
+            className="input w-full sm:w-auto"
+            value={period}
+            onChange={(e) => setPeriod(e.target.value)}
+          >
+            <option value="daily">Harian</option>
+            <option value="weekly">Mingguan</option>
+            <option value="monthly">Bulanan</option>
+          </select>
+        )}
+      </div>
       <div className="flex items-center gap-2">
         <input
           type="number"

--- a/src/components/BudgetSection.jsx
+++ b/src/components/BudgetSection.jsx
@@ -1,4 +1,5 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
+import { useToast } from "../context/ToastContext";
 
 function toRupiah(n = 0) {
   return new Intl.NumberFormat("id-ID", {
@@ -21,6 +22,8 @@ export default function BudgetSection({
     month: filterMonth || "",
     amount: "",
   });
+
+  const { addToast } = useToast();
 
   const handleChange = (e) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -54,6 +57,21 @@ export default function BudgetSection({
     });
     return map;
   }, [txs, filterMonth]);
+
+  useEffect(() => {
+    list.forEach((b) => {
+      const used = Number(spentByCat[b.category] || 0);
+      const cap = Number(b.amount || 0);
+      const pct = cap <= 0 ? 0 : Math.min(100, Math.round((used / cap) * 100));
+      if (pct >= 80) {
+        const key = `hw:budget-toast:${filterMonth}:${b.category}`;
+        if (!sessionStorage.getItem(key)) {
+          addToast(`Budget ${b.category} sudah ${pct}% terpakai bulan ini.`, 'warning');
+          sessionStorage.setItem(key, '1');
+        }
+      }
+    });
+  }, [list, spentByCat, filterMonth, addToast]);
 
   return (
     <div className="space-y-4">

--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+
+const colors = {
+  info: 'border-blue-500',
+  success: 'border-green-500',
+  warning: 'border-amber-500',
+  danger: 'border-red-500',
+};
+
+function ToastItem({ toast, onDismiss }) {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => setShow(true));
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  return (
+    <div
+      className={`card shadow-lg p-3 flex items-start gap-2 border-l-4 ${
+        colors[toast.type] || colors.info
+      } transition-opacity duration-300 ${show ? 'opacity-100' : 'opacity-0'}`}
+    >
+      <div className="flex-1 text-sm">{toast.message}</div>
+      <button
+        type="button"
+        className="text-sm"
+        onClick={() => onDismiss(toast.id)}
+      >
+        &times;
+      </button>
+    </div>
+  );
+}
+
+export default function Toast({ toasts = [], onDismiss }) {
+  return (
+    <div className="fixed top-4 right-4 space-y-2 z-50">
+      {toasts.map((t) => (
+        <ToastItem key={t.id} toast={t} onDismiss={onDismiss} />
+      ))}
+    </div>
+  );
+}

--- a/src/context/ToastContext.jsx
+++ b/src/context/ToastContext.jsx
@@ -1,0 +1,33 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useState, useCallback } from 'react';
+import Toast from '../components/Toast';
+
+const ToastContext = createContext(null);
+
+export function useToast() {
+  return useContext(ToastContext);
+}
+
+export default function ToastProvider({ children }) {
+  const [toasts, setToasts] = useState([]);
+
+  const removeToast = useCallback((id) => {
+    setToasts((ts) => ts.filter((t) => t.id !== id));
+  }, []);
+
+  const addToast = useCallback(
+    (message, type = 'info') => {
+      const id = globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+      setToasts((ts) => [...ts, { id, type, message }]);
+      setTimeout(() => removeToast(id), 5000);
+    },
+    [removeToast]
+  );
+
+  return (
+    <ToastContext.Provider value={{ addToast, removeToast }}>
+      {children}
+      <Toast toasts={toasts} onDismiss={removeToast} />
+    </ToastContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
- add global ToastProvider and UI for notifications
- extend AddForm with recurring transaction support
- warn when budgets exceed 80% and remind recurring transactions

## Testing
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c751a6ad9c8332959c7b4ebe2e8d5b