### PR TITLE
feat: add accent color settings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,13 @@ const defaultCategories = {
   ],
 };
 
+const ACCENTS = {
+  blue: "#3898f8",
+  emerald: "#10b981",
+  violet: "#8b5cf6",
+  amber: "#f59e0b",
+};
+
 function loadInitial() {
   try {
     const raw = localStorage.getItem("hematwoi:v3");
@@ -58,7 +65,13 @@ function AppContent() {
   const [theme, setTheme] = useState(() => localStorage.getItem('hematwoi:v3:theme') || 'system');
   const [prefs, setPrefs] = useState(() => {
     const raw = localStorage.getItem('hematwoi:v3:prefs');
-    return raw ? JSON.parse(raw) : { density: 'comfortable', defaultMonth: 'current', currency: 'IDR' };
+    const base = { density: 'comfortable', defaultMonth: 'current', currency: 'IDR', accent: 'blue' };
+    if (!raw) return base;
+    try {
+      return { ...base, ...JSON.parse(raw) };
+    } catch {
+      return base;
+    }
   });
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [useCloud, setUseCloud] = useState(false);
@@ -131,6 +144,10 @@ function AppContent() {
     root.classList.toggle('dark', isDark);
     localStorage.setItem('hematwoi:v3:theme', theme);
   }, [theme]);
+  useEffect(() => {
+    const color = ACCENTS[prefs.accent] || ACCENTS.blue;
+    document.documentElement.style.setProperty('--brand', color);
+  }, [prefs.accent]);
 
   useEffect(() => {
     localStorage.setItem('hematwoi:v3:prefs', JSON.stringify(prefs));
@@ -573,9 +590,9 @@ function AppContent() {
         onClose={() => setSettingsOpen(false)}
         value={{ theme, ...prefs }}
         onChange={(val) => {
-          const { theme: nextTheme, density, defaultMonth, currency } = val;
+          const { theme: nextTheme, density, defaultMonth, currency, accent } = val;
           setTheme(nextTheme);
-          setPrefs({ density, defaultMonth, currency });
+          setPrefs({ density, defaultMonth, currency, accent });
         }}
       />
       {!hideNav && <FAB />}

--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -4,7 +4,7 @@ import { Home, Plus, BarChart3, Settings } from "lucide-react";
 export default function BottomNav() {
   const base =
     "flex flex-1 flex-col items-center justify-center gap-1 py-2 text-xs text-slate-600 dark:text-slate-300";
-  const active = "text-brand";
+  const active = "text-brand-var";
   return (
     <nav className="fixed bottom-0 inset-x-0 z-40 bg-white dark:bg-slate-900 border-t md:hidden pb-safe">
       <div className="flex">

--- a/src/components/BudgetSection.jsx
+++ b/src/components/BudgetSection.jsx
@@ -146,7 +146,7 @@ export default function BudgetSection({
 
                 <div className="h-2 w-full rounded-full bg-slate-200">
                   <div
-                    className="h-2 rounded-full bg-brand"
+                    className="h-2 rounded-full bg-brand-var"
                     style={{ width: `${pct}%` }}
                   />
                 </div>

--- a/src/components/FAB.jsx
+++ b/src/components/FAB.jsx
@@ -9,7 +9,7 @@ export default function FAB() {
       onClick={() => navigate("/add")}
       className={[
         "fixed right-4 bottom-[calc(4rem+env(safe-area-inset-bottom))]",
-        "z-60 rounded-full bg-brand text-white p-4 shadow-lg",
+        "z-60 rounded-full bg-brand-var text-white p-4 shadow-lg",
       ].join(" ")}
     >
       <Plus className="h-6 w-6" />

--- a/src/components/Logo.jsx
+++ b/src/components/Logo.jsx
@@ -1,6 +1,6 @@
 export default function Logo() {
   return (
-    <div className="w-10 h-10 flex items-center justify-center bg-brand text-white rounded-lg font-bold">
+    <div className="w-10 h-10 flex items-center justify-center bg-brand-var text-white rounded-lg font-bold">
       HW
       <span className="sr-only">HematWoi</span>
     </div>

--- a/src/components/Reports.jsx
+++ b/src/components/Reports.jsx
@@ -298,7 +298,7 @@ export default function Reports({
                       <td className="p-1 w-32">
                         <div className="h-2 rounded-full bg-slate-200">
                           <div
-                            className="h-2 rounded-full bg-brand"
+                            className="h-2 rounded-full bg-brand-var"
                             style={{ width: `${Math.min(100, b.progress * 100)}%` }}
                           />
                         </div>

--- a/src/components/Row.jsx
+++ b/src/components/Row.jsx
@@ -67,7 +67,7 @@ export default function Row({ item, onRemove, onUpdate }) {
       <td className="p-2 text-right">
         {edit ? (
           <div className="flex gap-1 justify-end">
-            <button className="btn bg-brand border-brand text-white" onClick={save}>
+            <button className="btn btn-primary" onClick={save}>
               Simpan
             </button>
             <button className="btn" onClick={() => setEdit(false)}>

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -1,5 +1,13 @@
 import { useEffect, useState } from "react";
 import Modal from "./Modal";
+import ColorDot from "./ColorDot";
+
+const ACCENTS = {
+  blue: "#3898f8",
+  emerald: "#10b981",
+  violet: "#8b5cf6",
+  amber: "#f59e0b",
+};
 
 export default function SettingsPanel({ open, onClose, value, onChange }) {
   const [form, setForm] = useState(value);
@@ -60,6 +68,29 @@ export default function SettingsPanel({ open, onClose, value, onChange }) {
                       }
                     />
                     {label}
+                  </label>
+                ))}
+              </div>
+            </div>
+            <div>
+              <div className="text-sm mb-1">Accent Color</div>
+              <div className="flex gap-2">
+                {Object.entries(ACCENTS).map(([val, color]) => (
+                  <label
+                    key={val}
+                    className="flex items-center gap-1 text-sm capitalize"
+                  >
+                    <input
+                      type="radio"
+                      name="accent"
+                      value={val}
+                      checked={form.accent === val}
+                      onChange={(e) =>
+                        setForm((f) => ({ ...f, accent: e.target.value }))
+                      }
+                    />
+                    <ColorDot color={color} />
+                    {val}
                   </label>
                 ))}
               </div>

--- a/src/components/ui/CurrencyInput.jsx
+++ b/src/components/ui/CurrencyInput.jsx
@@ -31,11 +31,12 @@ export default function CurrencyInput({ label = "Jumlah", value, onChangeNumber,
         inputMode="numeric"
         placeholder=" "
         {...props}
-        className="peer w-full rounded-xl border border-slate-300 bg-white dark:bg-slate-900 px-3 pt-5 pb-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
+        className="peer w-full rounded-xl border border-slate-300 bg-white dark:bg-slate-900 px-3 pt-5 pb-2 text-sm focus:outline-none focus:ring-2"
+        style={{ '--tw-ring-color': 'var(--brand)' }}
       />
       <label
         htmlFor={id}
-        className="absolute left-3 top-2 text-xs text-slate-500 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs peer-focus:text-brand"
+        className="absolute left-3 top-2 text-xs text-slate-500 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs peer-focus:text-[var(--brand)]"
       >
         {label}
       </label>

--- a/src/components/ui/Input.jsx
+++ b/src/components/ui/Input.jsx
@@ -13,11 +13,12 @@ export default function Input({ label, type = "text", value, onChange, name, req
         placeholder=" "
         required={required}
         {...props}
-        className="peer w-full rounded-xl border border-slate-300 bg-white dark:bg-slate-900 px-3 pt-5 pb-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
+        className="peer w-full rounded-xl border border-slate-300 bg-white dark:bg-slate-900 px-3 pt-5 pb-2 text-sm focus:outline-none focus:ring-2"
+        style={{ '--tw-ring-color': 'var(--brand)' }}
       />
       <label
         htmlFor={id}
-        className="absolute left-3 top-2 text-xs text-slate-500 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs peer-focus:text-brand"
+        className="absolute left-3 top-2 text-xs text-slate-500 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs peer-focus:text-[var(--brand)]"
       >
         {label}
       </label>

--- a/src/components/ui/Segmented.jsx
+++ b/src/components/ui/Segmented.jsx
@@ -7,7 +7,7 @@ export default function Segmented({ value, onChange, options = [] }) {
           type="button"
           className={`px-3 py-2 text-sm flex-1 ${
             value === opt.value
-              ? "bg-brand text-white"
+              ? "bg-brand-var text-white"
               : "bg-white dark:bg-slate-900"
           }`}
           onClick={() => onChange(opt.value)}

--- a/src/components/ui/Select.jsx
+++ b/src/components/ui/Select.jsx
@@ -10,8 +10,9 @@ export default function Select({ label, options = [], value, onChange, placehold
         value={value}
         onChange={onChange}
         {...props}
-        className="w-full rounded-xl border border-slate-300 bg-white dark:bg-slate-900 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand"
-      >
+        className="w-full rounded-xl border border-slate-300 bg-white dark:bg-slate-900 px-3 py-2 focus:outline-none focus:ring-2"
+        style={{ '--tw-ring-color': 'var(--brand)' }}
+        >
         <option value="" disabled>
           {placeholder}
         </option>

--- a/src/components/ui/Stepper.jsx
+++ b/src/components/ui/Stepper.jsx
@@ -7,7 +7,7 @@ export default function Stepper({ current = 0, steps = [] }) {
           <div
             key={s}
             className={`flex-1 text-center text-xs ${
-              i <= current ? "text-brand font-semibold" : "text-slate-500"
+              i <= current ? "text-brand-var font-semibold" : "text-slate-500"
             }`}
           >
             {s}
@@ -22,7 +22,7 @@ export default function Stepper({ current = 0, steps = [] }) {
         aria-valuemax={steps.length - 1}
       >
         <div
-          className="absolute left-0 top-0 h-2 bg-brand rounded-full"
+          className="absolute left-0 top-0 h-2 bg-brand-var rounded-full"
           style={{ width: `${percent}%` }}
         />
       </div>

--- a/src/components/ui/Textarea.jsx
+++ b/src/components/ui/Textarea.jsx
@@ -12,11 +12,12 @@ export default function Textarea({ label, value, onChange, name, required, ...pr
         placeholder=" "
         required={required}
         {...props}
-        className="peer w-full rounded-xl border border-slate-300 bg-white dark:bg-slate-900 px-3 pt-5 pb-2 text-sm min-h-24 focus:outline-none focus:ring-2 focus:ring-brand"
+        className="peer w-full rounded-xl border border-slate-300 bg-white dark:bg-slate-900 px-3 pt-5 pb-2 text-sm min-h-24 focus:outline-none focus:ring-2"
+        style={{ '--tw-ring-color': 'var(--brand)' }}
       />
       <label
         htmlFor={id}
-        className="absolute left-3 top-2 text-xs text-slate-500 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs peer-focus:text-brand"
+        className="absolute left-3 top-2 text-xs text-slate-500 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs peer-focus:text-[var(--brand)]"
       >
         {label}
       </label>

--- a/src/index.css
+++ b/src/index.css
@@ -2,8 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --brand: #3898f8;
+  color-scheme: light dark;
+}
+
 .btn { @apply inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm; }
-.btn-primary { @apply bg-brand border-brand text-white; }
+.btn-primary { background-color: var(--brand); border-color: var(--brand); color: white; }
 .card { @apply bg-white rounded-xl shadow-sm border p-4; }
 .input { @apply w-full rounded-lg border px-3 py-2; }
 .badge { @apply inline-block rounded-full border px-2 py-0.5 text-xs; }
@@ -13,18 +18,17 @@
 .table-compact td { @apply py-1; }
 
 /* dark mode surfaces */
-:root { color-scheme: light dark; }
 .dark body { @apply bg-slate-950 text-slate-100; }
 .dark .card { @apply bg-slate-900 border-slate-800; }
 .dark .input { @apply bg-slate-900 border-slate-700 text-slate-100; }
 .dark .btn { @apply border-slate-700; }
 .dark .badge { @apply border-slate-700; }
+.dark { --brand: #3898f8; }
 
 @layer utilities {
-  .pb-safe {
-    padding-bottom: env(safe-area-inset-bottom);
-  }
-  .z-60 {
-    z-index: 60;
-  }
+  .pb-safe { padding-bottom: env(safe-area-inset-bottom); }
+  .z-60 { z-index: 60; }
+  .text-brand-var { color: var(--brand); }
+  .bg-brand-var { background-color: var(--brand); }
+  .border-brand-var { border-color: var(--brand); }
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,6 +4,7 @@ module.exports = {
   content: ["./index.html","./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {
+      // default accent color
       colors: { brand: "#3898f8" },
     },
   },


### PR DESCRIPTION
## Summary
- add accent color preference and selector
- manage brand color through CSS variables
- apply accent selection across UI components

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68c7646859dc8332b262d79e2bcd6f6c