### PR TITLE
Add calendar heatmap and KPI sparklines

### DIFF
--- a/src/components/HeatmapCalendar.jsx
+++ b/src/components/HeatmapCalendar.jsx
@@ -1,0 +1,82 @@
+import { ResponsiveContainer } from "recharts";
+
+function toRupiah(n = 0) {
+  return new Intl.NumberFormat("id-ID", {
+    style: "currency",
+    currency: "IDR",
+    minimumFractionDigits: 0,
+  }).format(n);
+}
+
+function HeatmapSVG({ cells, weeks, width, height }) {
+  const cellW = width / weeks;
+  const cellH = height / 7;
+  return (
+    <svg width={width} height={height}>
+      {cells.map((c) => (
+        <rect
+          key={c.date}
+          x={c.week * cellW}
+          y={c.dow * cellH}
+          width={cellW - 2}
+          height={cellH - 2}
+          rx={2}
+          ry={2}
+          fill={c.color}
+          className="cursor-pointer"
+          onClick={() =>
+            window.dispatchEvent(
+              new CustomEvent("hw:filter-day", { detail: c.date })
+            )
+          }
+        >
+          <title>{toRupiah(c.total)}</title>
+        </rect>
+      ))}
+    </svg>
+  );
+}
+
+export default function HeatmapCalendar({ month, txs = [] }) {
+  const [y, m] = month.split("-").map(Number);
+  const first = new Date(y, m - 1, 1);
+  const start = (first.getDay() + 6) % 7; // Monday=0
+  const daysInMonth = new Date(y, m, 0).getDate();
+  const weeks = Math.ceil((start + daysInMonth) / 7);
+
+  const totals = {};
+  txs.forEach((t) => {
+    if (t.type === "expense" && String(t.date).slice(0, 7) === month) {
+      const d = String(t.date).slice(8, 10);
+      totals[d] = (totals[d] || 0) + Number(t.amount || 0);
+    }
+  });
+
+  const cells = [];
+  for (let i = 1; i <= daysInMonth; i++) {
+    const dStr = String(i).padStart(2, "0");
+    const dow = (start + i - 1) % 7;
+    const week = Math.floor((start + i - 1) / 7);
+    const total = totals[dStr] || 0;
+    cells.push({ date: `${month}-${dStr}`, dow, week, total });
+  }
+
+  const max = Math.max(...cells.map((c) => c.total), 0);
+  const low = [226, 232, 240]; // #e2e8f0
+  const high = [251, 113, 133]; // #fb7185
+  const colored = cells.map((c) => {
+    const ratio = max ? c.total / max : 0;
+    const rgb = low.map((l, i) => Math.round(l + (high[i] - l) * ratio));
+    return { ...c, color: `rgb(${rgb.join(",")})` };
+  });
+
+  return (
+    <div className="card">
+      <h3 className="mb-2 font-semibold">Kalender Pengeluaran</h3>
+      <ResponsiveContainer width="100%" height={weeks * 24}>
+        <HeatmapSVG cells={colored} weeks={weeks} />
+      </ResponsiveContainer>
+    </div>
+  );
+}
+

--- a/src/components/KPITiles.jsx
+++ b/src/components/KPITiles.jsx
@@ -1,4 +1,5 @@
 import { ArrowUpRight, ArrowDownRight } from "lucide-react";
+import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis } from "recharts";
 
 function toRupiah(n = 0) {
   return new Intl.NumberFormat("id-ID", {
@@ -14,6 +15,33 @@ function toPercent(n = 0) {
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
   });
+}
+
+function Sparkline({ data = [], color }) {
+  const id = `spark-${color.replace("#", "")}`;
+  const points = data.map((v, i) => ({ i, v }));
+  return (
+    <ResponsiveContainer width="100%" height={36}>
+      <AreaChart data={points} margin={{ left: 0, right: 0, top: 2, bottom: 2 }}>
+        <defs>
+          <linearGradient id={id} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity={0.4} />
+            <stop offset="100%" stopColor={color} stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <XAxis dataKey="i" hide />
+        <YAxis hide domain={[0, "dataMax"]} />
+        <Area
+          type="monotone"
+          dataKey="v"
+          stroke={color}
+          fill={`url(#${id})`}
+          strokeWidth={1}
+          dot={false}
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
 }
 
 export default function KPITiles({ income = 0, expense = 0, prevIncome = 0, prevExpense = 0 }) {
@@ -43,25 +71,33 @@ export default function KPITiles({ income = 0, expense = 0, prevIncome = 0, prev
     );
   };
 
+  const series = typeof window !== "undefined" ? window.__hw_kpiSeries || {} : {};
+  const incomeSeries = series.income || [];
+  const expenseSeries = series.expense || [];
+  const balanceSeries = series.balance || [];
+
   return (
     <div className="card">
       <div className="grid gap-4 text-center sm:grid-cols-4">
-        <div>
+        <div className="space-y-1">
           <div className="text-sm">Pemasukan</div>
           <div className="text-lg font-semibold text-green-600">{toRupiah(income)}</div>
           <div className="text-xs">{renderDelta(incomeDelta)}</div>
+          <Sparkline data={incomeSeries} color="#16a34a" />
         </div>
-        <div>
+        <div className="space-y-1">
           <div className="text-sm">Pengeluaran</div>
           <div className="text-lg font-semibold text-red-600">{toRupiah(expense)}</div>
           <div className="text-xs">{renderDelta(expenseDelta)}</div>
+          <Sparkline data={expenseSeries} color="#dc2626" />
         </div>
-        <div>
+        <div className="space-y-1">
           <div className="text-sm">Saldo</div>
           <div className="text-lg font-semibold text-blue-600">{toRupiah(balance)}</div>
           <div className="text-xs">{renderDelta(balanceDelta)}</div>
+          <Sparkline data={balanceSeries} color="#3898f8" />
         </div>
-        <div>
+        <div className="space-y-1">
           <div className="text-sm">Savings Rate</div>
           <div className="text-lg font-semibold">{toPercent(savings)}</div>
           <div className="text-xs">{renderDelta(savingsDelta)}</div>
@@ -70,3 +106,4 @@ export default function KPITiles({ income = 0, expense = 0, prevIncome = 0, prev
     </div>
   );
 }
+

--- a/src/components/Reports.jsx
+++ b/src/components/Reports.jsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import KPITiles from "./KPITiles";
+import HeatmapCalendar from "./HeatmapCalendar";
 import ExportReport from "./ExportReport";
 import {
   ResponsiveContainer,
@@ -116,6 +117,17 @@ export default function Reports({
     };
   });
 
+  const incomeSeries = byDay.map((d) => d.income);
+  const expenseSeries = byDay.map((d) => d.expense);
+  const balanceSeries = byDay.map((d) => d.income - d.expense);
+  if (typeof window !== "undefined") {
+    window.__hw_kpiSeries = {
+      income: incomeSeries,
+      expense: expenseSeries,
+      balance: balanceSeries,
+    };
+  }
+
   const budgetsForMonth = budgets
     .filter((b) => b.month === month)
     .map((b) => {
@@ -208,6 +220,7 @@ export default function Reports({
           prevIncome={prevIncome}
           prevExpense={prevExpense}
         />
+        <HeatmapCalendar month={month} txs={txs} />
         <div className="grid gap-4 md:grid-cols-2">
           <div className="h-[260px] md:h-[300px]">
             {pieData.length ? (
@@ -323,3 +336,4 @@ export default function Reports({
     </section>
   );
 }
+


### PR DESCRIPTION
## Summary
- Visualize monthly expenses with a clickable calendar heatmap
- Show mini sparklines for income, expense, and balance in KPI tiles
- Expose daily totals to KPI tiles and embed heatmap in reports

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c76954a81c8332a2dea6b27de35c49