### PR TITLE
feat: add keyboard shortcuts and accessibility polish

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -92,6 +92,34 @@ function AppContent() {
   const hideNav = location.pathname.startsWith("/add");
 
   useEffect(() => {
+    let gPressed = false;
+    const handler = (e) => {
+      const tag = e.target.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || e.target.isContentEditable)
+        return;
+
+      if (e.key === "n") {
+        navigate("/add");
+      } else if (e.key === "/" && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        e.preventDefault();
+        document.querySelector('input[placeholder="Cari"]')?.focus();
+      } else if (gPressed && (e.key === "d" || e.key === "r")) {
+        navigate(e.key === "d" ? "/" : "/reports");
+        gPressed = false;
+      } else if (e.key === "g") {
+        gPressed = true;
+        setTimeout(() => {
+          gPressed = false;
+        }, 1000);
+      } else {
+        gPressed = false;
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [navigate]);
+
+  useEffect(() => {
     try {
       const raw = localStorage.getItem('hematwoi:recurrings');
       if (!raw) return;
@@ -535,69 +563,71 @@ function AppContent() {
 
   return (
     <CategoryProvider catMeta={catMeta}>
-      <TopBar stats={stats} useCloud={useCloud} setUseCloud={setUseCloud} />
-      <nav className="max-w-5xl mx-auto px-4 gap-2 pb-2 text-sm hidden md:flex">
-        <Link to="/" className="btn">
-          Dashboard
-        </Link>
-        <Link to="/add" className="btn">
-          Tambah
-        </Link>
-      </nav>
-      <Routes>
-        <Route
-          path="/"
-          element={
-            <Dashboard
-              months={months}
-              filter={filter}
-              setFilter={setFilter}
-              stats={stats}
-              data={data}
-              addTx={addTx}
-              removeTx={removeTx}
-              updateTx={updateTx}
-              currentMonth={currentMonth}
-              setShowCat={setShowCat}
-              addBudget={addBudget}
-              removeBudget={removeBudget}
-              onExport={handleExport}
-              onImportJSON={handleImportJSON}
-              onImportCSV={handleImportCSV}
+        <TopBar stats={stats} useCloud={useCloud} setUseCloud={setUseCloud} />
+        <main id="main" tabIndex="-1" className="focus:outline-none">
+          <nav className="max-w-5xl mx-auto px-4 gap-2 pb-2 text-sm hidden md:flex">
+            <Link to="/" className="btn">
+              Dashboard
+            </Link>
+            <Link to="/add" className="btn">
+              Tambah
+            </Link>
+          </nav>
+          <Routes>
+            <Route
+              path="/"
+              element={
+                <Dashboard
+                  months={months}
+                  filter={filter}
+                  setFilter={setFilter}
+                  stats={stats}
+                  data={data}
+                  addTx={addTx}
+                  removeTx={removeTx}
+                  updateTx={updateTx}
+                  currentMonth={currentMonth}
+                  setShowCat={setShowCat}
+                  addBudget={addBudget}
+                  removeBudget={removeBudget}
+                  onExport={handleExport}
+                  onImportJSON={handleImportJSON}
+                  onImportCSV={handleImportCSV}
+                />
+              }
             />
-          }
-        />
-        <Route
-          path="/add"
-          element={
-            <AddWizard
-              categories={data.cat}
-              onAdd={addTx}
-              onCancel={() => navigate("/")}
+            <Route
+              path="/add"
+              element={
+                <AddWizard
+                  categories={data.cat}
+                  onAdd={addTx}
+                  onCancel={() => navigate("/")}
+                />
+              }
             />
-          }
+          </Routes>
+        </main>
+        <Modal
+          open={showCat}
+          title="Kelola Kategori"
+          onClose={() => setShowCat(false)}
+        >
+          <ManageCategories cat={data.cat} onSave={saveCategories} />
+        </Modal>
+        <SettingsPanel
+          open={settingsOpen}
+          onClose={() => setSettingsOpen(false)}
+          value={{ theme, ...prefs }}
+          onChange={(val) => {
+            const { theme: nextTheme, density, defaultMonth, currency, accent } = val;
+            setTheme(nextTheme);
+            setPrefs({ density, defaultMonth, currency, accent });
+          }}
         />
-      </Routes>
-      <Modal
-        open={showCat}
-        title="Kelola Kategori"
-        onClose={() => setShowCat(false)}
-      >
-        <ManageCategories cat={data.cat} onSave={saveCategories} />
-      </Modal>
-      <SettingsPanel
-        open={settingsOpen}
-        onClose={() => setSettingsOpen(false)}
-        value={{ theme, ...prefs }}
-        onChange={(val) => {
-          const { theme: nextTheme, density, defaultMonth, currency, accent } = val;
-          setTheme(nextTheme);
-          setPrefs({ density, defaultMonth, currency, accent });
-        }}
-      />
-      {!hideNav && <FAB />}
-      {!hideNav && <BottomNav />}
-    </CategoryProvider>
+        {!hideNav && <FAB />}
+        {!hideNav && <BottomNav />}
+      </CategoryProvider>
   );
 }
 

--- a/src/components/Animations.css
+++ b/src/components/Animations.css
@@ -1,0 +1,72 @@
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slide-up {
+  from { opacity: 0; transform: translateY(0.5rem); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes confetti-fall {
+  from { transform: translateY(-10px) rotate(0deg); opacity: 1; }
+  to { transform: translateY(100vh) rotate(360deg); opacity: 0; }
+}
+
+@keyframes fab-pop {
+  from { transform: scale(0); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+
+.animate-fade {
+  animation: fade-in 0.2s ease-out both;
+}
+
+.animate-slide {
+  animation: slide-up 0.3s ease-out both;
+}
+
+.animate-fab {
+  animation: fab-pop 0.3s ease-out both;
+}
+
+.confetti {
+  position: absolute;
+  top: 0;
+  width: 6px;
+  height: 6px;
+  background: var(--brand);
+  border-radius: 50%;
+  animation-name: confetti-fall;
+  animation-timing-function: linear;
+  animation-fill-mode: forwards;
+}
+
+/* Modal overlay and content */
+.fixed.inset-0.z-50.flex.items-center.justify-center.bg-black\/50 {
+  animation: fade-in 0.2s ease-out both;
+}
+.fixed.inset-0.z-50.flex.items-center.justify-center.bg-black\/50 .card {
+  animation: slide-up 0.2s ease-out both;
+}
+
+/* Toasts container */
+.fixed.top-4.right-4.space-y-2.z-50 .card {
+  animation: slide-up 0.3s ease-out both;
+}
+
+[role='progressbar'] > div {
+  transition: width 0.3s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade,
+  .animate-slide,
+  .animate-fab,
+  .confetti {
+    animation: none;
+  }
+  [role='progressbar'] > div {
+    transition: none;
+  }
+}

--- a/src/components/FAB.jsx
+++ b/src/components/FAB.jsx
@@ -3,14 +3,20 @@ import { useNavigate } from "react-router-dom";
 
 export default function FAB() {
   const navigate = useNavigate();
+  const reduceMotion =
+    typeof window !== "undefined" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   return (
     <button
       type="button"
       onClick={() => navigate("/add")}
+      aria-label="Tambah transaksi"
       className={[
         "fixed right-4 bottom-[calc(4rem+env(safe-area-inset-bottom))]",
         "z-60 rounded-full bg-brand-var text-white p-4 shadow-lg",
-      ].join(" ")}
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand",
+        reduceMotion ? "" : "animate-fab",
+      ].filter(Boolean).join(" ")}
     >
       <Plus className="h-6 w-6" />
     </button>

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -16,6 +16,7 @@ function formatCurrency(n = 0) {
 export default function TopBar({ stats, useCloud, setUseCloud }) {
   const [sessionUser, setSessionUser] = useState(null);
   const [showSignIn, setShowSignIn] = useState(false);
+  const [showConfetti, setShowConfetti] = useState(false);
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data }) => setSessionUser(data.user ?? null));
@@ -47,8 +48,42 @@ export default function TopBar({ stats, useCloud, setUseCloud }) {
     if (useCloud) setUseCloud(false);
   };
 
+  useEffect(() => {
+    const month = new Date().toISOString().slice(0, 7);
+    if (
+      stats?.balance > 0 &&
+      !window.matchMedia('(prefers-reduced-motion: reduce)').matches &&
+      !sessionStorage.getItem(`hw:confetti:${month}`)
+    ) {
+      sessionStorage.setItem(`hw:confetti:${month}`, '1');
+      setShowConfetti(true);
+      setTimeout(() => setShowConfetti(false), 1200);
+    }
+  }, [stats]);
+
   return (
-    <div className="max-w-5xl mx-auto p-4 flex items-center justify-between">
+    <header className="relative">
+      <a
+        href="#main"
+        className="sr-only focus:not-sr-only absolute left-2 top-2 z-50 bg-white text-blue-600 px-3 py-2 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600"
+      >
+        Lewati ke konten
+      </a>
+      {showConfetti && (
+        <div className="pointer-events-none absolute inset-0 overflow-hidden">
+          {Array.from({ length: 15 }).map((_, i) => (
+            <span
+              key={i}
+              className="confetti"
+              style={{
+                left: `${Math.random() * 100}%`,
+                animationDuration: `${700 + Math.random() * 500}ms`,
+              }}
+            />
+          ))}
+        </div>
+      )}
+      <div className="max-w-5xl mx-auto p-4 flex items-center justify-between">
       <div className="flex items-center gap-2">
         <Logo />
         <h1 className="font-bold text-lg">HematWoi</h1>
@@ -63,10 +98,11 @@ export default function TopBar({ stats, useCloud, setUseCloud }) {
           Saldo: {formatCurrency(stats?.balance || 0)}
         </div>
         <button
-          className="btn"
+          className="btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
           onClick={() =>
             window.dispatchEvent(new CustomEvent("hw:open-settings"))
           }
+          aria-label="Buka pengaturan"
         >
           ⚙️
         </button>
@@ -83,7 +119,8 @@ export default function TopBar({ stats, useCloud, setUseCloud }) {
           </button>
         )}
       </div>
-      <SignIn open={showSignIn} onClose={() => setShowSignIn(false)} />
-    </div>
+        <SignIn open={showSignIn} onClose={() => setShowSignIn(false)} />
+      </div>
+    </header>
   );
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
+import "./components/Animations.css";
 
 createRoot(document.getElementById("root")).render(
   <BrowserRouter>


### PR DESCRIPTION
## Summary
- add animation utilities and import globally
- support keyboard shortcuts and skip link to main content
- improve top bar and FAB accessibility with aria labels, confetti, and reduced motion

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c76c200e5c833285f2914556cd547a