### PR TITLE
feat: add bank statement import wizard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import Budgets from "./pages/Budgets";
 import Categories from "./pages/Categories";
 import DataToolsPage from "./pages/DataToolsPage";
 import AddWizard from "./pages/AddWizard";
+import ImportWizard from "./pages/ImportWizard";
 import { supabase } from "./lib/supabase";
 import {
   listTransactions,
@@ -17,7 +18,7 @@ import {
   upsertCategories,
 } from "./lib/api";
 import CategoryProvider from "./context/CategoryContext";
-import ToastProvider, { useToast } from "./context/ToastContext";
+import ToastProvider from "./context/ToastContext";
 
 const uid = () =>
   globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
@@ -90,9 +91,15 @@ function AppContent() {
     }
   });
   const [catMap, setCatMap] = useState({});
+  const [rules, setRules] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem("hematwoi:v3:rules")) || {};
+    } catch {
+      return {};
+    }
+  });
   window.__hw_prefs = prefs;
 
-  const { addToast } = useToast();
   const navigate = useNavigate();
   const location = useLocation();
   const hideNav = location.pathname.startsWith("/add");
@@ -185,6 +192,10 @@ function AppContent() {
   useEffect(() => {
     localStorage.setItem("hematwoi:v3:catMeta", JSON.stringify(catMeta));
   }, [catMeta]);
+
+  useEffect(() => {
+    localStorage.setItem("hematwoi:v3:rules", JSON.stringify(rules));
+  }, [rules]);
 
   useEffect(() => {
     if (useCloud && sessionUser) {
@@ -587,6 +598,19 @@ function AppContent() {
                 onExport={handleExport}
                 onImportJSON={handleImportJSON}
                 onImportCSV={handleImportCSV}
+              />
+            }
+          />
+          <Route
+            path="/import"
+            element={
+              <ImportWizard
+                txs={data.txs}
+                onAdd={addTx}
+                categories={data.cat}
+                rules={rules}
+                setRules={setRules}
+                onCancel={() => navigate("/data")}
               />
             }
           />

--- a/src/components/BankImportButton.jsx
+++ b/src/components/BankImportButton.jsx
@@ -1,0 +1,9 @@
+import { Link } from "react-router-dom";
+
+export default function BankImportButton() {
+  return (
+    <Link to="/import" className="btn btn-primary">
+      Import Mutasi Bank
+    </Link>
+  );
+}

--- a/src/components/ImportMappingForm.jsx
+++ b/src/components/ImportMappingForm.jsx
@@ -1,0 +1,57 @@
+export default function ImportMappingForm({ headers = [], mapping, setMapping, onNext, onBack }) {
+  const handleChange = (field) => (e) => {
+    setMapping({ ...mapping, [field]: e.target.value });
+  };
+  return (
+    <div className="space-y-4">
+      <div className="card space-y-2">
+        <div>
+          <label className="block text-sm">Tanggal</label>
+          <select className="input w-full" value={mapping.date} onChange={handleChange("date")}>
+            <option value="">Pilih kolom</option>
+            {headers.map((h) => (
+              <option key={h} value={h}>
+                {h}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm">Jumlah</label>
+          <select className="input w-full" value={mapping.amount} onChange={handleChange("amount")}>
+            <option value="">Pilih kolom</option>
+            {headers.map((h) => (
+              <option key={h} value={h}>
+                {h}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm">Catatan</label>
+          <select className="input w-full" value={mapping.note} onChange={handleChange("note")}>
+            <option value="">Pilih kolom</option>
+            {headers.map((h) => (
+              <option key={h} value={h}>
+                {h}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <div className="flex justify-between">
+        <button className="btn" type="button" onClick={onBack}>
+          Kembali
+        </button>
+        <button
+          className="btn btn-primary"
+          type="button"
+          onClick={onNext}
+          disabled={!mapping.date || !mapping.amount || !mapping.note}
+        >
+          Lanjut
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ImportPreview.jsx
+++ b/src/components/ImportPreview.jsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from "react";
+import { isDuplicate } from "../lib/statement";
+
+export default function ImportPreview({ rows = [], txs = [], categories, rules = {}, onBack, onImport }) {
+  const [items, setItems] = useState([]);
+  useEffect(() => {
+    const init = rows.map((r) => {
+      const type = r.amount >= 0 ? "income" : "expense";
+      const amount = Math.abs(Number(r.amount));
+      const lcNote = (r.note || "").toLowerCase();
+      let category = "";
+      for (const [key, cat] of Object.entries(rules)) {
+        if (lcNote.includes(key)) {
+          category = cat;
+          break;
+        }
+      }
+      if (!category) category = categories[type]?.[0] || "";
+      return {
+        date: r.date,
+        note: r.note,
+        amount,
+        type,
+        category,
+        duplicate: isDuplicate({ date: r.date, amount, note: r.note }, txs),
+        remember: false,
+      };
+    });
+    setItems(init);
+  }, [rows, txs, categories, rules]);
+
+  const handleCatChange = (idx, val) => {
+    setItems((it) => it.map((r, i) => (i === idx ? { ...r, category: val } : r)));
+  };
+  const handleRemember = (idx, val) => {
+    setItems((it) => it.map((r, i) => (i === idx ? { ...r, remember: val } : r)));
+  };
+
+  const handleImport = () => {
+    const toImport = items.filter((i) => !i.duplicate);
+    const newRules = {};
+    items.forEach((i) => {
+      if (i.remember && i.note) {
+        newRules[i.note.toLowerCase()] = i.category;
+      }
+    });
+    onImport(toImport, newRules);
+  };
+
+  const formatter = new Intl.NumberFormat("id-ID", {
+    style: "currency",
+    currency: "IDR",
+    minimumFractionDigits: 0,
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="overflow-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="p-2">Tanggal</th>
+              <th className="p-2">Catatan</th>
+              <th className="p-2 text-right">Jumlah</th>
+              <th className="p-2">Kategori</th>
+              <th className="p-2">Duplikat</th>
+              <th className="p-2">Rule</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((r, idx) => (
+              <tr key={idx} className="border-t border-slate-200 dark:border-slate-700">
+                <td className="p-2 whitespace-nowrap">{r.date}</td>
+                <td className="p-2">{r.note}</td>
+                <td className="p-2 text-right">{formatter.format(r.amount)}</td>
+                <td className="p-2">
+                  <select
+                    className="input"
+                    value={r.category}
+                    onChange={(e) => handleCatChange(idx, e.target.value)}
+                  >
+                    {(categories[r.type] || []).map((c) => (
+                      <option key={c} value={c}>
+                        {c}
+                      </option>
+                    ))}
+                  </select>
+                </td>
+                <td className="p-2">
+                  {r.duplicate && (
+                    <span className="px-2 py-1 text-xs rounded bg-red-200 text-red-700">
+                      Duplikat
+                    </span>
+                  )}
+                </td>
+                <td className="p-2 text-center">
+                  <input
+                    type="checkbox"
+                    checked={r.remember}
+                    onChange={(e) => handleRemember(idx, e.target.checked)}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="flex justify-between">
+        <button className="btn" type="button" onClick={onBack}>
+          Kembali
+        </button>
+        <button className="btn btn-primary" type="button" onClick={handleImport}>
+          Import
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/statement.js
+++ b/src/lib/statement.js
@@ -1,0 +1,64 @@
+export function parseCSV(text) {
+  const lines = text
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+  if (!lines.length) return { headers: [], rows: [] };
+  const headers = lines[0].split(",").map((h) => h.trim());
+  const rows = lines.slice(1).map((line) => {
+    const cols = line.split(",");
+    const obj = {};
+    headers.forEach((h, i) => {
+      obj[h] = cols[i]?.trim() ?? "";
+    });
+    return obj;
+  });
+  return { headers, rows };
+}
+
+export function parseOFX(text) {
+  const rows = [];
+  const trnRegex = /<STMTTRN>([\s\S]*?)<\/STMTTRN>/gi;
+  let match;
+  while ((match = trnRegex.exec(text))) {
+    const block = match[1];
+    const getTag = (tag) => {
+      const m = new RegExp(`<${tag}>([^<]+)`, "i").exec(block);
+      return m ? m[1].trim() : "";
+    };
+    let date = getTag("DTPOSTED").slice(0, 8);
+    if (/^\d{8}$/.test(date)) {
+      date = `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}`;
+    }
+    const amount = parseFloat(getTag("TRNAMT") || "0");
+    const note = getTag("MEMO") || getTag("NAME");
+    rows.push({ date, amount, note });
+  }
+  return { headers: ["date", "amount", "note"], rows };
+}
+
+export function normalizeRows(rows, mapping) {
+  return rows.map((r) => {
+    let date = r[mapping.date] || "";
+    if (/^\d{8}$/.test(date)) {
+      date = `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}`;
+    } else {
+      const d = new Date(date);
+      if (!isNaN(d)) date = d.toISOString().slice(0, 10);
+    }
+    const amount = parseFloat(r[mapping.amount] || "0");
+    const note = r[mapping.note] || "";
+    return { date, amount, note };
+  });
+}
+
+export function isDuplicate(row, txs) {
+  const amt = Math.abs(Number(row.amount));
+  const note = (row.note || "").trim().toLowerCase();
+  return txs.some(
+    (t) =>
+      t.date === row.date &&
+      Math.abs(Number(t.amount)) === amt &&
+      (t.note || "").trim().toLowerCase() === note
+  );
+}

--- a/src/pages/DataToolsPage.jsx
+++ b/src/pages/DataToolsPage.jsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import DataTools from "../components/DataTools";
+import BankImportButton from "../components/BankImportButton";
 
 export default function DataToolsPage({ onExport, onImportJSON, onImportCSV }) {
   const navigate = useNavigate();
@@ -14,6 +15,9 @@ export default function DataToolsPage({ onExport, onImportJSON, onImportCSV }) {
         onImportCSV={onImportCSV}
         onManageCat={() => navigate("/categories")}
       />
+      <div className="card p-4">
+        <BankImportButton />
+      </div>
     </main>
   );
 }

--- a/src/pages/ImportWizard.jsx
+++ b/src/pages/ImportWizard.jsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import Stepper from "../components/ui/Stepper";
+import ImportMappingForm from "../components/ImportMappingForm";
+import ImportPreview from "../components/ImportPreview";
+import { parseCSV, parseOFX, normalizeRows } from "../lib/statement";
+
+export default function ImportWizard({ txs, onAdd, categories, rules, setRules, onCancel }) {
+  const steps = ["Upload", "Mapping", "Preview"];
+  const [step, setStep] = useState(0);
+  const [rawRows, setRawRows] = useState([]);
+  const [headers, setHeaders] = useState([]);
+  const [mapping, setMapping] = useState({ date: "", amount: "", note: "" });
+  const [rows, setRows] = useState([]);
+
+  const handleFile = (file) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const text = String(e.target.result || "");
+      let parsed;
+      if (file.name.toLowerCase().endsWith(".ofx")) parsed = parseOFX(text);
+      else parsed = parseCSV(text);
+      setRawRows(parsed.rows);
+      setHeaders(parsed.headers);
+      setMapping({
+        date: parsed.headers[0] || "",
+        amount: parsed.headers[1] || "",
+        note: parsed.headers[2] || "",
+      });
+      setStep(1);
+    };
+    reader.readAsText(file);
+  };
+
+  const handleUpload = (e) => {
+    const file = e.target.files?.[0];
+    if (file) handleFile(file);
+    e.target.value = "";
+  };
+
+  const handleMappingNext = () => {
+    const normalized = normalizeRows(rawRows, mapping);
+    setRows(normalized);
+    setStep(2);
+  };
+
+  const handleImport = (items, newRules) => {
+    if (newRules && Object.keys(newRules).length) {
+      setRules((prev) => ({ ...prev, ...newRules }));
+    }
+    items.forEach(onAdd);
+    onCancel();
+  };
+
+  return (
+    <main className="max-w-5xl mx-auto p-4 space-y-4">
+      <Stepper current={step} steps={steps} />
+      {step === 0 && (
+        <div className="card p-4 space-y-4">
+          <div>
+            <label className="btn cursor-pointer">
+              Pilih File
+              <input
+                type="file"
+                accept=".csv,.ofx,text/csv,application/x-ofx,application/vnd.ms-ofx"
+                className="hidden"
+                onChange={handleUpload}
+              />
+            </label>
+          </div>
+          <div className="flex justify-end">
+            <button className="btn" onClick={onCancel}>
+              Batal
+            </button>
+          </div>
+        </div>
+      )}
+      {step === 1 && (
+        <ImportMappingForm
+          headers={headers}
+          mapping={mapping}
+          setMapping={setMapping}
+          onNext={handleMappingNext}
+          onBack={() => setStep(0)}
+        />
+      )}
+      {step === 2 && (
+        <ImportPreview
+          rows={rows}
+          txs={txs}
+          categories={categories}
+          rules={rules}
+          onBack={() => setStep(1)}
+          onImport={handleImport}
+        />
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add CSV/OFX statement parser with normalization and duplicate detection
- implement 3-step bank statement import wizard with mapping and preview
- persist keyword-based category rules and expose wizard via Data Tools

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c771c2b26083328b1c84a2ade6cbd2