### PR TITLE
feat: add goals and envelopes management

### DIFF
--- a/src/components/AutoAllocationRules.jsx
+++ b/src/components/AutoAllocationRules.jsx
@@ -1,0 +1,81 @@
+import { useState, useEffect } from "react";
+
+export default function AutoAllocationRules({ goals = [], envelopes = [], rules, onSave }) {
+  const [local, setLocal] = useState(rules || { goals: {}, envelopes: {} });
+
+  useEffect(() => setLocal(rules || { goals: {}, envelopes: {} }), [rules]);
+
+  const handleGoal = (id, field, value) => {
+    setLocal((prev) => ({
+      ...prev,
+      goals: { ...prev.goals, [id]: { ...prev.goals[id], [field]: value } },
+    }));
+  };
+  const handleEnv = (cat, field, value) => {
+    setLocal((prev) => ({
+      ...prev,
+      envelopes: {
+        ...prev.envelopes,
+        [cat]: { ...prev.envelopes[cat], [field]: value },
+      },
+    }));
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold">Aturan Alokasi Otomatis</h2>
+      <div className="space-y-2">
+        {goals.map((g) => (
+          <div key={g.id} className="flex gap-2 items-center">
+            <span className="flex-1">{g.name}</span>
+            <input
+              type="number"
+              className="w-24 p-1 border rounded"
+              placeholder="Fix"
+              value={local.goals?.[g.id]?.fixed || ""}
+              onChange={(e) => handleGoal(g.id, "fixed", Number(e.target.value))}
+            />
+            <input
+              type="number"
+              className="w-20 p-1 border rounded"
+              placeholder="%"
+              value={local.goals?.[g.id]?.percent || ""}
+              onChange={(e) => handleGoal(g.id, "percent", Number(e.target.value))}
+            />
+          </div>
+        ))}
+      </div>
+      <div className="space-y-2 pt-4">
+        {envelopes.map((e) => (
+          <div key={e.category} className="flex gap-2 items-center">
+            <span className="flex-1">{e.category}</span>
+            <input
+              type="number"
+              className="w-24 p-1 border rounded"
+              placeholder="Fix"
+              value={local.envelopes?.[e.category]?.fixed || ""}
+              onChange={(ev) =>
+                handleEnv(e.category, "fixed", Number(ev.target.value))
+              }
+            />
+            <input
+              type="number"
+              className="w-20 p-1 border rounded"
+              placeholder="%"
+              value={local.envelopes?.[e.category]?.percent || ""}
+              onChange={(ev) =>
+                handleEnv(e.category, "percent", Number(ev.target.value))
+              }
+            />
+          </div>
+        ))}
+      </div>
+      <button
+        className="px-3 py-1 rounded bg-brand text-white"
+        onClick={() => onSave(local)}
+      >
+        Simpan Aturan
+      </button>
+    </div>
+  );
+}

--- a/src/components/EnvelopeManager.jsx
+++ b/src/components/EnvelopeManager.jsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import { PieChart, Pie, Cell, ResponsiveContainer } from "recharts";
+
+const COLORS = ["#8884d8", "#82ca9d", "#ffc658", "#ff8042", "#a4de6c", "#d0ed57"];
+
+export default function EnvelopeManager({ envelopes = [], onSave }) {
+  const [name, setName] = useState("");
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-end gap-2">
+        <input
+          className="flex-1 p-2 border rounded"
+          placeholder="Kategori"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <button
+          className="px-3 py-1 rounded bg-brand text-white"
+          onClick={() => {
+            if (!name) return;
+            onSave({ category: name, balance: 0 });
+            setName("");
+          }}
+        >
+          Tambah
+        </button>
+      </div>
+      <div className="w-full h-48">
+        <ResponsiveContainer>
+          <PieChart>
+            <Pie
+              data={envelopes}
+              dataKey="balance"
+              nameKey="category"
+              innerRadius={30}
+              outerRadius={50}
+              paddingAngle={2}
+            >
+              {envelopes.map((_, i) => (
+                <Cell key={i} fill={COLORS[i % COLORS.length]} />
+              ))}
+            </Pie>
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        {envelopes.map((e) => (
+          <div
+            key={e.category}
+            className="p-4 border rounded shadow-sm bg-white dark:bg-slate-800"
+          >
+            <div className="font-medium">{e.category}</div>
+            <div className="text-sm text-slate-500">Rp {e.balance?.toFixed(0)}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/GoalForm.jsx
+++ b/src/components/GoalForm.jsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+
+export default function GoalForm({ initial = {}, onSave, onCancel }) {
+  const [form, setForm] = useState({
+    name: initial.name || "",
+    target: initial.target || 0,
+    targetDate: initial.targetDate || "",
+  });
+
+  return (
+    <form
+      className="space-y-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSave({ ...initial, ...form });
+      }}
+    >
+      <input
+        className="w-full p-2 border rounded"
+        placeholder="Nama tujuan"
+        value={form.name}
+        onChange={(e) => setForm({ ...form, name: e.target.value })}
+        required
+      />
+      <input
+        type="number"
+        className="w-full p-2 border rounded"
+        placeholder="Target"
+        value={form.target}
+        onChange={(e) => setForm({ ...form, target: Number(e.target.value) })}
+        required
+      />
+      <input
+        type="date"
+        className="w-full p-2 border rounded"
+        value={form.targetDate}
+        onChange={(e) => setForm({ ...form, targetDate: e.target.value })}
+      />
+      <div className="flex gap-2 justify-end pt-2">
+        <button
+          type="button"
+          className="px-3 py-1 rounded bg-slate-200 dark:bg-slate-700"
+          onClick={onCancel}
+        >
+          Batal
+        </button>
+        <button
+          type="submit"
+          className="px-3 py-1 rounded bg-brand text-white"
+        >
+          Simpan
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/GoalList.jsx
+++ b/src/components/GoalList.jsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import GoalForm from "./GoalForm";
+import { goalProgress } from "../lib/goals";
+
+export default function GoalList({ goals = [], onSave }) {
+  const [adding, setAdding] = useState(false);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-between items-center">
+        <h2 className="text-lg font-semibold">Goals</h2>
+        <button
+          className="px-3 py-1 rounded bg-brand text-white"
+          onClick={() => setAdding(true)}
+        >
+          Tambah
+        </button>
+      </div>
+      {adding && (
+        <GoalForm
+          onSave={(g) => {
+            onSave({ ...g, id: crypto.randomUUID(), allocated: 0 });
+            setAdding(false);
+          }}
+          onCancel={() => setAdding(false)}
+        />
+      )}
+      <div className="grid gap-4 md:grid-cols-2">
+        {goals.map((g) => (
+          <div
+            key={g.id}
+            className="p-4 border rounded shadow-sm bg-white dark:bg-slate-800"
+          >
+            <div className="font-medium mb-1">{g.name}</div>
+            <div className="text-sm text-slate-500 mb-2">
+              Rp {g.allocated?.toFixed(0)} / Rp {g.target.toFixed(0)}
+            </div>
+            <div className="w-full h-2 bg-slate-200 dark:bg-slate-700 rounded">
+              <div
+                className="h-2 bg-brand rounded"
+                style={{ width: `${goalProgress(g) * 100}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/goals.js
+++ b/src/lib/goals.js
@@ -1,0 +1,53 @@
+export function goalProgress(goal) {
+  if (!goal || !goal.target) return 0;
+  return Math.min(goal.allocated / goal.target, 1);
+}
+
+export function updateGoalBalance(goals, id, amount) {
+  return goals.map((g) => (g.id === id ? { ...g, allocated: amount } : g));
+}
+
+export function updateEnvelopeBalance(envelopes, category, amount) {
+  return envelopes.map((e) =>
+    e.category === category ? { ...e, balance: amount } : e
+  );
+}
+
+// rules: { goals: { [id]: { fixed?:number, percent?:number } }, envelopes: { [cat]: { fixed?:number, percent?:number } } }
+export function allocateIncome(amount, goals, envelopes, rules = {}) {
+  let remaining = amount;
+  const gRules = rules.goals || {};
+  const eRules = rules.envelopes || {};
+
+  const newGoals = goals.map((g) => {
+    const r = gRules[g.id] || {};
+    let add = 0;
+    if (r.fixed) {
+      add += r.fixed;
+      remaining -= r.fixed;
+    }
+    if (r.percent) {
+      const v = (amount * r.percent) / 100;
+      add += v;
+      remaining -= v;
+    }
+    return { ...g, allocated: (g.allocated || 0) + add };
+  });
+
+  const newEnvelopes = envelopes.map((e) => {
+    const r = eRules[e.category] || {};
+    let add = 0;
+    if (r.fixed) {
+      add += r.fixed;
+      remaining -= r.fixed;
+    }
+    if (r.percent) {
+      const v = (amount * r.percent) / 100;
+      add += v;
+      remaining -= v;
+    }
+    return { ...e, balance: (e.balance || 0) + add };
+  });
+
+  return { goals: newGoals, envelopes: newEnvelopes, remaining };
+}

--- a/src/pages/Goals.jsx
+++ b/src/pages/Goals.jsx
@@ -1,0 +1,25 @@
+import GoalList from "../components/GoalList";
+import EnvelopeManager from "../components/EnvelopeManager";
+import AutoAllocationRules from "../components/AutoAllocationRules";
+
+export default function Goals({
+  goals,
+  envelopes,
+  rules,
+  onAddGoal,
+  onAddEnvelope,
+  onSaveRules,
+}) {
+  return (
+    <div className="p-4 space-y-8">
+      <GoalList goals={goals} onSave={onAddGoal} />
+      <EnvelopeManager envelopes={envelopes} onSave={onAddEnvelope} />
+      <AutoAllocationRules
+        goals={goals}
+        envelopes={envelopes}
+        rules={rules}
+        onSave={onSaveRules}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add goal and envelope utilities for income allocation
- create goals page with forms, charts, and allocation rules
- wire new route and automatic allocations on income

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c779cc3b0c833281e767686475d7ce