### PR TITLE
Enhance dashboard UI with quick actions and richer filters

### DIFF
--- a/src/components/BudgetSection.jsx
+++ b/src/components/BudgetSection.jsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useEffect } from "react";
 import { useToast } from "../context/ToastContext";
+import { Edit3, Trash2 } from "lucide-react";
 
 function toRupiah(n = 0) {
   return new Intl.NumberFormat("id-ID", {
@@ -22,6 +23,7 @@ export default function BudgetSection({
     month: filterMonth || "",
     amount: "",
   });
+  const [editingId, setEditingId] = useState(null);
 
   const { addToast } = useToast();
 
@@ -32,12 +34,14 @@ export default function BudgetSection({
   const submit = (e) => {
     e.preventDefault();
     if (!form.category || !form.month || !form.amount) return;
+    if (editingId) onRemove(editingId);
     onAdd({
       category: form.category,
       month: form.month,
       amount: Number(form.amount),
     });
     setForm({ category: "", month: filterMonth || "", amount: "" });
+    setEditingId(null);
   };
 
   // Budgets untuk bulan terpilih
@@ -134,6 +138,12 @@ export default function BudgetSection({
             const cap = Number(b.amount || 0);
             const pct =
               cap <= 0 ? 0 : Math.min(100, Math.round((used / cap) * 100));
+            const color =
+              pct >= 100
+                ? "bg-red-500"
+                : pct >= 80
+                ? "bg-yellow-400"
+                : "bg-brand-var";
 
             return (
               <li key={b.id} className="space-y-1">
@@ -146,18 +156,36 @@ export default function BudgetSection({
 
                 <div className="h-2 w-full rounded-full bg-slate-200">
                   <div
-                    className="h-2 rounded-full bg-brand-var"
+                    className={`h-2 rounded-full ${color}`}
                     style={{ width: `${pct}%` }}
                   />
                 </div>
 
-                <button
-                  type="button"
-                  className="btn mt-1"
-                  onClick={() => onRemove(b.id)}
-                >
-                  Hapus
-                </button>
+                <div className="flex gap-1 mt-1">
+                  <button
+                    type="button"
+                    className="btn p-1"
+                    aria-label="Edit budget"
+                    onClick={() => {
+                      setForm({
+                        category: b.category,
+                        month: b.month,
+                        amount: b.amount,
+                      });
+                      setEditingId(b.id);
+                    }}
+                  >
+                    <Edit3 className="h-4 w-4" />
+                  </button>
+                  <button
+                    type="button"
+                    className="btn p-1"
+                    aria-label="Hapus budget"
+                    onClick={() => onRemove(b.id)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
               </li>
             );
           })}

--- a/src/components/Filters.jsx
+++ b/src/components/Filters.jsx
@@ -4,7 +4,12 @@ function formatMonth(m) {
   return date.toLocaleDateString('id-ID', { month: 'short', year: 'numeric' });
 }
 
-export default function Filters({ months = [], filter, setFilter }) {
+export default function Filters({
+  months = [],
+  categories = [],
+  filter,
+  setFilter,
+}) {
   return (
     <div className="card flex flex-wrap items-center gap-2">
       <select
@@ -27,6 +32,28 @@ export default function Filters({ months = [], filter, setFilter }) {
             {formatMonth(m)}
           </option>
         ))}
+      </select>
+      <select
+        className="rounded-lg border px-3 py-2"
+        value={filter.category}
+        onChange={(e) => setFilter({ ...filter, category: e.target.value })}
+      >
+        <option value="all">Semua Kategori</option>
+        {categories.map((c) => (
+          <option key={c} value={c}>
+            {c}
+          </option>
+        ))}
+      </select>
+      <select
+        className="rounded-lg border px-3 py-2"
+        value={filter.sort}
+        onChange={(e) => setFilter({ ...filter, sort: e.target.value })}
+      >
+        <option value="date-desc">Terbaru</option>
+        <option value="date-asc">Terlama</option>
+        <option value="amount-desc">Jumlah Terbesar</option>
+        <option value="amount-asc">Jumlah Terkecil</option>
       </select>
       <input
         type="text"

--- a/src/components/QuickActions.jsx
+++ b/src/components/QuickActions.jsx
@@ -1,0 +1,43 @@
+import { Link } from "react-router-dom";
+import { PlusCircle, Wallet, CreditCard } from "lucide-react";
+
+export default function QuickActions() {
+  const actions = [
+    {
+      to: "/add",
+      label: "Tambah Transaksi",
+      icon: PlusCircle,
+    },
+    {
+      to: "/budgets",
+      label: "Tambah Budget",
+      icon: Wallet,
+    },
+    {
+      to: "/subscriptions",
+      label: "Tambah Subscription",
+      icon: CreditCard,
+    },
+  ];
+
+  return (
+    <div className="card">
+      <h2 className="font-semibold mb-3">Quick Actions</h2>
+      <div className="grid sm:grid-cols-3 gap-2">
+        {actions.map((action) => {
+          const Icon = action.icon;
+          return (
+            <Link
+              key={action.to}
+              to={action.to}
+              className="btn btn-secondary justify-center"
+            >
+              <Icon className="h-4 w-4" />
+              {action.label}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/RecentTransactions.jsx
+++ b/src/components/RecentTransactions.jsx
@@ -1,0 +1,62 @@
+import { useMemo, useState } from "react";
+import Segmented from "./ui/Segmented";
+
+function formatCurrency(n = 0) {
+  return new Intl.NumberFormat("id-ID", {
+    style: "currency",
+    currency: "IDR",
+    minimumFractionDigits: 0,
+  }).format(n);
+}
+
+export default function RecentTransactions({ txs = [] }) {
+  const [period, setPeriod] = useState("week");
+
+  const filtered = useMemo(() => {
+    const now = new Date();
+    return txs
+      .filter((t) => {
+        const d = new Date(t.date);
+        const diff = (now - d) / (1000 * 60 * 60 * 24);
+        if (period === "day") return diff < 1;
+        if (period === "week") return diff < 7;
+        return diff < 30;
+      })
+      .sort((a, b) => new Date(b.date) - new Date(a.date))
+      .slice(0, 5);
+  }, [txs, period]);
+
+  return (
+    <div className="card">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-semibold">Transaksi Terbaru</h2>
+        <Segmented
+          value={period}
+          onChange={setPeriod}
+          options={[
+            { label: "Hari", value: "day" },
+            { label: "Minggu", value: "week" },
+            { label: "Bulan", value: "month" },
+          ]}
+        />
+      </div>
+      {!filtered.length && (
+        <div className="text-sm text-slate-500">Belum ada transaksi.</div>
+      )}
+      <ul className="space-y-2">
+        {filtered.map((t) => (
+          <li key={t.id} className="flex justify-between text-sm">
+            <span>{t.note || t.category}</span>
+            <span
+              className={
+                t.type === "income" ? "text-green-600" : "text-red-600"
+              }
+            >
+              {formatCurrency(t.amount)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2,15 +2,25 @@
 @tailwind components;
 @tailwind utilities;
 
-.btn { @apply inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm; }
-.btn-primary { @apply bg-brand border-brand text-white; }
-.card { @apply bg-white rounded-xl shadow-sm border p-4; }
-.input { @apply w-full rounded-lg border px-3 py-2; }
-.badge { @apply inline-block rounded-full border px-2 py-0.5 text-xs; }
-.table-wrap { @apply overflow-auto; }
+@layer base {
+  body { @apply bg-white text-brand-text; }
+  h1, h2, h3, h4, h5, h6 { @apply font-semibold; }
+}
+
+@layer components {
+  .btn { @apply inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors; }
+  .btn-primary { @apply bg-brand text-white border-brand hover:bg-brand-hover; }
+  .btn-secondary { @apply bg-brand-secondary text-white border-brand-secondary hover:bg-brand-secondary-hover; }
+  .card { @apply bg-white rounded-xl shadow-sm border p-4; }
+  .input { @apply w-full rounded-lg border px-3 py-2; }
+  .badge { @apply inline-block rounded-full border px-2 py-0.5 text-xs; }
+  .table-wrap { @apply overflow-auto; }
+}
 
 .dark body { @apply bg-slate-950 text-slate-100; }
 .dark .card { @apply bg-slate-900 border-slate-800; }
 .dark .input { @apply bg-slate-900 border-slate-700 text-slate-100; }
 .dark .btn { @apply border-slate-700; }
 .dark .badge { @apply border-slate-700; }
+.dark .btn-primary { @apply bg-brand hover:bg-brand-hover border-brand; }
+.dark .btn-secondary { @apply bg-brand-secondary hover:bg-brand-secondary-hover border-brand-secondary; }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,11 +1,10 @@
-import AddForm from "../components/AddForm";
 import Summary from "../components/Summary";
 import DashboardCharts from "../components/DashboardCharts";
 import Reports from "../components/Reports";
+import QuickActions from "../components/QuickActions";
+import RecentTransactions from "../components/RecentTransactions";
 
 export default function Dashboard({
-  categories,
-  onAdd,
   stats,
   monthForReport,
   txs,
@@ -13,12 +12,13 @@ export default function Dashboard({
   months = [],
 }) {
   return (
-    <main className="max-w-5xl mx-auto p-4 space-y-4">
+    <main className="max-w-5xl mx-auto p-4 space-y-6">
+      <Summary stats={stats} />
+      <QuickActions />
       <div className="grid gap-4 md:grid-cols-2">
-        <AddForm categories={categories} onAdd={onAdd} />
-        <Summary stats={stats} />
+        <DashboardCharts month={monthForReport} txs={txs} />
+        <RecentTransactions txs={txs} />
       </div>
-      <DashboardCharts month={monthForReport} txs={txs} />
       <Reports
         month={monthForReport}
         months={months}

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -1,8 +1,10 @@
 import Filters from "../components/Filters";
 import TxTable from "../components/TxTable";
+import FAB from "../components/FAB";
 
 export default function Transactions({
   months,
+  categories,
   filter,
   setFilter,
   items,
@@ -14,8 +16,14 @@ export default function Transactions({
       <div className="card">
         <h1 className="text-sm font-semibold">Transaksi</h1>
       </div>
-      <Filters months={months} filter={filter} setFilter={setFilter} />
+      <Filters
+        months={months}
+        categories={categories}
+        filter={filter}
+        setFilter={setFilter}
+      />
       <TxTable items={items} onRemove={onRemove} onUpdate={onUpdate} />
+      <FAB />
     </main>
   );
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,8 +4,16 @@ module.exports = {
   content: ["./index.html","./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {
-      // default accent color
-      colors: { brand: "#3898f8" },
+      // default accent color palette used across the app
+      colors: {
+        brand: "#3898f8",
+        "brand-hover": "#2584e4",
+        "brand-secondary": "#50b6ff",
+        "brand-secondary-hover": "#379de7",
+        "brand-text": "#13436d",
+        // keep legacy name to avoid breaking existing classes
+        "brand-var": "#3898f8",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- add brand color palette and modern button styles
- introduce dashboard quick actions and recent transactions widgets
- support category and sort filters on transactions with color-coded budgets

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c782800b6c8332b2c96cc7e24f82d5