### PR TITLE
feat: add gamification to dashboard

### DIFF
--- a/src/components/AchievementBadges.jsx
+++ b/src/components/AchievementBadges.jsx
@@ -1,0 +1,54 @@
+import { Award, Target, Star } from "lucide-react";
+import "./Animations.css";
+
+function toRupiah(n = 0) {
+  return new Intl.NumberFormat("id-ID", {
+    style: "currency",
+    currency: "IDR",
+    minimumFractionDigits: 0,
+  }).format(n);
+}
+
+export default function AchievementBadges({ stats = {}, streak = 0, target = 0 }) {
+  const badges = [];
+  const balance = stats?.balance ?? 0;
+  if (balance >= 500000) {
+    badges.push({
+      id: "saving",
+      icon: <Star className="w-4 h-4 text-yellow-500" />,
+      text: `Badge Hemat ${toRupiah(balance)} bulan ini 🎉`,
+    });
+  }
+  if (target && balance >= target) {
+    badges.push({
+      id: "target",
+      icon: <Target className="w-4 h-4 text-green-500" />,
+      text: "Target tabungan tercapai 🎯",
+    });
+  }
+  if (streak >= 3) {
+    badges.push({
+      id: "streak",
+      icon: <Award className="w-4 h-4 text-orange-500" />,
+      text: `Streak ${streak} hari 🔥`,
+    });
+  }
+  if (!badges.length) return null;
+
+  return (
+    <div className="card animate-slide">
+      <h2 className="font-semibold mb-2">Achievements</h2>
+      <ul className="space-y-2">
+        {badges.map((b) => (
+          <li
+            key={b.id}
+            className="flex items-center gap-2 text-sm bg-slate-50 dark:bg-slate-700 p-2 rounded"
+          >
+            {b.icon}
+            <span>{b.text}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/DailyStreak.jsx
+++ b/src/components/DailyStreak.jsx
@@ -1,0 +1,12 @@
+import { Flame } from "lucide-react";
+import "./Animations.css";
+
+export default function DailyStreak({ streak = 0 }) {
+  if (streak <= 0) return null;
+  return (
+    <div className="card flex items-center gap-2 animate-slide">
+      <Flame className="text-orange-500 w-5 h-5 animate-pulse" />
+      <span className="font-semibold">{streak} hari streak</span>
+    </div>
+  );
+}

--- a/src/components/SavingsProgress.jsx
+++ b/src/components/SavingsProgress.jsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import { CheckCircle } from "lucide-react";
+import "./Animations.css";
+
+export default function SavingsProgress({ current = 0, target = 0 }) {
+  const progress = target ? Math.min(current / target, 1) : 0;
+  const [showCongrats, setShowCongrats] = useState(false);
+
+  useEffect(() => {
+    if (progress >= 1) {
+      setShowCongrats(true);
+      const t = setTimeout(() => setShowCongrats(false), 3000);
+      return () => clearTimeout(t);
+    }
+  }, [progress]);
+
+  return (
+    <div className="card relative animate-slide">
+      <h2 className="font-semibold mb-2 flex items-center gap-2">
+        <span>Progress Tabungan</span>
+        <span className="text-sm text-slate-500">
+          Rp {current.toLocaleString("id-ID")} / Rp {target.toLocaleString("id-ID")}
+        </span>
+      </h2>
+      <div
+        className="w-full h-3 bg-slate-200 dark:bg-slate-700 rounded"
+        role="progressbar"
+      >
+        <div
+          className="h-3 bg-green-500 rounded"
+          style={{ width: `${progress * 100}%` }}
+        />
+      </div>
+      <div className="text-sm mt-1">{Math.round(progress * 100)}% tercapai</div>
+      {showCongrats && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/50">
+          <div className="card flex items-center gap-2 animate-slide">
+            <CheckCircle className="text-green-500" />
+            <span>Milestone tercapai! 🎉</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,9 +1,13 @@
+import { useMemo } from "react";
 import Summary from "../components/Summary";
 import DashboardCharts from "../components/DashboardCharts";
 import Reports from "../components/Reports";
 import QuickActions from "../components/QuickActions";
 import RecentTransactions from "../components/RecentTransactions";
 import SmartFinancialInsights from "../components/SmartFinancialInsights";
+import DailyStreak from "../components/DailyStreak";
+import SavingsProgress from "../components/SavingsProgress";
+import AchievementBadges from "../components/AchievementBadges";
 
 export default function Dashboard({
   stats,
@@ -12,9 +16,32 @@ export default function Dashboard({
   budgets,
   months = [],
 }) {
+  const streak = useMemo(() => {
+    const dates = new Set(txs.map((t) => new Date(t.date).toDateString()));
+    let count = 0;
+    const today = new Date();
+    while (
+      dates.has(
+        new Date(
+          today.getFullYear(),
+          today.getMonth(),
+          today.getDate() - count
+        ).toDateString()
+      )
+    ) {
+      count++;
+    }
+    return count;
+  }, [txs]);
+
+  const savingsTarget = stats?.savingsTarget || 1_000_000;
+
   return (
     <main className="max-w-5xl mx-auto p-4 space-y-6">
       <Summary stats={stats} />
+      <DailyStreak streak={streak} />
+      <SavingsProgress current={stats?.balance || 0} target={savingsTarget} />
+      <AchievementBadges stats={stats} streak={streak} target={savingsTarget} />
       <SmartFinancialInsights txs={txs} />
       <QuickActions />
       <div className="grid gap-4 md:grid-cols-2">


### PR DESCRIPTION
## Summary
- add daily streak, savings progress, and achievement badges to dashboard
- show milestone popup once saving target is reached

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c78a0d81b08332a5972a11a10f6233