### PR TITLE
feat: add avatar leveling system

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.1",
     "@supabase/supabase-js": "^2.57.4",
+    "canvas-confetti": "^1.9.3",
     "clsx": "^2.1.1",
     "html2canvas": "^1.4.1",
     "jspdf": "^2.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.57.4
         version: 2.57.4
+      canvas-confetti:
+        specifier: ^1.9.3
+        version: 1.9.3
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -793,6 +796,9 @@ packages:
 
   caniuse-lite@1.0.30001741:
     resolution: {integrity: sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==}
+
+  canvas-confetti@1.9.3:
+    resolution: {integrity: sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==}
 
   canvg@3.0.11:
     resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
@@ -2505,6 +2511,8 @@ snapshots:
   camelcase-css@2.0.1: {}
 
   caniuse-lite@1.0.30001741: {}
+
+  canvas-confetti@1.9.3: {}
 
   canvg@3.0.11:
     dependencies:

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ import {
 
 import CategoryProvider from "./context/CategoryContext";
 import ToastProvider, { useToast } from "./context/ToastContext";
+import UserProfileProvider from "./context/UserProfileContext.jsx";
 import { loadSubscriptions, findUpcoming } from "./lib/subscriptions";
 import { allocateIncome } from "./lib/goals";
 
@@ -793,8 +794,10 @@ function AppContent() {
 
 export default function App() {
   return (
-    <ToastProvider>
-      <AppContent />
-    </ToastProvider>
+    <UserProfileProvider>
+      <ToastProvider>
+        <AppContent />
+      </ToastProvider>
+    </UserProfileProvider>
   );
 }

--- a/src/assets/avatars/expert.svg
+++ b/src/assets/avatars/expert.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="45" fill="#fde68a" />
+  <text x="50" y="60" font-size="45" text-anchor="middle" fill="#92400e">E</text>
+</svg>

--- a/src/assets/avatars/novice.svg
+++ b/src/assets/avatars/novice.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="45" fill="#d1d5db" />
+  <text x="50" y="60" font-size="50" text-anchor="middle" fill="#374151">N</text>
+</svg>

--- a/src/assets/avatars/planner.svg
+++ b/src/assets/avatars/planner.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="45" fill="#c7d2fe" />
+  <text x="50" y="60" font-size="45" text-anchor="middle" fill="#1e3a8a">P</text>
+</svg>

--- a/src/assets/avatars/saver.svg
+++ b/src/assets/avatars/saver.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="45" fill="#bbf7d0" />
+  <text x="50" y="60" font-size="45" text-anchor="middle" fill="#166534">S</text>
+</svg>

--- a/src/assets/avatars/sultan.svg
+++ b/src/assets/avatars/sultan.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="45" fill="#fcd34d" />
+  <text x="50" y="60" font-size="40" text-anchor="middle">👑</text>
+</svg>

--- a/src/components/AvatarLevel.jsx
+++ b/src/components/AvatarLevel.jsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from "react";
+import useLeveling from "../hooks/useLeveling.js";
+import confetti from "canvas-confetti";
+
+import novice from "../assets/avatars/novice.svg";
+import planner from "../assets/avatars/planner.svg";
+import saver from "../assets/avatars/saver.svg";
+import expert from "../assets/avatars/expert.svg";
+import sultan from "../assets/avatars/sultan.svg";
+
+const STAGES = [
+  { min: 1, src: novice, label: "Novice" },
+  { min: 3, src: planner, label: "Planner" },
+  { min: 5, src: saver, label: "Saver" },
+  { min: 7, src: expert, label: "Expert" },
+  { min: 9, src: sultan, label: "Sultan Hemat \uD83D\uDC51" },
+];
+
+export default function AvatarLevel({ transactions, insights, challenges }) {
+  const { level, progress, needed } = useLeveling({
+    transactions,
+    insights,
+    challenges,
+  });
+  const prevLevel = useRef(level);
+
+  useEffect(() => {
+    if (level > prevLevel.current) {
+      confetti({ particleCount: 80, spread: 60, origin: { y: 0.6 } });
+      prevLevel.current = level;
+    }
+  }, [level]);
+
+  const stage = STAGES.slice().reverse().find((s) => level >= s.min) || STAGES[0];
+  const percent = needed ? Math.min(100, (progress / needed) * 100) : 0;
+
+  return (
+    <section
+      aria-labelledby="avatar-level-heading"
+      className="max-w-xs mx-auto text-center space-y-2"
+    >
+      <h2 id="avatar-level-heading" className="text-lg font-semibold">
+        Level {level}
+      </h2>
+      <img src={stage.src} alt={stage.label} className="w-24 h-24 mx-auto" />
+      <p className="text-sm">{stage.label}</p>
+      <div
+        role="progressbar"
+        aria-valuenow={progress}
+        aria-valuemin={0}
+        aria-valuemax={needed}
+        className="w-full bg-gray-200 rounded h-2"
+        title="Dapatkan XP: transaksi harian (+5), hemat mingguan \u2265 10% (+20), selesaikan challenge (+50)"
+      >
+        <div
+          className="bg-emerald-500 h-2 rounded"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+      <p className="text-xs">
+        {progress}/{needed} XP
+      </p>
+    </section>
+  );
+}

--- a/src/context/UserProfileContext.jsx
+++ b/src/context/UserProfileContext.jsx
@@ -1,0 +1,27 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useState, useCallback } from "react";
+
+export const LEVEL_BASE = 50; // adjustable constant
+
+export const UserProfileContext = createContext({
+  profile: { xp: 0, level: 1 },
+  addXP: () => {},
+});
+
+export default function UserProfileProvider({ children }) {
+  const [profile, setProfile] = useState({ xp: 0, level: 1 });
+
+  const addXP = useCallback((amount = 0) => {
+    setProfile((prev) => {
+      const totalXP = prev.xp + amount;
+      const level = Math.floor(Math.sqrt(totalXP / LEVEL_BASE)) + 1;
+      return { ...prev, xp: totalXP, level };
+    });
+  }, []);
+
+  return (
+    <UserProfileContext.Provider value={{ profile, addXP }}>
+      {children}
+    </UserProfileContext.Provider>
+  );
+}

--- a/src/hooks/useLeveling.js
+++ b/src/hooks/useLeveling.js
@@ -1,0 +1,59 @@
+import { useContext, useEffect, useRef, useCallback } from "react";
+import { UserProfileContext, LEVEL_BASE } from "../context/UserProfileContext.jsx";
+import EventBus from "../lib/eventBus";
+
+export default function useLeveling({ transactions = [], insights = {}, challenges = [] } = {}) {
+  const { profile, addXP } = useContext(UserProfileContext);
+  const txnRef = useRef(transactions.length);
+  const challengeRef = useRef(challenges.filter((c) => c.completed).length);
+
+  const manualAddXP = useCallback(
+    (code, amount = 0) => {
+      addXP(amount);
+    },
+    [addXP]
+  );
+
+  useEffect(() => {
+    const handler = ({ code, amount }) => manualAddXP(code, amount);
+    const unsubscribe = EventBus.on("xp:add", handler);
+    return unsubscribe;
+  }, [manualAddXP]);
+
+  useEffect(() => {
+    if (transactions.length > txnRef.current) {
+      const diff = transactions.length - txnRef.current;
+      manualAddXP("transaction", diff * 5);
+      txnRef.current = transactions.length;
+    }
+  }, [transactions, manualAddXP]);
+
+  useEffect(() => {
+    if (insights?.weeklySavingDelta >= 0.1) {
+      manualAddXP("weekly_saving", 20);
+    }
+  }, [insights?.weeklySavingDelta, manualAddXP]);
+
+  useEffect(() => {
+    const completed = challenges.filter((c) => c.completed).length;
+    if (completed > challengeRef.current) {
+      const diff = completed - challengeRef.current;
+      manualAddXP("challenge", diff * 50);
+      challengeRef.current = completed;
+    }
+  }, [challenges, manualAddXP]);
+
+  const nextLevelXP = Math.pow(profile.level, 2) * LEVEL_BASE;
+  const currentLevelBaseXP = Math.pow(profile.level - 1, 2) * LEVEL_BASE;
+  const progress = profile.xp - currentLevelBaseXP;
+  const needed = nextLevelXP - currentLevelBaseXP;
+
+  return {
+    xp: profile.xp,
+    level: profile.level,
+    progress,
+    needed,
+    nextLevelXP,
+    addXP: manualAddXP,
+  };
+}

--- a/src/lib/eventBus.js
+++ b/src/lib/eventBus.js
@@ -1,0 +1,18 @@
+const listeners = {};
+
+export function on(event, fn) {
+  listeners[event] = listeners[event] || [];
+  listeners[event].push(fn);
+  return () => off(event, fn);
+}
+
+export function off(event, fn) {
+  listeners[event] = (listeners[event] || []).filter((l) => l !== fn);
+}
+
+export function emit(event, payload) {
+  (listeners[event] || []).forEach((fn) => fn(payload));
+}
+
+const EventBus = { on, off, emit };
+export default EventBus;

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -10,6 +10,8 @@ import SavingsProgress from "../components/SavingsProgress";
 import AchievementBadges from "../components/AchievementBadges";
 import DailyQuote from "../components/DailyQuote";
 import FinanceMascot from "../components/FinanceMascot";
+import AvatarLevel from "../components/AvatarLevel.jsx";
+import EventBus from "../lib/eventBus";
 
 
 export default function Dashboard({
@@ -114,6 +116,14 @@ export default function Dashboard({
       <Summary stats={stats} />
       <FinanceMascot summary={summary} budgets={budgets} onRefresh={() => {}} />
       <DailyStreak streak={streak} />
+      <AvatarLevel transactions={txs} />
+      <button
+        type="button"
+        onClick={() => EventBus.emit("xp:add", { code: "demo", amount: 10 })}
+        className="px-2 py-1 text-xs bg-emerald-500 text-white rounded"
+      >
+        +10 XP Demo
+      </button>
       <DailyQuote />
       <SavingsProgress current={stats?.balance || 0} target={savingsTarget} />
       <AchievementBadges stats={stats} streak={streak} target={savingsTarget} />


### PR DESCRIPTION
## Summary
- introduce user profile context to track XP and level
- add `useLeveling` hook and simple event bus for XP events
- show avatar leveling UI with progress bar and confetti

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c79800d55483328eaa68b55b4a0896