### PR TITLE
feat: add challenge feature with templates and tracking

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,8 @@ import AddWizard from "./pages/AddWizard";
 import Subscriptions from "./pages/Subscriptions";
 import ImportWizard from "./pages/ImportWizard";
 import GoalsPage from "./pages/Goals";
+import ChallengesPage from "./pages/Challenges.jsx";
+import useChallenges from "./hooks/useChallenges.js";
 
 import { supabase } from "./lib/supabase";
 import {
@@ -130,6 +132,8 @@ function AppContent() {
     }
   });
   const { addToast } = useToast();
+  const { challenges, addChallenge, updateChallenge, removeChallenge } =
+    useChallenges(data.txs);
   window.__hw_prefs = prefs;
 
   const navigate = useNavigate();
@@ -694,6 +698,7 @@ function AppContent() {
                 txs={data.txs}
                 budgets={data.budgets}
                 months={months}
+                challenges={challenges}
               />
             }
           />
@@ -732,6 +737,18 @@ function AppContent() {
                 onAddGoal={addGoal}
                 onAddEnvelope={addEnvelope}
                 onSaveRules={setAllocRules}
+              />
+            }
+          />
+          <Route
+            path="/challenges"
+            element={
+              <ChallengesPage
+                challenges={challenges}
+                onAdd={addChallenge}
+                onUpdate={updateChallenge}
+                onRemove={removeChallenge}
+                txs={data.txs}
               />
             }
           />

--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -1,5 +1,5 @@
 import { NavLink } from "react-router-dom";
-import { Home, Plus, BarChart3, Settings } from "lucide-react";
+import { Home, Plus, BarChart3, Settings, Flag } from "lucide-react";
 
 export default function BottomNav() {
   const base =
@@ -19,6 +19,10 @@ export default function BottomNav() {
         <NavLink to="/reports" className={({ isActive }) => `${base} ${isActive ? active : ""}`}>
           <BarChart3 className="h-5 w-5" />
           <span>Laporan</span>
+        </NavLink>
+        <NavLink to="/challenges" className={({ isActive }) => `${base} ${isActive ? active : ""}`}>
+          <Flag className="h-5 w-5" />
+          <span>Challenges</span>
         </NavLink>
         <NavLink to="/settings" className={({ isActive }) => `${base} ${isActive ? active : ""}`}>
           <Settings className="h-5 w-5" />

--- a/src/components/ChallengeCard.jsx
+++ b/src/components/ChallengeCard.jsx
@@ -1,0 +1,34 @@
+import { remainingDays } from "../lib/challenges.js";
+
+export default function ChallengeCard({ challenge, onView, onEdit, onEnd }) {
+  const daysLeft = remainingDays(challenge);
+  const percent = Math.round((challenge.progress || 0) * 100);
+  return (
+    <div className="card flex flex-col gap-2">
+      <div className="flex justify-between items-center">
+        <h3 className="font-semibold">{challenge.title}</h3>
+        {challenge.status === "active" && (
+          <span className="text-xs text-slate-500">{daysLeft} hari lagi</span>
+        )}
+      </div>
+      <div className="w-full bg-gray-200 rounded h-2">
+        <div className="bg-emerald-500 h-2 rounded" style={{ width: `${percent}%` }} />
+      </div>
+      <div className="flex gap-2 text-xs">
+        <button type="button" onClick={() => onView(challenge)} className="underline">
+          View
+        </button>
+        {challenge.status === "active" && (
+          <>
+            <button type="button" onClick={() => onEdit(challenge)} className="underline">
+              Edit
+            </button>
+            <button type="button" onClick={() => onEnd(challenge)} className="underline">
+              End
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ChallengeCreatorModal.jsx
+++ b/src/components/ChallengeCreatorModal.jsx
@@ -1,0 +1,133 @@
+import { useState } from "react";
+import Modal from "./Modal.jsx";
+import { CHALLENGE_TEMPLATES } from "../lib/challenges.js";
+
+const uid = () =>
+  globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+
+export default function ChallengeCreatorModal({ open, onClose, onSave }) {
+  const [form, setForm] = useState({
+    title: "",
+    type: "avoid",
+    category: "",
+    amount: 0,
+    durationDays: 7,
+    reminder: false,
+  });
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const start = new Date();
+    const end = new Date(start);
+    end.setDate(end.getDate() + Number(form.durationDays));
+    const challenge = {
+      id: uid(),
+      title: form.title,
+      type: form.type,
+      durationDays: Number(form.durationDays),
+      startDate: start.toISOString(),
+      endDate: end.toISOString(),
+      rules:
+        form.type === "avoid"
+          ? { category: form.category }
+          : form.type === "limit"
+          ? { category: form.category, limit: Number(form.amount), period: "day" }
+          : { category: form.category, target: Number(form.amount) },
+      rewardXP: 50,
+      status: "active",
+      progress: 0,
+      reminder: form.reminder,
+    };
+    onSave(challenge);
+    onClose();
+  };
+
+  const addTemplate = (tpl) => {
+    const start = new Date();
+    const end = new Date(start);
+    end.setDate(end.getDate() + tpl.durationDays);
+    const challenge = {
+      ...tpl,
+      id: uid(),
+      startDate: start.toISOString(),
+      endDate: end.toISOString(),
+      status: "active",
+      progress: 0,
+    };
+    onSave(challenge);
+    onClose();
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title="Buat Challenge">
+      <div className="space-y-4">
+        <div className="grid grid-cols-2 gap-2">
+          {CHALLENGE_TEMPLATES.map((t) => (
+            <button
+              key={t.title}
+              type="button"
+              className="btn"
+              onClick={() => addTemplate(t)}
+            >
+              {t.title}
+            </button>
+          ))}
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-2">
+          <input
+            required
+            type="text"
+            placeholder="Judul"
+            className="input w-full"
+            value={form.title}
+            onChange={(e) => setForm({ ...form, title: e.target.value })}
+          />
+          <select
+            className="input w-full"
+            value={form.type}
+            onChange={(e) => setForm({ ...form, type: e.target.value })}
+          >
+            <option value="avoid">Hindari</option>
+            <option value="limit">Batasi</option>
+            <option value="target">Target</option>
+          </select>
+          <input
+            required
+            type="text"
+            placeholder="Kategori"
+            className="input w-full"
+            value={form.category}
+            onChange={(e) => setForm({ ...form, category: e.target.value })}
+          />
+          {form.type !== "avoid" && (
+            <input
+              type="number"
+              placeholder="Jumlah"
+              className="input w-full"
+              value={form.amount}
+              onChange={(e) => setForm({ ...form, amount: e.target.value })}
+            />
+          )}
+          <input
+            type="number"
+            placeholder="Durasi (hari)"
+            className="input w-full"
+            value={form.durationDays}
+            onChange={(e) => setForm({ ...form, durationDays: e.target.value })}
+          />
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={form.reminder}
+              onChange={(e) => setForm({ ...form, reminder: e.target.checked })}
+            />
+            Reminder harian
+          </label>
+          <button type="submit" className="btn w-full">
+            Simpan
+          </button>
+        </form>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/ChallengeDetail.jsx
+++ b/src/components/ChallengeDetail.jsx
@@ -1,0 +1,48 @@
+import { evaluateChallenge } from "../lib/challenges.js";
+
+export default function ChallengeDetail({ challenge, txs = [], onClose }) {
+  if (!challenge) return null;
+  const related = txs.filter((t) => {
+    const d = new Date(t.date);
+    return (
+      d >= new Date(challenge.startDate) &&
+      d <= new Date(challenge.endDate) &&
+      t.category === challenge.rules?.category
+    );
+  });
+  const { status, progress } = evaluateChallenge(challenge, txs);
+  const percent = Math.round(progress * 100);
+
+  return (
+    <div className="p-4 space-y-4">
+      <button type="button" className="underline text-sm" onClick={onClose}>
+        Close
+      </button>
+      <h2 className="text-lg font-semibold">{challenge.title}</h2>
+      <p className="text-sm">Status: {status}</p>
+      <div className="w-full bg-gray-200 rounded h-2">
+        <div className="bg-emerald-500 h-2 rounded" style={{ width: `${percent}%` }} />
+      </div>
+      <div>
+        <h3 className="font-semibold">Log</h3>
+        {related.length ? (
+          <ul className="text-sm list-disc pl-4">
+            {related.map((t) => (
+              <li key={t.id}>
+                {t.date}: {t.type} {t.amount}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm">Belum ada transaksi terkait</p>
+        )}
+      </div>
+      {status === "completed" && (
+        <p className="text-sm">Mascot: Mantap! Challenge selesai.</p>
+      )}
+      {status === "failed" && (
+        <p className="text-sm">Mascot: Yah, coba lagi besok.</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/ChallengeList.jsx
+++ b/src/components/ChallengeList.jsx
@@ -1,0 +1,19 @@
+import ChallengeCard from "./ChallengeCard.jsx";
+
+export default function ChallengeList({ challenges = [], onView, onEdit, onEnd }) {
+  if (!challenges.length)
+    return <p className="text-sm text-center text-slate-500">Belum ada challenge</p>;
+  return (
+    <div className="space-y-4">
+      {challenges.map((c) => (
+        <ChallengeCard
+          key={c.id}
+          challenge={c}
+          onView={onView}
+          onEdit={onEdit}
+          onEnd={onEnd}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useChallenges.js
+++ b/src/hooks/useChallenges.js
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import EventBus from "../lib/eventBus";
+import { evaluateChallenge } from "../lib/challenges.js";
+import { useToast } from "../context/ToastContext.jsx";
+
+const STORAGE_KEY = "hematwoi:v3:challenges";
+
+export default function useChallenges(txs = []) {
+  const [challenges, setChallenges] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+    } catch {
+      return [];
+    }
+  });
+  const { addToast } = useToast();
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(challenges));
+  }, [challenges]);
+
+  useEffect(() => {
+    setChallenges((prev) =>
+      prev.map((c) => {
+        if (c.status !== "active") return c;
+        const { status, progress } = evaluateChallenge(c, txs);
+        let updated = { ...c, status, progress, completed: status === "completed" };
+        if (c.status === "active" && status === "completed" && c.rewardXP) {
+          EventBus.emit("xp:add", { code: "challenge", amount: c.rewardXP });
+        }
+        return updated;
+      })
+    );
+  }, [txs]);
+
+  useEffect(() => {
+    const todayStr = new Date().toDateString();
+    setChallenges((prev) =>
+      prev.map((c) => {
+        if (!c.reminder || c.status !== "active") return c;
+        if (c.lastReminder === todayStr) return c;
+        addToast({ message: `Jangan lupa challenge: ${c.title}` });
+        return { ...c, lastReminder: todayStr };
+      })
+    );
+  }, [addToast]);
+
+  const addChallenge = (challenge) => {
+    setChallenges((prev) => [...prev, challenge]);
+  };
+
+  const updateChallenge = (id, updates) => {
+    setChallenges((prev) => prev.map((c) => (c.id === id ? { ...c, ...updates } : c)));
+  };
+
+  const removeChallenge = (id) => {
+    setChallenges((prev) => prev.filter((c) => c.id !== id));
+  };
+
+  return { challenges, addChallenge, updateChallenge, removeChallenge };
+}

--- a/src/lib/challenges.js
+++ b/src/lib/challenges.js
@@ -1,0 +1,133 @@
+export const CHALLENGE_TEMPLATES = [
+  {
+    title: "No Boba 7 Hari",
+    type: "avoid",
+    durationDays: 7,
+    rules: { category: "Hiburan" },
+    rewardXP: 50,
+  },
+  {
+    title: "No GoFood 7 Hari",
+    type: "avoid",
+    durationDays: 7,
+    rules: { category: "Makan" },
+    rewardXP: 50,
+  },
+  {
+    title: "Batasi Transport 50k/Hari",
+    type: "limit",
+    durationDays: 7,
+    rules: { category: "Transport", limit: 50000, period: "day" },
+    rewardXP: 50,
+  },
+  {
+    title: "Batasi Jajan 50k/Hari",
+    type: "limit",
+    durationDays: 7,
+    rules: { category: "Belanja", limit: 50000, period: "day" },
+    rewardXP: 50,
+  },
+  {
+    title: "Tabung 100k/Minggu",
+    type: "target",
+    durationDays: 7,
+    rules: { category: "Tabungan", target: 100000 },
+    rewardXP: 50,
+  },
+  {
+    title: "Hemat Ongkir 20k/Hari",
+    type: "limit",
+    durationDays: 7,
+    rules: { category: "Transport", limit: 20000, period: "day" },
+    rewardXP: 50,
+  },
+  {
+    title: "No Kopi Seminggu",
+    type: "avoid",
+    durationDays: 7,
+    rules: { category: "Makan" },
+    rewardXP: 50,
+  },
+  {
+    title: "Tabung 500k/Bulan",
+    type: "target",
+    durationDays: 30,
+    rules: { category: "Tabungan", target: 500000 },
+    rewardXP: 100,
+  },
+];
+
+const DAY = 24 * 60 * 60 * 1000;
+
+export function evaluateChallenge(challenge, txs, today = new Date()) {
+  if (!challenge) return { status: "active", progress: 0 };
+  const start = new Date(challenge.startDate);
+  const end = new Date(challenge.endDate);
+  const now = today > end ? end : today;
+  const duration = Math.max(1, challenge.durationDays || 1);
+  let status = "active";
+  let progress = 0;
+
+  if (challenge.type === "avoid") {
+    const violated = txs.some(
+      (t) =>
+        t.category === challenge.rules?.category &&
+        new Date(t.date) >= start &&
+        new Date(t.date) <= end
+    );
+    const daysPassed = Math.floor((now - start) / DAY) + 1;
+    progress = Math.min(daysPassed / duration, 1);
+    if (violated) status = "failed";
+    else if (today > end) status = "completed";
+  } else if (challenge.type === "limit") {
+    const { category, limit, period = "day" } = challenge.rules || {};
+    const interval = period === "week" ? 7 : 1;
+    const checkEnd = now;
+    let passed = 0;
+    let failed = false;
+    for (let d = new Date(start); d <= checkEnd; d.setDate(d.getDate() + interval)) {
+      const periodStart = new Date(d);
+      const periodEnd = new Date(d);
+      periodEnd.setDate(periodEnd.getDate() + interval);
+      const total = txs
+        .filter(
+          (t) =>
+            t.category === category &&
+            t.type === "expense" &&
+            new Date(t.date) >= periodStart &&
+            new Date(t.date) < periodEnd
+        )
+        .reduce((sum, t) => sum + t.amount, 0);
+      if (total <= limit) passed += interval;
+      else {
+        failed = true;
+        break;
+      }
+    }
+    progress = Math.min(passed / duration, 1);
+    if (failed) status = "failed";
+    else if (today > end) status = "completed";
+  } else if (challenge.type === "target") {
+    const { category, target } = challenge.rules || {};
+    const total = txs
+      .filter(
+        (t) =>
+          t.category === category &&
+          t.type === "income" &&
+          new Date(t.date) >= start &&
+          new Date(t.date) <= end
+      )
+      .reduce((sum, t) => sum + t.amount, 0);
+    progress = target ? Math.min(total / target, 1) : 0;
+    if (progress >= 1) status = "completed";
+    else if (today > end) status = "failed";
+  }
+
+  return { status, progress };
+}
+
+export function remainingDays(challenge, today = new Date()) {
+  const end = new Date(challenge.endDate);
+  const diff = Math.ceil((end - today) / DAY);
+  return diff > 0 ? diff : 0;
+}

--- a/src/lib/challenges.test.js
+++ b/src/lib/challenges.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { evaluateChallenge } from "./challenges.js";
+
+const today = new Date().toISOString().split("T")[0];
+
+describe("evaluateChallenge", () => {
+  it("fails avoid challenge when violation occurs", () => {
+    const challenge = {
+      type: "avoid",
+      rules: { category: "Makan" },
+      durationDays: 7,
+      startDate: today,
+      endDate: new Date(Date.now() + 6 * 86400000).toISOString(),
+      status: "active",
+    };
+    const txs = [
+      { id: 1, category: "Makan", date: today, type: "expense", amount: 10000 },
+    ];
+    const { status } = evaluateChallenge(challenge, txs, new Date());
+    expect(status).toBe("failed");
+  });
+
+  it("fails limit challenge when exceeding limit", () => {
+    const start = new Date();
+    const end = new Date(start);
+    end.setDate(end.getDate() + 2);
+    const challenge = {
+      type: "limit",
+      rules: { category: "Transport", limit: 5000, period: "day" },
+      durationDays: 3,
+      startDate: start.toISOString(),
+      endDate: end.toISOString(),
+      status: "active",
+    };
+    const txs = [
+      { id: 1, category: "Transport", date: start.toISOString(), type: "expense", amount: 6000 },
+    ];
+    const { status } = evaluateChallenge(challenge, txs, start);
+    expect(status).toBe("failed");
+  });
+
+  it("completes target challenge when target reached", () => {
+    const start = new Date();
+    const end = new Date(start);
+    end.setDate(end.getDate() + 6);
+    const challenge = {
+      type: "target",
+      rules: { category: "Tabungan", target: 10000 },
+      durationDays: 7,
+      startDate: start.toISOString(),
+      endDate: end.toISOString(),
+      status: "active",
+    };
+    const txs = [
+      { id: 1, category: "Tabungan", date: start.toISOString(), type: "income", amount: 10000 },
+    ];
+    const { status } = evaluateChallenge(challenge, txs, end);
+    expect(status).toBe("completed");
+  });
+});

--- a/src/pages/Challenges.jsx
+++ b/src/pages/Challenges.jsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import ChallengeList from "../components/ChallengeList.jsx";
+import ChallengeCreatorModal from "../components/ChallengeCreatorModal.jsx";
+import ChallengeDetail from "../components/ChallengeDetail.jsx";
+
+export default function ChallengesPage({ challenges, onAdd, onUpdate, onRemove, txs }) {
+  const [tab, setTab] = useState("active");
+  const [creatorOpen, setCreatorOpen] = useState(false);
+  const [detail, setDetail] = useState(null);
+
+  const actives = challenges.filter((c) => c.status === "active");
+  const completed = challenges.filter((c) => c.status !== "active");
+
+  return (
+    <main className="max-w-3xl mx-auto p-4 space-y-4">
+      <h1 className="text-lg font-semibold">Challenges</h1>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          className={`px-3 py-1 rounded ${tab === "active" ? "bg-brand-var text-white" : "bg-gray-200"}`}
+          onClick={() => setTab("active")}
+        >
+          Active
+        </button>
+        <button
+          type="button"
+          className={`px-3 py-1 rounded ${tab === "completed" ? "bg-brand-var text-white" : "bg-gray-200"}`}
+          onClick={() => setTab("completed")}
+        >
+          Completed
+        </button>
+        <button
+          type="button"
+          className="ml-auto btn"
+          onClick={() => setCreatorOpen(true)}
+        >
+          +
+        </button>
+      </div>
+      {tab === "active" ? (
+        <ChallengeList
+          challenges={actives}
+          onView={(c) => setDetail(c)}
+          onEdit={(c) => setDetail(c)}
+          onEnd={(c) => onUpdate(c.id, { status: "failed" })}
+        />
+      ) : (
+        <ChallengeList
+          challenges={completed}
+          onView={(c) => setDetail(c)}
+          onEdit={() => {}}
+          onEnd={() => {}}
+        />
+      )}
+      <ChallengeCreatorModal
+        open={creatorOpen}
+        onClose={() => setCreatorOpen(false)}
+        onSave={onAdd}
+      />
+      <ChallengeDetail
+        challenge={detail}
+        txs={txs}
+        onClose={() => setDetail(null)}
+      />
+    </main>
+  );
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -20,6 +20,7 @@ export default function Dashboard({
   txs,
   budgets,
   months = [],
+  challenges = [],
 }) {
   const streak = useMemo(() => {
     const dates = new Set(txs.map((t) => new Date(t.date).toDateString()));
@@ -116,7 +117,7 @@ export default function Dashboard({
       <Summary stats={stats} />
       <FinanceMascot summary={summary} budgets={budgets} onRefresh={() => {}} />
       <DailyStreak streak={streak} />
-      <AvatarLevel transactions={txs} />
+        <AvatarLevel transactions={txs} challenges={challenges} />
       <button
         type="button"
         onClick={() => EventBus.emit("xp:add", { code: "demo", amount: 10 })}


### PR DESCRIPTION
## Summary
- add reusable challenge templates and evaluation helpers
- introduce `useChallenges` hook with local storage, XP reward, and reminders
- build challenge management UI and routing including creator modal and detail view

## Testing
- `npm test` *(fails: vitest not found)*
- `npx vitest run` *(fails: process could not complete in env)*

------
https://chatgpt.com/codex/tasks/task_e_68c7999268788332a8e456d9c98b2869