### PR TITLE
feat: add late month survival mode

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -97,6 +97,9 @@ function AppContent() {
       walletSound: false,
       walletSensitivity: "default",
       walletShowTips: true,
+      lateMode: "auto",
+      lateModeDay: 24,
+      lateModeBalance: 0.4,
       };
     if (!raw) return base;
     try {
@@ -806,9 +809,9 @@ function AppContent() {
         onClose={() => setSettingsOpen(false)}
         value={{ theme, ...prefs }}
         onChange={(val) => {
-          const { theme: nextTheme, density, defaultMonth, currency, accent, walletSound = false, walletSensitivity = "default", walletShowTips = true } = val;
+          const { theme: nextTheme, density, defaultMonth, currency, accent, walletSound = false, walletSensitivity = "default", walletShowTips = true, lateMode = "auto", lateModeDay = 24, lateModeBalance = 0.4 } = val;
           setTheme(nextTheme);
-          setPrefs({ density, defaultMonth, currency, accent, walletSound, walletSensitivity, walletShowTips });
+          setPrefs({ density, defaultMonth, currency, accent, walletSound, walletSensitivity, walletShowTips, lateMode, lateModeDay, lateModeBalance });
         }}
       />
     </CategoryProvider>

--- a/src/components/Animations.css
+++ b/src/components/Animations.css
@@ -59,11 +59,21 @@
   transition: width 0.3s ease;
 }
 
+@keyframes slow-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.animate-pulse-slow {
+  animation: slow-pulse 2s ease-in-out infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .animate-fade,
   .animate-slide,
   .animate-fab,
-  .confetti {
+  .confetti,
+  .animate-pulse-slow {
     animation: none;
   }
   [role='progressbar'] > div {

--- a/src/components/LateMonthMode.jsx
+++ b/src/components/LateMonthMode.jsx
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+import LowBalanceBanner from "./LowBalanceBanner";
+import "./Animations.css";
+
+export default function LateMonthMode({ active, onDismiss, onCreateChallenge }) {
+  useEffect(() => {
+    document.body.classList.toggle("late-month-mode", active);
+    return () => document.body.classList.remove("late-month-mode");
+  }, [active]);
+
+  if (!active) return null;
+
+  const actions = [
+    {
+      label: "Lihat Pengeluaran Terbesar",
+      onClick: () => onDismiss && onDismiss(),
+    },
+    {
+      label: "Buat Challenge Hemat 3 Hari",
+      onClick: onCreateChallenge,
+    },
+    {
+      label: "Tunda Belanja Non-Urgent",
+      onClick: () => onDismiss && onDismiss(),
+    },
+  ];
+
+  return (
+    <div className="fixed inset-0 z-40 flex justify-center p-4 pointer-events-none">
+      <LowBalanceBanner
+        message="⚠️ Tanggal Tua detected. Dompet memasuki mode bertahan hidup."
+        actions={actions}
+        onClose={onDismiss}
+      />
+    </div>
+  );
+}

--- a/src/components/LowBalanceBanner.jsx
+++ b/src/components/LowBalanceBanner.jsx
@@ -1,0 +1,40 @@
+import "./Animations.css";
+
+export default function LowBalanceBanner({ message, actions = [], onClose }) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="card bg-amber-100 text-amber-900 border-amber-300 max-w-md pointer-events-auto"
+    >
+      <div className="flex items-start gap-2">
+        <span className="animate-pulse-slow" aria-hidden="true">🪫</span>
+        <div className="flex-1 text-sm">
+          {message} <span className="animate-pulse-slow">😅</span>
+          {actions.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-2">
+              {actions.map((a) => (
+                <button
+                  key={a.label}
+                  onClick={a.onClick}
+                  className="btn btn-secondary text-xs"
+                >
+                  {a.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        {onClose && (
+          <button
+            onClick={onClose}
+            aria-label="Dismiss"
+            className="text-sm ml-2"
+          >
+            ✕
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -179,6 +179,51 @@ export default function SettingsPanel({ open, onClose, value, onChange }) {
             </label>
           </div>
         </div>
+        <div>
+          <h3 className="font-semibold mb-2">Tanggal Tua Mode</h3>
+          <div className="space-y-3">
+            <label className="block text-sm">
+              <div className="mb-1">Mode</div>
+              <select
+                className="input"
+                value={form.lateMode}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, lateMode: e.target.value }))
+                }
+              >
+                <option value="auto">Auto</option>
+                <option value="on">Always On</option>
+                <option value="off">Disabled</option>
+              </select>
+            </label>
+            <label className="block text-sm">
+              <div className="mb-1">Tanggal mulai</div>
+              <input
+                type="number"
+                min="1"
+                max="31"
+                className="input"
+                value={form.lateModeDay}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, lateModeDay: Number(e.target.value) }))
+                }
+              />
+            </label>
+            <label className="block text-sm">
+              <div className="mb-1">Saldo menipis &lt; % pengeluaran bulanan</div>
+              <input
+                type="number"
+                min="1"
+                max="100"
+                className="input"
+                value={Math.round(form.lateModeBalance * 100)}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, lateModeBalance: Number(e.target.value) / 100 }))
+                }
+              />
+            </label>
+          </div>
+        </div>
         <div className="flex justify-end gap-2">
           <button className="btn" onClick={onClose}>
             Batal

--- a/src/hooks/useLateMonthMode.js
+++ b/src/hooks/useLateMonthMode.js
@@ -1,0 +1,24 @@
+import { useState, useMemo } from "react";
+
+export function shouldActivateLateMonthMode({ date = new Date(), balance = 0, avgMonthlyExpense = 0 } = {}, prefs = {}) {
+  const {
+    lateMode = "auto",
+    lateModeDay = 24,
+    lateModeBalance = 0.4,
+  } = prefs;
+  const isLate = date.getDate() >= lateModeDay;
+  const isLow = avgMonthlyExpense > 0 ? balance < lateModeBalance * avgMonthlyExpense : false;
+  if (lateMode === "on") return true;
+  if (lateMode === "off") return false;
+  return isLate && isLow;
+}
+
+export default function useLateMonthMode(values = {}, prefs = {}) {
+  const [dismissed, setDismissed] = useState(false);
+  const active = useMemo(
+    () => !dismissed && shouldActivateLateMonthMode(values, prefs),
+    [dismissed, values, prefs]
+  );
+  const dismiss = () => setDismissed(true);
+  return { active, dismiss };
+}

--- a/src/hooks/useLateMonthMode.test.js
+++ b/src/hooks/useLateMonthMode.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { shouldActivateLateMonthMode } from "./useLateMonthMode";
+
+describe("shouldActivateLateMonthMode", () => {
+  it("activates when late date and low balance", () => {
+    const date = new Date(2024, 0, 25);
+    const res = shouldActivateLateMonthMode(
+      { date, balance: 100, avgMonthlyExpense: 1000 },
+      { lateMode: "auto", lateModeDay: 24, lateModeBalance: 0.2 }
+    );
+    expect(res).toBe(true);
+  });
+
+  it("respects manual off override", () => {
+    const date = new Date(2024, 0, 25);
+    const res = shouldActivateLateMonthMode(
+      { date, balance: 10, avgMonthlyExpense: 1000 },
+      { lateMode: "off" }
+    );
+    expect(res).toBe(false);
+  });
+
+  it("respects manual on override", () => {
+    const date = new Date(2024, 0, 1);
+    const res = shouldActivateLateMonthMode(
+      { date, balance: 900, avgMonthlyExpense: 1000 },
+      { lateMode: "on" }
+    );
+    expect(res).toBe(true);
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -24,3 +24,16 @@
 .dark .badge { @apply border-slate-700; }
 .dark .btn-primary { @apply bg-brand hover:bg-brand-hover border-brand; }
 .dark .btn-secondary { @apply bg-brand-secondary hover:bg-brand-secondary-hover border-brand-secondary; }
+
+.late-month-mode {
+  filter: grayscale(0.3) brightness(0.95);
+}
+.late-month-mode::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: radial-gradient(rgba(0,0,0,0.1) 1px, transparent 1px);
+  background-size: 3px 3px;
+  opacity: 0.2;
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -14,6 +14,9 @@ import WalletAvatar from "../components/WalletAvatar";
 import WalletPanel from "../components/WalletPanel";
 import useFinanceSummary from "../hooks/useFinanceSummary";
 import useWalletStatus from "../hooks/useWalletStatus";
+import LateMonthMode from "../components/LateMonthMode";
+import useLateMonthMode from "../hooks/useLateMonthMode";
+
 
 import AvatarLevel from "../components/AvatarLevel.jsx";
 import EventBus from "../lib/eventBus";
@@ -50,6 +53,7 @@ export default function Dashboard({
 
   const finance = useFinanceSummary(txs, budgets);
   const wallet = useWalletStatus({ balance: finance.balance, avgMonthlyExpense: finance.avgMonthlyExpense, weeklyTrend: finance.weeklyTrend }, { sensitivity: prefs?.walletSensitivity });
+  const lateMode = useLateMonthMode({ balance: finance.balance, avgMonthlyExpense: finance.avgMonthlyExpense }, prefs);
   const [walletOpen, setWalletOpen] = useState(false);
 
   const summary = useMemo(() => {
@@ -124,6 +128,7 @@ export default function Dashboard({
 
   return (
     <main className="max-w-5xl mx-auto p-4 space-y-6">
+      <LateMonthMode active={lateMode.active} onDismiss={lateMode.dismiss} onCreateChallenge={() => EventBus.emit("challenge:create", { days: 3 })} />
       <Summary stats={stats} />
             <div className="relative flex justify-end">
         <WalletAvatar


### PR DESCRIPTION
## Summary
- introduce LateMonthMode that activates when end-of-month and low balance
- add LowBalanceBanner with playful warning and quick actions
- support configurable thresholds and manual override in settings

## Testing
- `npm run lint`
- `npm install vitest@3.2.4 --no-save` *(failed: Cannot read properties of null (reading 'matches'))*

------
https://chatgpt.com/codex/tasks/task_e_68c79d4fd8a48332a1b14cb54d2b7863