### PR TITLE
feat: add money talk bubble feature

### DIFF
--- a/src/components/MoneyTalkBubble.jsx
+++ b/src/components/MoneyTalkBubble.jsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import clsx from "clsx";
+
+export default function MoneyTalkBubble({ message, tip, avatar = "coin", onDismiss }) {
+  const [open, setOpen] = useState(false);
+  const icon = avatar === "bill" ? "💵" : "🪙";
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50" aria-live="polite">
+      <div
+        tabIndex={0}
+        role="status"
+        className={clsx(
+          "card shadow-lg p-3 flex items-start gap-2 cursor-pointer focus:outline-none",
+          "animate-slide"
+        )}
+        onClick={() => setOpen((o) => !o)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") setOpen((o) => !o);
+          if (e.key === "Escape") onDismiss();
+        }}
+      >
+        <span className="text-2xl" aria-hidden="true">{icon}</span>
+        <div className="flex-1 text-sm">{message}</div>
+        <button
+          type="button"
+          className="ml-2 text-xs"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDismiss();
+          }}
+        >
+          &times;
+        </button>
+      </div>
+      {open && tip && (
+        <div className="mt-2 card shadow p-2 text-xs animate-slide" role="dialog">
+          {tip}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -180,6 +180,56 @@ export default function SettingsPanel({ open, onClose, value, onChange }) {
           </div>
         </div>
         <div>
+          <h3 className="font-semibold mb-2">Uang Bicara</h3>
+          <div className="space-y-3">
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={form.moneyTalkEnabled}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, moneyTalkEnabled: e.target.checked }))
+                }
+              />
+              Aktifkan
+            </label>
+            <div>
+              <div className="text-sm mb-1">Intensitas</div>
+              <div className="flex gap-2">
+                {["jarang", "normal", "ramai"].map((val) => (
+                  <label
+                    key={val}
+                    className="flex items-center gap-1 text-sm capitalize"
+                  >
+                    <input
+                      type="radio"
+                      name="moneyTalkIntensity"
+                      value={val}
+                      checked={form.moneyTalkIntensity === val}
+                      onChange={(e) =>
+                        setForm((f) => ({ ...f, moneyTalkIntensity: e.target.value }))
+                      }
+                    />
+                    {val}
+                  </label>
+                ))}
+              </div>
+            </div>
+            <label className="block text-sm">
+              <div className="mb-1">Bahasa</div>
+              <select
+                className="input"
+                value={form.moneyTalkLang}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, moneyTalkLang: e.target.value }))
+                }
+              >
+                <option value="id">Indonesia</option>
+                <option value="en">English</option>
+              </select>
+            </label>
+          </div>
+        </div>
+        <div>
           <h3 className="font-semibold mb-2">Tanggal Tua Mode</h3>
           <div className="space-y-3">
             <label className="block text-sm">

--- a/src/context/MoneyTalkContext.jsx
+++ b/src/context/MoneyTalkContext.jsx
@@ -1,0 +1,91 @@
+import { createContext, useCallback, useContext, useRef, useState } from "react";
+import MoneyTalkBubble from "../components/MoneyTalkBubble";
+import { quotes, tips, special } from "../lib/moneyTalkContent";
+
+const MoneyTalkContext = createContext({ speak: () => {} });
+
+export function useMoneyTalk() {
+  return useContext(MoneyTalkContext);
+}
+
+export default function MoneyTalkProvider({ prefs = {}, children }) {
+  const [current, setCurrent] = useState(null);
+  const queue = useRef([]);
+  const lastShown = useRef([]);
+
+  const handleDismiss = useCallback(() => {
+    setCurrent(null);
+  }, []);
+
+  const process = useCallback(() => {
+    if (current || !queue.current.length) return;
+    const now = Date.now();
+    lastShown.current = lastShown.current.filter((t) => now - t < 60000);
+    const maxPerMin =
+      prefs.moneyTalkIntensity === "jarang"
+        ? 1
+        : prefs.moneyTalkIntensity === "ramai"
+        ? 3
+        : 2;
+    if (lastShown.current.length >= maxPerMin) return;
+    const next = queue.current.shift();
+    setCurrent(next);
+    lastShown.current.push(now);
+    setTimeout(() => {
+      handleDismiss();
+      process();
+    }, next.duration || 5000);
+  }, [current, prefs.moneyTalkIntensity, handleDismiss]);
+
+  const speak = useCallback(
+    ({ category, amount, context = {} }) => {
+      if (!prefs.moneyTalkEnabled) return;
+      const chanceMap = { jarang: 0.3, normal: 0.7, ramai: 1 };
+      if (Math.random() > (chanceMap[prefs.moneyTalkIntensity] || 0.7)) return;
+      const lang = prefs.moneyTalkLang || "id";
+      let message = "";
+      if (context.isSavings) message = special[lang].savings;
+      else if (context.isOverBudget) message = special[lang].overbudget;
+      else if (context.isHigh) message = special[lang].high;
+      else {
+        const list = quotes[lang]?.[category] || [];
+        if (!list.length) return;
+        message = list[Math.floor(Math.random() * list.length)];
+      }
+      const tipList = tips[lang]?.[category] || [];
+      const tip = tipList.length
+        ? tipList[Math.floor(Math.random() * tipList.length)]
+        : "";
+      queue.current.push({
+        id:
+          globalThis.crypto?.randomUUID?.() ||
+          Math.random().toString(36).slice(2),
+        message,
+        tip,
+        avatar: Math.random() > 0.5 ? "bill" : "coin",
+        duration: 4000 + Math.random() * 2000,
+      });
+      if (queue.current.length > 3) queue.current.splice(3);
+      process();
+    },
+    [prefs.moneyTalkEnabled, prefs.moneyTalkIntensity, prefs.moneyTalkLang, process]
+  );
+
+  return (
+    <MoneyTalkContext.Provider value={{ speak }}>
+      {children}
+      {current && (
+        <MoneyTalkBubble
+          key={current.id}
+          message={current.message}
+          tip={current.tip}
+          avatar={current.avatar}
+          onDismiss={() => {
+            handleDismiss();
+            process();
+          }}
+        />
+      )}
+    </MoneyTalkContext.Provider>
+  );
+}

--- a/src/lib/moneyTalkContent.js
+++ b/src/lib/moneyTalkContent.js
@@ -1,0 +1,171 @@
+export const quotes = {
+  id: {
+    Makan: [
+      "Aku masuk mulut, bukan dompet! 🍜",
+      "Habis makan enak, aku langsung melangsing. 😅",
+      "Perut kenyang, dompet kempes!",
+      "Makan lagi? Aku butuh diet.",
+      "Setiap gigitan, aku semakin tipis.",
+      "Aku lebih suka disimpan daripada dimakan.",
+    ],
+    Transport: [
+      "Wusshh! Aku ikut ngebut. 🚗",
+      "Aku capek jadi uang ojek.",
+      "Bensin lagi? Aku kan bukan minyak.",
+      "Mungkin coba jalan kaki?",
+      "Tiap kilometer, aku berpamitan.",
+      "Bis kan murah? hemat dong.",
+    ],
+    Hiburan: [
+      "Yay, diajak bersenang-senang!",
+      "Tiket lagi? Aku ingin liburan juga.",
+      "Nonton boleh, asal aku nggak habis.",
+      "Game baru? Ingat cicilan!",
+      "Aku tertawa, tapi sambil nangis.",
+      "Seru-seru, tapi tabungan melambai.",
+    ],
+    Belanja: [
+      "Keranjangmu penuh, aku kosong.",
+      "Diskon? Aku tetap keluar.",
+      "Belanja terus, aku pusing.",
+      "Mungkin cari yang second?",
+      "Aku berharap kita cuma window shopping.",
+      "Barang baru lagi? Aku belum pulih.",
+    ],
+    Tagihan: [
+      "Halo, bulan ini aku datang lagi.",
+      "Bayar listrik biar terang, tapi aku gelap.",
+      "Tagihan air? Aku mengalir deras.",
+      "Aku pergi begitu saja tiap tanggal tua.",
+      "Langganan banyak, aku seret.",
+      "Mungkin matikan lampu kalau tidak dipakai.",
+    ],
+    Tabungan: [
+      "Tidur dulu ya, bangunkan nanti.",
+      "Aku berkembang di sini.",
+      "Hemat pangkal kaya, ayo!",
+      "Aku senang di celengan.",
+      "Tambah lagi dong biar gemuk.",
+      "Pelan-pelan jadi bukit.",
+    ],
+  },
+  en: {
+    Makan: [
+      "I go to your belly, not your wallet! 🍜",
+      "Great meal, sudden slim wallet. 😅",
+      "Full tummy, empty pocket!",
+      "Eating again? I need a diet.",
+      "Every bite makes me thinner.",
+      "I'd rather be saved than eaten.",
+    ],
+    Transport: [
+      "Zoom! I'm speeding away. 🚗",
+      "Tired of being ride money.",
+      "Fuel again? I'm not oil.",
+      "Maybe try walking?",
+      "Each kilometer, I say goodbye.",
+      "Buses are cheaper, you know.",
+    ],
+    Hiburan: [
+      "Yay, out for fun!",
+      "Tickets again? I need a vacation too.",
+      "Movies are fine, just don't spend me all.",
+      "New game? Remember the bills!",
+      "I'm laughing while crying inside.",
+      "Fun times, waving goodbye to savings.",
+    ],
+    Belanja: [
+      "Your cart is full, I'm empty.",
+      "Sale? I'm still leaving.",
+      "Shopping spree makes me dizzy.",
+      "Maybe buy second-hand?",
+      "I hoped it was just window shopping.",
+      "Another new item? I'm not recovered yet.",
+    ],
+    Tagihan: [
+      "Hello, it's that time of month.",
+      "Paying electricity, but I'm in the dark.",
+      "Water bill? I'm flowing fast.",
+      "I vanish every due date.",
+      "Too many subscriptions drain me.",
+      "Turn off unused lights maybe?",
+    ],
+    Tabungan: [
+      "Let me sleep for the future.",
+      "I'm growing safely here.",
+      "Save now, rich later!",
+      "Happy inside the piggy bank.",
+      "Feed me more to grow fat.",
+      "Slowly but surely I pile up.",
+    ],
+  },
+};
+
+export const tips = {
+  id: {
+    Makan: [
+      "Coba masak sendiri untuk lebih hemat.",
+      "Bawa bekal dari rumah.",
+    ],
+    Transport: [
+      "Gunakan transportasi umum saat bisa.",
+      "Jadwalkan carpool dengan teman.",
+    ],
+    Hiburan: [
+      "Cari hiburan gratis atau diskon.",
+      "Batasi langganan yang jarang dipakai.",
+    ],
+    Belanja: [
+      "Buat daftar belanja dan patuhi.",
+      "Tunggu 24 jam sebelum membeli barang mahal.",
+    ],
+    Tagihan: [
+      "Matikan alat listrik saat tidak digunakan.",
+      "Tinjau langganan bulananmu.",
+    ],
+    Tabungan: [
+      "Setor otomatis tiap bulan.",
+      "Pisahkan rekening tabungan.",
+    ],
+  },
+  en: {
+    Makan: [
+      "Cook at home to save more.",
+      "Bring your own lunch.",
+    ],
+    Transport: [
+      "Use public transport when possible.",
+      "Arrange carpools with friends.",
+    ],
+    Hiburan: [
+      "Look for free or discounted fun.",
+      "Trim unused subscriptions.",
+    ],
+    Belanja: [
+      "Make a shopping list and stick to it.",
+      "Wait 24 hours before big purchases.",
+    ],
+    Tagihan: [
+      "Turn off appliances when unused.",
+      "Review your monthly subscriptions.",
+    ],
+    Tabungan: [
+      "Automate monthly deposits.",
+      "Keep a separate savings account.",
+    ],
+  },
+};
+
+export const special = {
+  id: {
+    high: "Kenapa aku dibelikan mahal-mahal? 😵",
+    savings: "Nice! Aku disimpan buat masa depan 💰✨",
+    overbudget: "Aku capek dipakai terus… istirahat dulu ya 😭",
+  },
+  en: {
+    high: "Why am I bought so pricey? 😵",
+    savings: "Nice! I'm saved for the future 💰✨",
+    overbudget: "I'm tired of being spent… give me a break 😭",
+  },
+};
+

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Summary from "../components/Summary";
 import DashboardCharts from "../components/DashboardCharts";
 import Reports from "../components/Reports";
@@ -20,6 +20,7 @@ import useLateMonthMode from "../hooks/useLateMonthMode";
 
 import AvatarLevel from "../components/AvatarLevel.jsx";
 import EventBus from "../lib/eventBus";
+import { useMoneyTalk } from "../context/MoneyTalkContext.jsx";
 
 
 export default function Dashboard({
@@ -55,6 +56,7 @@ export default function Dashboard({
   const wallet = useWalletStatus({ balance: finance.balance, avgMonthlyExpense: finance.avgMonthlyExpense, weeklyTrend: finance.weeklyTrend }, { sensitivity: prefs?.walletSensitivity });
   const lateMode = useLateMonthMode({ balance: finance.balance, avgMonthlyExpense: finance.avgMonthlyExpense }, prefs);
   const [walletOpen, setWalletOpen] = useState(false);
+  const { speak } = useMoneyTalk();
 
   const summary = useMemo(() => {
     const today = new Date();
@@ -125,6 +127,16 @@ export default function Dashboard({
       },
     };
   }, [txs]);
+
+  useEffect(() => {
+    if (finance.isAnyOverBudget) {
+      speak({
+        category: finance.topSpenderCategory || "Belanja",
+        amount: 0,
+        context: { isOverBudget: true },
+      });
+    }
+  }, [finance.isAnyOverBudget, finance.topSpenderCategory, speak]);
 
   return (
     <main className="max-w-5xl mx-auto p-4 space-y-6">


### PR DESCRIPTION
## Summary
- add MoneyTalkProvider and useMoneyTalk hook for queued humorous bubbles
- seed bilingual quotes and tips for finance categories
- integrate bubble triggers and settings for "Uang Bicara"

## Testing
- `npx vitest run` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a03289288332aab5c2f9e9555646