### PR TITLE
feat: page layout helpers and moneytalk limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,58 @@
-# React + Vite
+# HematWoi
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A personal finance playground built with React 19 and Vite. The project now
+includes a reusable layout system and basic accessibility helpers.
 
-Currently, two official plugins are available:
+## Getting Started
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+```bash
+pnpm install
+pnpm dev
+```
 
-## Expanding the ESLint configuration
+Run unit tests with:
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+```bash
+pnpm test
+```
+
+## Folder Structure
+
+```
+src/
+  layout/        # App-wide layout helpers (breadcrumbs, page headers)
+  components/    # Feature components
+  pages/         # Route pages
+  context/       # React context providers
+  lib/           # Utilities and tests
+```
+
+## UI Guidelines
+
+The app uses TailwindCSS with a unified colour palette:
+- `brand` `#3898f8`
+- `brand-hover` `#2584e4`
+- `brand-secondary` `#50b6ff`
+- `brand-secondary-hover` `#379de7`
+- `brand-text` `#13436d`
+
+Dark mode is supported via the `dark` class on `<html>`.
+
+## Layout Components
+
+- **Breadcrumbs** – renders a path based on the current route.
+- **PageHeader** – shows page title, description and optional action buttons.
+
+These components aim to keep spacing and typography consistent across pages.
+
+## Feature Toggles
+
+User preferences such as dark mode, MoneyTalk intensity and late-month mode are
+stored in `localStorage` under the `hematwoi:v3:prefs` key. They can be tweaked
+from the settings panel within the app.
+
+## Contributing
+
+Pull requests are welcome. Please run `pnpm test` before submitting to ensure
+all unit tests—including MoneyTalk queue, wallet status mapper, challenge
+evaluation and late-month mode activation—pass.

--- a/src/layout/Breadcrumbs.jsx
+++ b/src/layout/Breadcrumbs.jsx
@@ -1,0 +1,39 @@
+import { NavLink, useLocation } from "react-router-dom";
+
+function capitalize(str = "") {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+export default function Breadcrumbs() {
+  const { pathname } = useLocation();
+  const segments = pathname.split("/").filter(Boolean);
+  if (!segments.length) return null;
+  let path = "";
+  return (
+    <nav aria-label="Breadcrumb" className="mb-2 text-xs text-slate-600 dark:text-slate-400">
+      <ol className="flex items-center gap-1">
+        <li>
+          <NavLink to="/" className="hover:text-brand">
+            Home
+          </NavLink>
+        </li>
+        {segments.map((seg, idx) => {
+          path += `/${seg}`;
+          const isLast = idx === segments.length - 1;
+          return (
+            <li key={path} className="flex items-center gap-1">
+              <span>/</span>
+              {isLast ? (
+                <span>{capitalize(seg)}</span>
+              ) : (
+                <NavLink to={path} className="hover:text-brand">
+                  {capitalize(seg)}
+                </NavLink>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/src/layout/PageHeader.jsx
+++ b/src/layout/PageHeader.jsx
@@ -1,0 +1,22 @@
+import Breadcrumbs from "./Breadcrumbs";
+
+export default function PageHeader({ title, description, children }) {
+  return (
+    <div className="mb-6">
+      <Breadcrumbs />
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-xl font-bold text-brand-text dark:text-white">
+            {title}
+          </h1>
+          {description && (
+            <p className="text-sm text-slate-600 dark:text-slate-300">
+              {description}
+            </p>
+          )}
+        </div>
+        {children && <div className="flex gap-2">{children}</div>}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/moneyTalkQueue.js
+++ b/src/lib/moneyTalkQueue.js
@@ -1,0 +1,13 @@
+export function createMoneyTalkLimiter(intensity = "normal") {
+  const events = [];
+  const max = intensity === "jarang" ? 1 : intensity === "ramai" ? 3 : 2;
+  function tryConsume(now = Date.now()) {
+    while (events.length && now - events[0] > 60000) {
+      events.shift();
+    }
+    if (events.length >= max) return false;
+    events.push(now);
+    return true;
+  }
+  return { tryConsume, get count() { return events.length; } };
+}

--- a/src/lib/moneyTalkQueue.test.js
+++ b/src/lib/moneyTalkQueue.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { createMoneyTalkLimiter } from "./moneyTalkQueue";
+
+describe("moneyTalk limiter", () => {
+  it("limits messages per minute", () => {
+    const limiter = createMoneyTalkLimiter("normal"); // max 2 per minute
+    const base = 0;
+    expect(limiter.tryConsume(base)).toBe(true);
+    expect(limiter.tryConsume(base + 1000)).toBe(true);
+    // third within same minute should be blocked
+    expect(limiter.tryConsume(base + 2000)).toBe(false);
+    // after a minute it should allow again
+    expect(limiter.tryConsume(base + 61000)).toBe(true);
+  });
+});

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -12,6 +12,7 @@ import DailyQuote from "../components/DailyQuote";
 import FinanceMascot from "../components/FinanceMascot";
 import WalletAvatar from "../components/WalletAvatar";
 import WalletPanel from "../components/WalletPanel";
+import PageHeader from "../layout/PageHeader";
 import useFinanceSummary from "../hooks/useFinanceSummary";
 import useWalletStatus from "../hooks/useWalletStatus";
 import LateMonthMode from "../components/LateMonthMode";
@@ -140,6 +141,7 @@ export default function Dashboard({
 
   return (
     <main className="max-w-5xl mx-auto p-4 space-y-6">
+      <PageHeader title="Dashboard" description="Ringkasan keuanganmu" />
       <LateMonthMode active={lateMode.active} onDismiss={lateMode.dismiss} onCreateChallenge={() => EventBus.emit("challenge:create", { days: 3 })} />
       <Summary stats={stats} />
             <div className="relative flex justify-end">

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -1,6 +1,7 @@
 import Filters from "../components/Filters";
 import TxTable from "../components/TxTable";
 import FAB from "../components/FAB";
+import PageHeader from "../layout/PageHeader";
 
 export default function Transactions({
   months,
@@ -13,9 +14,7 @@ export default function Transactions({
 }) {
   return (
     <main className="max-w-5xl mx-auto p-4 space-y-4">
-      <div className="card">
-        <h1 className="text-sm font-semibold">Transaksi</h1>
-      </div>
+      <PageHeader title="Transaksi" description="Kelola catatan keuangan" />
       <Filters
         months={months}
         categories={categories}


### PR DESCRIPTION
## Summary
- add reusable PageHeader and Breadcrumbs for consistent layout
- limit MoneyTalk bubbles with new queue helper and tests
- document project structure and styling guidelines

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a3c637f48332a1c4e65203f33ea6