### PR TITLE
Add data mode provider with goals refactor and basic auth pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Run unit tests with:
 pnpm test
 ```
 
+## Data Mode
+
+HematWoi now supports a cloud or local data mode. The default mode uses
+Supabase for persistent storage. Switch to local mode from the Settings
+page and optionally seed dummy data for quick testing. The current mode is
+stored in `localStorage` under `hw:mode`.
+
 ## Folder Structure
 
 ```

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,8 +13,13 @@ import AddWizard from "./pages/AddWizard";
 import Subscriptions from "./pages/Subscriptions";
 import ImportWizard from "./pages/ImportWizard";
 import GoalsPage from "./pages/Goals";
+import SettingsPage from "./pages/Settings";
+import ProfilePage from "./pages/Profile";
+import AuthPage from "./pages/Auth";
 import ChallengesPage from "./pages/Challenges.jsx";
 import useChallenges from "./hooks/useChallenges.js";
+import AuthGuard from "./components/AuthGuard";
+import { DataProvider } from "./context/DataContext";
 
 import { supabase } from "./lib/supabase";
 import { playChaChing } from "./lib/walletSound";
@@ -715,113 +720,106 @@ function AppShell({ prefs, setPrefs }) {
       )}
       <main id="main" tabIndex="-1" className="focus:outline-none">
         <Routes>
-          <Route
-            path="/"
-            element={
-              <Dashboard
-                stats={stats}
-                monthForReport={
-                  filter.month === "all" ? currentMonth : filter.month
-                }
-                txs={data.txs}
-                budgets={data.budgets}
-                months={months}
-                challenges={challenges}
-                prefs={prefs}
-              />
-            }
-          />
-          <Route
-            path="/transactions"
-            element={
-              <Transactions
-                months={months}
-                categories={allCategories}
-                filter={filter}
-                setFilter={setFilter}
-                items={filtered}
-                onRemove={removeTx}
-                onUpdate={updateTx}
-              />
-            }
-          />
-          <Route
-            path="/budgets"
-            element={
-              <Budgets
-                currentMonth={currentMonth}
-                data={data}
-                onAdd={addBudget}
-                onRemove={removeBudget}
-              />
-            }
-          />
-          <Route
-            path="/goals"
-            element={
-              <GoalsPage
-                goals={data.goals}
-                envelopes={data.envelopes}
-                rules={allocRules}
-                onAddGoal={addGoal}
-                onAddEnvelope={addEnvelope}
-                onSaveRules={setAllocRules}
-              />
-            }
-          />
-          <Route
-            path="/challenges"
-            element={
-              <ChallengesPage
-                challenges={challenges}
-                onAdd={addChallenge}
-                onUpdate={updateChallenge}
-                onRemove={removeChallenge}
-                txs={data.txs}
-              />
-            }
-          />
-          <Route
-            path="/categories"
-            element={<Categories cat={data.cat} onSave={saveCategories} />}
-          />
-          <Route
-            path="/subscriptions"
-            element={<Subscriptions categories={data.cat} />}
-          />
-          <Route
-            path="/data"
-            element={
-              <DataToolsPage
-                onExport={handleExport}
-                onImportJSON={handleImportJSON}
-                onImportCSV={handleImportCSV}
-              />
-            }
-          />
-          <Route
-            path="/import"
-            element={
-              <ImportWizard
-                txs={data.txs}
-                onAdd={addTx}
-                categories={data.cat}
-                rules={rules}
-                setRules={setRules}
-                onCancel={() => navigate("/data")}
-              />
-            }
-          />
-          <Route
-            path="/add"
-            element={
-              <AddWizard
-                categories={data.cat}
-                onAdd={addTx}
-                onCancel={() => navigate("/")}
-              />
-            }
-          />
+          <Route path="/auth" element={<AuthPage />} />
+          <Route element={<AuthGuard />}>
+            <Route
+              path="/"
+              element={
+                <Dashboard
+                  stats={stats}
+                  monthForReport={
+                    filter.month === "all" ? currentMonth : filter.month
+                  }
+                  txs={data.txs}
+                  budgets={data.budgets}
+                  months={months}
+                  challenges={challenges}
+                  prefs={prefs}
+                />
+              }
+            />
+            <Route
+              path="/transactions"
+              element={
+                <Transactions
+                  months={months}
+                  categories={allCategories}
+                  filter={filter}
+                  setFilter={setFilter}
+                  items={filtered}
+                  onRemove={removeTx}
+                  onUpdate={updateTx}
+                />
+              }
+            />
+            <Route
+              path="/budgets"
+              element={
+                <Budgets
+                  currentMonth={currentMonth}
+                  data={data}
+                  onAdd={addBudget}
+                  onRemove={removeBudget}
+                />
+              }
+            />
+            <Route path="/goals" element={<GoalsPage />} />
+            <Route
+              path="/challenges"
+              element={
+                <ChallengesPage
+                  challenges={challenges}
+                  onAdd={addChallenge}
+                  onUpdate={updateChallenge}
+                  onRemove={removeChallenge}
+                  txs={data.txs}
+                />
+              }
+            />
+            <Route
+              path="/categories"
+              element={<Categories cat={data.cat} onSave={saveCategories} />}
+            />
+            <Route
+              path="/subscriptions"
+              element={<Subscriptions categories={data.cat} />}
+            />
+            <Route
+              path="/data"
+              element={
+                <DataToolsPage
+                  onExport={handleExport}
+                  onImportJSON={handleImportJSON}
+                  onImportCSV={handleImportCSV}
+                />
+              }
+            />
+            <Route
+              path="/import"
+              element={
+                <ImportWizard
+                  txs={data.txs}
+                  onAdd={addTx}
+                  categories={data.cat}
+                  rules={rules}
+                  setRules={setRules}
+                  onCancel={() => navigate("/data")}
+                />
+              }
+            />
+            <Route
+              path="/add"
+              element={
+                <AddWizard
+                  categories={data.cat}
+                  onAdd={addTx}
+                  onCancel={() => navigate("/")}
+                />
+              }
+            />
+            <Route path="/settings" element={<SettingsPage />} />
+            <Route path="/profile" element={<ProfilePage />} />
+          </Route>
         </Routes>
       </main>
       <SettingsPanel
@@ -903,7 +901,9 @@ export default function App() {
   return (
     <UserProfileProvider>
       <ToastProvider>
-        <AppContent />
+        <DataProvider>
+          <AppContent />
+        </DataProvider>
       </ToastProvider>
     </UserProfileProvider>
   );

--- a/src/components/AuthGuard.jsx
+++ b/src/components/AuthGuard.jsx
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabase';
+import { Navigate, useLocation, Outlet } from 'react-router-dom';
+
+export default function AuthGuard({ children }) {
+  const [session, setSession] = useState();
+  const location = useLocation();
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => setSession(data.session));
+    const { data: sub } = supabase.auth.onAuthStateChange((_e, sess) => setSession(sess));
+    return () => sub.subscription.unsubscribe();
+  }, []);
+  if (session === undefined) return null;
+  if (!session) return <Navigate to="/auth" state={{ from: location }} replace />;
+  return children ? children : <Outlet />;
+}

--- a/src/components/AuthMenu.jsx
+++ b/src/components/AuthMenu.jsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabase';
+import { Link } from 'react-router-dom';
+
+export default function AuthMenu() {
+  const [user, setUser] = useState(null);
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => setUser(data.user));
+    const { data: sub } = supabase.auth.onAuthStateChange((_e, session) => setUser(session?.user || null));
+    return () => sub.subscription.unsubscribe();
+  }, []);
+  if (!user) return null;
+  return (
+    <div className="relative group">
+      <button className="w-8 h-8 rounded-full bg-brand text-white flex items-center justify-center">
+        {user.email?.charAt(0).toUpperCase()}
+      </button>
+      <div className="absolute right-0 mt-2 w-40 bg-white rounded shadow-md border hidden group-focus-within:block group-hover:block">
+        <Link className="block px-4 py-2 hover:bg-slate-100" to="/profile">
+          Profile
+        </Link>
+        <Link className="block px-4 py-2 hover:bg-slate-100" to="/settings">
+          Settings
+        </Link>
+        <button
+          onClick={() => supabase.auth.signOut()}
+          className="block w-full text-left px-4 py-2 hover:bg-slate-100"
+        >
+          Logout
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/GoalCard.jsx
+++ b/src/components/GoalCard.jsx
@@ -1,0 +1,29 @@
+import GoalProgressBar from './GoalProgressBar';
+import { formatCurrency } from '../lib/format';
+
+export default function GoalCard({ goal, onEdit, onDelete }) {
+  return (
+    <div className="p-4 border rounded shadow-sm bg-white dark:bg-slate-800 flex flex-col gap-2">
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="font-medium truncate" title={goal.name}>{goal.name}</h3>
+        {onEdit && (
+          <button className="text-sm text-brand" onClick={() => onEdit(goal)}>
+            Edit
+          </button>
+        )}
+      </div>
+      <div className="text-sm text-slate-500">
+        {formatCurrency(goal.allocated)} / {formatCurrency(goal.target)}
+      </div>
+      <GoalProgressBar goal={goal} />
+      {onDelete && (
+        <button
+          className="self-end text-xs text-red-600 hover:underline"
+          onClick={() => onDelete(goal.id)}
+        >
+          Delete
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/GoalFormModal.jsx
+++ b/src/components/GoalFormModal.jsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import Modal from './Modal';
+
+export default function GoalFormModal({ open, onClose, onSave, initial }) {
+  const [form, setForm] = useState({ name: '', target: 0 });
+  useEffect(() => {
+    if (open) {
+      setForm({
+        name: initial?.name || '',
+        target: initial?.target || 0,
+        allocated: initial?.allocated || 0,
+      });
+    }
+  }, [open, initial]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSave(form);
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title={initial ? 'Edit Goal' : 'Tambah Goal'}>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input
+          className="w-full p-2 border rounded"
+          placeholder="Nama goal"
+          value={form.name}
+          onChange={(e) => setForm({ ...form, name: e.target.value })}
+          required
+        />
+        <input
+          type="number"
+          className="w-full p-2 border rounded"
+          placeholder="Target"
+          value={form.target}
+          min={1}
+          onChange={(e) => setForm({ ...form, target: Number(e.target.value) })}
+          required
+        />
+        <div className="flex justify-end gap-2 pt-2">
+          <button type="button" className="btn" onClick={onClose}>
+            Batal
+          </button>
+          <button type="submit" className="btn btn-primary">
+            Simpan
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/src/components/GoalList.jsx
+++ b/src/components/GoalList.jsx
@@ -1,49 +1,56 @@
-import { useState } from "react";
-import GoalForm from "./GoalForm";
-import { goalProgress } from "../lib/goals";
+import { useState } from 'react';
+import GoalCard from './GoalCard';
+import GoalFormModal from './GoalFormModal';
 
-export default function GoalList({ goals = [], onSave }) {
-  const [adding, setAdding] = useState(false);
+export default function GoalList({ goals, onAdd, onUpdate, onDelete }) {
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState(null);
+
+  const startAdd = () => {
+    setEditing(null);
+    setOpen(true);
+  };
+  const startEdit = (g) => {
+    setEditing(g);
+    setOpen(true);
+  };
+
+  const handleSave = (data) => {
+    if (editing) {
+      onUpdate(editing.id, data);
+    } else {
+      onAdd({ ...data, id: crypto.randomUUID(), allocated: 0 });
+    }
+    setOpen(false);
+  };
 
   return (
     <div className="space-y-4">
-      <div className="flex justify-between items-center">
+      <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold">Goals</h2>
-        <button
-          className="px-3 py-1 rounded bg-brand text-white"
-          onClick={() => setAdding(true)}
-        >
+        <button className="btn btn-primary" onClick={startAdd}>
           Tambah
         </button>
       </div>
-      {adding && (
-        <GoalForm
-          onSave={(g) => {
-            onSave({ ...g, id: crypto.randomUUID(), allocated: 0 });
-            setAdding(false);
-          }}
-          onCancel={() => setAdding(false)}
-        />
+      {goals.length === 0 && (
+        <div className="text-center text-sm text-slate-500">
+          Belum ada goal.{' '}
+          <button className="text-brand" onClick={startAdd}>
+            Buat Goal Pertama
+          </button>
+        </div>
       )}
-      <div className="grid gap-4 md:grid-cols-2">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {goals.map((g) => (
-          <div
-            key={g.id}
-            className="p-4 border rounded shadow-sm bg-white dark:bg-slate-800"
-          >
-            <div className="font-medium mb-1">{g.name}</div>
-            <div className="text-sm text-slate-500 mb-2">
-              Rp {g.allocated?.toFixed(0)} / Rp {g.target.toFixed(0)}
-            </div>
-            <div className="w-full h-2 bg-slate-200 dark:bg-slate-700 rounded">
-              <div
-                className="h-2 bg-brand rounded"
-                style={{ width: `${goalProgress(g) * 100}%` }}
-              />
-            </div>
-          </div>
+          <GoalCard key={g.id} goal={g} onEdit={startEdit} onDelete={onDelete} />
         ))}
       </div>
+      <GoalFormModal
+        open={open}
+        onClose={() => setOpen(false)}
+        onSave={handleSave}
+        initial={editing}
+      />
     </div>
   );
 }

--- a/src/components/GoalProgressBar.jsx
+++ b/src/components/GoalProgressBar.jsx
@@ -1,0 +1,10 @@
+import { goalProgress } from '../lib/goals';
+
+export default function GoalProgressBar({ goal }) {
+  const pct = goalProgress(goal) * 100;
+  return (
+    <div className="w-full bg-slate-200 dark:bg-slate-700 rounded h-2">
+      <div className="h-2 bg-brand rounded" style={{ width: `${pct}%` }} />
+    </div>
+  );
+}

--- a/src/context/DataContext.jsx
+++ b/src/context/DataContext.jsx
@@ -1,0 +1,27 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { supabase } from '../lib/supabase';
+import { CloudRepo, LocalRepo } from '../lib/repo';
+
+const DataContext = createContext();
+
+export function DataProvider({ children, initialMode = 'cloud' }) {
+  const [mode, setMode] = useState(() => localStorage.getItem('hw:mode') || initialMode);
+  const repo = useMemo(() => (mode === 'cloud' ? new CloudRepo(supabase) : new LocalRepo()), [mode]);
+  useEffect(() => {
+    localStorage.setItem('hw:mode', mode);
+  }, [mode]);
+  return (
+    <DataContext.Provider value={{ mode, setMode, repo }}>
+      {children}
+    </DataContext.Provider>
+  );
+}
+
+export function useRepo() {
+  return useContext(DataContext).repo;
+}
+
+export function useDataMode() {
+  const { mode, setMode } = useContext(DataContext);
+  return { mode, setMode };
+}

--- a/src/hooks/useGoals.js
+++ b/src/hooks/useGoals.js
@@ -1,0 +1,28 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useRepo } from '../context/DataContext';
+
+export default function useGoals() {
+  const repo = useRepo();
+  const [goals, setGoals] = useState([]);
+
+  useEffect(() => {
+    repo.goals.list().then(setGoals);
+  }, [repo]);
+
+  const addGoal = useCallback(async (goal) => {
+    await repo.goals.add(goal);
+    setGoals((g) => [...g, goal]);
+  }, [repo]);
+
+  const updateGoal = useCallback(async (id, data) => {
+    await repo.goals.update(id, data);
+    setGoals((g) => g.map((it) => (it.id === id ? { ...it, ...data } : it)));
+  }, [repo]);
+
+  const deleteGoal = useCallback(async (id) => {
+    await repo.goals.remove(id);
+    setGoals((g) => g.filter((it) => it.id !== id));
+  }, [repo]);
+
+  return { goals, addGoal, updateGoal, deleteGoal };
+}

--- a/src/lib/format.js
+++ b/src/lib/format.js
@@ -1,0 +1,12 @@
+export function formatCurrency(n = 0, currency = 'IDR') {
+  return new Intl.NumberFormat(currency === 'USD' ? 'en-US' : 'id-ID', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 0,
+  }).format(n ?? 0);
+}
+
+export function humanDate(date) {
+  const d = new Date(date);
+  return d.toLocaleDateString('id-ID');
+}

--- a/src/lib/goals.js
+++ b/src/lib/goals.js
@@ -3,6 +3,16 @@ export function goalProgress(goal) {
   return Math.min(goal.allocated / goal.target, 1);
 }
 
+export function estimateGoalETA(goal, avgPerDay = 0) {
+  if (!goal || !avgPerDay) return null;
+  const remaining = (goal.target || 0) - (goal.allocated || 0);
+  if (remaining <= 0) return new Date();
+  const days = Math.ceil(remaining / avgPerDay);
+  const eta = new Date();
+  eta.setDate(eta.getDate() + days);
+  return eta;
+}
+
 export function updateGoalBalance(goals, id, amount) {
   return goals.map((g) => (g.id === id ? { ...g, allocated: amount } : g));
 }

--- a/src/lib/goals.test.js
+++ b/src/lib/goals.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { goalProgress, estimateGoalETA } from './goals';
+
+describe('goalProgress', () => {
+  it('returns progress ratio', () => {
+    const g = { allocated: 50, target: 200 };
+    expect(goalProgress(g)).toBe(0.25);
+  });
+});
+
+describe('estimateGoalETA', () => {
+  it('estimates completion date', () => {
+    const g = { allocated: 100, target: 400 };
+    const eta = estimateGoalETA(g, 30); // 300 remaining -> 10 days
+    const now = new Date();
+    const expected = new Date(now);
+    expected.setDate(now.getDate() + 10);
+    expect(eta.toDateString()).toBe(expected.toDateString());
+  });
+});

--- a/src/lib/repo.js
+++ b/src/lib/repo.js
@@ -1,0 +1,58 @@
+export class CloudRepo {
+  constructor(client) {
+    this.client = client;
+  }
+  goals = {
+    list: async () => {
+      const { data } = await this.client.from('goals').select('*');
+      return data || [];
+    },
+    add: async (goal) => {
+      await this.client.from('goals').insert(goal);
+      return goal;
+    },
+    update: async (id, data) => {
+      await this.client.from('goals').update(data).eq('id', id);
+    },
+    remove: async (id) => {
+      await this.client.from('goals').delete().eq('id', id);
+    },
+  };
+}
+
+const LS_KEY = 'hw:localRepo';
+
+export class LocalRepo {
+  constructor() {
+    const raw = localStorage.getItem(LS_KEY);
+    this.db = raw
+      ? JSON.parse(raw)
+      : { goals: [], transactions: [], budgets: [], categories: [], subscriptions: [], challenges: [], profile: {} };
+  }
+  _save() {
+    localStorage.setItem(LS_KEY, JSON.stringify(this.db));
+  }
+  goals = {
+    list: async () => this.db.goals,
+    add: async (goal) => {
+      this.db.goals.push(goal);
+      this._save();
+      return goal;
+    },
+    update: async (id, data) => {
+      this.db.goals = this.db.goals.map((g) => (g.id === id ? { ...g, ...data } : g));
+      this._save();
+    },
+    remove: async (id) => {
+      this.db.goals = this.db.goals.filter((g) => g.id !== id);
+      this._save();
+    },
+  };
+  seedDummy() {
+    if (this.db.goals.length) return;
+    this.db.goals = [
+      { id: crypto.randomUUID(), name: 'Dana Darurat', target: 1000000, allocated: 200000 },
+    ];
+    this._save();
+  }
+}

--- a/src/lib/repo.test.js
+++ b/src/lib/repo.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { LocalRepo } from './repo';
+
+// simple in-memory localStorage polyfill
+global.localStorage = {
+  store: {},
+  getItem(k) {
+    return this.store[k] || null;
+  },
+  setItem(k, v) {
+    this.store[k] = String(v);
+  },
+  removeItem(k) {
+    delete this.store[k];
+  },
+};
+
+describe('LocalRepo', () => {
+  it('seeds dummy goals', async () => {
+    const repo = new LocalRepo();
+    repo.seedDummy();
+    const goals = await repo.goals.list();
+    expect(goals.length).toBeGreaterThan(0);
+  });
+});

--- a/src/pages/Auth.jsx
+++ b/src/pages/Auth.jsx
@@ -1,0 +1,144 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '../lib/supabase';
+import { useNavigate, useLocation } from 'react-router-dom';
+
+export default function AuthPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [tab, setTab] = useState('login');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [name, setName] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      if (data.session) {
+        navigate('/dashboard');
+      }
+    });
+  }, [navigate]);
+
+  const handleLogin = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) setError(error.message);
+    else {
+      const from = location.state?.from?.pathname || '/dashboard';
+      navigate(from);
+    }
+    setLoading(false);
+  };
+
+  const handleRegister = async (e) => {
+    e.preventDefault();
+    if (password !== confirm) {
+      setError('Password tidak cocok');
+      return;
+    }
+    setLoading(true);
+    setError('');
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: { data: { name } },
+    });
+    if (error) setError(error.message);
+    else setTab('login');
+    setLoading(false);
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-4 space-y-4">
+      <div className="flex gap-2">
+        <button
+          className={`flex-1 py-2 ${tab === 'login' ? 'bg-brand text-white' : 'border'}`}
+          onClick={() => setTab('login')}
+        >
+          Login
+        </button>
+        <button
+          className={`flex-1 py-2 ${tab === 'register' ? 'bg-brand text-white' : 'border'}`}
+          onClick={() => setTab('register')}
+        >
+          Register
+        </button>
+      </div>
+      {tab === 'login' && (
+        <form onSubmit={handleLogin} className="space-y-3">
+          <input
+            type="email"
+            className="w-full p-2 border rounded"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+          <input
+            type="password"
+            className="w-full p-2 border rounded"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            minLength={8}
+          />
+          <button
+            disabled={loading}
+            className="w-full btn btn-primary disabled:opacity-50"
+          >
+            {loading ? '...' : 'Login'}
+          </button>
+        </form>
+      )}
+      {tab === 'register' && (
+        <form onSubmit={handleRegister} className="space-y-3">
+          <input
+            className="w-full p-2 border rounded"
+            placeholder="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+          <input
+            type="email"
+            className="w-full p-2 border rounded"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+          <input
+            type="password"
+            className="w-full p-2 border rounded"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            minLength={8}
+          />
+          <input
+            type="password"
+            className="w-full p-2 border rounded"
+            placeholder="Confirm Password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            required
+            minLength={8}
+          />
+          <button
+            disabled={loading}
+            className="w-full btn btn-primary disabled:opacity-50"
+          >
+            {loading ? '...' : 'Register'}
+          </button>
+        </form>
+      )}
+      {error && <p className="text-sm text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/src/pages/Goals.jsx
+++ b/src/pages/Goals.jsx
@@ -1,24 +1,15 @@
-import GoalList from "../components/GoalList";
-import EnvelopeManager from "../components/EnvelopeManager";
-import AutoAllocationRules from "../components/AutoAllocationRules";
+import GoalList from '../components/GoalList';
+import useGoals from '../hooks/useGoals';
 
-export default function Goals({
-  goals,
-  envelopes,
-  rules,
-  onAddGoal,
-  onAddEnvelope,
-  onSaveRules,
-}) {
+export default function GoalsPage() {
+  const { goals, addGoal, updateGoal, deleteGoal } = useGoals();
   return (
-    <div className="p-4 space-y-8">
-      <GoalList goals={goals} onSave={onAddGoal} />
-      <EnvelopeManager envelopes={envelopes} onSave={onAddEnvelope} />
-      <AutoAllocationRules
+    <div className="p-4">
+      <GoalList
         goals={goals}
-        envelopes={envelopes}
-        rules={rules}
-        onSave={onSaveRules}
+        onAdd={addGoal}
+        onUpdate={updateGoal}
+        onDelete={deleteGoal}
       />
     </div>
   );

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabase';
+
+export default function ProfilePage() {
+  const [user, setUser] = useState(null);
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => setUser(data.user));
+  }, []);
+  if (!user) return <div className="p-4">Belum login.</div>;
+  return (
+    <div className="p-4 space-y-2">
+      <h1 className="text-xl font-semibold">Profile</h1>
+      <div>
+        <strong>Name:</strong> {user.user_metadata?.name || '-'}
+      </div>
+      <div>
+        <strong>Email:</strong> {user.email}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,0 +1,28 @@
+import { useDataMode, useRepo } from '../context/DataContext';
+
+export default function SettingsPage() {
+  const { mode, setMode } = useDataMode();
+  const repo = useRepo();
+  const seed = () => repo.seedDummy && repo.seedDummy();
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">Settings</h1>
+      <label className="block">
+        <span className="mr-2">Data Mode</span>
+        <select
+          value={mode}
+          onChange={(e) => setMode(e.target.value)}
+          className="border rounded p-1"
+        >
+          <option value="cloud">Cloud</option>
+          <option value="local">Local</option>
+        </select>
+      </label>
+      {mode === 'local' && (
+        <button className="btn" onClick={seed}>
+          Seed dummy data
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce repository pattern with cloud/local data modes and seeding utilities
- refactor goals into card-based UI with progress bar
- add auth, profile and settings pages

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7a68f95148332881823eca89f0633