### PR TITLE
feat(dashboard): insights, trend charts, and top spends

### DIFF
--- a/src/components/CategoryDonut.jsx
+++ b/src/components/CategoryDonut.jsx
@@ -1,0 +1,46 @@
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip, Legend } from "recharts";
+
+function toRupiah(n = 0) {
+  return new Intl.NumberFormat("id-ID", {
+    style: "currency",
+    currency: "IDR",
+    minimumFractionDigits: 0,
+  }).format(n);
+}
+
+const COLORS = ["#dc2626", "#f97316", "#eab308", "#16a34a", "#0ea5e9", "#6366f1", "#d946ef", "#475569"];
+
+export default function CategoryDonut({ data = [] }) {
+  const renderTooltip = ({ payload }) => {
+    if (!payload?.length) return null;
+    const p = payload[0];
+    return (
+      <div className="rounded bg-white p-2 text-xs shadow">
+        {p.name}: {toRupiah(p.value)}
+      </div>
+    );
+  };
+
+  return (
+    <div className="card h-[260px]">
+      {data.length ? (
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie data={data} dataKey="value" innerRadius="60%" outerRadius="80%">
+              {data.map((entry, i) => (
+                <Cell key={i} fill={COLORS[i % COLORS.length]} />
+              ))}
+            </Pie>
+            <Tooltip content={renderTooltip} />
+            <Legend />
+          </PieChart>
+        </ResponsiveContainer>
+      ) : (
+        <div className="flex h-full items-center justify-center text-sm text-slate-500">
+          Tidak ada data
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/KpiCards.jsx
+++ b/src/components/KpiCards.jsx
@@ -1,0 +1,33 @@
+function toRupiah(n = 0) {
+  return new Intl.NumberFormat("id-ID", {
+    style: "currency",
+    currency: "IDR",
+    minimumFractionDigits: 0,
+  }).format(n);
+}
+
+export default function KpiCards({ income = 0, expense = 0, net = 0, avgDaily = 0 }) {
+  return (
+    <div className="card">
+      <div className="grid gap-4 text-center sm:grid-cols-4">
+        <div className="space-y-1">
+          <div className="text-sm">Pemasukan</div>
+          <div className="text-lg font-semibold text-green-600">{toRupiah(income)}</div>
+        </div>
+        <div className="space-y-1">
+          <div className="text-sm">Pengeluaran</div>
+          <div className="text-lg font-semibold text-red-600">{toRupiah(expense)}</div>
+        </div>
+        <div className="space-y-1">
+          <div className="text-sm">Saldo</div>
+          <div className="text-lg font-semibold text-blue-600">{toRupiah(net)}</div>
+        </div>
+        <div className="space-y-1">
+          <div className="text-sm">Rata-rata/Hari</div>
+          <div className="text-lg font-semibold">{toRupiah(avgDaily)}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/MonthlyTrendChart.jsx
+++ b/src/components/MonthlyTrendChart.jsx
@@ -1,0 +1,37 @@
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid } from "recharts";
+
+function toRupiah(n = 0) {
+  return new Intl.NumberFormat("id-ID", {
+    style: "currency",
+    currency: "IDR",
+    minimumFractionDigits: 0,
+  }).format(n);
+}
+
+export default function MonthlyTrendChart({ data = [] }) {
+  const renderTooltip = ({ payload, label }) => {
+    if (!payload?.length) return null;
+    const p = payload[0];
+    return (
+      <div className="rounded bg-white p-2 text-xs shadow">
+        <div>{label}</div>
+        <div>{toRupiah(p.value)}</div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="card h-[260px]">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="month" />
+          <YAxis />
+          <Tooltip content={renderTooltip} />
+          <Line type="monotone" dataKey="net" stroke="#3898f8" />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+

--- a/src/components/TopSpendsTable.jsx
+++ b/src/components/TopSpendsTable.jsx
@@ -1,0 +1,59 @@
+import { useMemo, useState } from "react";
+
+function toRupiah(n = 0) {
+  return new Intl.NumberFormat("id-ID", {
+    style: "currency",
+    currency: "IDR",
+    minimumFractionDigits: 0,
+  }).format(n);
+}
+
+export default function TopSpendsTable({ data = [], onSelect }) {
+  const [sort, setSort] = useState("desc");
+
+  const sorted = useMemo(() => {
+    return [...data].sort((a, b) =>
+      sort === "asc" ? a.amount - b.amount : b.amount - a.amount
+    );
+  }, [data, sort]);
+
+  const toggleSort = () => setSort((s) => (s === "asc" ? "desc" : "asc"));
+
+  return (
+    <div className="card">
+      <div className="mb-2 flex items-center justify-between">
+        <h2 className="font-semibold">Top Pengeluaran</h2>
+        <button className="btn" onClick={toggleSort}>
+          Sort {sort === "asc" ? "↑" : "↓"}
+        </button>
+      </div>
+      <div className="table-wrap overflow-auto">
+        <table className="min-w-full text-sm">
+          <thead className="text-left">
+            <tr>
+              <th className="p-2">Catatan</th>
+              <th className="p-2">Tanggal</th>
+              <th className="p-2 text-right">Jumlah</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((t) => (
+              <tr
+                key={t.id}
+                className="cursor-pointer hover:bg-slate-50"
+                onClick={() => onSelect && onSelect(t)}
+              >
+                <td className="p-2">{t.note || t.category || "-"}</td>
+                <td className="p-2">{t.date}</td>
+                <td className="p-2 text-right text-red-600">
+                  {toRupiah(t.amount)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+

--- a/src/hooks/useInsights.js
+++ b/src/hooks/useInsights.js
@@ -1,0 +1,70 @@
+import { useMemo } from "react";
+
+export function aggregateInsights(txs = []) {
+  const today = new Date();
+  const monthStr = today.toISOString().slice(0, 7);
+
+  const monthTx = txs.filter((t) => String(t.date).slice(0, 7) === monthStr);
+  const income = monthTx
+    .filter((t) => t.type === "income")
+    .reduce((s, t) => s + Number(t.amount || 0), 0);
+  const expense = monthTx
+    .filter((t) => t.type === "expense")
+    .reduce((s, t) => s + Number(t.amount || 0), 0);
+  const net = income - expense;
+  const day = today.getDate();
+  const avgDaily = day ? expense / day : 0;
+
+  // trend last 6 months (including current)
+  const trendMap = {};
+  const start = new Date(today.getFullYear(), today.getMonth() - 5, 1);
+  for (const t of txs) {
+    const d = new Date(t.date);
+    if (d < start || d > today) continue;
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+    if (!trendMap[key]) trendMap[key] = { month: key, income: 0, expense: 0 };
+    trendMap[key][t.type] += Number(t.amount || 0);
+  }
+  const trend = Array.from({ length: 6 }).map((_, i) => {
+    const d = new Date(today.getFullYear(), today.getMonth() - 5 + i, 1);
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+    const entry = trendMap[key] || { month: key, income: 0, expense: 0 };
+    return { month: key, net: entry.income - entry.expense };
+  });
+
+  // category breakdown for current month
+  const catMap = monthTx
+    .filter((t) => t.type === "expense")
+    .reduce((acc, t) => {
+      const key = t.category || "Lainnya";
+      acc[key] = (acc[key] || 0) + Number(t.amount || 0);
+      return acc;
+    }, {});
+  const categories = Object.entries(catMap).map(([name, value]) => ({ name, value }));
+
+  // top spends for current month
+  const topSpends = monthTx
+    .filter((t) => t.type === "expense")
+    .sort((a, b) => Number(b.amount || 0) - Number(a.amount || 0))
+    .slice(0, 10);
+
+  return {
+    kpis: { income, expense, net, avgDaily },
+    trend,
+    categories,
+    topSpends,
+  };
+}
+
+const cache = new Map();
+
+export default function useInsights(txs = []) {
+  const key = txs.map((t) => `${t.id || t.date}-${t.amount}-${t.type}`).join("|");
+  return useMemo(() => {
+    if (cache.has(key)) return cache.get(key);
+    const data = aggregateInsights(txs);
+    cache.set(key, data);
+    return data;
+  }, [key, txs]);
+}
+

--- a/src/hooks/useInsights.test.js
+++ b/src/hooks/useInsights.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { aggregateInsights } from "./useInsights";
+
+describe("aggregateInsights", () => {
+  beforeAll(() => {
+    vi.setSystemTime(new Date("2024-06-15"));
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  const txs = [
+    { id: 1, date: "2024-06-01", type: "income", amount: 1000 },
+    { id: 2, date: "2024-06-02", type: "expense", amount: 200, category: "Food", note: "A" },
+    { id: 3, date: "2024-06-03", type: "expense", amount: 300, category: "Transport", note: "B" },
+    { id: 4, date: "2024-06-04", type: "expense", amount: 400, category: "Food", note: "C" },
+    { id: 5, date: "2024-05-10", type: "income", amount: 1000 },
+    { id: 6, date: "2024-05-11", type: "expense", amount: 500 },
+    { id: 7, date: "2024-04-10", type: "income", amount: 1000 },
+    { id: 8, date: "2024-04-11", type: "expense", amount: 900 },
+    { id: 9, date: "2024-03-10", type: "income", amount: 1000 },
+    { id: 10, date: "2024-03-11", type: "expense", amount: 300 },
+    { id: 11, date: "2024-02-10", type: "income", amount: 1000 },
+    { id: 12, date: "2024-02-11", type: "expense", amount: 700 },
+    { id: 13, date: "2024-01-10", type: "income", amount: 1000 },
+    { id: 14, date: "2024-01-11", type: "expense", amount: 1200 },
+  ];
+
+  it("calculates kpis", () => {
+    const res = aggregateInsights(txs);
+    expect(res.kpis.income).toBe(1000);
+    expect(res.kpis.expense).toBe(900);
+    expect(res.kpis.net).toBe(100);
+    expect(res.kpis.avgDaily).toBeCloseTo(60, 0);
+  });
+
+  it("builds 6 month trend", () => {
+    const res = aggregateInsights(txs);
+    expect(res.trend).toHaveLength(6);
+    expect(res.trend[5]).toEqual({ month: "2024-06", net: 100 });
+  });
+
+  it("aggregates categories", () => {
+    const res = aggregateInsights(txs);
+    const food = res.categories.find((c) => c.name === "Food");
+    const transport = res.categories.find((c) => c.name === "Transport");
+    expect(food.value).toBe(600);
+    expect(transport.value).toBe(300);
+  });
+
+  it("lists top spends", () => {
+    const res = aggregateInsights(txs);
+    expect(res.topSpends.map((t) => t.amount)).toEqual([400, 300, 200]);
+  });
+});

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -17,6 +17,11 @@ import useFinanceSummary from "../hooks/useFinanceSummary";
 import useWalletStatus from "../hooks/useWalletStatus";
 import LateMonthMode from "../components/LateMonthMode";
 import useLateMonthMode from "../hooks/useLateMonthMode";
+import KpiCards from "../components/KpiCards";
+import MonthlyTrendChart from "../components/MonthlyTrendChart";
+import CategoryDonut from "../components/CategoryDonut";
+import TopSpendsTable from "../components/TopSpendsTable";
+import useInsights from "../hooks/useInsights";
 
 
 import AvatarLevel from "../components/AvatarLevel.jsx";
@@ -58,6 +63,7 @@ export default function Dashboard({
   const lateMode = useLateMonthMode({ balance: finance.balance, avgMonthlyExpense: finance.avgMonthlyExpense }, prefs);
   const [walletOpen, setWalletOpen] = useState(false);
   const { speak } = useMoneyTalk();
+  const insights = useInsights(txs);
 
   const summary = useMemo(() => {
     const today = new Date();
@@ -182,6 +188,15 @@ export default function Dashboard({
       <AchievementBadges stats={stats} streak={streak} target={savingsTarget} />
       <SmartFinancialInsights txs={txs} />
       <QuickActions />
+      <KpiCards {...insights.kpis} />
+      <div className="grid gap-4 md:grid-cols-2">
+        <MonthlyTrendChart data={insights.trend} />
+        <CategoryDonut data={insights.categories} />
+      </div>
+      <TopSpendsTable
+        data={insights.topSpends}
+        onSelect={(t) => EventBus.emit("tx:open", t)}
+      />
       <div className="grid gap-4 md:grid-cols-2">
         <DashboardCharts month={monthForReport} txs={txs} />
         <RecentTransactions txs={txs} />


### PR DESCRIPTION
## Summary
- aggregate dashboard insights with memoized hook and tests
- add KPI cards, monthly net trend line chart, category donut, and sortable top spend table
- surface new insight widgets on dashboard with transaction detail links

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7c4be6af48332850d2dece6d768fd