### PR TITLE
feat(sync): online-first data layer with offline queue + auto flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ Run unit tests with:
 pnpm test
 ```
 
+## Online-first Sync
+
+The app now writes to Supabase when online and queues operations when offline.
+Data is cached locally so reads still work without a connection. Pending
+operations are flushed automatically on reconnect. To reset all cached data and
+the offline queue, run the following in the browser console:
+
+```js
+import("./lib/sync/localdb.js").then((m) => m.clearAll());
+```
+
 ## Data Mode
 
 HematWoi now supports a cloud or local data mode. The default mode uses

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "clsx": "^2.1.1",
     "html2canvas": "^1.4.1",
     "jspdf": "^2.5.1",
+    "localforage": "^1.10.0",
     "lucide-react": "^0.474.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       jspdf:
         specifier: ^2.5.1
         version: 2.5.1
+      localforage:
+        specifier: ^1.10.0
+        version: 1.10.0
       lucide-react:
         specifier: ^0.474.0
         version: 0.474.0(react@19.1.1)
@@ -1297,6 +1300,9 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -1402,6 +1408,9 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lie@3.1.1:
+    resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
+
   lightningcss-darwin-arm64@1.30.1:
     resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
     engines: {node: '>= 12.0.0'}
@@ -1472,6 +1481,9 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  localforage@1.10.0:
+    resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -3288,6 +3300,8 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  immediate@3.0.6: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -3399,6 +3413,10 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lie@3.1.1:
+    dependencies:
+      immediate: 3.0.6
+
   lightningcss-darwin-arm64@1.30.1:
     optional: true
 
@@ -3448,6 +3466,10 @@ snapshots:
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
+
+  localforage@1.10.0:
+    dependencies:
+      lie: 3.1.1
 
   locate-path@6.0.0:
     dependencies:

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ import ChallengesPage from "./pages/Challenges.jsx";
 import useChallenges from "./hooks/useChallenges.js";
 import AuthGuard from "./components/AuthGuard";
 import { DataProvider } from "./context/DataContext";
+import SyncBanner from "./components/SyncBanner.jsx";
 
 import { supabase } from "./lib/supabase";
 import { playChaChing } from "./lib/walletSound";
@@ -900,6 +901,7 @@ export default function App() {
     <UserProfileProvider>
       <ToastProvider>
         <DataProvider>
+          <SyncBanner />
           <AppContent />
         </DataProvider>
       </ToastProvider>

--- a/src/components/SyncBanner.jsx
+++ b/src/components/SyncBanner.jsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+import useNetworkStatus from "../hooks/useNetworkStatus.js";
+import syncEngine from "../lib/sync/SyncEngine.js";
+
+export default function SyncBanner() {
+  const online = useNetworkStatus();
+  const [status, setStatus] = useState(syncEngine.syncing ? "syncing" : "idle");
+  useEffect(() => syncEngine.onStatus(setStatus), []);
+  const text = !online
+    ? "Offline"
+    : status === "syncing"
+    ? "Syncing..."
+    : "All synced";
+  const bg = !online
+    ? "bg-red-500"
+    : status === "syncing"
+    ? "bg-yellow-500"
+    : "bg-green-600";
+  return (
+    <div className={`fixed top-0 inset-x-0 z-50 text-center text-white text-xs py-1 ${bg}`}>
+      {text}
+    </div>
+  );
+}

--- a/src/hooks/useNetworkStatus.js
+++ b/src/hooks/useNetworkStatus.js
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+
+export default function useNetworkStatus() {
+  const [online, setOnline] = useState(navigator.onLine);
+  useEffect(() => {
+    const goOnline = () => setOnline(true);
+    const goOffline = () => setOnline(false);
+    window.addEventListener("online", goOnline);
+    window.addEventListener("offline", goOffline);
+    return () => {
+      window.removeEventListener("online", goOnline);
+      window.removeEventListener("offline", goOffline);
+    };
+  }, []);
+  return online;
+}

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,28 +1,40 @@
 // src/lib/api.js
 import { supabase } from "./supabase";
+import syncEngine, { normalize } from "./sync/SyncEngine.js";
+import * as localdb from "./sync/localdb.js";
 
 /**
- * List transaksi dari Supabase dengan filter & pagination.
- * @param {Object} opts
- * @param {"income"|"expense"|"all"|undefined} opts.type
- * @param {string|undefined} opts.month - "YYYY-MM" atau "all"
- * @param {string|undefined} opts.q - query pencarian
- * @param {number} opts.page - mulai 1
- * @param {number} opts.pageSize - default 20
- * @returns {{rows: Array, total: number, page: number, pageSize: number}}
+ * List transaksi dengan filter & pagination.
  */
 export async function listTransactions(
-  { type, month, q, page = 1, pageSize = 20 } = {}
+  { type, month, q, page = 1, pageSize = 20 } = {},
 ) {
+  if (!navigator.onLine) {
+    let rows = await localdb.getCache("transactions");
+    rows = rows.map((t) => ({ ...t }));
+    if (type && type !== "all") rows = rows.filter((r) => r.type === type);
+    if (month && month !== "all") rows = rows.filter((r) => r.date.startsWith(month));
+    if (q && q.trim()) {
+      const like = q.toLowerCase();
+      rows = rows.filter(
+        (r) =>
+          r.note?.toLowerCase().includes(like) ||
+          r.category?.toLowerCase().includes(like),
+      );
+    }
+    const total = rows.length;
+    const from = (page - 1) * pageSize;
+    const paged = rows.slice(from, from + pageSize);
+    return { rows: paged, total, page, pageSize };
+  }
+
   let query = supabase
     .from("transactions")
     .select(
-      // ambil kategori via FK alias `categories`
       "id,date,type,amount,note,category_id,categories:category_id (name)",
-      { count: "exact" }
+      { count: "exact" },
     )
     .order("date", { ascending: false });
-
   if (type && type !== "all") {
     query = query.eq("type", type);
   }
@@ -34,73 +46,66 @@ export async function listTransactions(
   }
   if (q && q.trim()) {
     const like = `%${q}%`;
-    // cari di note atau nama kategori
     query = query.or(`note.ilike.${like},categories.name.ilike.${like}`);
   }
-
   const from = (page - 1) * pageSize;
   const to = from + pageSize - 1;
-
   const { data, error, count } = await query.range(from, to);
   if (error) throw error;
-
   const rows = (data || []).map((t) => ({
     ...t,
     category: t.categories?.name || null,
   }));
+  await localdb.setCache("transactions", rows);
   return { rows, total: count || 0, page, pageSize };
 }
 
 /**
  * Insert transaksi baru
- * @returns {Promise<Object>}
  */
 export async function addTransaction({ date, type, amount, note, category_id }) {
-  const { data, error } = await supabase
-    .from("transactions")
-    .insert({
-      date,
-      type,
-      amount,
-      note: note || null,
-      category_id: category_id || null,
-    })
-    .select("id,date,type,amount,note,category_id,categories:category_id (name)")
-    .single();
-  if (error) throw error;
-  return { ...data, category: data.categories?.name || null };
+  const record = normalize("transactions", {
+    date,
+    type,
+    amount,
+    note: note || null,
+    category_id: category_id || null,
+  });
+  await syncEngine.enqueueOrRun("transactions", "UPSERT", record);
+  const cats = await localdb.getCache("categories");
+  const category = cats.find((c) => c.id === record.category_id)?.name || null;
+  return { ...record, category };
 }
 
 /**
  * Update transaksi by id
- * @returns {Promise<Object>}
  */
 export async function updateTransaction(id, patch) {
-  const { data, error } = await supabase
-    .from("transactions")
-    .update(patch)
-    .eq("id", id)
-    .select("id,date,type,amount,note,category_id,categories:category_id (name)")
-    .single();
-  if (error) throw error;
-  return { ...data, category: data.categories?.name || null };
+  const record = normalize("transactions", { id, ...patch });
+  await syncEngine.enqueueOrRun("transactions", "UPSERT", record);
+  const cats = await localdb.getCache("categories");
+  const category = cats.find((c) => c.id === record.category_id)?.name || null;
+  return { ...record, category };
 }
 
 /**
  * Hapus transaksi by id
  */
 export async function deleteTransaction(id) {
-  const { error } = await supabase.from("transactions").delete().eq("id", id);
-  if (error) throw error;
+  await syncEngine.enqueueOrRun("transactions", "DELETE", { id });
 }
 
 // -- CATEGORIES ----------------------------------------
 
 /**
  * List kategori (opsional filter type)
- * @param {"income"|"expense"|undefined} type
  */
 export async function listCategories(type) {
+  if (!navigator.onLine) {
+    let rows = await localdb.getCache("categories");
+    if (type) rows = rows.filter((c) => c.type === type);
+    return rows;
+  }
   let query = supabase
     .from("categories")
     .select("id,type,name")
@@ -108,6 +113,7 @@ export async function listCategories(type) {
   if (type) query = query.eq("type", type);
   const { data, error } = await query;
   if (error) throw error;
+  await localdb.setCache("categories", data || []);
   return data || [];
 }
 
@@ -115,19 +121,13 @@ export async function listCategories(type) {
  * Tambah satu kategori
  */
 export async function addCategory({ type, name }) {
-  const { data, error } = await supabase
-    .from("categories")
-    .insert({ type, name })
-    .select("id,type,name")
-    .single();
-  if (error) throw error;
-  return data;
+  const record = normalize("categories", { type, name });
+  await syncEngine.enqueueOrRun("categories", "UPSERT", record);
+  return record;
 }
 
 /**
  * Upsert daftar kategori income/expense (idempotent)
- * @param {{income?: string[], expense?: string[]}} payload
- * @returns {Promise<Array<{id:string,type:string,name:string}>>}
  */
 export async function upsertCategories({ income = [], expense = [] }) {
   const { data: existing, error } = await supabase
@@ -154,6 +154,6 @@ export async function upsertCategories({ income = [], expense = [] }) {
     .select("id,type,name")
     .order("name", { ascending: true });
   if (errFinal) throw errFinal;
-
+  await localdb.setCache("categories", final || []);
   return final || [];
 }

--- a/src/lib/sync/SyncEngine.js
+++ b/src/lib/sync/SyncEngine.js
@@ -1,0 +1,126 @@
+import { supabase } from "../supabase";
+import * as db from "./localdb";
+import { calcBackoff, normalize } from "./utils.js";
+export { calcBackoff, normalize } from "./utils.js";
+
+class SyncEngine {
+  constructor() {
+    this.maxRetries = 5;
+    this.listeners = new Set();
+    this.syncing = false;
+  }
+
+  onStatus(fn) {
+    this.listeners.add(fn);
+    return () => this.listeners.delete(fn);
+  }
+
+  _notify(status) {
+    this.syncing = status === "syncing";
+    this.listeners.forEach((fn) => fn(status));
+  }
+
+  async enqueueOrRun(entity, type, payload) {
+    const record = normalize(entity, payload);
+    try {
+      if (!navigator.onLine) throw new Error("offline");
+      await this._apply(entity, type, record);
+      await this._applyCache(entity, type, record);
+      return { synced: true, record };
+    } catch {
+      const op = {
+        opId: crypto.randomUUID(),
+        entity,
+        type,
+        payload: record,
+        ts: Date.now(),
+      };
+      await db.enqueue(op);
+      await this._applyCache(entity, type, record);
+      return { queued: true, record };
+    }
+  }
+
+  async _apply(entity, type, record) {
+    if (type === "UPSERT") {
+      const { data: existing } = await supabase
+        .from(entity)
+        .select("rev")
+        .eq("id", record.id)
+        .single();
+      if (existing && existing.rev > record.rev) {
+        await db.logConflict({
+          entity,
+          id: record.id,
+          localRev: record.rev,
+          serverRev: existing.rev,
+        });
+      }
+      const { error } = await supabase
+        .from(entity)
+        .upsert(record, { onConflict: "id" });
+      if (error) throw error;
+    } else {
+      const { error } = await supabase.from(entity).delete().eq("id", record.id);
+      if (error) throw error;
+    }
+  }
+
+  async _applyCache(entity, type, record) {
+    const cache = await db.getCache(entity);
+    const idx = cache.findIndex((r) => r.id === record.id);
+    if (type === "UPSERT") {
+      if (idx >= 0) cache[idx] = { ...cache[idx], ...record };
+      else cache.push(record);
+    } else if (idx >= 0) {
+      cache.splice(idx, 1);
+    }
+    await db.setCache(entity, cache);
+  }
+
+  async refreshEntityCache(entity) {
+    if (!navigator.onLine) return;
+    const { data, error } = await supabase.from(entity).select("*");
+    if (error) throw error;
+    await db.setCache(entity, data || []);
+  }
+
+  async flushQueue() {
+    if (this.syncing) return;
+    const queue = await db.getQueue();
+    if (!queue.length) return;
+    this._notify("syncing");
+    const remaining = [];
+    for (const op of queue) {
+      const ok = await this._runWithRetry(op);
+      if (!ok) remaining.push(op);
+    }
+    await db.setQueue(remaining);
+    const processed = new Set(
+      queue.filter((op) => !remaining.includes(op)).map((op) => op.entity)
+    );
+    for (const e of processed) {
+      await this.refreshEntityCache(e);
+    }
+    this._notify("idle");
+  }
+
+  async _runWithRetry(op) {
+    for (let attempt = 0; attempt < this.maxRetries; attempt++) {
+      try {
+        await this._apply(op.entity, op.type, op.payload);
+        return true;
+      } catch (err) {
+        if (attempt === this.maxRetries - 1) {
+          await db.logConflict({ op, error: err.message });
+          return false;
+        }
+        await new Promise((res) => setTimeout(res, calcBackoff(attempt)));
+      }
+    }
+  }
+}
+
+const engine = new SyncEngine();
+export default engine;
+export { SyncEngine };

--- a/src/lib/sync/localdb.js
+++ b/src/lib/sync/localdb.js
@@ -1,0 +1,51 @@
+import localforage from "localforage";
+
+const cache = localforage.createInstance({
+  name: "hw-sync",
+  storeName: "cache",
+});
+
+const oplog = localforage.createInstance({
+  name: "hw-sync",
+  storeName: "oplog",
+});
+
+const conflicts = localforage.createInstance({
+  name: "hw-sync",
+  storeName: "conflicts",
+});
+
+export async function getCache(entity) {
+  return (await cache.getItem(entity)) || [];
+}
+
+export async function setCache(entity, rows) {
+  await cache.setItem(entity, rows);
+}
+
+export async function enqueue(op) {
+  const q = (await oplog.getItem("queue")) || [];
+  q.push(op);
+  await oplog.setItem("queue", q);
+}
+
+export async function getQueue() {
+  return (await oplog.getItem("queue")) || [];
+}
+
+export async function setQueue(q) {
+  await oplog.setItem("queue", q);
+}
+
+export async function logConflict(c) {
+  const list = (await conflicts.getItem("list")) || [];
+  list.push(c);
+  await conflicts.setItem("list", list);
+}
+
+export async function clearAll() {
+  await cache.clear();
+  await oplog.clear();
+  await conflicts.clear();
+}
+

--- a/src/lib/sync/utils.js
+++ b/src/lib/sync/utils.js
@@ -1,0 +1,11 @@
+export function calcBackoff(attempt) {
+  return Math.min(30000, 500 * 2 ** attempt);
+}
+
+export function normalize(_entity, payload) {
+  return {
+    id: payload.id || crypto.randomUUID(),
+    rev: payload.rev || 0,
+    ...payload,
+  };
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,11 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
+import syncEngine from "./lib/sync/SyncEngine.js";
+
+syncEngine.flushQueue();
+window.addEventListener("online", () => syncEngine.flushQueue());
+setInterval(() => syncEngine.flushQueue(), 10000);
 
 createRoot(document.getElementById("root")).render(
   <BrowserRouter>

--- a/tests/sync/utils.test.js
+++ b/tests/sync/utils.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { calcBackoff, normalize } from "../../src/lib/sync/utils.js";
+
+describe("calcBackoff", () => {
+  it("doubles delay", () => {
+    expect(calcBackoff(0)).toBe(500);
+    expect(calcBackoff(1)).toBe(1000);
+    expect(calcBackoff(2)).toBe(2000);
+  });
+});
+
+describe("normalize", () => {
+  it("adds id and rev", () => {
+    const rec = normalize("transactions", { amount: 1 });
+    expect(rec.id).toBeTruthy();
+    expect(rec.rev).toBe(0);
+  });
+  it("keeps existing", () => {
+    const rec = normalize("transactions", { id: "x", rev: 2 });
+    expect(rec.id).toBe("x");
+    expect(rec.rev).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add SyncEngine using IndexedDB for offline queue and entity cache
- implement network status hook and banner to show online/offline/syncing
- wrap API calls for transactions and categories with online-first sync logic

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7cc3a259c8332af2738f910399771