### PR TITLE
feat: dashboard cleanup and profile avatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ Dark mode is supported via the `dark` class on `<html>`.
 
 These components aim to keep spacing and typography consistent across pages.
 
+## Dashboard & Profile
+
+- Wallet avatar and finance mascot icons now appear on a single centred row.
+- Avatar level and XP controls moved from the dashboard to the new Profile page.
+- Daily quote card simplified with no category selector or repeat button.
+
 ## Settings & Preferences
 
 The `/settings` page groups application preferences into:

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -818,7 +818,10 @@ function AppShell({ prefs, setPrefs }) {
               }
             />
             <Route path="/settings" element={<SettingsPage />} />
-            <Route path="/profile" element={<ProfilePage />} />
+            <Route
+              path="/profile"
+              element={<ProfilePage transactions={data.txs} challenges={challenges} />}
+            />
           </Route>
         </Routes>
       </main>

--- a/src/components/DailyQuote.jsx
+++ b/src/components/DailyQuote.jsx
@@ -2,36 +2,17 @@ import { useDailyQuote } from "../hooks/useDailyQuote";
 import "./Animations.css";
 
 export default function DailyQuote({ lang = "id" }) {
-  const { quote, shuffle, category, setCategory } = useDailyQuote({ lang });
+  const { quote } = useDailyQuote({ lang });
   if (!quote) return null;
   const icons = { motivasi: "💡", humor: "😄", tips: "🛟" };
   return (
-    <div className="card space-y-3" role="region" aria-label="Daily quote">
-      <div className="flex items-start justify-between gap-4">
-        <p key={quote.id} className="flex-1 animate-fade">
-          <span className="mr-2" aria-hidden>{icons[quote.category]}</span>
-          {quote.text}
-        </p>
-        <button onClick={shuffle} className="btn btn-secondary text-sm">
-          Ulangi
-        </button>
-      </div>
-      <div className="flex items-center gap-2">
-        <label htmlFor="quote-category" className="sr-only">
-          Kategori
-        </label>
-        <select
-          id="quote-category"
-          className="input w-auto"
-          value={category}
-          onChange={(e) => setCategory(e.target.value)}
-        >
-          <option value="all">Semua</option>
-          <option value="motivasi">Motivasi</option>
-          <option value="humor">Humor</option>
-          <option value="tips">Tips</option>
-        </select>
-      </div>
+    <div className="card" role="region" aria-label="Daily quote">
+      <p key={quote.id} className="text-center animate-fade">
+        <span className="mr-2" aria-hidden>
+          {icons[quote.category]}
+        </span>
+        {quote.text}
+      </p>
     </div>
   );
 }

--- a/src/lib/sync/SyncEngine.js
+++ b/src/lib/sync/SyncEngine.js
@@ -1,7 +1,7 @@
 import { supabase } from "../supabase";
 import { dbCache, oplogStore } from "./localdb";
 import { processStoragePutBatch } from "./attachments";
-import { calcBackoff, groupOps, normalizeRecord, resolveConflict } from "./utils";
+import { calcBackoff, groupOps, normalizeRecord } from "./utils";
 
 export const SYNC_INTERVAL_MS = 20000;
 export const SYNC_BATCH_SIZE = 100;

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -24,7 +24,6 @@ import TopSpendsTable from "../components/TopSpendsTable";
 import useInsights from "../hooks/useInsights";
 
 
-import AvatarLevel from "../components/AvatarLevel.jsx";
 import EventBus from "../lib/eventBus";
 import { useMoneyTalk } from "../context/MoneyTalkContext.jsx";
 
@@ -35,7 +34,6 @@ export default function Dashboard({
   txs,
   budgets,
   months = [],
-  challenges = [],
   prefs = {},
 }) {
   const streak = useMemo(() => {
@@ -150,39 +148,32 @@ export default function Dashboard({
       <PageHeader title="Dashboard" description="Ringkasan keuanganmu" />
       <LateMonthMode active={lateMode.active} onDismiss={lateMode.dismiss} onCreateChallenge={() => EventBus.emit("challenge:create", { days: 3 })} />
       <Summary stats={stats} />
-            <div className="relative flex justify-end">
-        <WalletAvatar
-          status={wallet.status}
-          trend={finance.weeklyTrend}
-          balance={finance.balance}
-          isOverBudget={finance.isAnyOverBudget}
-          soundEnabled={prefs?.walletSound}
-          onClick={() => setWalletOpen((o) => !o)}
-        />
-        {walletOpen && (
-          <WalletPanel
-            insights={{
-              balance: finance.balance,
-              weeklyTrend: finance.weeklyTrend,
-              topSpenderCategory: finance.topSpenderCategory,
-              tip: wallet.tip,
-            }}
-            showTips={prefs?.walletShowTips}
-            onClose={() => setWalletOpen(false)}
+      <div className="flex items-center justify-center gap-4">
+        <FinanceMascot summary={summary} budgets={budgets} onRefresh={() => {}} />
+        <div className="relative">
+          <WalletAvatar
+            status={wallet.status}
+            trend={finance.weeklyTrend}
+            balance={finance.balance}
+            isOverBudget={finance.isAnyOverBudget}
+            soundEnabled={prefs?.walletSound}
+            onClick={() => setWalletOpen((o) => !o)}
           />
-        )}
+          {walletOpen && (
+            <WalletPanel
+              insights={{
+                balance: finance.balance,
+                weeklyTrend: finance.weeklyTrend,
+                topSpenderCategory: finance.topSpenderCategory,
+                tip: wallet.tip,
+              }}
+              showTips={prefs?.walletShowTips}
+              onClose={() => setWalletOpen(false)}
+            />
+          )}
+        </div>
       </div>
-
-      <FinanceMascot summary={summary} budgets={budgets} onRefresh={() => {}} />
       <DailyStreak streak={streak} />
-        <AvatarLevel transactions={txs} challenges={challenges} />
-      <button
-        type="button"
-        onClick={() => EventBus.emit("xp:add", { code: "demo", amount: 10 })}
-        className="px-2 py-1 text-xs bg-emerald-500 text-white rounded"
-      >
-        +10 XP Demo
-      </button>
       <DailyQuote />
       <SavingsProgress current={stats?.balance || 0} target={savingsTarget} />
       <AchievementBadges stats={stats} streak={streak} target={savingsTarget} />

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,15 +1,25 @@
 import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabase';
+import AvatarLevel from '../components/AvatarLevel.jsx';
+import EventBus from '../lib/eventBus';
 
-export default function ProfilePage() {
+export default function ProfilePage({ transactions = [], challenges = [] }) {
   const [user, setUser] = useState(null);
   useEffect(() => {
     supabase.auth.getUser().then(({ data }) => setUser(data.user));
   }, []);
   if (!user) return <div className="p-4">Belum login.</div>;
   return (
-    <div className="p-4 space-y-2">
+    <div className="p-4 space-y-4">
       <h1 className="text-xl font-semibold">Profile</h1>
+      <AvatarLevel transactions={transactions} challenges={challenges} />
+      <button
+        type="button"
+        onClick={() => EventBus.emit('xp:add', { code: 'demo', amount: 10 })}
+        className="px-2 py-1 text-xs bg-emerald-500 text-white rounded"
+      >
+        +10 XP Demo
+      </button>
       <div>
         <strong>Name:</strong> {user.user_metadata?.name || '-'}
       </div>


### PR DESCRIPTION
## Summary
- align wallet and finance mascot icons on dashboard
- move avatar level and XP actions to new profile page
- simplify daily quote card
- document dashboard/profile refresh

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7ee41a1b08332827e8c1c3d0d6322