### PR TITLE
Polish dashboard KPI, quote, progress, and achievements

### DIFF
--- a/src/components/AchievementBadges.jsx
+++ b/src/components/AchievementBadges.jsx
@@ -37,15 +37,12 @@ export default function AchievementBadges({ stats = {}, streak = 0, target = 0 }
 
   return (
     <div className="card animate-slide">
-      <h2 className="font-semibold mb-2">Achievements</h2>
-      <ul className="space-y-2">
+      <h2 className="mb-2 font-semibold">Achievements</h2>
+      <ul className="divide-y divide-slate-200 text-sm dark:divide-slate-700">
         {badges.map((b) => (
-          <li
-            key={b.id}
-            className="flex items-center gap-2 text-sm bg-slate-50 dark:bg-slate-700 p-2 rounded"
-          >
+          <li key={b.id} className="flex items-center gap-2 py-1.5">
             {b.icon}
-            <span>{b.text}</span>
+            <span className="flex-1 leading-tight line-clamp-2">{b.text}</span>
           </li>
         ))}
       </ul>

--- a/src/components/KpiCard.jsx
+++ b/src/components/KpiCard.jsx
@@ -1,7 +1,12 @@
 import clsx from "clsx";
 import Card, { CardBody } from "./Card";
 
-export default function KpiCard({ label, value = "-", variant = "brand" }) {
+export default function KpiCard({
+  label,
+  value = "-",
+  variant = "brand",
+  loading = false,
+}) {
   const color =
     variant === "income" || variant === "success"
       ? "text-success"
@@ -12,8 +17,19 @@ export default function KpiCard({ label, value = "-", variant = "brand" }) {
   return (
     <Card className="text-center">
       <CardBody className="space-y-1">
-        <div className="text-sm text-muted">{label}</div>
-        <div className={clsx("text-2xl font-semibold", color)}>{value}</div>
+        <div className="text-sm text-muted whitespace-nowrap">{label}</div>
+        {loading ? (
+          <div className="mx-auto h-6 w-24 rounded bg-slate-200 dark:bg-slate-700 animate-pulse" />
+        ) : (
+          <div
+            className={clsx(
+              "text-2xl font-semibold whitespace-nowrap",
+              color
+            )}
+          >
+            {value}
+          </div>
+        )}
       </CardBody>
     </Card>
   );

--- a/src/components/KpiCards.jsx
+++ b/src/components/KpiCards.jsx
@@ -8,12 +8,32 @@ function toRupiah(n = 0) {
   }).format(n);
 }
 
-export default function KpiCards({ income = 0, expense = 0, net = 0 }) {
+export default function KpiCards({
+  income = 0,
+  expense = 0,
+  net = 0,
+  loading = false,
+}) {
   return (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      <KpiCard label="Pemasukan" value={toRupiah(income)} variant="success" />
-      <KpiCard label="Pengeluaran" value={toRupiah(expense)} variant="danger" />
-      <KpiCard label="Saldo" value={toRupiah(net)} variant="brand" />
+      <KpiCard
+        label="Pemasukan"
+        value={toRupiah(income)}
+        variant="success"
+        loading={loading}
+      />
+      <KpiCard
+        label="Pengeluaran"
+        value={toRupiah(expense)}
+        variant="danger"
+        loading={loading}
+      />
+      <KpiCard
+        label={net < 0 ? "Defisit" : "Saldo"}
+        value={toRupiah(net)}
+        variant={net < 0 ? "danger" : "brand"}
+        loading={loading}
+      />
     </div>
   );
 }

--- a/src/components/QuoteBubble.jsx
+++ b/src/components/QuoteBubble.jsx
@@ -10,14 +10,12 @@ export default function QuoteBubble({ lang = "id" }) {
   }
 
   return (
-    <figure className="mx-auto max-w-md">
-      <blockquote className="relative bg-brand/5 border border-brand/20 text-left rounded-xl p-4 shadow-sm after:absolute after:-bottom-2 after:left-6 after:h-4 after:w-4 after:rotate-45 after:bg-inherit after:border-b after:border-r after:border-brand/20 dark:bg-slate-800 dark:border-slate-700 dark:after:border-slate-700">
+    <figure className="mx-auto w-full max-w-3xl">
+      <blockquote className="relative w-full rounded-xl border border-brand/20 bg-brand/5 p-4 text-left shadow-sm dark:border-slate-700 dark:bg-slate-800">
         <span className="absolute -top-2 left-4 text-2xl text-brand" aria-hidden>
           “
         </span>
-        <p className="pr-2 pl-2 text-sm leading-relaxed line-clamp-3">
-          {quote.text}
-        </p>
+        <p className="px-4 text-sm leading-relaxed line-clamp-3">{quote.text}</p>
         <span className="absolute -bottom-2 right-4 text-2xl text-brand" aria-hidden>
           ”
         </span>

--- a/src/components/SavingsProgress.jsx
+++ b/src/components/SavingsProgress.jsx
@@ -2,44 +2,54 @@ import { useEffect, useState } from "react";
 import { CheckCircle } from "lucide-react";
 import "./Animations.css";
 
+const STORAGE_KEY = "savings-milestone-achieved";
+
 export default function SavingsProgress({ current = 0, target = 0 }) {
-  const progress = target ? Math.min(current / target, 1) : 0;
-  const [showCongrats, setShowCongrats] = useState(false);
+  const progress = target ? current / target : 0;
+  const [achieved, setAchieved] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return localStorage.getItem(STORAGE_KEY) === "true";
+  });
 
   useEffect(() => {
     if (progress >= 1) {
-      setShowCongrats(true);
-      const t = setTimeout(() => setShowCongrats(false), 3000);
-      return () => clearTimeout(t);
+      setAchieved(true);
+      if (typeof window !== "undefined") {
+        localStorage.setItem(STORAGE_KEY, "true");
+      }
+    } else {
+      setAchieved(false);
+      if (typeof window !== "undefined") {
+        localStorage.removeItem(STORAGE_KEY);
+      }
     }
   }, [progress]);
 
   return (
-    <div className="card relative animate-slide">
-      <h2 className="font-semibold mb-2 flex items-center gap-2">
-        <span>Progress Tabungan</span>
-        <span className="text-sm text-slate-500">
-          Rp {current.toLocaleString("id-ID")} / Rp {target.toLocaleString("id-ID")}
-        </span>
-      </h2>
+    <div className="card animate-slide">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <h2 className="font-semibold">Progress Tabungan</h2>
+        {achieved && (
+          <span className="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/20 dark:text-green-400">
+            <CheckCircle className="h-4 w-4" /> Milestone tercapai!
+          </span>
+        )}
+      </div>
+      <div className="mb-2 text-sm text-slate-500">
+        Rp {current.toLocaleString("id-ID")} / Rp {target.toLocaleString("id-ID")}
+      </div>
       <div
-        className="w-full h-3 bg-slate-200 dark:bg-slate-700 rounded"
+        className="h-3 w-full rounded bg-slate-200 dark:bg-slate-700"
         role="progressbar"
       >
         <div
-          className="h-3 bg-green-500 rounded"
-          style={{ width: `${progress * 100}%` }}
+          className="h-3 rounded bg-green-500"
+          style={{ width: `${Math.min(progress, 1) * 100}%` }}
         />
       </div>
-      <div className="text-sm mt-1">{Math.round(progress * 100)}% tercapai</div>
-      {showCongrats && (
-        <div className="absolute inset-0 flex items-center justify-center bg-black/50">
-          <div className="card flex items-center gap-2 animate-slide">
-            <CheckCircle className="text-green-500" />
-            <span>Milestone tercapai! 🎉</span>
-          </div>
-        </div>
-      )}
+      <div className="mt-1 text-sm">
+        {Math.round(Math.min(progress, 1) * 100)}% tercapai
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- unify saldo KPI styling and colors with consistent skeleton
- make quote bubble span full width with typographic quotes
- keep milestone label pinned when savings target is reached
- streamline achievements list with compact dividers

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7f706b7e4833282d32d7a64a6dfb1