### PR TITLE
feat: dashboard layout v3

### DIFF
--- a/docs/dashboard-layout.md
+++ b/docs/dashboard-layout.md
@@ -1,0 +1,21 @@
+# Dashboard Layout Guidelines
+
+## Two-Column Cards
+- Wrap related cards in `grid` container.
+- Breakpoints:
+  - `lg:grid-cols-12` for desktop.
+  - `md:grid-cols-2` for tablet.
+- Use column spans for proportion `7/12` and `5/12` on desktop:
+  - `lg:col-span-7` for Progress/Milestone card.
+  - `lg:col-span-5` for Achievements card.
+- Cards should stretch equally (`h-full`) and internal lists may scroll.
+
+## Action Tiles
+- Use `grid gap-3 md:grid-cols-2 lg:grid-cols-3` for responsive layout.
+- Each tile is a focusable link/button with:
+  - Circular brand-tinted icon (`bg-brand-500/10 text-brand-600`).
+  - Title and optional shortcut description.
+- States:
+  - `hover:shadow-md` for elevation.
+  - `focus:ring-2 focus:ring-brand-500 focus:ring-offset-2` for accessibility.
+  - `active:bg-surface-2` for pressed state.

--- a/src/components/AchievementBadges.jsx
+++ b/src/components/AchievementBadges.jsx
@@ -15,37 +15,44 @@ export default function AchievementBadges({ stats = {}, streak = 0, target = 0 }
   if (balance >= 500000) {
     badges.push({
       id: "saving",
-      icon: <Star className="w-4 h-4 text-yellow-500" />,
+      icon: <Star className="h-4 w-4 text-yellow-500" />,
       text: `Badge Hemat ${toRupiah(balance)} bulan ini 🎉`,
     });
   }
   if (target && balance >= target) {
     badges.push({
       id: "target",
-      icon: <Target className="w-4 h-4 text-green-500" />,
+      icon: <Target className="h-4 w-4 text-green-500" />,
       text: "Target tabungan tercapai 🎯",
     });
   }
   if (streak >= 3) {
     badges.push({
       id: "streak",
-      icon: <Award className="w-4 h-4 text-orange-500" />,
+      icon: <Award className="h-4 w-4 text-orange-500" />,
       text: `Streak ${streak} hari 🔥`,
     });
   }
   if (!badges.length) return null;
 
+  const visible = badges.slice(0, 4);
+  const hasMore = badges.length > 4;
+
   return (
-    <div className="card animate-slide">
-      <h2 className="font-semibold mb-2">Achievements</h2>
-      <ul className="space-y-2">
-        {badges.map((b) => (
-          <li
-            key={b.id}
-            className="flex items-center gap-2 text-sm bg-slate-50 dark:bg-slate-700 p-2 rounded"
-          >
+    <div className="card animate-slide h-full flex flex-col">
+      <div className="mb-2 flex items-center justify-between">
+        <h2 className="font-semibold">Achievements</h2>
+        {hasMore && (
+          <a href="#" className="text-xs text-brand-600 hover:underline">
+            Lihat semua
+          </a>
+        )}
+      </div>
+      <ul className="divide-y divide-slate-200 overflow-y-auto flex-1 min-h-0">
+        {visible.map((b) => (
+          <li key={b.id} className="flex items-center gap-2 py-2 text-sm">
             {b.icon}
-            <span>{b.text}</span>
+            <span className="line-clamp-1 sm:line-clamp-none">{b.text}</span>
           </li>
         ))}
       </ul>

--- a/src/components/QuickActions.jsx
+++ b/src/components/QuickActions.jsx
@@ -7,33 +7,41 @@ export default function QuickActions() {
       to: "/add",
       label: "Tambah Transaksi",
       icon: PlusCircle,
+      shortcut: "Ctrl/Cmd + T",
     },
     {
       to: "/budgets",
       label: "Tambah Budget",
       icon: Wallet,
+      shortcut: "Ctrl/Cmd + B",
     },
     {
       to: "/subscriptions",
       label: "Tambah Subscription",
       icon: CreditCard,
+      shortcut: "Ctrl/Cmd + S",
     },
   ];
 
   return (
     <div className="card">
-      <h2 className="font-semibold mb-3">Quick Actions</h2>
-      <div className="grid sm:grid-cols-3 gap-2">
+      <h2 className="mb-3 font-semibold">Quick Actions</h2>
+      <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
         {actions.map((action) => {
           const Icon = action.icon;
           return (
             <Link
               key={action.to}
               to={action.to}
-              className="btn btn-secondary justify-center"
+              className="group flex items-start gap-3 rounded-lg border p-3 transition shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 active:bg-surface-2"
             >
-              <Icon className="h-4 w-4" />
-              {action.label}
+              <span className="flex h-10 w-10 items-center justify-center rounded-full bg-brand-500/10 text-brand-600">
+                <Icon className="h-5 w-5" />
+              </span>
+              <span className="flex flex-col">
+                <span className="font-medium">{action.label}</span>
+                <span className="text-xs text-slate-500">{action.shortcut}</span>
+              </span>
             </Link>
           );
         })}

--- a/src/components/SavingsProgress.jsx
+++ b/src/components/SavingsProgress.jsx
@@ -25,8 +25,17 @@ export default function SavingsProgress({ current = 0, target = 0 }) {
     }
   }, [progress]);
 
+  if (!target) {
+    return (
+      <div className="card animate-slide">
+        <h2 className="font-semibold">Progress Tabungan</h2>
+        <p className="text-sm text-slate-500">Belum ada target tabungan</p>
+      </div>
+    );
+  }
+
   return (
-    <div className="card animate-slide">
+    <div className="card animate-slide h-full">
       <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
         <h2 className="font-semibold">Progress Tabungan</h2>
         {achieved && (

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -77,8 +77,21 @@ export default function Dashboard({
       <DailyStreak streak={streak} />
       <QuoteBubble />
       <SmartFinancialInsights txs={txs} />
-      <SavingsProgress current={stats?.balance || 0} target={savingsTarget} />
-      <AchievementBadges stats={stats} streak={streak} target={savingsTarget} />
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-12">
+        <div className="lg:col-span-7">
+          <SavingsProgress
+            current={stats?.balance || 0}
+            target={savingsTarget}
+          />
+        </div>
+        <div className="lg:col-span-5">
+          <AchievementBadges
+            stats={stats}
+            streak={streak}
+            target={savingsTarget}
+          />
+        </div>
+      </div>
       <QuickActions />
       <SectionHeader title="Analisis Bulanan" />
       <div className="grid gap-4 md:grid-cols-2">


### PR DESCRIPTION
## Summary
- display milestone progress and achievements side by side with responsive grid
- redesign quick actions into responsive action tiles with shortcuts
- document dashboard layout and action tile guidelines

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7fbf535b48332b0aff60a571fd7b5