### PR TITLE
feat: add css-variable theme system and controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,21 @@ Preferences are stored in `localStorage` under the `hw:prefs` key with the schem
 }
 ```
 
+## Theme System Guide
+
+Colors across the app are driven by CSS custom properties with light, dark and
+system modes. Key tokens include:
+
+- `--bg`, `--surface`, `--surface-2`, `--border`
+- `--text`, `--text-muted`, `--heading`
+- `--brand-h`, `--brand-s`, `--brand-l`, `--brand-foreground`
+
+User preferences are stored in `localStorage` under `hwTheme` with structure
+`{ mode: 'light' | 'dark' | 'system', brand: { h, s, l } }`. An inline script in
+`index.html` applies these settings before React mounts to prevent a flash of the
+default theme. Sidebar controls allow switching mode and picking a brand color,
+which updates the variables globally.
+
 ## Contributing
 
 Pull requests are welcome. Please run `pnpm test` before submitting to ensure

--- a/index.html
+++ b/index.html
@@ -5,6 +5,29 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
+    <script>
+      (() => {
+        try {
+          const stored = JSON.parse(localStorage.getItem('hwTheme') || '{}');
+          const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          const mode = stored.mode || 'system';
+          const theme = mode === 'system' ? (prefersDark ? 'dark' : 'light') : mode;
+          const root = document.documentElement;
+          root.setAttribute('data-theme', theme);
+          if (stored.brand) {
+            const b = stored.brand;
+            root.style.setProperty('--brand-h', b.h);
+            root.style.setProperty('--brand-s', b.s + '%');
+            root.style.setProperty('--brand-l', b.l + '%');
+            root.style.setProperty('--brand-foreground', b.l > 50 ? '#000000' : '#ffffff');
+            root.style.setProperty('--brand-soft', `hsl(${b.h} ${b.s}% ${Math.min(95, b.l + 40)}%)`);
+            root.style.setProperty('--brand-ring', `hsl(${b.h} ${b.s}% ${Math.max(0, b.l - 20)}%)`);
+          }
+        } catch (e) {
+          console.error('theme init failed', e);
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/index.css
+++ b/src/index.css
@@ -4,13 +4,47 @@
 
 @layer base {
   html { @apply scroll-smooth; }
-  body { @apply bg-surface-1 text-text transition-colors duration-300 dark:bg-slate-950 dark:text-slate-100; }
+  :root {
+    --bg: #f8fafc;
+    --surface: #ffffff;
+    --surface-2: #f1f5f9;
+    --border: #e2e8f0;
+    --muted: #94a3b8;
+    --text: #0f172a;
+    --text-muted: #64748b;
+    --heading: #0f172a;
+    --brand-h: 211;
+    --brand-s: 92%;
+    --brand-l: 60%;
+    --brand-foreground: #ffffff;
+    --brand-soft: hsl(var(--brand-h) var(--brand-s) 90%);
+    --brand-ring: hsl(var(--brand-h) var(--brand-s) 50%);
+    --success: #22c55e;
+    --warning: #f59e0b;
+    --danger: #ef4444;
+    --info: #3b82f6;
+    --ring: hsl(var(--brand-h) var(--brand-s) var(--brand-l));
+  }
+  [data-theme='dark'] {
+    --bg: #0f172a;
+    --surface: #1e293b;
+    --surface-2: #334155;
+    --border: #475569;
+    --muted: #94a3b8;
+    --text: #f1f5f9;
+    --text-muted: #94a3b8;
+    --heading: #f8fafc;
+    --brand-foreground: #ffffff;
+    --brand-soft: hsl(var(--brand-h) var(--brand-s) 20%);
+    --brand-ring: hsl(var(--brand-h) var(--brand-s) 70%);
+  }
+  body { @apply bg-bg text-text transition-colors duration-300; }
   h1, h2, h3, h4, h5, h6 { @apply font-semibold; }
 }
 
 @layer components {
   .card {
-    @apply bg-surface-2 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl shadow-sm p-4 md:p-6;
+    @apply bg-surface-2 border border-border rounded-xl shadow-sm p-4 md:p-6;
   }
 }
 

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,24 +1,27 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  darkMode: 'class',
+  darkMode: ['class', '[data-theme="dark"]'],
   content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: {
     extend: {
       colors: {
         brand: {
-          DEFAULT: '#3898f8',
-          300: '#50b6ff',
-          500: '#3898f8',
-          600: '#2584e4',
+          DEFAULT: 'hsl(var(--brand-h) var(--brand-s) var(--brand-l))',
+          foreground: 'var(--brand-foreground)',
+          soft: 'var(--brand-soft)',
+          ring: 'var(--brand-ring)'
         },
-        success: '#22c55e',
-        danger: '#ef4444',
-        surface: {
-          1: '#ffffff',
-          2: '#f1f5f9',
-        },
-        text: '#0f172a',
-        muted: '#94a3b8',
+        success: 'var(--success)',
+        warning: 'var(--warning)',
+        danger: 'var(--danger)',
+        info: 'var(--info)',
+        bg: 'var(--bg)',
+        'surface-1': 'var(--surface)',
+        'surface-2': 'var(--surface-2)',
+        border: 'var(--border)',
+        text: 'var(--text)',
+        muted: 'var(--text-muted)',
+        ring: 'var(--ring)'
       },
       fontSize: {
         h1: ['clamp(2rem,5vw,2.5rem)', { lineHeight: '1.2' }],


### PR DESCRIPTION
## Summary
- use semantic CSS custom properties for light and dark themes
- persist theme & brand settings and apply before React mounts
- add sidebar theme controls with mode toggle and brand color picker

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c804ae8a1c833288727287028a0796