### PR TITLE
fix(dashboard): normalize page/section spacing and grid gaps

### DIFF
--- a/src/components/KpiCards.jsx
+++ b/src/components/KpiCards.jsx
@@ -15,7 +15,7 @@ export default function KpiCards({
   loading = false,
 }) {
   return (
-    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div className="grid gap-[var(--block-y)] sm:grid-cols-2 lg:grid-cols-3">
       <KpiCard
         label="Pemasukan"
         value={toRupiah(income)}

--- a/src/index.css
+++ b/src/index.css
@@ -24,6 +24,9 @@
     --danger: #ef4444;
     --info: #3b82f6;
     --ring: hsl(var(--brand-h) var(--brand-s) var(--brand-l));
+    --page-y: clamp(16px, 4vw, 28px);
+    --section-y: clamp(12px, 3vw, 24px);
+    --block-y: clamp(8px, 2vw, 16px);
   }
   [data-theme='dark'] {
     --bg: #0f172a;

--- a/src/layout/Page.jsx
+++ b/src/layout/Page.jsx
@@ -1,0 +1,14 @@
+/**
+ * Page container enforcing global vertical rhythm.
+ * Applies top and bottom padding using --page-y.
+ */
+export default function Page({ children }) {
+  return (
+    <main
+      className="mx-auto max-w-5xl px-4"
+      style={{ paddingTop: "var(--page-y)", paddingBottom: "var(--page-y)" }}
+    >
+      {children}
+    </main>
+  );
+}

--- a/src/layout/PageHeader.jsx
+++ b/src/layout/PageHeader.jsx
@@ -2,7 +2,7 @@ import Breadcrumbs from "./Breadcrumbs";
 
 export default function PageHeader({ title, description, children }) {
   return (
-    <div className="mb-6">
+    <div className="mb-[var(--section-y)]">
       <Breadcrumbs />
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>

--- a/src/layout/Section.jsx
+++ b/src/layout/Section.jsx
@@ -1,0 +1,13 @@
+import clsx from "clsx";
+
+/**
+ * Section block to manage vertical spacing between page sections.
+ * Don't add local mt/mb on children—use this component instead.
+ */
+export default function Section({ children, className, first = false }) {
+  return (
+    <section className={clsx(!first && "mt-[var(--section-y)]", className)}>
+      {children}
+    </section>
+  );
+}

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -1,6 +1,8 @@
 import Filters from "../components/Filters";
 import TxTable from "../components/TxTable";
 import FAB from "../components/FAB";
+import Page from "../layout/Page";
+import Section from "../layout/Section";
 import PageHeader from "../layout/PageHeader";
 
 export default function Transactions({
@@ -13,16 +15,20 @@ export default function Transactions({
   onUpdate,
 }) {
   return (
-    <main className="max-w-5xl mx-auto p-4 space-y-4">
+    <Page>
       <PageHeader title="Transaksi" description="Kelola catatan keuangan" />
-      <Filters
-        months={months}
-        categories={categories}
-        filter={filter}
-        setFilter={setFilter}
-      />
-      <TxTable items={items} onRemove={onRemove} onUpdate={onUpdate} />
+      <Section first>
+        <Filters
+          months={months}
+          categories={categories}
+          filter={filter}
+          setFilter={setFilter}
+        />
+      </Section>
+      <Section>
+        <TxTable items={items} onRemove={onRemove} onUpdate={onUpdate} />
+      </Section>
       <FAB />
-    </main>
+    </Page>
   );
 }


### PR DESCRIPTION
## Summary
- add Page and Section layout wrappers backed by global spacing tokens
- refactor dashboard and transactions to use consistent section spacing and block gaps
- tighten KPI grid and header spacing using `--section-y` and `--block-y`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c8084c2e6083329b3500ce08caa642