### PR TITLE
fix: make sidebar fixed-width and viewport height

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
           const theme = mode === 'system' ? (prefersDark ? 'dark' : 'light') : mode;
           const root = document.documentElement;
           root.setAttribute('data-theme', theme);
+          const collapsed = localStorage.getItem('hw:sidebar-collapsed') === '1';
+          root.setAttribute('data-nav', collapsed ? 'mini' : 'full');
           if (stored.brand) {
             const b = stored.brand;
             root.style.setProperty('--brand-h', b.h);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -692,20 +692,23 @@ function AppShell({ prefs, setPrefs }) {
 
   return (
     <CategoryProvider catMeta={catMeta}>
-      <SyncBanner />
-      <div className="flex min-h-screen">
-        {!hideNav && (
-          <Sidebar
-            theme={theme}
-            setTheme={setTheme}
-            brand={brand}
-            setBrand={setBrand}
-            useCloud={useCloud}
-            setUseCloud={setUseCloud}
-          />
-        )}
-        <main id="main" tabIndex="-1" className="flex-1 focus:outline-none">
-          <Routes>
+      {!hideNav && (
+        <Sidebar
+          theme={theme}
+          setTheme={setTheme}
+          brand={brand}
+          setBrand={setBrand}
+          useCloud={useCloud}
+          setUseCloud={setUseCloud}
+        />
+      )}
+      <main
+        id="main"
+        tabIndex="-1"
+        className={`${hideNav ? '' : 'md:ml-[var(--sidebar-w)]'} h-screen [height:100dvh] overflow-y-auto focus:outline-none max-w-[var(--content-max)]`}
+      >
+        <SyncBanner />
+        <Routes>
           <Route path="/auth" element={<AuthPage />} />
           <Route element={<AuthGuard />}>
             <Route
@@ -810,8 +813,7 @@ function AppShell({ prefs, setPrefs }) {
             />
           </Route>
         </Routes>
-        </main>
-      </div>
+      </main>
       <SettingsPanel
         open={settingsOpen}
         onClose={() => setSettingsOpen(false)}

--- a/src/index.css
+++ b/src/index.css
@@ -27,6 +27,10 @@
     --page-y: clamp(16px, 4vw, 28px);
     --section-y: clamp(12px, 3vw, 24px);
     --block-y: clamp(8px, 2vw, 16px);
+    --nav-w: 17rem;
+    --nav-w-mini: 4rem;
+    --nav-z: 30;
+    --content-max: 80rem;
   }
   [data-theme='dark'] {
     --bg: #0f172a;
@@ -41,7 +45,23 @@
     --brand-soft: hsl(var(--brand-h) var(--brand-s) 20%);
     --brand-ring: hsl(var(--brand-h) var(--brand-s) 70%);
   }
-  body { @apply bg-bg text-text transition-colors duration-300; }
+  body {
+    @apply bg-bg text-text transition-colors duration-300;
+    height: 100vh;
+    height: 100dvh;
+    overflow: hidden;
+  }
+  body[data-nav='full'] { --sidebar-w: var(--nav-w); }
+  body[data-nav='mini'] { --sidebar-w: var(--nav-w-mini); }
+  #main {
+    height: 100vh;
+    height: 100dvh;
+    overflow-y: auto;
+    max-width: var(--content-max);
+  }
+  @media (min-width: 768px) {
+    #main { margin-left: var(--sidebar-w); }
+  }
   h1, h2, h3, h4, h5, h6 { @apply font-semibold; }
 }
 

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -82,6 +82,7 @@ export default function Sidebar({ theme, setTheme, brand, setBrand, useCloud, se
 
   useEffect(() => {
     localStorage.setItem('hw:sidebar-collapsed', collapsed ? '1' : '0');
+    document.documentElement.setAttribute('data-nav', collapsed ? 'mini' : 'full');
   }, [collapsed]);
 
   const shortEmail = (email = '') =>
@@ -96,7 +97,10 @@ export default function Sidebar({ theme, setTheme, brand, setBrand, useCloud, se
 
   const content = (
     <div
-      className={`flex flex-col h-full ${collapsed ? 'w-16' : 'w-64'} transition-all bg-surface-1 text-text shadow-md`}
+      className={`relative flex flex-col h-screen overflow-hidden bg-surface-1 text-text shadow-md transition-[width] ${
+        collapsed ? 'w-16' : 'w-64'
+      }`}
+      style={{ width: collapsed ? 'var(--nav-w-mini)' : 'var(--nav-w)', height: '100dvh' }}
     >
       <div className="flex items-center justify-between p-4">
         <div className="flex items-center gap-2">
@@ -150,7 +154,7 @@ export default function Sidebar({ theme, setTheme, brand, setBrand, useCloud, se
           </ul>
         )}
       </nav>
-      <div className="p-4 border-t border-border space-y-4">
+      <div className="mt-auto p-4 border-t border-border space-y-4 bg-surface-1">
         <div className="flex items-center justify-between">
           {!collapsed && <span className="text-sm">All synced</span>}
         </div>
@@ -256,7 +260,7 @@ export default function Sidebar({ theme, setTheme, brand, setBrand, useCloud, se
         onClick={() => setMobileOpen(false)}
       />
       <div
-        className={`${mobileOpen ? 'translate-x-0' : '-translate-x-full'} md:translate-x-0 fixed z-50 inset-y-0 left-0 md:static md:flex`}
+        className={`${mobileOpen ? 'translate-x-0' : '-translate-x-full'} md:translate-x-0 fixed inset-y-0 left-0 z-[var(--nav-z)] flex`}
       >
         {content}
       </div>


### PR DESCRIPTION
## Summary
- anchor sidebar to viewport with 100dvh height and independent scroll
- offset main content using CSS variables for expanded/collapsed widths
- persist sidebar collapsed state and apply data-nav on initial load

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c80b157f7483328f980e0378abe425