### PR TITLE
refactor: align dark mode styles across app

### DIFF
--- a/src/components/AchievementBadges.jsx
+++ b/src/components/AchievementBadges.jsx
@@ -22,7 +22,7 @@ export default function AchievementBadges({ stats = {}, streak = 0, target = 0 }
   if (target && balance >= target) {
     badges.push({
       id: "target",
-      icon: <Target className="h-4 w-4 text-green-500" />,
+      icon: <Target className="h-4 w-4 text-success" />,
       text: "Target tabungan tercapai 🎯",
     });
   }
@@ -42,7 +42,7 @@ export default function AchievementBadges({ stats = {}, streak = 0, target = 0 }
         {badges.map((b) => (
           <li
             key={b.id}
-            className="flex items-center gap-2 text-sm bg-slate-50 dark:bg-slate-700 p-2 rounded"
+            className="flex items-center gap-2 text-sm bg-surface-2 p-2 rounded"
           >
             {b.icon}
             <span>{b.text}</span>

--- a/src/components/AuthGate.jsx
+++ b/src/components/AuthGate.jsx
@@ -35,15 +35,15 @@ export default function AuthGate({ children }) {
   if (loading) return <div className="p-6">Loading…</div>
   if (!user) {
     return (
-      <div className="min-h-screen grid place-items-center bg-slate-50">
-        <form onSubmit={signIn} className="w-[360px] space-y-3 bg-white p-4 rounded-xl border">
+      <div className="min-h-screen grid place-items-center bg-bg">
+        <form onSubmit={signIn} className="w-[360px] space-y-3 bg-surface-1 p-4 rounded-xl border border-border">
           <h1 className="text-xl font-bold">Masuk HematWoi</h1>
-          <input className="w-full border rounded-lg p-2" placeholder="email" value={email} onChange={e=>setEmail(e.target.value)} />
-          <input className="w-full border rounded-lg p-2" type="password" placeholder="password" value={password} onChange={e=>setPassword(e.target.value)} />
-          {err && <p className="text-sm text-red-600">{err}</p>}
+          <input className="input" placeholder="email" value={email} onChange={e=>setEmail(e.target.value)} />
+          <input className="input" type="password" placeholder="password" value={password} onChange={e=>setPassword(e.target.value)} />
+          {err && <p className="text-sm text-danger">{err}</p>}
           <div className="flex gap-2">
-            <button className="px-3 py-2 rounded-lg bg-blue-600 text-white">Masuk</button>
-            <button type="button" onClick={signUp} className="px-3 py-2 rounded-lg border">Daftar</button>
+            <button className="btn btn-primary">Masuk</button>
+            <button type="button" onClick={signUp} className="btn">Daftar</button>
           </div>
         </form>
       </div>
@@ -51,9 +51,9 @@ export default function AuthGate({ children }) {
   }
   return (
     <div>
-      <div className="p-2 text-sm bg-slate-100 flex items-center justify-between">
+      <div className="p-2 text-sm bg-surface-2 flex items-center justify-between">
         <span>Login sebagai <b>{user.email}</b></span>
-        <button onClick={signOut} className="px-2 py-1 rounded border">Keluar</button>
+        <button onClick={signOut} className="btn">Keluar</button>
       </div>
       {children}
     </div>

--- a/src/components/AuthMenu.jsx
+++ b/src/components/AuthMenu.jsx
@@ -12,19 +12,19 @@ export default function AuthMenu() {
   if (!user) return null;
   return (
     <div className="relative group">
-      <button className="w-8 h-8 rounded-full bg-brand text-white flex items-center justify-center">
+      <button className="w-8 h-8 rounded-full bg-brand text-brand-foreground flex items-center justify-center">
         {user.email?.charAt(0).toUpperCase()}
       </button>
-      <div className="absolute right-0 mt-2 w-40 bg-white rounded shadow-md border hidden group-focus-within:block group-hover:block">
-        <Link className="block px-4 py-2 hover:bg-slate-100" to="/profile">
+      <div className="absolute right-0 mt-2 w-40 bg-surface-1 border border-border rounded shadow-md hidden group-focus-within:block group-hover:block">
+        <Link className="block px-4 py-2 hover:bg-surface-2" to="/profile">
           Profile
         </Link>
-        <Link className="block px-4 py-2 hover:bg-slate-100" to="/settings">
+        <Link className="block px-4 py-2 hover:bg-surface-2" to="/settings">
           Settings
         </Link>
         <button
           onClick={() => supabase.auth.signOut()}
-          className="block w-full text-left px-4 py-2 hover:bg-slate-100"
+          className="block w-full text-left px-4 py-2 hover:bg-surface-2"
         >
           Logout
         </button>

--- a/src/components/AvatarLevel.jsx
+++ b/src/components/AvatarLevel.jsx
@@ -49,11 +49,11 @@ export default function AvatarLevel({ transactions, insights, challenges }) {
         aria-valuenow={progress}
         aria-valuemin={0}
         aria-valuemax={needed}
-        className="w-full bg-gray-200 rounded h-2"
+        className="w-full bg-surface-2 rounded h-2"
         title="Dapatkan XP: transaksi harian (+5), hemat mingguan \u2265 10% (+20), selesaikan challenge (+50)"
       >
         <div
-          className="bg-emerald-500 h-2 rounded"
+          className="bg-success h-2 rounded"
           style={{ width: `${percent}%` }}
         />
       </div>

--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -3,10 +3,10 @@ import { Home, Plus, BarChart3, Settings, Flag } from "lucide-react";
 
 export default function BottomNav() {
   const base =
-    "flex flex-1 flex-col items-center justify-center gap-1 py-2 text-xs text-slate-600 dark:text-slate-300";
+    "flex flex-1 flex-col items-center justify-center gap-1 py-2 text-xs text-muted";
   const active = "text-brand-var";
   return (
-    <nav className="fixed bottom-0 inset-x-0 z-40 bg-white dark:bg-slate-900 border-t md:hidden pb-safe">
+    <nav className="fixed bottom-0 inset-x-0 z-40 bg-surface-1 border-t border-border md:hidden pb-safe">
       <div className="flex">
         <NavLink to="/" end className={({ isActive }) => `${base} ${isActive ? active : ""}`}>
           <Home className="h-5 w-5" />

--- a/src/components/BudgetSection.jsx
+++ b/src/components/BudgetSection.jsx
@@ -127,7 +127,7 @@ export default function BudgetSection({
         <h2 className="font-semibold mb-2">Daftar Budget</h2>
 
         {!list.length && (
-          <div className="text-sm text-slate-500">
+          <div className="text-sm text-muted">
             Belum ada budget bulan ini.
           </div>
         )}
@@ -140,9 +140,9 @@ export default function BudgetSection({
               cap <= 0 ? 0 : Math.min(100, Math.round((used / cap) * 100));
             const color =
               pct >= 100
-                ? "bg-red-500"
+                ? "bg-danger"
                 : pct >= 80
-                ? "bg-yellow-400"
+                ? "bg-warning"
                 : "bg-brand-var";
 
             return (
@@ -154,7 +154,7 @@ export default function BudgetSection({
                   </span>
                 </div>
 
-                <div className="h-2 w-full rounded-full bg-slate-200">
+                <div className="h-2 w-full rounded-full bg-surface-2">
                   <div
                     className={`h-2 rounded-full ${color}`}
                     style={{ width: `${pct}%` }}

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -34,7 +34,7 @@ export function CardFooter({ className = "", children }) {
   return (
     <div
       className={clsx(
-        "mt-4 border-t border-slate-200 pt-4 dark:border-slate-700",
+        "mt-4 border-t border-border pt-4",
         className
       )}
     >

--- a/src/components/CategoryDock.jsx
+++ b/src/components/CategoryDock.jsx
@@ -8,8 +8,8 @@ function Chip({ name }) {
   return (
     <span
       ref={setNodeRef}
-      className={`badge rounded-full whitespace-nowrap cursor-pointer select-none border bg-white dark:bg-slate-900 hover:bg-slate-100 dark:hover:bg-slate-800 ${
-        isOver ? "bg-slate-100 dark:bg-slate-800" : ""
+      className={`badge rounded-full whitespace-nowrap cursor-pointer select-none border border-border bg-surface-1 hover:bg-surface-2 ${
+        isOver ? "bg-surface-2" : ""
       }`}
       style={{
         backgroundColor: getColor(name),

--- a/src/components/CategoryDonut.jsx
+++ b/src/components/CategoryDonut.jsx
@@ -15,7 +15,7 @@ export default function CategoryDonut({ data = [] }) {
     if (!payload?.length) return null;
     const p = payload[0];
     return (
-      <div className="rounded bg-white p-2 text-xs shadow">
+      <div className="rounded bg-surface-1 border border-border p-2 text-xs shadow">
         {p.name}: {toRupiah(p.value)}
       </div>
     );
@@ -36,7 +36,7 @@ export default function CategoryDonut({ data = [] }) {
           </PieChart>
         </ResponsiveContainer>
       ) : (
-        <div className="flex h-full items-center justify-center text-sm text-slate-500">
+        <div className="flex h-full items-center justify-center text-sm text-muted">
           Tidak ada data
         </div>
       )}

--- a/src/components/ChallengeCard.jsx
+++ b/src/components/ChallengeCard.jsx
@@ -8,11 +8,11 @@ export default function ChallengeCard({ challenge, onView, onEdit, onEnd }) {
       <div className="flex justify-between items-center">
         <h3 className="font-semibold">{challenge.title}</h3>
         {challenge.status === "active" && (
-          <span className="text-xs text-slate-500">{daysLeft} hari lagi</span>
+          <span className="text-xs text-muted">{daysLeft} hari lagi</span>
         )}
       </div>
-      <div className="w-full bg-gray-200 rounded h-2">
-        <div className="bg-emerald-500 h-2 rounded" style={{ width: `${percent}%` }} />
+      <div className="w-full bg-surface-2 rounded h-2">
+        <div className="bg-success h-2 rounded" style={{ width: `${percent}%` }} />
       </div>
       <div className="flex gap-2 text-xs">
         <button type="button" onClick={() => onView(challenge)} className="underline">

--- a/src/components/ChallengeDetail.jsx
+++ b/src/components/ChallengeDetail.jsx
@@ -20,8 +20,8 @@ export default function ChallengeDetail({ challenge, txs = [], onClose }) {
       </button>
       <h2 className="text-lg font-semibold">{challenge.title}</h2>
       <p className="text-sm">Status: {status}</p>
-      <div className="w-full bg-gray-200 rounded h-2">
-        <div className="bg-emerald-500 h-2 rounded" style={{ width: `${percent}%` }} />
+      <div className="w-full bg-surface-2 rounded h-2">
+        <div className="bg-success h-2 rounded" style={{ width: `${percent}%` }} />
       </div>
       <div>
         <h3 className="font-semibold">Log</h3>

--- a/src/components/ChallengeList.jsx
+++ b/src/components/ChallengeList.jsx
@@ -2,7 +2,7 @@ import ChallengeCard from "./ChallengeCard.jsx";
 
 export default function ChallengeList({ challenges = [], onView, onEdit, onEnd }) {
   if (!challenges.length)
-    return <p className="text-sm text-center text-slate-500">Belum ada challenge</p>;
+    return <p className="text-sm text-center text-muted">Belum ada challenge</p>;
   return (
     <div className="space-y-4">
       {challenges.map((c) => (

--- a/src/components/DashboardCharts.jsx
+++ b/src/components/DashboardCharts.jsx
@@ -82,7 +82,7 @@ export default function DashboardCharts({ month, txs = [] }) {
     if (!payload?.length) return null;
     const p = payload[0];
     return (
-      <div className="rounded-lg bg-white p-2 text-xs shadow">
+      <div className="rounded-lg bg-surface-1 border border-border p-2 text-xs shadow">
         {p.name}: {toRupiah(p.value)}
       </div>
     );
@@ -91,12 +91,12 @@ export default function DashboardCharts({ month, txs = [] }) {
   const renderAreaTooltip = ({ payload, label }) => {
     if (!payload?.length) return null;
     return (
-      <div className="rounded-lg bg-white p-2 text-xs shadow">
+      <div className="rounded-lg bg-surface-1 border border-border p-2 text-xs shadow">
         <div>Hari {label}</div>
         {payload.map((p) => (
           <div
             key={p.dataKey}
-            className={p.dataKey === "income" ? "text-green-600" : "text-red-600"}
+            className={p.dataKey === "income" ? "text-success" : "text-danger"}
           >
             {p.name}: {toRupiah(p.value)}
           </div>
@@ -109,7 +109,7 @@ export default function DashboardCharts({ month, txs = [] }) {
     if (!payload?.length) return null;
     const p = payload[0];
     return (
-      <div className="rounded-lg bg-white p-2 text-xs shadow">
+      <div className="rounded-lg bg-surface-1 border border-border p-2 text-xs shadow">
         {p.payload.name}: {toRupiah(p.value)}
       </div>
     );

--- a/src/components/EnvelopeManager.jsx
+++ b/src/components/EnvelopeManager.jsx
@@ -10,13 +10,13 @@ export default function EnvelopeManager({ envelopes = [], onSave }) {
     <div className="space-y-4">
       <div className="flex items-end gap-2">
         <input
-          className="flex-1 p-2 border rounded"
+          className="input flex-1"
           placeholder="Kategori"
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
         <button
-          className="px-3 py-1 rounded bg-brand text-white"
+          className="px-3 py-1 rounded bg-brand text-brand-foreground"
           onClick={() => {
             if (!name) return;
             onSave({ category: name, balance: 0 });
@@ -48,10 +48,10 @@ export default function EnvelopeManager({ envelopes = [], onSave }) {
         {envelopes.map((e) => (
           <div
             key={e.category}
-            className="p-4 border rounded shadow-sm bg-white dark:bg-slate-800"
+            className="p-4 border border-border rounded shadow-sm bg-surface-2"
           >
             <div className="font-medium">{e.category}</div>
-            <div className="text-sm text-slate-500">Rp {e.balance?.toFixed(0)}</div>
+            <div className="text-sm text-muted">Rp {e.balance?.toFixed(0)}</div>
           </div>
         ))}
       </div>

--- a/src/components/GoalCard.jsx
+++ b/src/components/GoalCard.jsx
@@ -22,7 +22,7 @@ export default function GoalCard({ goal, onEdit, onDelete, onQuickAdd }) {
   };
 
   return (
-    <div className="p-4 border rounded shadow-sm bg-white dark:bg-slate-800 flex flex-col gap-2">
+    <div className="p-4 border border-border rounded shadow-sm bg-surface-2 flex flex-col gap-2">
       <div className="flex items-start justify-between gap-2">
         <h3 className="font-medium truncate" title={goal.name}>{goal.name}</h3>
         <div className="flex gap-2 text-sm">
@@ -33,15 +33,15 @@ export default function GoalCard({ goal, onEdit, onDelete, onQuickAdd }) {
             <button className="text-brand" onClick={() => onEdit(goal)} aria-label="Edit goal">Edit</button>
           )}
           {onDelete && (
-            <button className="text-red-600" onClick={() => onDelete(goal.id)} aria-label="Delete goal">Delete</button>
+            <button className="text-danger" onClick={() => onDelete(goal.id)} aria-label="Delete goal">Delete</button>
           )}
         </div>
       </div>
-      <div className="text-sm text-slate-500">
+      <div className="text-sm text-muted">
         {formatCurrency(goal.saved)} / {formatCurrency(goal.target)}
       </div>
       <GoalProgressBar goal={goal} />
-      <div className="text-xs text-slate-500">ETA: {etaText}</div>
+      <div className="text-xs text-muted">ETA: {etaText}</div>
     </div>
   );
 }

--- a/src/components/GoalForm.jsx
+++ b/src/components/GoalForm.jsx
@@ -16,7 +16,7 @@ export default function GoalForm({ initial = {}, onSave, onCancel }) {
       }}
     >
       <input
-        className="w-full p-2 border rounded"
+        className="input"
         placeholder="Nama tujuan"
         value={form.name}
         onChange={(e) => setForm({ ...form, name: e.target.value })}
@@ -24,7 +24,7 @@ export default function GoalForm({ initial = {}, onSave, onCancel }) {
       />
       <input
         type="number"
-        className="w-full p-2 border rounded"
+        className="input"
         placeholder="Target"
         value={form.target}
         onChange={(e) => setForm({ ...form, target: Number(e.target.value) })}
@@ -32,21 +32,21 @@ export default function GoalForm({ initial = {}, onSave, onCancel }) {
       />
       <input
         type="date"
-        className="w-full p-2 border rounded"
+        className="input"
         value={form.targetDate}
         onChange={(e) => setForm({ ...form, targetDate: e.target.value })}
       />
       <div className="flex gap-2 justify-end pt-2">
         <button
           type="button"
-          className="px-3 py-1 rounded bg-slate-200 dark:bg-slate-700"
+          className="px-3 py-1 rounded bg-surface-2 border border-border"
           onClick={onCancel}
         >
           Batal
         </button>
         <button
           type="submit"
-          className="px-3 py-1 rounded bg-brand text-white"
+          className="px-3 py-1 rounded bg-brand text-brand-foreground"
         >
           Simpan
         </button>

--- a/src/components/GoalList.jsx
+++ b/src/components/GoalList.jsx
@@ -33,7 +33,7 @@ export default function GoalList({ goals, onAdd, onUpdate, onDelete, onQuickAdd 
         </button>
       </div>
       {goals.length === 0 && (
-        <div className="text-center text-sm text-slate-500">
+        <div className="text-center text-sm text-muted">
           Belum ada goal.{' '}
           <button className="text-brand" onClick={startAdd}>
             Buat Goal Pertama

--- a/src/components/GoalProgressBar.jsx
+++ b/src/components/GoalProgressBar.jsx
@@ -3,7 +3,7 @@ import { goalProgress } from '../lib/goals';
 export default function GoalProgressBar({ goal }) {
   const pct = goalProgress(goal) * 100;
   return (
-    <div className="w-full bg-slate-200 dark:bg-slate-700 rounded h-2">
+    <div className="w-full bg-surface-2 rounded h-2">
       <div className="h-2 bg-brand rounded" style={{ width: `${pct}%` }} />
     </div>
   );

--- a/src/components/ImportPreview.jsx
+++ b/src/components/ImportPreview.jsx
@@ -69,7 +69,7 @@ export default function ImportPreview({ rows = [], txs = [], categories, rules =
           </thead>
           <tbody>
             {items.map((r, idx) => (
-              <tr key={idx} className="border-t border-slate-200 dark:border-slate-700">
+              <tr key={idx} className="border-t border-border">
                 <td className="p-2 whitespace-nowrap">{r.date}</td>
                 <td className="p-2">{r.note}</td>
                 <td className="p-2 text-right">{formatter.format(r.amount)}</td>
@@ -88,7 +88,7 @@ export default function ImportPreview({ rows = [], txs = [], categories, rules =
                 </td>
                 <td className="p-2">
                   {r.duplicate && (
-                    <span className="px-2 py-1 text-xs rounded bg-red-200 text-red-700">
+                    <span className="px-2 py-1 text-xs rounded bg-danger/20 text-danger">
                       Duplikat
                     </span>
                   )}

--- a/src/components/KPITiles.jsx
+++ b/src/components/KPITiles.jsx
@@ -58,7 +58,7 @@ export default function KPITiles({ income = 0, expense = 0, prevIncome = 0, prev
   const renderDelta = (delta) => {
     if (delta == null || !isFinite(delta)) return "—";
     const Arrow = delta >= 0 ? ArrowUpRight : ArrowDownRight;
-    const color = delta >= 0 ? "text-green-600" : "text-red-600";
+    const color = delta >= 0 ? "text-success" : "text-danger";
     return (
       <span className={`flex items-center justify-center gap-1 ${color}`}>
         <Arrow className="h-3 w-3" />
@@ -81,19 +81,19 @@ export default function KPITiles({ income = 0, expense = 0, prevIncome = 0, prev
       <div className="grid gap-4 text-center sm:grid-cols-4">
         <div className="space-y-1">
           <div className="text-sm">Pemasukan</div>
-          <div className="text-lg font-semibold text-green-600">{toRupiah(income)}</div>
+          <div className="text-lg font-semibold text-success">{toRupiah(income)}</div>
           <div className="text-xs">{renderDelta(incomeDelta)}</div>
           <Sparkline data={incomeSeries} color="#16a34a" />
         </div>
         <div className="space-y-1">
           <div className="text-sm">Pengeluaran</div>
-          <div className="text-lg font-semibold text-red-600">{toRupiah(expense)}</div>
+          <div className="text-lg font-semibold text-danger">{toRupiah(expense)}</div>
           <div className="text-xs">{renderDelta(expenseDelta)}</div>
           <Sparkline data={expenseSeries} color="#dc2626" />
         </div>
         <div className="space-y-1">
           <div className="text-sm">Saldo</div>
-          <div className="text-lg font-semibold text-blue-600">{toRupiah(balance)}</div>
+          <div className="text-lg font-semibold text-brand">{toRupiah(balance)}</div>
           <div className="text-xs">{renderDelta(balanceDelta)}</div>
           <Sparkline data={balanceSeries} color="#3898f8" />
         </div>

--- a/src/components/KpiCard.jsx
+++ b/src/components/KpiCard.jsx
@@ -19,7 +19,7 @@ export default function KpiCard({
       <CardBody className="space-y-1">
         <div className="text-sm text-muted whitespace-nowrap">{label}</div>
         {loading ? (
-          <div className="mx-auto h-6 w-24 rounded bg-slate-200 dark:bg-slate-700 animate-pulse" />
+          <div className="mx-auto h-6 w-24 rounded bg-surface-2 animate-pulse" />
         ) : (
           <div
             className={clsx(

--- a/src/components/ManageCategories.jsx
+++ b/src/components/ManageCategories.jsx
@@ -27,10 +27,10 @@ function Item({ item, onNameChange, onNameBlur, onColorChange, onRemove }) {
     transition,
   };
   return (
-    <div
+      <div
       ref={setNodeRef}
       style={style}
-      className="flex items-center gap-2 justify-between border rounded-lg px-2 py-1 bg-white"
+      className="flex items-center gap-2 justify-between border border-border rounded-lg px-2 py-1 bg-surface-1"
     >
       <div className="flex items-center gap-2 flex-1">
         <span
@@ -54,7 +54,7 @@ function Item({ item, onNameChange, onNameBlur, onColorChange, onRemove }) {
         onChange={(e) => onColorChange(item.id, e.target.value)}
         className="h-6 w-6"
       />
-      <button onClick={() => onRemove(item.id)} className="text-red-500">
+      <button onClick={() => onRemove(item.id)} className="text-danger">
         ✕
       </button>
     </div>

--- a/src/components/MonthlyTrendChart.jsx
+++ b/src/components/MonthlyTrendChart.jsx
@@ -13,7 +13,7 @@ export default function MonthlyTrendChart({ data = [] }) {
     if (!payload?.length) return null;
     const p = payload[0];
     return (
-      <div className="rounded bg-white p-2 text-xs shadow">
+      <div className="rounded bg-surface-1 border border-border p-2 text-xs shadow">
         <div>{label}</div>
         <div>{toRupiah(p.value)}</div>
       </div>

--- a/src/components/QuickActions.jsx
+++ b/src/components/QuickActions.jsx
@@ -40,7 +40,7 @@ export default function QuickActions() {
               </span>
               <span className="flex flex-col">
                 <span className="font-medium">{action.label}</span>
-                <span className="text-xs text-slate-500">{action.shortcut}</span>
+                <span className="text-xs text-muted">{action.shortcut}</span>
               </span>
             </Link>
           );

--- a/src/components/QuoteBubble.jsx
+++ b/src/components/QuoteBubble.jsx
@@ -11,7 +11,7 @@ export default function QuoteBubble({ lang = "id" }) {
 
   return (
     <figure className="mx-auto w-full max-w-3xl">
-      <blockquote className="relative w-full rounded-xl border border-brand/20 bg-brand/5 p-4 text-left shadow-sm dark:border-slate-700 dark:bg-slate-800">
+      <blockquote className="relative w-full rounded-xl border border-brand/20 bg-brand/5 p-4 text-left shadow-sm dark:border-border dark:bg-surface-2">
         <span className="absolute -top-2 left-4 text-2xl text-brand" aria-hidden>
           “
         </span>

--- a/src/components/RecentTransactions.jsx
+++ b/src/components/RecentTransactions.jsx
@@ -41,7 +41,7 @@ export default function RecentTransactions({ txs = [] }) {
         />
       </div>
       {!filtered.length && (
-        <div className="text-sm text-slate-500">Belum ada transaksi.</div>
+        <div className="text-sm text-muted">Belum ada transaksi.</div>
       )}
       <ul className="space-y-2">
         {filtered.map((t) => (
@@ -49,7 +49,7 @@ export default function RecentTransactions({ txs = [] }) {
             <span>{t.note || t.category}</span>
             <span
               className={
-                t.type === "income" ? "text-green-600" : "text-red-600"
+                t.type === "income" ? "text-success" : "text-danger"
               }
             >
               {formatCurrency(t.amount)}

--- a/src/components/Row.jsx
+++ b/src/components/Row.jsx
@@ -88,7 +88,7 @@ export default function Row({ item, onRemove, onUpdate }) {
       </td>
       <td
         className={`p-2 text-right ${
-          item.type === "income" ? "text-green-600" : "text-red-600"
+          item.type === "income" ? "text-success" : "text-danger"
         }`}
       >
         {edit ? (
@@ -148,7 +148,7 @@ export default function Row({ item, onRemove, onUpdate }) {
       </td>
       <td className="absolute inset-y-0 right-0 flex items-center pr-2 md:hidden">
         <button
-          className="btn bg-red-500 text-white"
+          className="btn bg-danger text-white"
           onClick={() => {
             onRemove(item.id);
             resetSwipe();

--- a/src/components/SavingsProgress.jsx
+++ b/src/components/SavingsProgress.jsx
@@ -29,7 +29,7 @@ export default function SavingsProgress({ current = 0, target = 0 }) {
     return (
       <div className="card animate-slide">
         <h2 className="font-semibold">Progress Tabungan</h2>
-        <p className="text-sm text-slate-500">Belum ada target tabungan</p>
+        <p className="text-sm text-muted">Belum ada target tabungan</p>
       </div>
     );
   }
@@ -39,20 +39,20 @@ export default function SavingsProgress({ current = 0, target = 0 }) {
       <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
         <h2 className="font-semibold">Progress Tabungan</h2>
         {achieved && (
-          <span className="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/20 dark:text-green-400">
+          <span className="inline-flex items-center gap-1 rounded-full bg-success/20 px-2 py-0.5 text-xs font-medium text-success">
             <CheckCircle className="h-4 w-4" /> Milestone tercapai!
           </span>
         )}
       </div>
-      <div className="mb-2 text-sm text-slate-500">
+      <div className="mb-2 text-sm text-muted">
         Rp {current.toLocaleString("id-ID")} / Rp {target.toLocaleString("id-ID")}
       </div>
       <div
-        className="h-3 w-full rounded bg-slate-200 dark:bg-slate-700"
+        className="h-3 w-full rounded bg-surface-2"
         role="progressbar"
       >
         <div
-          className="h-3 rounded bg-green-500"
+          className="h-3 rounded bg-success"
           style={{ width: `${Math.min(progress, 1) * 100}%` }}
         />
       </div>

--- a/src/components/SignIn.jsx
+++ b/src/components/SignIn.jsx
@@ -32,8 +32,8 @@ export default function SignIn({ open, onClose }) {
 
   return (
     <Modal open={open} title="Masuk HematWoi" onClose={onClose}>
-      {message && <p className="text-green-600 text-sm mb-2">{message}</p>}
-      {error && <p className="text-red-500 text-sm mb-2">{error}</p>}
+      {message && <p className="text-success text-sm mb-2">{message}</p>}
+      {error && <p className="text-danger text-sm mb-2">{error}</p>}
       <form onSubmit={handleSubmit} className="space-y-2">
         <input
           type="email"

--- a/src/components/Skeleton.jsx
+++ b/src/components/Skeleton.jsx
@@ -1,3 +1,3 @@
 export default function Skeleton({ className = "" }) {
-  return <div className={`animate-pulse rounded-lg bg-slate-200 ${className}`} />;
+  return <div className={`animate-pulse rounded-lg bg-surface-2 ${className}`} />;
 }

--- a/src/components/SmartFinancialInsights.jsx
+++ b/src/components/SmartFinancialInsights.jsx
@@ -110,8 +110,8 @@ export default function SmartFinancialInsights({ txs = [] }) {
     <span
       className={`text-xs px-2 py-0.5 rounded-full ${
         weekly.trend === "hemat"
-          ? "bg-green-100 text-green-700"
-          : "bg-red-100 text-red-700"
+          ? "bg-success/20 text-success"
+          : "bg-danger/20 text-danger"
       }`}
     >
       {weekly.trend === "hemat" ? "Hemat" : "Boros"}

--- a/src/components/SubscriptionList.jsx
+++ b/src/components/SubscriptionList.jsx
@@ -14,11 +14,11 @@ export default function SubscriptionList({ items = [], onEdit, onDelete }) {
           <div key={s.id} className="card p-3 flex justify-between items-start">
             <div className="space-y-1">
               <div className="font-semibold">{s.name}</div>
-              <div className="text-xs text-slate-500">
+              <div className="text-xs text-muted">
                 Rp {fmt.format(s.amount)} - {s.category}
               </div>
               <div className="text-xs flex items-center gap-2">
-                <span className="px-2 py-0.5 rounded bg-slate-200 dark:bg-slate-700">
+                <span className="px-2 py-0.5 rounded bg-surface-2">
                   {s.period === 'monthly' ? 'Bulanan' : 'Tahunan'}
                 </span>
                 <span>Jatuh tempo {due.toLocaleDateString('id-ID')}</span>

--- a/src/components/Summary.jsx
+++ b/src/components/Summary.jsx
@@ -11,13 +11,13 @@ export default function Summary({ stats }) {
     <div className="grid gap-4 sm:grid-cols-3">
       <div className="card text-center">
         <div className="text-sm">Pemasukan</div>
-        <div className="text-lg font-semibold text-green-600">
+        <div className="text-lg font-semibold text-success">
           {toRupiah(stats?.income || 0)}
         </div>
       </div>
       <div className="card text-center">
         <div className="text-sm">Pengeluaran</div>
-        <div className="text-lg font-semibold text-red-600">
+        <div className="text-lg font-semibold text-danger">
           {toRupiah(stats?.expense || 0)}
         </div>
       </div>

--- a/src/components/SyncBanner.jsx
+++ b/src/components/SyncBanner.jsx
@@ -21,7 +21,7 @@ export default function SyncBanner() {
   else text = "All synced";
 
   return (
-    <div className="bg-slate-100 dark:bg-slate-800 text-center text-sm py-1">
+    <div className="bg-surface-2 text-center text-sm py-1">
       <span>{text}</span>
       {count > 0 && (
         <button

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -72,7 +72,7 @@ export default function TopBar({
     <header className="relative">
       <a
         href="#main"
-        className="sr-only focus:not-sr-only absolute left-2 top-2 z-50 bg-white text-blue-600 px-3 py-2 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600"
+        className="sr-only focus:not-sr-only absolute left-2 top-2 z-50 bg-surface-1 text-brand px-3 py-2 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-ring"
       >
         Lewati ke konten
       </a>

--- a/src/components/TopSpendsTable.jsx
+++ b/src/components/TopSpendsTable.jsx
@@ -40,12 +40,12 @@ export default function TopSpendsTable({ data = [], onSelect }) {
             {sorted.map((t) => (
               <tr
                 key={t.id}
-                className="cursor-pointer hover:bg-slate-50"
+                className="cursor-pointer hover:bg-surface-2"
                 onClick={() => onSelect && onSelect(t)}
               >
                 <td className="p-2">{t.note || t.category || "-"}</td>
                 <td className="p-2">{t.date}</td>
-                <td className="p-2 text-right text-red-600">
+                <td className="p-2 text-right text-danger">
                   {toRupiah(t.amount)}
                 </td>
               </tr>

--- a/src/components/TxTable.jsx
+++ b/src/components/TxTable.jsx
@@ -43,7 +43,7 @@ export default function TxTable({ items = [], onRemove, onUpdate }) {
       <CategoryDock />
       <div className="table-wrap overflow-auto">
         <table className={`min-w-full text-sm ${density === "compact" ? "table-compact" : ""}`}>
-          <thead className="bg-white md:sticky md:top-0">
+          <thead className="bg-surface-1 md:sticky md:top-0">
             <tr className="text-left">
               <th className="p-2">Kategori</th>
               <th className="p-2">Tanggal</th>

--- a/src/components/WalletPanel.jsx
+++ b/src/components/WalletPanel.jsx
@@ -11,7 +11,7 @@ export default function WalletPanel({ insights, showTips = true, onClose }) {
   const { balance, weeklyTrend, topSpenderCategory, tip } = insights;
   return (
     <div
-      className="absolute z-10 mt-2 right-0 w-64 rounded-lg bg-white shadow p-4 text-sm text-text"
+      className="absolute z-10 mt-2 right-0 w-64 rounded-lg bg-surface-1 border border-border shadow p-4 text-sm text-text"
       role="dialog"
     >
       <button

--- a/src/components/ui/CurrencyInput.jsx
+++ b/src/components/ui/CurrencyInput.jsx
@@ -31,12 +31,12 @@ export default function CurrencyInput({ label = "Jumlah", value, onChangeNumber,
         inputMode="numeric"
         placeholder=" "
         {...props}
-        className="peer w-full rounded-xl border border-slate-300 bg-white dark:bg-slate-900 px-3 pt-5 pb-2 text-sm focus:outline-none focus:ring-2"
+        className="peer w-full rounded-xl border border-border bg-surface-1 px-3 pt-5 pb-2 text-sm text-text focus:outline-none focus:ring-2"
         style={{ '--tw-ring-color': 'var(--brand)' }}
       />
       <label
         htmlFor={id}
-        className="absolute left-3 top-2 text-xs text-slate-500 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs peer-focus:text-[var(--brand)]"
+        className="absolute left-3 top-2 text-xs text-muted transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs peer-focus:text-[var(--brand)]"
       >
         {label}
       </label>

--- a/src/components/ui/Input.jsx
+++ b/src/components/ui/Input.jsx
@@ -13,12 +13,12 @@ export default function Input({ label, type = "text", value, onChange, name, req
         placeholder=" "
         required={required}
         {...props}
-        className="peer w-full rounded-xl border border-slate-300 bg-white dark:bg-slate-900 px-3 pt-5 pb-2 text-sm focus:outline-none focus:ring-2"
+        className="peer w-full rounded-xl border border-border bg-surface-1 px-3 pt-5 pb-2 text-sm text-text focus:outline-none focus:ring-2"
         style={{ '--tw-ring-color': 'var(--brand)' }}
       />
       <label
         htmlFor={id}
-        className="absolute left-3 top-2 text-xs text-slate-500 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs peer-focus:text-[var(--brand)]"
+        className="absolute left-3 top-2 text-xs text-muted transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs peer-focus:text-[var(--brand)]"
       >
         {label}
       </label>

--- a/src/components/ui/Segmented.jsx
+++ b/src/components/ui/Segmented.jsx
@@ -1,14 +1,14 @@
 export default function Segmented({ value, onChange, options = [] }) {
   return (
-    <div className="inline-flex rounded-xl border overflow-hidden">
+    <div className="inline-flex rounded-xl border border-border overflow-hidden">
       {options.map((opt) => (
         <button
           key={opt.value}
           type="button"
           className={`px-3 py-2 text-sm flex-1 ${
             value === opt.value
-              ? "bg-brand-var text-white"
-              : "bg-white dark:bg-slate-900"
+              ? "bg-brand-var text-brand-foreground"
+              : "bg-surface-1"
           }`}
           onClick={() => onChange(opt.value)}
         >

--- a/src/components/ui/Select.jsx
+++ b/src/components/ui/Select.jsx
@@ -10,7 +10,7 @@ export default function Select({ label, options = [], value, onChange, placehold
         value={value}
         onChange={onChange}
         {...props}
-        className="w-full rounded-xl border border-slate-300 bg-white dark:bg-slate-900 px-3 py-2 focus:outline-none focus:ring-2"
+        className="w-full rounded-xl border border-border bg-surface-1 px-3 py-2 text-text focus:outline-none focus:ring-2"
         style={{ '--tw-ring-color': 'var(--brand)' }}
         >
         <option value="" disabled>

--- a/src/components/ui/Stepper.jsx
+++ b/src/components/ui/Stepper.jsx
@@ -7,7 +7,7 @@ export default function Stepper({ current = 0, steps = [] }) {
           <div
             key={s}
             className={`flex-1 text-center text-xs ${
-              i <= current ? "text-brand-var font-semibold" : "text-slate-500"
+              i <= current ? "text-brand-var font-semibold" : "text-muted"
             }`}
           >
             {s}
@@ -15,7 +15,7 @@ export default function Stepper({ current = 0, steps = [] }) {
         ))}
       </div>
       <div
-        className="relative h-2 bg-slate-200 rounded-full dark:bg-slate-700"
+        className="relative h-2 bg-surface-2 rounded-full"
         role="progressbar"
         aria-valuenow={current}
         aria-valuemin={0}

--- a/src/components/ui/Textarea.jsx
+++ b/src/components/ui/Textarea.jsx
@@ -12,12 +12,12 @@ export default function Textarea({ label, value, onChange, name, required, ...pr
         placeholder=" "
         required={required}
         {...props}
-        className="peer w-full rounded-xl border border-slate-300 bg-white dark:bg-slate-900 px-3 pt-5 pb-2 text-sm min-h-24 focus:outline-none focus:ring-2"
+        className="peer w-full rounded-xl border border-border bg-surface-1 px-3 pt-5 pb-2 text-sm text-text min-h-24 focus:outline-none focus:ring-2"
         style={{ '--tw-ring-color': 'var(--brand)' }}
       />
       <label
         htmlFor={id}
-        className="absolute left-3 top-2 text-xs text-slate-500 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs peer-focus:text-[var(--brand)]"
+        className="absolute left-3 top-2 text-xs text-muted transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs peer-focus:text-[var(--brand)]"
       >
         {label}
       </label>

--- a/src/index.css
+++ b/src/index.css
@@ -49,6 +49,9 @@
   .card {
     @apply bg-surface-2 border border-border rounded-xl shadow-sm p-4 md:p-6;
   }
+  .input {
+    @apply w-full rounded-xl border border-border bg-surface-1 px-3 py-2 text-sm text-text focus:outline-none focus:ring-2 focus:ring-brand-ring;
+  }
 }
 
 @layer utilities {

--- a/src/layout/Breadcrumbs.jsx
+++ b/src/layout/Breadcrumbs.jsx
@@ -10,7 +10,7 @@ export default function Breadcrumbs() {
   if (!segments.length) return null;
   let path = "";
   return (
-    <nav aria-label="Breadcrumb" className="mb-2 text-xs text-slate-600 dark:text-slate-400">
+    <nav aria-label="Breadcrumb" className="mb-2 text-xs text-muted">
       <ol className="flex items-center gap-1">
         <li>
           <NavLink to="/" className="hover:text-brand">

--- a/src/layout/PageHeader.jsx
+++ b/src/layout/PageHeader.jsx
@@ -6,11 +6,11 @@ export default function PageHeader({ title, description, children }) {
       <Breadcrumbs />
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-xl font-bold text-text dark:text-white">
+          <h1 className="text-xl font-bold text-text">
             {title}
           </h1>
           {description && (
-            <p className="text-sm text-slate-600 dark:text-slate-300">
+            <p className="text-sm text-muted">
               {description}
             </p>
           )}

--- a/src/pages/AddWizard.jsx
+++ b/src/pages/AddWizard.jsx
@@ -144,7 +144,7 @@ export default function AddWizard({ categories, onAdd, onCancel }) {
         </div>
       )}
 
-      <footer className="sticky bottom-0 bg-white dark:bg-slate-950 p-4 flex justify-between">
+      <footer className="sticky bottom-0 bg-surface-1 p-4 flex justify-between border-t border-border">
         <button className="btn" onClick={back} disabled={step === 0}>
           Kembali
         </button>

--- a/src/pages/Auth.jsx
+++ b/src/pages/Auth.jsx
@@ -56,13 +56,13 @@ export default function AuthPage() {
     <div className="max-w-md mx-auto p-4 space-y-4">
       <div className="flex gap-2">
         <button
-          className={`flex-1 py-2 ${tab === 'login' ? 'bg-brand text-white' : 'border'}`}
+          className={`flex-1 py-2 rounded ${tab === 'login' ? 'bg-brand text-brand-foreground' : 'border border-border bg-surface-2'}`}
           onClick={() => setTab('login')}
         >
           Login
         </button>
         <button
-          className={`flex-1 py-2 ${tab === 'register' ? 'bg-brand text-white' : 'border'}`}
+          className={`flex-1 py-2 rounded ${tab === 'register' ? 'bg-brand text-brand-foreground' : 'border border-border bg-surface-2'}`}
           onClick={() => setTab('register')}
         >
           Register
@@ -72,7 +72,7 @@ export default function AuthPage() {
         <form onSubmit={handleLogin} className="space-y-3">
           <input
             type="email"
-            className="w-full p-2 border rounded"
+            className="input"
             placeholder="Email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
@@ -80,7 +80,7 @@ export default function AuthPage() {
           />
           <input
             type="password"
-            className="w-full p-2 border rounded"
+            className="input"
             placeholder="Password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
@@ -98,7 +98,7 @@ export default function AuthPage() {
       {tab === 'register' && (
         <form onSubmit={handleRegister} className="space-y-3">
           <input
-            className="w-full p-2 border rounded"
+            className="input"
             placeholder="Name"
             value={name}
             onChange={(e) => setName(e.target.value)}
@@ -106,7 +106,7 @@ export default function AuthPage() {
           />
           <input
             type="email"
-            className="w-full p-2 border rounded"
+            className="input"
             placeholder="Email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
@@ -114,7 +114,7 @@ export default function AuthPage() {
           />
           <input
             type="password"
-            className="w-full p-2 border rounded"
+            className="input"
             placeholder="Password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
@@ -123,7 +123,7 @@ export default function AuthPage() {
           />
           <input
             type="password"
-            className="w-full p-2 border rounded"
+            className="input"
             placeholder="Confirm Password"
             value={confirm}
             onChange={(e) => setConfirm(e.target.value)}
@@ -138,7 +138,7 @@ export default function AuthPage() {
           </button>
         </form>
       )}
-      {error && <p className="text-sm text-red-600">{error}</p>}
+      {error && <p className="text-sm text-danger">{error}</p>}
     </div>
   );
 }

--- a/src/pages/Challenges.jsx
+++ b/src/pages/Challenges.jsx
@@ -17,14 +17,14 @@ export default function ChallengesPage({ challenges, onAdd, onUpdate, txs }) {
       <div className="flex gap-2">
         <button
           type="button"
-          className={`px-3 py-1 rounded ${tab === "active" ? "bg-brand-var text-white" : "bg-gray-200"}`}
+          className={`px-3 py-1 rounded ${tab === "active" ? "bg-brand-var text-brand-foreground" : "bg-surface-2"}`}
           onClick={() => setTab("active")}
         >
           Active
         </button>
         <button
           type="button"
-          className={`px-3 py-1 rounded ${tab === "completed" ? "bg-brand-var text-white" : "bg-gray-200"}`}
+          className={`px-3 py-1 rounded ${tab === "completed" ? "bg-brand-var text-brand-foreground" : "bg-surface-2"}`}
           onClick={() => setTab("completed")}
         >
           Completed

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -16,7 +16,7 @@ export default function ProfilePage({ transactions = [], challenges = [] }) {
       <button
         type="button"
         onClick={() => EventBus.emit('xp:add', { code: 'demo', amount: 10 })}
-        className="px-2 py-1 text-xs bg-emerald-500 text-white rounded"
+        className="px-2 py-1 text-xs bg-success text-white rounded"
       >
         +10 XP Demo
       </button>

--- a/src/pages/Reports/Reports.tsx
+++ b/src/pages/Reports/Reports.tsx
@@ -18,7 +18,7 @@ export default function Reports() {
         <div className="text-sm">No reports available.</div>
       )}
       {error && (
-        <div role="alert" className="text-red-600 text-sm">
+        <div role="alert" className="text-danger text-sm">
           {error}
         </div>
       )}


### PR DESCRIPTION
## Summary
- ensure inputs and surfaces respect theme tokens
- replace hardcoded light colors with theme-aware classes across pages
- unify text styling with muted and brand colors for dark mode

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c80e856734833284c4b361b4a34151