### PR TITLE
Revamp dashboard layout and fixed sidebar

### DIFF
--- a/docs/ui-guidelines.md
+++ b/docs/ui-guidelines.md
@@ -1,0 +1,17 @@
+# UI Guidelines
+
+## Spacing Tokens
+- `--page-y`: vertical padding for pages.
+- `--section-y`: gap between sections on a page.
+- `--block-y`: internal gap for cards and grids.
+
+## Layout Pattern
+1. **Page** – applies `--page-y` as top/bottom padding.
+2. **Section** – use `<Section>` to add `--section-y` spacing between blocks.
+3. **Card/Block** – internal spacing uses `--block-y`; avoid extra margin/padding on child elements.
+
+## Sidebar
+- Fixed at `100dvh` with its own scroll.
+- Width variables: `--sidebar-w-expanded` (280px) and `--sidebar-w-collapsed` (72px).
+- Current width is exposed as `--sidebar-width` and updates with the collapse toggle.
+- Main content should offset using `margin-left: var(--sidebar-width)` on desktop.

--- a/index.html
+++ b/index.html
@@ -23,6 +23,9 @@
             root.style.setProperty('--brand-soft', `hsl(${b.h} ${b.s}% ${Math.min(95, b.l + 40)}%)`);
             root.style.setProperty('--brand-ring', `hsl(${b.h} ${b.s}% ${Math.max(0, b.l - 20)}%)`);
           }
+          const collapsed = localStorage.getItem('hw:sidebar-collapsed') === '1';
+          root.dataset.sidebarCollapsed = collapsed ? '1' : '0';
+          root.style.setProperty('--sidebar-width', collapsed ? 'var(--sidebar-w-collapsed)' : 'var(--sidebar-w-expanded)');
         } catch (e) {
           console.error('theme init failed', e);
         }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -692,23 +692,29 @@ function AppShell({ prefs, setPrefs }) {
 
   return (
     <CategoryProvider catMeta={catMeta}>
-      <SyncBanner />
-      <div className="flex min-h-screen">
-        {!hideNav && (
-          <Sidebar
-            theme={theme}
-            setTheme={setTheme}
-            brand={brand}
-            setBrand={setBrand}
-            useCloud={useCloud}
-            setUseCloud={setUseCloud}
-          />
-        )}
-        <main id="main" tabIndex="-1" className="flex-1 focus:outline-none">
+      {!hideNav && (
+        <Sidebar
+          theme={theme}
+          setTheme={setTheme}
+          brand={brand}
+          setBrand={setBrand}
+          useCloud={useCloud}
+          setUseCloud={setUseCloud}
+        />
+      )}
+      <div
+        className={`min-h-[100dvh] flex flex-col overflow-x-hidden ${!hideNav ? 'md:ml-[var(--sidebar-width)]' : ''}`}
+      >
+        <SyncBanner />
+        <main
+          id="main"
+          tabIndex="-1"
+          className="flex-1 overflow-y-auto focus:outline-none"
+        >
           <Routes>
-          <Route path="/auth" element={<AuthPage />} />
-          <Route element={<AuthGuard />}>
-            <Route
+            <Route path="/auth" element={<AuthPage />} />
+            <Route element={<AuthGuard />}>
+              <Route
               path="/"
               element={
                 <Dashboard
@@ -809,7 +815,7 @@ function AppShell({ prefs, setPrefs }) {
               element={<ProfilePage transactions={data.txs} challenges={challenges} />}
             />
           </Route>
-        </Routes>
+          </Routes>
         </main>
       </div>
       <SettingsPanel

--- a/src/components/AchievementBadges.jsx
+++ b/src/components/AchievementBadges.jsx
@@ -35,20 +35,27 @@ export default function AchievementBadges({ stats = {}, streak = 0, target = 0 }
   }
   if (!badges.length) return null;
 
+  const visible = badges.slice(0, 4);
+
   return (
-    <div className="card animate-slide">
-      <h2 className="font-semibold mb-2">Achievements</h2>
-      <ul className="space-y-2">
-        {badges.map((b) => (
+    <div className="card animate-slide h-full">
+      <h2 className="mb-[var(--block-y)] font-semibold">Achievements</h2>
+      <ul className="space-y-[var(--block-y)]">
+        {visible.map((b) => (
           <li
             key={b.id}
-            className="flex items-center gap-2 text-sm bg-surface-2 p-2 rounded"
+            className="flex items-center gap-2 rounded bg-surface-2 p-2 text-sm"
           >
             {b.icon}
-            <span>{b.text}</span>
+            <span className="line-clamp-2">{b.text}</span>
           </li>
         ))}
       </ul>
+      {badges.length > visible.length && (
+        <div className="mt-[var(--block-y)] text-right text-xs">
+          <button className="underline">Lihat semua</button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/CategoryDonut.jsx
+++ b/src/components/CategoryDonut.jsx
@@ -22,7 +22,7 @@ export default function CategoryDonut({ data = [] }) {
   };
 
   return (
-    <div className="card h-[260px]">
+    <div className="card aspect-video min-h-[200px]">
       {data.length ? (
         <ResponsiveContainer width="100%" height="100%">
           <PieChart>

--- a/src/components/MonthlyTrendChart.jsx
+++ b/src/components/MonthlyTrendChart.jsx
@@ -21,14 +21,14 @@ export default function MonthlyTrendChart({ data = [] }) {
   };
 
   return (
-    <div className="card h-[260px]">
+    <div className="card aspect-video min-h-[200px]">
       <ResponsiveContainer width="100%" height="100%">
         <LineChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="month" />
-          <YAxis />
+          <XAxis dataKey="month" tick={{ fill: 'var(--text-muted)' }} stroke="var(--text-muted)" />
+          <YAxis tick={{ fill: 'var(--text-muted)' }} stroke="var(--text-muted)" />
           <Tooltip content={renderTooltip} />
-          <Line type="monotone" dataKey="net" stroke="#3898f8" />
+          <Line type="monotone" dataKey="net" stroke="hsl(var(--brand-h) var(--brand-s) var(--brand-l))" />
         </LineChart>
       </ResponsiveContainer>
     </div>

--- a/src/components/QuickActions.jsx
+++ b/src/components/QuickActions.jsx
@@ -25,8 +25,8 @@ export default function QuickActions() {
 
   return (
     <div className="card">
-      <h2 className="mb-3 font-semibold">Quick Actions</h2>
-      <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+      <h2 className="mb-[var(--block-y)] font-semibold">Quick Actions</h2>
+      <div className="grid gap-[var(--block-y)] sm:grid-cols-2 lg:grid-cols-3">
         {actions.map((action) => {
           const Icon = action.icon;
           return (

--- a/src/components/QuoteBubble.jsx
+++ b/src/components/QuoteBubble.jsx
@@ -10,7 +10,7 @@ export default function QuoteBubble({ lang = "id" }) {
   }
 
   return (
-    <figure className="mx-auto w-full max-w-3xl">
+    <figure className="w-full">
       <blockquote className="relative w-full rounded-xl border border-brand/20 bg-brand/5 p-4 text-left shadow-sm dark:border-border dark:bg-surface-2">
         <span className="absolute -top-2 left-4 text-2xl text-brand" aria-hidden>
           “
@@ -21,7 +21,7 @@ export default function QuoteBubble({ lang = "id" }) {
         </span>
       </blockquote>
       {quote.author && (
-        <figcaption className="mt-2 text-right text-xs text-muted">
+        <figcaption className="mt-[var(--block-y)] text-right text-xs text-muted">
           — {quote.author}
         </figcaption>
       )}

--- a/src/components/SavingsProgress.jsx
+++ b/src/components/SavingsProgress.jsx
@@ -36,7 +36,7 @@ export default function SavingsProgress({ current = 0, target = 0 }) {
 
   return (
     <div className="card animate-slide h-full">
-      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+      <div className="mb-[var(--block-y)] flex flex-wrap items-center justify-between gap-2">
         <h2 className="font-semibold">Progress Tabungan</h2>
         {achieved && (
           <span className="inline-flex items-center gap-1 rounded-full bg-success/20 px-2 py-0.5 text-xs font-medium text-success">
@@ -44,7 +44,7 @@ export default function SavingsProgress({ current = 0, target = 0 }) {
           </span>
         )}
       </div>
-      <div className="mb-2 text-sm text-muted">
+      <div className="mb-[var(--block-y)] text-sm text-muted">
         Rp {current.toLocaleString("id-ID")} / Rp {target.toLocaleString("id-ID")}
       </div>
       <div
@@ -56,7 +56,7 @@ export default function SavingsProgress({ current = 0, target = 0 }) {
           style={{ width: `${Math.min(progress, 1) * 100}%` }}
         />
       </div>
-      <div className="mt-1 text-sm">
+      <div className="mt-[calc(var(--block-y)/2)] text-sm">
         {Math.round(Math.min(progress, 1) * 100)}% tercapai
       </div>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -27,6 +27,9 @@
     --page-y: clamp(16px, 4vw, 28px);
     --section-y: clamp(12px, 3vw, 24px);
     --block-y: clamp(8px, 2vw, 16px);
+    --sidebar-w-expanded: 280px;
+    --sidebar-w-collapsed: 72px;
+    --sidebar-width: var(--sidebar-w-expanded);
   }
   [data-theme='dark'] {
     --bg: #0f172a;

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -67,7 +67,9 @@ function hexToHsl(hex) {
 }
 
 export default function Sidebar({ theme, setTheme, brand, setBrand, useCloud, setUseCloud }) {
-  const [collapsed, setCollapsed] = useState(() => localStorage.getItem('hw:sidebar-collapsed') === '1');
+  const [collapsed, setCollapsed] = useState(
+    () => localStorage.getItem('hw:sidebar-collapsed') === '1'
+  );
   const [mobileOpen, setMobileOpen] = useState(false);
   const [sessionUser, setSessionUser] = useState(null);
   const [showSignIn, setShowSignIn] = useState(false);
@@ -82,6 +84,12 @@ export default function Sidebar({ theme, setTheme, brand, setBrand, useCloud, se
 
   useEffect(() => {
     localStorage.setItem('hw:sidebar-collapsed', collapsed ? '1' : '0');
+    const root = document.documentElement;
+    root.dataset.sidebarCollapsed = collapsed ? '1' : '0';
+    root.style.setProperty(
+      '--sidebar-width',
+      collapsed ? 'var(--sidebar-w-collapsed)' : 'var(--sidebar-w-expanded)'
+    );
   }, [collapsed]);
 
   const shortEmail = (email = '') =>
@@ -96,7 +104,8 @@ export default function Sidebar({ theme, setTheme, brand, setBrand, useCloud, se
 
   const content = (
     <div
-      className={`flex flex-col h-full ${collapsed ? 'w-16' : 'w-64'} transition-all bg-surface-1 text-text shadow-md`}
+      className="flex h-[100dvh] flex-col overflow-hidden bg-surface-1 text-text shadow-md transition-[width]"
+      style={{ width: collapsed ? 'var(--sidebar-w-collapsed)' : 'var(--sidebar-w-expanded)' }}
     >
       <div className="flex items-center justify-between p-4">
         <div className="flex items-center gap-2">
@@ -252,11 +261,11 @@ export default function Sidebar({ theme, setTheme, brand, setBrand, useCloud, se
   return (
     <>
       <div
-        className={`fixed inset-0 bg-black/40 z-40 md:hidden ${mobileOpen ? 'block' : 'hidden'}`}
+        className={`fixed inset-0 z-40 bg-black/40 md:hidden ${mobileOpen ? 'block' : 'hidden'}`}
         onClick={() => setMobileOpen(false)}
       />
       <div
-        className={`${mobileOpen ? 'translate-x-0' : '-translate-x-full'} md:translate-x-0 fixed z-50 inset-y-0 left-0 md:static md:flex`}
+        className={`fixed inset-y-0 left-0 z-50 transform transition-transform md:translate-x-0 ${mobileOpen ? 'translate-x-0' : '-translate-x-full'}`}
       >
         {content}
       </div>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -52,20 +52,16 @@ export default function Dashboard({ stats, txs }) {
         <QuoteBubble />
       </Section>
       <Section>
-        <div className="grid gap-[var(--block-y)] md:grid-cols-2 lg:grid-cols-12">
-          <div className="lg:col-span-7">
-            <SavingsProgress
-              current={stats?.balance || 0}
-              target={savingsTarget}
-            />
-          </div>
-          <div className="lg:col-span-5">
-            <AchievementBadges
-              stats={stats}
-              streak={streak}
-              target={savingsTarget}
-            />
-          </div>
+        <div className="grid gap-[var(--block-y)] lg:grid-cols-2">
+          <SavingsProgress
+            current={stats?.balance || 0}
+            target={savingsTarget}
+          />
+          <AchievementBadges
+            stats={stats}
+            streak={streak}
+            target={savingsTarget}
+          />
         </div>
       </Section>
       <Section>


### PR DESCRIPTION
## Summary
- fix(shell): sidebar fixed width (expanded/collapsed) and 100dvh with independent scroll
- refactor(shell): global main offset & early persisted nav state
- feat(dashboard): layout revamp (kpi/quote/milestone+achievements/quick actions/charts)
- fix(dashboard): normalize page/section spacing and remove duplicate margins
- chore(docs): add spacing & sidebar guidelines

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68c82368cce48332b0213a587d993d82