### PR TITLE
Fix categoriesByType memo reference error

### DIFF
--- a/src/pages/TransactionAdd.jsx
+++ b/src/pages/TransactionAdd.jsx
@@ -131,6 +131,16 @@ export default function TransactionAdd({ onAdd }) {
     loadMasterData();
   }, [addToast]);
 
+  const categoriesByType = useMemo(() => {
+    const map = { income: [], expense: [], transfer: [] };
+    (categories || []).forEach((cat) => {
+      const key = (cat.type || "expense").toLowerCase();
+      if (!map[key]) map[key] = [];
+      map[key].push(cat);
+    });
+    return map;
+  }, [categories]);
+
   useEffect(() => {
     const list = categoriesByType[type] || [];
     if (list.length === 0) {
@@ -157,16 +167,6 @@ export default function TransactionAdd({ onAdd }) {
   useEffect(() => {
     localStorage.setItem(TEMPLATE_KEY, JSON.stringify(templates));
   }, [templates]);
-
-  const categoriesByType = useMemo(() => {
-    const map = { income: [], expense: [], transfer: [] };
-    (categories || []).forEach((cat) => {
-      const key = (cat.type || "expense").toLowerCase();
-      if (!map[key]) map[key] = [];
-      map[key].push(cat);
-    });
-    return map;
-  }, [categories]);
 
   const accountOptions = useMemo(() => accounts.map((acc) => ({ value: acc.id, label: acc.name || "(Tanpa Nama)" })), [accounts]);
 


### PR DESCRIPTION
## Summary
- ensure the categoriesByType memo is created before it is used in dependent effects to prevent runtime initialization errors

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c8fd2726ac8332a75c041a81d8e409