### PR TITLE
Fix Supabase sync errors and sanitize payloads

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -288,7 +288,6 @@ function normalizeTransactionInput(input = {}) {
     amount: Number(input.amount ?? 0),
     title: input.title ?? null,
     notes: noteValue,
-    note: noteValue,
     account_id: input.account_id ?? null,
     to_account_id: input.to_account_id ?? null,
     category_id: input.category_id ?? null,

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,7 +1,10 @@
 import { createClient } from '@supabase/supabase-js'
 
 const browserEnv = typeof import.meta !== 'undefined' ? import.meta.env ?? {} : {}
-const nodeEnv = typeof process !== 'undefined' && process.env ? process.env : {}
+const nodeEnv =
+  typeof globalThis !== 'undefined' && globalThis.process?.env
+    ? globalThis.process.env
+    : {}
 
 const supabaseUrl = browserEnv.VITE_SUPABASE_URL ?? nodeEnv.VITE_SUPABASE_URL
 const supabaseKey =

--- a/src/lib/supabase.test.js
+++ b/src/lib/supabase.test.js
@@ -7,9 +7,12 @@ describe('supabase client env handling', () => {
     vi.resetModules()
     vi.doUnmock('@supabase/supabase-js')
     console.warn = vi.fn()
-    delete process.env.VITE_SUPABASE_URL
-    delete process.env.VITE_SUPABASE_PUBLISHABLE_KEY
-    delete process.env.VITE_SUPABASE_ANON_KEY
+    const env = globalThis.process?.env
+    if (env) {
+      delete env.VITE_SUPABASE_URL
+      delete env.VITE_SUPABASE_PUBLISHABLE_KEY
+      delete env.VITE_SUPABASE_ANON_KEY
+    }
   })
 
   afterEach(() => {
@@ -20,8 +23,10 @@ describe('supabase client env handling', () => {
   })
 
   it('falls back to VITE_SUPABASE_ANON_KEY when publishable key is missing', async () => {
-    process.env.VITE_SUPABASE_URL = 'http://localhost'
-    process.env.VITE_SUPABASE_ANON_KEY = 'anon-key'
+    const env = globalThis.process?.env
+    if (!env) throw new Error('process.env tidak tersedia dalam lingkungan pengujian')
+    env.VITE_SUPABASE_URL = 'http://localhost'
+    env.VITE_SUPABASE_ANON_KEY = 'anon-key'
 
     const createClient = vi.fn(() => ({}))
     vi.doMock('@supabase/supabase-js', () => ({ createClient }))


### PR DESCRIPTION
## Summary
- disable remote profile sync when the Supabase profiles table is unavailable and refactor cloud fetch helpers to be reusable
- fetch budgets without relying on unavailable joins and derive category labels through fallbacks
- strip non-column properties from transaction payloads before syncing and access process env via globalThis in the Supabase client

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68c93a4f604c8332afb5d020798b8812