### PR TITLE
Fix cloud fetch effect initialization order

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -369,14 +369,6 @@ function AppShell({ prefs, setPrefs }) {
     localStorage.setItem("hematwoi:v3:alloc", JSON.stringify(allocRules));
   }, [allocRules]);
 
-  useEffect(() => {
-    if (useCloud && sessionUser) {
-      fetchCategoriesCloud();
-      fetchTxsCloud();
-      fetchBudgetsCloud();
-    }
-  }, [useCloud, sessionUser, fetchCategoriesCloud, fetchTxsCloud, fetchBudgetsCloud]);
-
   const fetchCategoriesCloud = useCallback(async () => {
     try {
       const rows = await apiListCategories();
@@ -494,6 +486,14 @@ function AppShell({ prefs, setPrefs }) {
       console.error("fetch budgets failed", e);
     }
   }, [sessionUser, categoryNameById]);
+
+  useEffect(() => {
+    if (useCloud && sessionUser) {
+      fetchCategoriesCloud();
+      fetchTxsCloud();
+      fetchBudgetsCloud();
+    }
+  }, [useCloud, sessionUser, fetchCategoriesCloud, fetchTxsCloud, fetchBudgetsCloud]);
 
   const triggerMoneyTalk = (tx) => {
     const category = tx.category;


### PR DESCRIPTION
## Summary
- move the cloud synchronization effect after the memoized fetch callbacks so they are initialized before use

## Testing
- pnpm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c940da8b5c8332a52e810a472d93bd