### PR TITLE
Fix Supabase schema mismatches for budgets and transactions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -424,7 +424,7 @@ function AppShell({ prefs, setPrefs }) {
       const { data: rows, error } = await supabase
         .from("budgets")
         .select(
-          "id, month, amount_planned, amount, carryover_enabled, carryover, notes, note, category_id"
+          "id, month, amount, carryover_enabled, carryover, notes, note, category_id"
         )
         .eq("user_id", sessionUser.id)
         .order("month", { ascending: false });
@@ -462,7 +462,7 @@ function AppShell({ prefs, setPrefs }) {
         });
       }
       const mapped = (rows || []).map((row) => {
-        const planned = Number(row?.amount_planned ?? row?.amount ?? 0);
+        const planned = Number(row?.amount ?? row?.amount_planned ?? 0);
         const categoryLabel =
           (row?.category_id &&
             (categoryNameById(row.category_id) ||
@@ -707,14 +707,14 @@ function AppShell({ prefs, setPrefs }) {
             user_id: sessionUser.id,
             category_id: categoryId,
             month: `${m}-01`,
-            amount_planned: amount,
+            amount,
           })
           .select(
-            "id, month, amount_planned, amount, carryover_enabled, carryover, notes, note, category_id"
+            "id, month, amount, carryover_enabled, carryover, notes, note, category_id"
           )
           .single();
         if (error) throw error;
-        const planned = Number(row?.amount_planned ?? row?.amount ?? amount);
+        const planned = Number(row?.amount ?? row?.amount_planned ?? amount);
         const categoryLabel =
           (row?.category_id && categoryNameById(row.category_id)) ||
           category ||

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -90,6 +90,15 @@ export function mapTransactionRow(tx = {}) {
     tx.merchants?.id ??
     null;
 
+  const createdAt =
+    tx.created_at ??
+    tx.createdAt ??
+    tx.inserted_at ??
+    tx.insertedAt ??
+    tx.created ??
+    tx.updated_at ??
+    null;
+
   const note =
     tx.note ??
     tx.notes ??
@@ -122,7 +131,7 @@ export function mapTransactionRow(tx = {}) {
     deleted_at: tx.deleted_at ?? null,
     rev: tx.rev ?? null,
     updated_at: tx.updated_at ?? null,
-    created_at: tx.created_at ?? null,
+    created_at: createdAt,
   };
 }
 
@@ -222,7 +231,6 @@ export async function listTransactions(
     receipt_url,
     rev,
     updated_at,
-    created_at,
     deleted_at,
     account:account_id (*),
     to_account:to_account_id (*),

--- a/src/lib/sync/SyncEngine.js
+++ b/src/lib/sync/SyncEngine.js
@@ -62,6 +62,8 @@ function requiresUserContext(entity) {
 function sanitizeForSupabase(entity, record) {
   if (entity === "transactions") {
     const cleaned = { ...record };
+    delete cleaned.created_at;
+    delete cleaned.createdAt;
     delete cleaned.note;
     delete cleaned.tags;
     delete cleaned.tag_ids;


### PR DESCRIPTION
## Summary
- request only existing Supabase budget columns and derive the planned amount from the `amount` field
- map transaction creation timestamps from available fields and stop querying/sending the missing `created_at` column
- strip `created_at` from transaction payloads before syncing so upserts succeed against the current schema

## Testing
- pnpm lint
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68c9493207888332a4b4bec599597914