### PR TITLE
Fix Supabase budget queries to use amount_planned column

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -424,7 +424,7 @@ function AppShell({ prefs, setPrefs }) {
       const { data: rows, error } = await supabase
         .from("budgets")
         .select(
-          "id, month, amount, carryover_enabled, carryover, notes, note, category_id"
+          "id, month, amount_planned, carryover_enabled, carryover, notes, note, category_id"
         )
         .eq("user_id", sessionUser.id)
         .order("month", { ascending: false });
@@ -707,10 +707,10 @@ function AppShell({ prefs, setPrefs }) {
             user_id: sessionUser.id,
             category_id: categoryId,
             month: `${m}-01`,
-            amount,
+            amount_planned: amount,
           })
           .select(
-            "id, month, amount, carryover_enabled, carryover, notes, note, category_id"
+            "id, month, amount_planned, carryover_enabled, carryover, notes, note, category_id"
           )
           .single();
         if (error) throw error;


### PR DESCRIPTION
## Summary
- update cloud budget fetch and insert queries to request the amount_planned column instead of the removed amount column
- send amount_planned when inserting new budgets so Supabase accepts the payload

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c964e1d8788332a7fda1c02b7d6e82