### PR TITLE
Fix Supabase transaction sync payload handling

### DIFF
--- a/src/components/SyncBanner.jsx
+++ b/src/components/SyncBanner.jsx
@@ -1,9 +1,17 @@
 import { useEffect, useState } from "react";
-import { flushQueue, onStatusChange, pending, SyncStatus } from "../lib/sync/SyncEngine";
+import { useToast } from "../context/ToastContext";
+import {
+  flushQueue,
+  onError,
+  onStatusChange,
+  pending,
+  SyncStatus,
+} from "../lib/sync/SyncEngine";
 
 export default function SyncBanner() {
   const [status, setStatus] = useState(SyncStatus.IDLE);
   const [count, setCount] = useState(0);
+  const { addToast } = useToast();
 
   useEffect(() => {
     const unsub = onStatusChange(async (s) => {
@@ -13,6 +21,14 @@ export default function SyncBanner() {
     (async () => setCount(await pending()))();
     return unsub;
   }, []);
+
+  useEffect(() => {
+    const unsubscribe = onError((error) => {
+      const detail = error?.message ? `: ${error.message}` : "";
+      addToast(`Sync gagal, cek log${detail}`, "error");
+    });
+    return unsubscribe;
+  }, [addToast]);
 
   let text = "";
   if (status === SyncStatus.OFFLINE) text = "Offline";

--- a/src/lib/sync/SyncEngine.js
+++ b/src/lib/sync/SyncEngine.js
@@ -55,40 +55,91 @@ const USER_SCOPED_TABLES = new Set([
   "tags",
 ]);
 
+const TRANSACTION_COLUMNS = [
+  "id",
+  "user_id",
+  "date",
+  "type",
+  "category_id",
+  "account_id",
+  "to_account_id",
+  "merchant_id",
+  "note",
+  "amount",
+  "receipt_url",
+  "parent_id",
+  "transfer_group_id",
+  "deleted_at",
+  "updated_at",
+  "rev",
+];
+
+const errorListeners = new Set();
+
 function requiresUserContext(entity) {
   return USER_SCOPED_TABLES.has(entity);
 }
 
-function sanitizeForSupabase(entity, record) {
+function emitError(error, context = {}) {
+  for (const listener of errorListeners) {
+    try {
+      listener(error, context);
+    } catch (listenerError) {
+      console.error("Sync error listener failed", listenerError);
+    }
+  }
+}
+
+export function onError(fn) {
+  errorListeners.add(fn);
+  return () => errorListeners.delete(fn);
+}
+
+function sanitizeTransaction(record) {
+  const cleaned = {};
+  for (const key of TRANSACTION_COLUMNS) {
+    if (record[key] !== undefined) cleaned[key] = record[key];
+  }
+  return cleaned;
+}
+
+function sanitizePayload(entity, record) {
   if (entity === "transactions") {
-    const cleaned = { ...record };
-    delete cleaned.created_at;
-    delete cleaned.createdAt;
-    delete cleaned.note;
-    delete cleaned.tags;
-    delete cleaned.tag_ids;
-    delete cleaned.tagNames;
-    delete cleaned.tag_labels;
-    delete cleaned.category;
-    delete cleaned.category_name;
-    delete cleaned.account;
-    delete cleaned.account_name;
-    delete cleaned.to_account;
-    delete cleaned.to_account_name;
-    delete cleaned.merchant;
-    delete cleaned.merchant_name;
-    delete cleaned.receipts;
-    return cleaned;
+    return sanitizeTransaction(record);
   }
   return record;
+}
+
+function sanitizeForSupabase(entity, record) {
+  const sanitized = sanitizePayload(entity, record);
+  if (sanitized === record) return sanitized;
+  const withoutNullish = {};
+  for (const [key, value] of Object.entries(sanitized)) {
+    if (value !== undefined) withoutNullish[key] = value;
+  }
+  return withoutNullish;
+}
+
+function handleSyncError(error, context = {}) {
+  if (!error) return;
+  if (error?.message === "offline") return;
+  console.error("Sync error", { context, error });
+  emitError(error, context);
 }
 
 async function sendOp(op) {
   if (op.type === "UPSERT") {
     const basePayload = op.meta?.normalized ? op.payload : normalizeRecord(op.payload);
     const payload = sanitizeForSupabase(op.entity, basePayload);
-    const onConflict = op.meta?.onConflict || "id";
-    const { error } = await supabase.from(op.entity).upsert([payload], { onConflict });
+    if (op.entity === "transactions") {
+      console.log("Syncing transaction payload:", payload);
+    }
+    const options = {};
+    if (op.entity === "transactions") options.onConflict = "id";
+    else if (op.meta?.onConflict) options.onConflict = op.meta.onConflict;
+    const { error } = await supabase
+      .from(op.entity)
+      .upsert([payload], Object.keys(options).length ? options : undefined);
     if (error) throw error;
     await dbCache.set(op.entity, payload);
   } else if (op.type === "DELETE") {
@@ -127,7 +178,8 @@ export async function upsert(entity, record) {
   };
   try {
     await tryImmediate(op);
-  } catch {
+  } catch (error) {
+    handleSyncError(error, { entity, opId: op.opId, stage: "immediate" });
     await dbCache.set(entity, normalized); // optimistic
     await oplogStore.add(op);
     setStatus(SyncStatus.OFFLINE);
@@ -158,53 +210,63 @@ export async function remove(entity, id) {
 export async function flushQueue({ batchSize = SYNC_BATCH_SIZE } = {}) {
   if (!navigator.onLine || window.__sync?.fakeOffline) return;
   setStatus(SyncStatus.SYNCING);
-  const now = Date.now();
-  const ops = await oplogStore.listReady(now);
-  if (ops.length === 0) {
-    setStatus(SyncStatus.IDLE);
-    return;
-  }
-  const groups = groupOps(ops);
-  for (const g of groups) {
-    const slice = g.items.slice(0, batchSize);
-    try {
-      if (g.type === "UPSERT") {
-        const payloads = slice.map((o) => {
-          const base = o.meta?.normalized ? o.payload : normalizeRecord(o.payload);
-          return sanitizeForSupabase(g.entity, base);
-        });
-        const onConflict = slice[0]?.meta?.onConflict || "id";
-        const { error } = await supabase
-          .from(g.entity)
-          .upsert(payloads, { onConflict });
-        if (error) throw error;
-        await dbCache.bulkSet(g.entity, payloads);
-      } else if (g.type === "DELETE") {
-        const ids = slice.map((o) => o.payload.id);
-        const { error } = await supabase.from(g.entity).delete().in("id", ids);
-        if (error) throw error;
-        for (const id of ids) await dbCache.remove(g.entity, id);
-      } else if (g.type === "STORAGE_PUT") {
-        await processStoragePutBatch(slice);
+  try {
+    const now = Date.now();
+    const ops = await oplogStore.listReady(now);
+    if (ops.length === 0) return;
+    const groups = groupOps(ops);
+    for (const g of groups) {
+      const slice = g.items.slice(0, batchSize);
+      try {
+        if (g.type === "UPSERT") {
+          const payloads = slice.map((o) => {
+            const base = o.meta?.normalized ? o.payload : normalizeRecord(o.payload);
+            const payload = sanitizeForSupabase(g.entity, base);
+            if (g.entity === "transactions") {
+              console.log("Syncing transaction payload:", payload);
+            }
+            return payload;
+          });
+          const options = {};
+          if (g.entity === "transactions") options.onConflict = "id";
+          else if (slice[0]?.meta?.onConflict) options.onConflict = slice[0].meta.onConflict;
+          const { error } = await supabase
+            .from(g.entity)
+            .upsert(payloads, Object.keys(options).length ? options : undefined);
+          if (error) throw error;
+          await dbCache.bulkSet(g.entity, payloads);
+        } else if (g.type === "DELETE") {
+          const ids = slice.map((o) => o.payload.id);
+          const { error } = await supabase.from(g.entity).delete().in("id", ids);
+          if (error) throw error;
+          for (const id of ids) await dbCache.remove(g.entity, id);
+        } else if (g.type === "STORAGE_PUT") {
+          await processStoragePutBatch(slice);
+        }
+        await oplogStore.bulkRemove(slice.map((o) => o.opId));
+      } catch (error) {
+        handleSyncError(error, { entity: g.entity, type: g.type });
+        for (const o of slice) {
+          const attempt = (o.attempts || 0) + 1;
+          const delay = calcBackoff(attempt);
+          await oplogStore.markDeferred(
+            o.opId,
+            attempt,
+            Date.now() + delay,
+            String(error?.message || error)
+          );
+        }
+        break;
       }
-      await oplogStore.bulkRemove(slice.map((o) => o.opId));
-    } catch (e) {
-      for (const o of slice) {
-        const attempt = (o.attempts || 0) + 1;
-        const delay = calcBackoff(attempt);
-        await oplogStore.markDeferred(
-          o.opId,
-          attempt,
-          Date.now() + delay,
-          String(e.message || e)
-        );
-      }
-      break;
+      if (!navigator.onLine || window.__sync?.fakeOffline) break;
     }
-    if (!navigator.onLine || window.__sync?.fakeOffline) break;
+  } catch (error) {
+    handleSyncError(error, { stage: "flushQueue" });
+  } finally {
+    const remaining = await oplogStore.count();
+    const nextStatus = remaining > 0 ? SyncStatus.SYNCING : SyncStatus.IDLE;
+    setStatus(nextStatus);
   }
-  const remaining = await oplogStore.count();
-  setStatus(remaining > 0 ? SyncStatus.SYNCING : SyncStatus.IDLE);
 }
 
 export async function pending() {


### PR DESCRIPTION
## Summary
- whitelist valid transaction fields before syncing and force transactions upserts to use `onConflict: "id"`
- add detailed sync error logging, retry handling improvements, and expose a new sync error event
- surface sync failures through toast notifications so users see "Sync gagal, cek log"

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c978f803bc8332a193cd9b7fa52786