### PR TITLE
Refine dashboard layout and shared UI components

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import {
 } from "react-router-dom";
 
 import Sidebar from "./layout/Sidebar";
+import MainLayout from "./layout/MainLayout";
 import SettingsPanel from "./components/SettingsPanel";
 import SyncBanner from "./components/SyncBanner";
 
@@ -1009,29 +1010,28 @@ function AppShell({ prefs, setPrefs }) {
 
   return (
     <CategoryProvider catMeta={catMeta}>
-      {!hideNav && (
-        <Sidebar
-          theme={theme}
-          setTheme={setTheme}
-          brand={brand}
-          setBrand={setBrand}
-        />
-      )}
-      <div
-        className={`min-h-[100dvh] flex flex-col overflow-x-hidden ${!hideNav ? 'md:ml-[var(--sidebar-width)]' : ''}`}
+      <MainLayout
+        hideSidebar={hideNav}
+        sidebar={
+          !hideNav ? (
+            <Sidebar
+              theme={theme}
+              setTheme={setTheme}
+              brand={brand}
+              setBrand={setBrand}
+            />
+          ) : null
+        }
       >
-        <SyncBanner />
-        <main
-          id="main"
-          tabIndex="-1"
-          className="flex-1 overflow-y-auto focus:outline-none"
-        >
-          <Routes>
-            <Route path="/auth" element={<AuthPage />} />
-            <Route element={<AuthGuard />}>
-              <Route
-              path="/"
-              element={
+        <div className="flex min-h-full flex-col">
+          <SyncBanner />
+          <div className="mx-auto w-full max-w-[1280px] px-4 py-6 sm:px-6 sm:py-8 lg:px-8 lg:py-10">
+            <Routes>
+              <Route path="/auth" element={<AuthPage />} />
+              <Route element={<AuthGuard />}>
+                <Route
+                path="/"
+                element={
                 <Dashboard
                   stats={stats}
                   monthForReport={
@@ -1125,9 +1125,10 @@ function AppShell({ prefs, setPrefs }) {
               element={<ProfilePage transactions={data.txs} challenges={challenges} />}
             />
           </Route>
-          </Routes>
-        </main>
-      </div>
+            </Routes>
+          </div>
+        </div>
+      </MainLayout>
       <SettingsPanel
         open={settingsOpen}
         onClose={() => setSettingsOpen(false)}

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,7 +1,17 @@
 import clsx from "clsx";
 
 export default function Card({ className = "", children }) {
-  return <div className={clsx("card", className)}>{children}</div>;
+  return (
+    <div
+      className={clsx(
+        "card relative isolate overflow-hidden text-sm text-text/90 dark:text-slate-200/90",
+        "supports-[backdrop-filter]:bg-white/60 supports-[backdrop-filter]:dark:bg-white/5",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
 }
 
 export function CardHeader({
@@ -13,13 +23,21 @@ export function CardHeader({
   return (
     <div
       className={clsx(
-        "mb-4 flex flex-wrap items-start justify-between gap-2",
+        "mb-4 flex flex-wrap items-start justify-between gap-3 text-left",
         className
       )}
     >
       <div className="min-w-0 flex-1">
-        {title && <h3 className="text-base font-semibold">{title}</h3>}
-        {subtext && <p className="text-sm text-muted">{subtext}</p>}
+        {title && (
+          <h3 className="text-lg font-semibold text-text dark:text-slate-100">
+            {title}
+          </h3>
+        )}
+        {subtext && (
+          <p className="text-sm text-muted/90 dark:text-slate-300/80">
+            {subtext}
+          </p>
+        )}
       </div>
       {actions && <div className="flex-shrink-0">{actions}</div>}
     </div>
@@ -27,14 +45,14 @@ export function CardHeader({
 }
 
 export function CardBody({ className = "", children }) {
-  return <div className={clsx("space-y-2", className)}>{children}</div>;
+  return <div className={clsx("space-y-3", className)}>{children}</div>;
 }
 
 export function CardFooter({ className = "", children }) {
   return (
     <div
       className={clsx(
-        "mt-4 border-t border-border pt-4",
+        "mt-4 border-t border-white/10 pt-4 dark:border-white/10",
         className
       )}
     >

--- a/src/components/CategoryDonut.jsx
+++ b/src/components/CategoryDonut.jsx
@@ -1,4 +1,5 @@
-import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip, Legend } from "recharts";
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from "recharts";
+import ChartCard from "./dashboard/ChartCard";
 
 function toRupiah(n = 0) {
   return new Intl.NumberFormat("id-ID", {
@@ -15,32 +16,56 @@ export default function CategoryDonut({ data = [] }) {
     if (!payload?.length) return null;
     const p = payload[0];
     return (
-      <div className="rounded bg-surface-1 border border-border p-2 text-xs shadow">
-        {p.name}: {toRupiah(p.value)}
+      <div className="rounded-lg border border-white/10 bg-white/95 px-3 py-2 text-xs text-text shadow-lg dark:bg-slate-900/90">
+        <div className="font-medium text-text">{p.name}</div>
+        <div className="text-brand">{toRupiah(p.value)}</div>
       </div>
     );
   };
 
   return (
-    <div className="card aspect-video min-h-[200px]">
-      {data.length ? (
-        <ResponsiveContainer width="100%" height="100%">
+    <ChartCard
+      title="Distribusi Kategori"
+      subtext="Persentase pengeluaran per kategori"
+      isEmpty={!data.length}
+      footer={
+        data.length ? (
+          <ul className="flex flex-wrap items-center gap-3 text-xs text-muted/90">
+            {data.map((item, index) => (
+              <li key={item.name} className="flex min-w-0 items-center gap-2">
+                <span
+                  className="h-3 w-3 flex-shrink-0 rounded-full"
+                  style={{ backgroundColor: COLORS[index % COLORS.length] }}
+                />
+                <span className="truncate">
+                  {item.name} · {toRupiah(item.value)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : null
+      }
+    >
+      {({ height }) => (
+        <ResponsiveContainer width="100%" height={height}>
           <PieChart>
-            <Pie data={data} dataKey="value" innerRadius="60%" outerRadius="80%">
+            <Pie
+              data={data}
+              dataKey="value"
+              nameKey="name"
+              innerRadius="55%"
+              outerRadius="80%"
+              paddingAngle={4}
+            >
               {data.map((entry, i) => (
-                <Cell key={i} fill={COLORS[i % COLORS.length]} />
+                <Cell key={entry.name || i} fill={COLORS[i % COLORS.length]} />
               ))}
             </Pie>
             <Tooltip content={renderTooltip} />
-            <Legend />
           </PieChart>
         </ResponsiveContainer>
-      ) : (
-        <div className="flex h-full items-center justify-center text-sm text-muted">
-          Tidak ada data
-        </div>
       )}
-    </div>
+    </ChartCard>
   );
 }
 

--- a/src/components/KpiCard.jsx
+++ b/src/components/KpiCard.jsx
@@ -16,14 +16,16 @@ export default function KpiCard({
 
   return (
     <Card className="text-center">
-      <CardBody className="space-y-1">
-        <div className="text-sm text-muted whitespace-nowrap">{label}</div>
+      <CardBody className="space-y-2">
+        <div className="whitespace-nowrap text-sm font-medium text-muted/90">
+          {label}
+        </div>
         {loading ? (
-          <div className="mx-auto h-6 w-24 rounded bg-surface-2 animate-pulse" />
+          <div className="mx-auto h-7 w-24 rounded-full bg-white/20 animate-pulse" />
         ) : (
           <div
             className={clsx(
-              "text-2xl font-semibold whitespace-nowrap",
+              "whitespace-nowrap text-2xl font-bold tracking-tight sm:text-3xl",
               color
             )}
           >

--- a/src/components/KpiCards.jsx
+++ b/src/components/KpiCards.jsx
@@ -15,7 +15,7 @@ export default function KpiCards({
   loading = false,
 }) {
   return (
-    <div className="grid gap-[var(--block-y)] sm:grid-cols-2 lg:grid-cols-3">
+    <div className="grid gap-4 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3 lg:gap-8">
       <KpiCard
         label="Pemasukan"
         value={toRupiah(income)}

--- a/src/components/MonthlyTrendChart.jsx
+++ b/src/components/MonthlyTrendChart.jsx
@@ -1,4 +1,13 @@
-import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid } from "recharts";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from "recharts";
+import ChartCard from "./dashboard/ChartCard";
 
 function toRupiah(n = 0) {
   return new Intl.NumberFormat("id-ID", {
@@ -13,25 +22,51 @@ export default function MonthlyTrendChart({ data = [] }) {
     if (!payload?.length) return null;
     const p = payload[0];
     return (
-      <div className="rounded bg-surface-1 border border-border p-2 text-xs shadow">
-        <div>{label}</div>
-        <div>{toRupiah(p.value)}</div>
+      <div className="rounded-lg border border-white/10 bg-white/95 px-3 py-2 text-xs text-text shadow-lg dark:bg-slate-900/90">
+        <div className="font-medium text-text">{label}</div>
+        <div className="text-brand">{toRupiah(p.value)}</div>
       </div>
     );
   };
 
   return (
-    <div className="card aspect-video min-h-[200px]">
-      <ResponsiveContainer width="100%" height="100%">
-        <LineChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="month" tick={{ fill: 'var(--text-muted)' }} stroke="var(--text-muted)" />
-          <YAxis tick={{ fill: 'var(--text-muted)' }} stroke="var(--text-muted)" />
-          <Tooltip content={renderTooltip} />
-          <Line type="monotone" dataKey="net" stroke="hsl(var(--brand-h) var(--brand-s) var(--brand-l))" />
-        </LineChart>
-      </ResponsiveContainer>
-    </div>
+    <ChartCard
+      title="Tren Saldo Bulanan"
+      subtext="Perubahan saldo bersih per bulan"
+      isEmpty={!data.length}
+    >
+      {({ height }) => (
+        <ResponsiveContainer width="100%" height={height}>
+          <LineChart
+            data={data}
+            margin={{ top: 16, right: 16, left: 0, bottom: 8 }}
+          >
+            <CartesianGrid stroke="rgba(255,255,255,0.08)" vertical={false} />
+            <XAxis
+              dataKey="month"
+              tick={{ fill: "var(--text-muted)" }}
+              tickLine={false}
+              axisLine={{ stroke: "rgba(255,255,255,0.12)" }}
+            />
+            <YAxis
+              tick={{ fill: "var(--text-muted)" }}
+              tickFormatter={(value) => `${Math.round(value / 1000)}k`}
+              tickLine={false}
+              axisLine={{ stroke: "rgba(255,255,255,0.12)" }}
+            />
+            <Tooltip content={renderTooltip} cursor={{ stroke: "var(--brand-ring)" }} />
+            <Line
+              type="monotone"
+              dataKey="net"
+              stroke="hsl(var(--brand-h) var(--brand-s) var(--brand-l))"
+              strokeWidth={3}
+              dot={false}
+              activeDot={{ r: 6 }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </ChartCard>
   );
 }
 

--- a/src/components/QuickActions.jsx
+++ b/src/components/QuickActions.jsx
@@ -1,5 +1,6 @@
-import { Link } from "react-router-dom";
 import { PlusCircle, Wallet, CreditCard } from "lucide-react";
+import Card, { CardHeader } from "./Card";
+import QuickActionCard from "./dashboard/QuickActionCard";
 
 export default function QuickActions() {
   const actions = [
@@ -24,28 +25,22 @@ export default function QuickActions() {
   ];
 
   return (
-    <div className="card">
-      <h2 className="mb-[var(--block-y)] font-semibold">Quick Actions</h2>
-      <div className="grid gap-[var(--block-y)] sm:grid-cols-2 lg:grid-cols-3">
-        {actions.map((action) => {
-          const Icon = action.icon;
-          return (
-            <Link
-              key={action.to}
-              to={action.to}
-              className="group flex items-start gap-3 rounded-lg border p-3 transition shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 active:bg-surface-2"
-            >
-              <span className="flex h-10 w-10 items-center justify-center rounded-full bg-brand-500/10 text-brand-600">
-                <Icon className="h-5 w-5" />
-              </span>
-              <span className="flex flex-col">
-                <span className="font-medium">{action.label}</span>
-                <span className="text-xs text-muted">{action.shortcut}</span>
-              </span>
-            </Link>
-          );
-        })}
+    <Card>
+      <CardHeader
+        title="Quick Actions"
+        subtext="Akses cepat ke aksi favoritmu"
+      />
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {actions.map((action) => (
+          <QuickActionCard
+            key={action.to}
+            to={action.to}
+            icon={action.icon}
+            title={action.label}
+            hint={action.shortcut}
+          />
+        ))}
       </div>
-    </div>
+    </Card>
   );
 }

--- a/src/components/RecentTransactions.jsx
+++ b/src/components/RecentTransactions.jsx
@@ -1,5 +1,7 @@
 import { useMemo, useState } from "react";
+import clsx from "clsx";
 import Segmented from "./ui/Segmented";
+import DataList from "./dashboard/DataList";
 
 function formatCurrency(n = 0) {
   return new Intl.NumberFormat("id-ID", {
@@ -26,10 +28,14 @@ export default function RecentTransactions({ txs = [] }) {
       .slice(0, 5);
   }, [txs, period]);
 
+  const periodLabel =
+    period === "day" ? "24 jam" : period === "week" ? "7 hari" : "30 hari";
+
   return (
-    <div className="card">
-      <div className="flex items-center justify-between mb-3">
-        <h2 className="font-semibold">Transaksi Terbaru</h2>
+    <DataList
+      title="Transaksi Terbaru"
+      subtext={`Ringkasan transaksi ${periodLabel} terakhir`}
+      actions={
         <Segmented
           value={period}
           onChange={setPeriod}
@@ -39,24 +45,40 @@ export default function RecentTransactions({ txs = [] }) {
             { label: "Bulan", value: "month" },
           ]}
         />
-      </div>
-      {!filtered.length && (
-        <div className="text-sm text-muted">Belum ada transaksi.</div>
-      )}
-      <ul className="space-y-2">
-        {filtered.map((t) => (
-          <li key={t.id} className="flex justify-between text-sm">
-            <span>{t.note || t.category}</span>
+      }
+      rows={filtered}
+      emptyMessage="Belum ada transaksi periode ini."
+      columns={[
+        {
+          key: "note",
+          label: "Transaksi",
+          render: (row) => (
+            <div className="flex flex-col gap-1">
+              <span className="truncate font-medium text-text dark:text-slate-100">
+                {row.note || row.category}
+              </span>
+              <span className="text-xs text-muted/80">{row.date}</span>
+            </div>
+          ),
+        },
+        {
+          key: "amount",
+          label: "Jumlah",
+          align: "right",
+          render: (row) => (
             <span
-              className={
-                t.type === "income" ? "text-success" : "text-danger"
-              }
+              className={clsx(
+                "inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold",
+                row.type === "income"
+                  ? "bg-success/10 text-success"
+                  : "bg-danger/10 text-danger"
+              )}
             >
-              {formatCurrency(t.amount)}
+              {formatCurrency(row.amount)}
             </span>
-          </li>
-        ))}
-      </ul>
-    </div>
+          ),
+        },
+      ]}
+    />
   );
 }

--- a/src/components/SectionHeader.jsx
+++ b/src/components/SectionHeader.jsx
@@ -1,8 +1,15 @@
-export default function SectionHeader({ title, children }) {
+export default function SectionHeader({ title, description, children }) {
   return (
-    <header className="mb-2 flex items-center justify-between gap-2">
-      <h2 className="text-lg font-semibold">{title}</h2>
-      {children && <div className="text-sm text-muted">{children}</div>}
+    <header className="flex flex-wrap items-end justify-between gap-4">
+      <div className="min-w-0 flex-1">
+        <h2 className="text-xl font-bold tracking-tight text-text sm:text-2xl">
+          {title}
+        </h2>
+        {description && (
+          <p className="mt-1 text-sm text-muted/90">{description}</p>
+        )}
+      </div>
+      {children && <div className="flex-shrink-0">{children}</div>}
     </header>
   );
 }

--- a/src/components/TopSpendsTable.jsx
+++ b/src/components/TopSpendsTable.jsx
@@ -1,4 +1,6 @@
 import { useMemo, useState } from "react";
+import clsx from "clsx";
+import DataList from "./dashboard/DataList";
 
 function toRupiah(n = 0) {
   return new Intl.NumberFormat("id-ID", {
@@ -20,40 +22,68 @@ export default function TopSpendsTable({ data = [], onSelect }) {
   const toggleSort = () => setSort((s) => (s === "asc" ? "desc" : "asc"));
 
   return (
-    <div className="card">
-      <div className="mb-2 flex items-center justify-between">
-        <h2 className="font-semibold">Top Pengeluaran</h2>
-        <button className="btn" onClick={toggleSort}>
-          Sort {sort === "asc" ? "↑" : "↓"}
+    <DataList
+      title="Top Pengeluaran"
+      subtext="Pengeluaran terbesar dalam periode ini"
+      actions={
+        <button
+          onClick={toggleSort}
+          className="inline-flex items-center gap-1 rounded-full border border-white/15 px-3 py-1 text-xs font-medium text-text transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+          aria-label="Urutkan pengeluaran"
+        >
+          Sortir {sort === "asc" ? "↑" : "↓"}
         </button>
-      </div>
-      <div className="table-wrap overflow-auto">
-        <table className="min-w-full text-sm">
-          <thead className="text-left">
-            <tr>
-              <th className="p-2">Catatan</th>
-              <th className="p-2">Tanggal</th>
-              <th className="p-2 text-right">Jumlah</th>
-            </tr>
-          </thead>
-          <tbody>
-            {sorted.map((t) => (
-              <tr
-                key={t.id}
-                className="cursor-pointer hover:bg-surface-2"
-                onClick={() => onSelect && onSelect(t)}
-              >
-                <td className="p-2">{t.note || t.category || "-"}</td>
-                <td className="p-2">{t.date}</td>
-                <td className="p-2 text-right text-danger">
-                  {toRupiah(t.amount)}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
+      }
+      rows={sorted}
+      onRowClick={onSelect}
+      columns={[
+        {
+          key: "note",
+          label: "Catatan",
+          render: (row) => (
+            <div className="flex flex-col gap-1">
+              <span className="truncate font-medium text-text dark:text-slate-100">
+                {row.note || row.category || "-"}
+              </span>
+              <span className="text-xs text-muted/80">{row.category}</span>
+            </div>
+          ),
+        },
+        {
+          key: "date",
+          label: "Tanggal",
+          render: (row) => (
+            <span className="whitespace-nowrap text-sm text-muted/80">
+              {row.date}
+            </span>
+          ),
+        },
+        {
+          key: "amount",
+          label: "Jumlah",
+          align: "right",
+          className: (row) =>
+            clsx(
+              "text-right",
+              row.amount < 0
+                ? "text-danger"
+                : "text-success"
+            ),
+          render: (row) => (
+            <span
+              className={clsx(
+                "inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold",
+                row.amount < 0
+                  ? "bg-danger/10 text-danger"
+                  : "bg-success/10 text-success"
+              )}
+            >
+              {toRupiah(row.amount)}
+            </span>
+          ),
+        },
+      ]}
+    />
   );
 }
 

--- a/src/components/dashboard/ChartCard.jsx
+++ b/src/components/dashboard/ChartCard.jsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from "react";
+import { LineChart as LineChartIcon } from "lucide-react";
+import clsx from "clsx";
+import Card, { CardHeader } from "../Card";
+
+function ChartSkeleton({ height }) {
+  return (
+    <div
+      className="flex h-full flex-col justify-center gap-4 rounded-xl bg-white/5 p-6 dark:bg-white/5"
+      style={{ minHeight: height }}
+    >
+      <div className="h-3 w-1/3 rounded-full bg-white/20" />
+      <div className="space-y-2">
+        <div className="h-32 rounded-xl bg-white/10" />
+        <div className="h-4 w-3/4 rounded-full bg-white/10" />
+      </div>
+    </div>
+  );
+}
+
+function EmptyChartState({ message }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-sm text-muted/90">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white/10 text-brand">
+        <LineChartIcon className="h-5 w-5" />
+      </div>
+      <p className="font-medium text-text/80 dark:text-slate-100/80">{message}</p>
+    </div>
+  );
+}
+
+export default function ChartCard({
+  title,
+  subtext,
+  actions,
+  children,
+  footer,
+  height = 320,
+  isEmpty = false,
+  emptyMessage = "Belum ada data bulan ini.",
+  className = "",
+}) {
+  const containerRef = useRef(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+
+    let debounceId;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      clearTimeout(debounceId);
+      debounceId = setTimeout(() => {
+        setReady(entry?.contentRect?.width > 0);
+      }, 160);
+    });
+
+    observer.observe(node);
+    setReady(node.getBoundingClientRect().width > 0);
+
+    return () => {
+      observer.disconnect();
+      clearTimeout(debounceId);
+    };
+  }, []);
+
+  return (
+    <Card className={clsx("flex min-h-[360px] flex-col", className)}>
+      {(title || subtext || actions) && (
+        <CardHeader title={title} subtext={subtext} actions={actions} />
+      )}
+      <div
+        ref={containerRef}
+        className="relative mt-2 flex-1 rounded-2xl bg-gradient-to-br from-white/4 via-transparent to-white/0 p-2"
+        style={{ minHeight: height }}
+      >
+        {isEmpty ? (
+          <EmptyChartState message={emptyMessage} />
+        ) : ready && typeof children === "function" ? (
+          children({ height })
+        ) : (
+          <ChartSkeleton height={height} />
+        )}
+      </div>
+      {footer && <div className="mt-6">{footer}</div>}
+    </Card>
+  );
+}

--- a/src/components/dashboard/DataList.jsx
+++ b/src/components/dashboard/DataList.jsx
@@ -1,0 +1,93 @@
+import clsx from "clsx";
+import { TrendingUp } from "lucide-react";
+import Card, { CardHeader } from "../Card";
+
+function EmptyListState({ message }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 py-10 text-center text-sm text-muted/90">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white/10 text-brand">
+        <TrendingUp className="h-5 w-5" />
+      </div>
+      <p className="font-medium text-text/80 dark:text-slate-100/80">{message}</p>
+    </div>
+  );
+}
+
+export default function DataList({
+  title,
+  subtext,
+  actions,
+  columns = [],
+  rows = [],
+  rowKey = (row) => row.id,
+  onRowClick,
+  emptyMessage = "Belum ada data bulan ini.",
+  className = "",
+  maxHeight = 320,
+}) {
+  const hasData = rows?.length > 0;
+
+  return (
+    <Card className={clsx("flex min-h-[360px] flex-col", className)}>
+      <CardHeader title={title} subtext={subtext} actions={actions} />
+      <div className="mt-4 flex-1">
+        {hasData ? (
+          <div
+            className="max-h-[320px] overflow-y-auto pr-1"
+            style={{ maxHeight }}
+          >
+            <table className="min-w-full table-fixed text-sm">
+              <thead className="text-left text-muted/80">
+                <tr>
+                  {columns.map((col) => (
+                    <th
+                      key={col.key}
+                      scope="col"
+                      className={clsx(
+                        "px-3 py-2 font-medium",
+                        col.align === "right" && "text-right",
+                        col.align === "center" && "text-center"
+                      )}
+                    >
+                      {col.label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/5">
+                {rows.slice(0, 8).map((row, index) => (
+                  <tr
+                    key={rowKey(row, index)}
+                    className={clsx(
+                      "group cursor-pointer transition-colors hover:bg-white/5",
+                      !onRowClick && "cursor-default"
+                    )}
+                    onClick={() => onRowClick?.(row)}
+                  >
+                    {columns.map((col) => (
+                      <td
+                        key={col.key}
+                        className={clsx(
+                          "px-3 py-3 text-sm",
+                          col.align === "right" && "text-right",
+                          col.align === "center" && "text-center",
+                          typeof col.className === "function"
+                            ? col.className(row)
+                            : col.className
+                        )}
+                      >
+                        {col.render ? col.render(row) : row[col.key]}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <EmptyListState message={emptyMessage} />
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/src/components/dashboard/QuickActionCard.jsx
+++ b/src/components/dashboard/QuickActionCard.jsx
@@ -1,0 +1,52 @@
+import { forwardRef } from "react";
+import { Link } from "react-router-dom";
+import clsx from "clsx";
+
+const baseClasses =
+  "group relative flex min-h-[92px] items-center gap-4 rounded-xl border border-white/10 bg-white/5 p-4 text-left transition-colors duration-200 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent sm:p-5";
+
+const circleClasses =
+  "flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-brand/10 text-brand ring-1 ring-inset ring-white/20";
+
+const QuickActionCard = forwardRef(
+  (
+    { icon: Icon, title, hint, to, onClick, className = "", "aria-label": ariaLabel, children, ...props },
+    ref
+  ) => {
+    const Component = to ? Link : "button";
+
+    return (
+      <Component
+        ref={ref}
+        to={to}
+        onClick={onClick}
+        aria-label={ariaLabel || title}
+        className={clsx(baseClasses, className)}
+        {...props}
+      >
+        {Icon && (
+          <span className={circleClasses} aria-hidden="true">
+            <Icon className="h-5 w-5" />
+          </span>
+        )}
+        <div className="min-w-0 flex-1">
+          <p className="text-base font-medium text-text dark:text-slate-100">
+            {title}
+          </p>
+          {hint && (
+            <p className="mt-1 text-xs text-muted/80">{hint}</p>
+          )}
+          {children}
+        </div>
+        <span
+          className="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-inset ring-white/10 transition group-hover:ring-white/20"
+          aria-hidden="true"
+        />
+      </Component>
+    );
+  }
+);
+
+QuickActionCard.displayName = "QuickActionCard";
+
+export default QuickActionCard;

--- a/src/index.css
+++ b/src/index.css
@@ -27,8 +27,8 @@
     --page-y: clamp(16px, 4vw, 28px);
     --section-y: clamp(12px, 3vw, 24px);
     --block-y: clamp(8px, 2vw, 16px);
-    --sidebar-w-expanded: 280px;
-    --sidebar-w-collapsed: 72px;
+    --sidebar-w-expanded: 264px;
+    --sidebar-w-collapsed: 80px;
     --sidebar-width: var(--sidebar-w-expanded);
   }
   [data-theme='dark'] {
@@ -44,13 +44,16 @@
     --brand-soft: hsl(var(--brand-h) var(--brand-s) 20%);
     --brand-ring: hsl(var(--brand-h) var(--brand-s) 70%);
   }
-  body { @apply bg-bg text-text transition-colors duration-300; }
+  body {
+    @apply bg-bg text-text transition-colors duration-300 overflow-hidden;
+  }
   h1, h2, h3, h4, h5, h6 { @apply font-semibold; }
 }
 
 @layer components {
   .card {
-    @apply bg-surface-2 border border-border rounded-xl shadow-sm p-4 md:p-6;
+    @apply rounded-2xl border border-white/10 bg-white/60 p-4 shadow-sm backdrop-blur
+      transition-colors duration-300 sm:p-5 lg:p-6 dark:bg-white/5;
   }
   .input {
     @apply w-full rounded-xl border border-border bg-surface-1 px-3 py-2 text-sm text-text focus:outline-none focus:ring-2 focus:ring-brand-ring;

--- a/src/layout/MainLayout.jsx
+++ b/src/layout/MainLayout.jsx
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+import clsx from "clsx";
+
+export default function MainLayout({
+  sidebar = null,
+  children,
+  hideSidebar = false,
+  topbar = null,
+  className = "",
+}) {
+  useEffect(() => {
+    const { style } = document.body;
+    const prevOverflow = style.overflow;
+    style.overflow = "hidden";
+    return () => {
+      style.overflow = prevOverflow;
+    };
+  }, []);
+
+  return (
+    <div className={clsx("relative flex min-h-screen bg-bg text-text", className)}>
+      {!hideSidebar && sidebar}
+      <div
+        className={clsx(
+          "flex min-h-screen w-full flex-col transition-[padding-left] duration-300 ease-out",
+          hideSidebar
+            ? "pl-0"
+            : "pl-0 md:pl-[var(--sidebar-width)]"
+        )}
+      >
+        {topbar}
+        <main
+          id="main"
+          tabIndex={-1}
+          className="flex-1 overflow-y-auto focus:outline-none"
+        >
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -106,8 +106,12 @@ export default function Sidebar({ theme, setTheme, brand, setBrand }) {
 
   const content = (
     <div
-      className="flex h-[100dvh] flex-col overflow-hidden bg-surface-1 text-text shadow-md transition-[width]"
-      style={{ width: collapsed ? 'var(--sidebar-w-collapsed)' : 'var(--sidebar-w-expanded)' }}
+      className="flex h-full flex-col overflow-hidden bg-surface-1/95 text-text shadow-lg ring-1 ring-black/5 transition-[width] duration-300"
+      style={{
+        width: collapsed
+          ? 'var(--sidebar-w-collapsed)'
+          : 'var(--sidebar-w-expanded)',
+      }}
     >
       <div className="flex items-center justify-between p-4">
         <div className="flex items-center gap-2">
@@ -161,7 +165,7 @@ export default function Sidebar({ theme, setTheme, brand, setBrand }) {
           </ul>
         )}
       </nav>
-      <div className="p-4 border-t border-border space-y-4">
+      <div className="space-y-4 border-t border-white/10 p-4">
         <div className="flex items-center justify-between">
           {!collapsed && (
             <button className="text-sm" onClick={toggle}>
@@ -243,7 +247,7 @@ export default function Sidebar({ theme, setTheme, brand, setBrand }) {
         )}
       </div>
       <button
-        className="absolute top-1/2 -right-3 hidden md:flex items-center justify-center w-6 h-6 rounded-full bg-surface-1 border border-border"
+        className="absolute top-1/2 -right-3 hidden h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full bg-surface-1/90 text-text shadow-md ring-1 ring-black/5 backdrop-blur md:flex"
         onClick={() => setCollapsed(!collapsed)}
         aria-label="Toggle sidebar"
       >
@@ -260,15 +264,16 @@ export default function Sidebar({ theme, setTheme, brand, setBrand }) {
       />
       <div
         className={`fixed inset-y-0 left-0 z-50 transform transition-transform md:translate-x-0 ${mobileOpen ? 'translate-x-0' : '-translate-x-full'}`}
+        style={{ width: collapsed ? 'var(--sidebar-w-collapsed)' : 'var(--sidebar-w-expanded)' }}
       >
         {content}
       </div>
       <button
-        className="md:hidden p-2"
+        className="fixed left-4 top-4 z-40 inline-flex h-10 w-10 items-center justify-center rounded-full bg-surface-1/90 text-text shadow-lg ring-1 ring-black/5 backdrop-blur md:hidden"
         onClick={() => setMobileOpen(true)}
         aria-label="Open sidebar"
       >
-        <Menu className="h-6 w-6" />
+        <Menu className="h-5 w-5" />
       </button>
       <SignIn open={showSignIn} onClose={() => setShowSignIn(false)} />
     </>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,7 +1,4 @@
 import { useMemo } from "react";
-import Page from "../layout/Page";
-import PageHeader from "../layout/PageHeader";
-import Section from "../layout/Section";
 import KpiCards from "../components/KpiCards";
 import QuoteBubble from "../components/QuoteBubble";
 import SavingsProgress from "../components/SavingsProgress";
@@ -39,48 +36,49 @@ export default function Dashboard({ stats, txs }) {
   const savingsTarget = stats?.savingsTarget || 1_000_000;
 
   return (
-    <Page>
-      <PageHeader title="Dashboard" description="Ringkasan keuanganmu" />
-      <Section first>
-        <KpiCards
-          income={stats?.income || 0}
-          expense={stats?.expense || 0}
-          net={stats?.balance || 0}
+    <div className="space-y-6 sm:space-y-8 lg:space-y-10">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+          Dashboard
+        </h1>
+        <p className="text-sm text-muted sm:text-base">
+          Ringkasan keuanganmu
+        </p>
+      </header>
+
+      <KpiCards
+        income={stats?.income || 0}
+        expense={stats?.expense || 0}
+        net={stats?.balance || 0}
+      />
+
+      <QuoteBubble />
+
+      <div className="grid gap-6 sm:gap-7 lg:gap-8 lg:grid-cols-2">
+        <SavingsProgress current={stats?.balance || 0} target={savingsTarget} />
+        <AchievementBadges
+          stats={stats}
+          streak={streak}
+          target={savingsTarget}
         />
-      </Section>
-      <Section>
-        <QuoteBubble />
-      </Section>
-      <Section>
-        <div className="grid gap-[var(--block-y)] lg:grid-cols-2">
-          <SavingsProgress
-            current={stats?.balance || 0}
-            target={savingsTarget}
-          />
-          <AchievementBadges
-            stats={stats}
-            streak={streak}
-            target={savingsTarget}
-          />
-        </div>
-      </Section>
-      <Section>
-        <QuickActions />
-      </Section>
-      <Section>
+      </div>
+
+      <QuickActions />
+
+      <section className="space-y-6 sm:space-y-8 lg:space-y-10">
         <SectionHeader title="Analisis Bulanan" />
-        <div className="grid gap-[var(--block-y)] md:grid-cols-2">
+        <div className="grid gap-6 sm:gap-7 lg:gap-8 lg:grid-cols-2">
           <MonthlyTrendChart data={insights.trend} />
           <CategoryDonut data={insights.categories} />
         </div>
-        <div className="grid gap-[var(--block-y)] md:grid-cols-2">
+        <div className="grid gap-6 sm:gap-7 lg:gap-8 lg:grid-cols-2">
           <TopSpendsTable
             data={insights.topSpends}
             onSelect={(t) => EventBus.emit("tx:open", t)}
           />
           <RecentTransactions txs={txs} />
         </div>
-      </Section>
-    </Page>
+      </section>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- introduce a shared MainLayout with fixed sidebar spacing and scrollable content
- rebuild dashboard cards, charts, and tables with new responsive UI primitives
- unify typography, spacing, and quick action styling for consistent presentation

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cab51f04148332add54077c9bd31d0