### PR TITLE
Allow main content to scroll

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -45,7 +45,7 @@
     --brand-ring: hsl(var(--brand-h) var(--brand-s) 70%);
   }
   body {
-    @apply bg-bg text-text transition-colors duration-300 overflow-hidden;
+    @apply bg-bg text-text transition-colors duration-300 overflow-x-hidden;
   }
   h1, h2, h3, h4, h5, h6 { @apply font-semibold; }
 }

--- a/src/layout/MainLayout.jsx
+++ b/src/layout/MainLayout.jsx
@@ -10,10 +10,10 @@ export default function MainLayout({
 }) {
   useEffect(() => {
     const { style } = document.body;
-    const prevOverflow = style.overflow;
-    style.overflow = "hidden";
+    const prevOverflowX = style.overflowX;
+    style.overflowX = "hidden";
     return () => {
-      style.overflow = prevOverflow;
+      style.overflowX = prevOverflowX;
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- allow the document body to scroll by limiting the MainLayout side effect to only hide horizontal overflow so vertical scrolling remains available

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cac14b7aec8332b18d22d6226307a7