### PR TITLE
Remove transaction type badge from category column

### DIFF
--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -1792,11 +1792,8 @@ function TransactionItem({
             ))}
           </select>
         ) : (
-          <div className="flex items-center gap-2 truncate" title={categoryLabel}>
-            <span className="truncate font-semibold text-white">{categoryLabel}</span>
-            {typeLabel && (
-              <span className="rounded-full bg-white/10 px-2 py-0.5 text-[11px] uppercase text-white/60">{typeLabel}</span>
-            )}
+          <div className="flex min-w-0 items-center gap-2" title={categoryLabel}>
+            <span className="min-w-0 truncate font-semibold text-white">{categoryLabel}</span>
           </div>
         )}
       </td>


### PR DESCRIPTION
## Summary
- remove the transaction type chip from the Kategori column in the transactions table
- keep the category name layout tight with min-w-0 and truncate styling to avoid layout shifts

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cc97a65978833286b9b5a764fccfa2