### PR TITLE
Fix mobile sidebar closing immediately

### DIFF
--- a/src/components/sidebar/MobileDrawer.tsx
+++ b/src/components/sidebar/MobileDrawer.tsx
@@ -24,6 +24,7 @@ export default function MobileDrawer({
   const panelRef = useRef<HTMLDivElement | null>(null);
   const lastFocusedElement = useRef<Element | null>(null);
   const location = useLocation();
+  const lastPathnameRef = useRef(location.pathname);
 
   useLockBodyScroll(open);
 
@@ -76,8 +77,12 @@ export default function MobileDrawer({
   }, [open, onOpenChange]);
 
   useEffect(() => {
-    if (!open) return;
-    onOpenChange(false);
+    if (lastPathnameRef.current !== location.pathname) {
+      lastPathnameRef.current = location.pathname;
+      if (open) {
+        onOpenChange(false);
+      }
+    }
   }, [location.pathname, onOpenChange, open]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- prevent the mobile drawer from closing as soon as it is opened by only reacting to pathname changes
- track the last rendered pathname so the drawer only closes after navigation

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cca8b4bfd483329962ce6519ba0089