### PR TITLE
Add legacy /debs route for debts page

### DIFF
--- a/src/router/nav.config.tsx
+++ b/src/router/nav.config.tsx
@@ -73,6 +73,13 @@ export const NAV_ITEMS: NavItem[] = [
     protected: true,
   },
   {
+    title: 'Hutang',
+    path: '/debs',
+    inSidebar: false,
+    protected: true,
+    breadcrumb: 'Hutang',
+  },
+  {
     title: 'Kategori',
     path: '/categories',
     icon: <Tags className="h-5 w-5" />,

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -19,6 +19,7 @@ function loadComponent(path: string) {
     case '/goals':
       return lazy(() => import('../pages/Goals'));
     case '/debts':
+    case '/debs':
       return lazy(() => import('../pages/Debts'));
     case '/categories':
       return lazy(() => import('../pages/Categories'));


### PR DESCRIPTION
## Summary
- map both `/debts` and legacy `/debs` paths to the debts page component
- add a hidden navigation item so the router generates the `/debs` route without exposing it in the sidebar

## Testing
- pnpm lint


------
https://chatgpt.com/codex/tasks/task_e_68cd77d021d08332bc9c448f731910f4