### PR TITLE
Add debts page route

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import SyncBanner from "./components/SyncBanner";
 import Dashboard from "./pages/Dashboard";
 import Transactions from "./pages/Transactions";
 import Budgets from "./pages/Budgets";
+import DebtsPage from "./pages/Debts";
 import Categories from "./pages/Categories";
 import DataToolsPage from "./pages/DataToolsPage";
 import TransactionAdd from "./pages/TransactionAdd";
@@ -1070,6 +1071,7 @@ function AppShell({ prefs, setPrefs }) {
                 />
               }
             />
+            <Route path="/debts" element={<DebtsPage />} />
             <Route path="/goals" element={<GoalsPage />} />
             <Route
               path="/challenges"


### PR DESCRIPTION
## Summary
- import the debts page into the main app router
- add a `/debts` route so the debts navigation item resolves correctly

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cd7d97a94083328c31a1c79ad1c320