### PR TITLE
Improve debts page responsiveness and drawer

### DIFF
--- a/src/components/debts/DebtsTable.tsx
+++ b/src/components/debts/DebtsTable.tsx
@@ -57,9 +57,9 @@ function isDueSoon(debt: DebtRecord) {
 
 export default function DebtsTable({ items, loading, onEdit, onDelete, onAddPayment }: DebtsTableProps) {
   return (
-    <div className="overflow-x-auto -mx-3 px-3 md:mx-0 md:px-0">
-      <table className="w-full min-w-[960px] table-fixed border-separate border-spacing-0 text-left text-sm">
-        <thead className="sticky top-0 z-10 bg-background/95 bg-bg/95 backdrop-blur">
+    <div className="-mx-3 overflow-x-auto px-3 md:mx-0 md:px-0">
+      <table className="w-full min-w-[960px] table-auto border-separate border-spacing-0 text-left text-sm md:table-fixed">
+        <thead className="sticky top-0 z-10 bg-background/95 backdrop-blur">
           <tr className="text-xs font-semibold uppercase tracking-wide text-muted">
             <th scope="col" className="p-3 text-center">Tipe</th>
             <th scope="col" className="p-3">Pihak</th>
@@ -74,7 +74,7 @@ export default function DebtsTable({ items, loading, onEdit, onDelete, onAddPaym
             <th scope="col" className="p-3 text-center">Aksi</th>
           </tr>
         </thead>
-        <tbody className="divide-y divide-border/60 bg-surface-1/80">
+        <tbody className="bg-surface-1/80">
           {loading ? (
             <tr>
               <td colSpan={11} className="p-6 text-center text-sm text-muted">
@@ -94,7 +94,10 @@ export default function DebtsTable({ items, loading, onEdit, onDelete, onAddPaym
               const statusClass = STATUS_STYLE[debt.status] ?? '';
               const showDueBadge = isDueSoon(debt);
               return (
-                <tr key={debt.id} className="odd:bg-surface-1/60 even:bg-surface-1">
+                <tr
+                  key={debt.id}
+                  className="odd:bg-muted/30 even:bg-surface-1/80 transition-colors hover:bg-muted/50"
+                >
                   <td className="p-3 text-center align-middle">
                     <span
                       className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-brand-soft/40 text-xs font-bold text-text"
@@ -103,7 +106,7 @@ export default function DebtsTable({ items, loading, onEdit, onDelete, onAddPaym
                       {TYPE_LABEL[debt.type]}
                     </span>
                   </td>
-                  <td className="max-w-[160px] p-3 align-middle">
+                  <td className="max-w-[180px] p-3 align-middle">
                     <p className="truncate font-medium text-text" title={debt.party_name}>
                       {debt.party_name}
                     </p>
@@ -113,15 +116,17 @@ export default function DebtsTable({ items, loading, onEdit, onDelete, onAddPaym
                       </p>
                     ) : null}
                   </td>
-                  <td className="max-w-[180px] p-3 align-middle">
-                    <span className="truncate font-medium text-text" title={debt.title}>
+                  <td className="max-w-[220px] p-3 align-middle">
+                    <span className="line-clamp-2 font-medium text-text" title={debt.title}>
                       {debt.title}
                     </span>
                   </td>
-                  <td className="p-3 align-middle text-sm text-text/80">{formatDate(debt.date)}</td>
+                  <td className="p-3 align-middle text-sm text-text/80 whitespace-nowrap">
+                    {formatDate(debt.date)}
+                  </td>
                   <td className="p-3 align-middle text-sm text-text/80">
-                    <div className="flex items-center gap-2">
-                      <span>{formatDate(debt.due_date)}</span>
+                    <div className="flex min-w-0 items-center gap-2">
+                      <span className="truncate">{formatDate(debt.due_date)}</span>
                       {showDueBadge ? (
                         <span className="inline-flex items-center rounded-full bg-rose-500/15 px-2 py-0.5 text-[11px] font-semibold text-rose-300">
                           Jatuh tempo
@@ -134,13 +139,13 @@ export default function DebtsTable({ items, loading, onEdit, onDelete, onAddPaym
                       ? `${debt.rate_percent.toFixed(2)}%`
                       : '-'}
                   </td>
-                  <td className="p-3 text-right align-middle tabular-nums text-text font-semibold">
+                  <td className="p-3 text-right align-middle font-semibold tabular-nums text-text">
                     {formatCurrency(debt.amount)}
                   </td>
                   <td className="p-3 text-right align-middle tabular-nums text-text/80">
                     {formatCurrency(debt.paid_total)}
                   </td>
-                  <td className="p-3 text-right align-middle tabular-nums font-semibold text-text">
+                  <td className="p-3 text-right align-middle font-semibold tabular-nums text-text">
                     {formatCurrency(debt.remaining)}
                   </td>
                   <td className="p-3 text-center align-middle">

--- a/src/components/debts/FilterBar.tsx
+++ b/src/components/debts/FilterBar.tsx
@@ -69,10 +69,13 @@ export default function FilterBar({ filters, onChange, onReset }: FilterBarProps
   };
 
   return (
-    <form onSubmit={handleSubmit} className="rounded-3xl border border-border/60 bg-surface-1/90 p-4 shadow-sm">
-      <div className="grid gap-3 min-[420px]:grid-cols-2 lg:grid-cols-7">
-        <label className="flex flex-col gap-1 text-xs font-medium uppercase tracking-wide text-muted min-w-0">
-          <span>Tipe</span>
+    <form
+      onSubmit={handleSubmit}
+      className="min-w-0 rounded-3xl border border-border/60 bg-surface-1/90 p-4 shadow-sm"
+    >
+      <div className="grid grid-cols-2 items-center gap-3 md:grid-cols-6">
+        <label className="flex min-w-0 flex-col gap-1 text-xs font-medium uppercase tracking-wide text-muted">
+          <span className="truncate">Tipe</span>
           <select
             value={filters.type}
             onChange={(event) => handleSelect(event, 'type')}
@@ -86,8 +89,8 @@ export default function FilterBar({ filters, onChange, onReset }: FilterBarProps
           </select>
         </label>
 
-        <label className="flex flex-col gap-1 text-xs font-medium uppercase tracking-wide text-muted min-w-0">
-          <span>Status</span>
+        <label className="flex min-w-0 flex-col gap-1 text-xs font-medium uppercase tracking-wide text-muted">
+          <span className="truncate">Status</span>
           <select
             value={filters.status}
             onChange={(event) => handleSelect(event, 'status')}
@@ -101,8 +104,8 @@ export default function FilterBar({ filters, onChange, onReset }: FilterBarProps
           </select>
         </label>
 
-        <label className="flex flex-col gap-1 text-xs font-medium uppercase tracking-wide text-muted min-w-0">
-          <span>Rentang</span>
+        <label className="flex min-w-0 flex-col gap-1 text-xs font-medium uppercase tracking-wide text-muted">
+          <span className="truncate">Rentang</span>
           <select
             value={filters.dateField}
             onChange={(event) => handleSelect(event, 'dateField')}
@@ -116,8 +119,8 @@ export default function FilterBar({ filters, onChange, onReset }: FilterBarProps
           </select>
         </label>
 
-        <label className="flex flex-col gap-1 text-xs font-medium uppercase tracking-wide text-muted min-w-0">
-          <span>Dari</span>
+        <label className="flex min-w-0 flex-col gap-1 text-xs font-medium uppercase tracking-wide text-muted">
+          <span className="truncate">Dari</span>
           <input
             type="date"
             value={filters.dateFrom ?? ''}
@@ -126,8 +129,8 @@ export default function FilterBar({ filters, onChange, onReset }: FilterBarProps
           />
         </label>
 
-        <label className="flex flex-col gap-1 text-xs font-medium uppercase tracking-wide text-muted min-w-0">
-          <span>Sampai</span>
+        <label className="flex min-w-0 flex-col gap-1 text-xs font-medium uppercase tracking-wide text-muted">
+          <span className="truncate">Sampai</span>
           <input
             type="date"
             value={filters.dateTo ?? ''}
@@ -136,8 +139,8 @@ export default function FilterBar({ filters, onChange, onReset }: FilterBarProps
           />
         </label>
 
-        <label className="flex flex-col gap-1 text-xs font-medium uppercase tracking-wide text-muted min-w-0">
-          <span>Urutkan</span>
+        <label className="flex min-w-0 flex-col gap-1 text-xs font-medium uppercase tracking-wide text-muted">
+          <span className="truncate">Urutkan</span>
           <select
             value={filters.sort}
             onChange={(event) => handleSelect(event, 'sort')}
@@ -151,14 +154,14 @@ export default function FilterBar({ filters, onChange, onReset }: FilterBarProps
           </select>
         </label>
 
-        <div className="col-span-full flex min-w-0 items-center gap-2 rounded-xl border border-border bg-surface-1 px-3 text-sm text-text shadow-sm focus-within:ring-2 focus-within:ring-[color:var(--brand-ring)] min-[420px]:col-span-2 lg:col-span-2">
+        <div className="col-span-2 flex h-[40px] min-w-0 items-center gap-2 rounded-xl border border-border bg-surface-1 px-3 text-sm text-text shadow-sm focus-within:ring-2 focus-within:ring-[color:var(--brand-ring)] md:col-span-6">
           <Search className="h-4 w-4 text-muted" aria-hidden="true" />
           <input
             type="search"
             value={filters.q}
             onChange={(event) => handleInput(event, 'q')}
             placeholder="Cari pihak, judul, atau catatan"
-            className="h-[38px] w-full min-w-0 bg-transparent text-sm text-text placeholder:text-muted focus-visible:outline-none"
+            className="h-full w-full min-w-0 bg-transparent text-sm text-text placeholder:text-muted focus-visible:outline-none"
             aria-label="Pencarian hutang"
           />
           {onReset ? (

--- a/src/components/debts/PaymentDrawer.tsx
+++ b/src/components/debts/PaymentDrawer.tsx
@@ -1,8 +1,9 @@
-import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import type { DebtPaymentRecord, DebtRecord } from '../../lib/api-debts';
 import PaymentsList from './PaymentsList';
+import { useLockBodyScroll } from '../../hooks/useLockBodyScroll';
 
 const currencyFormatter = new Intl.NumberFormat('id-ID', {
   style: 'currency',
@@ -53,6 +54,10 @@ export default function PaymentDrawer({
   const [date, setDate] = useState(todayIso());
   const [notes, setNotes] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useLockBodyScroll(open);
 
   useEffect(() => {
     if (!open) return undefined;
@@ -67,6 +72,34 @@ export default function PaymentDrawer({
   }, [open, onClose]);
 
   useEffect(() => {
+    if (!open) return undefined;
+    const node = panelRef.current;
+    if (!node) return undefined;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab') return;
+      const focusable = node.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey) {
+        if (document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        }
+        return;
+      }
+      if (document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    node.addEventListener('keydown', handleKeyDown);
+    return () => node.removeEventListener('keydown', handleKeyDown);
+  }, [open]);
+
+  useEffect(() => {
     if (open) {
       setAmount('');
       setDate(todayIso());
@@ -74,6 +107,12 @@ export default function PaymentDrawer({
       setError(null);
     }
   }, [open, debt?.id]);
+
+  useEffect(() => {
+    if (open) {
+      closeButtonRef.current?.focus();
+    }
+  }, [open]);
 
   const remainingLabel = useMemo(() => {
     if (!debt) return currencyFormatter.format(0);
@@ -105,113 +144,141 @@ export default function PaymentDrawer({
   if (!open || !debt) return null;
 
   return createPortal(
-    <div className="fixed inset-0 z-[75] flex justify-end bg-black/30" role="dialog" aria-modal="true">
-      <div className="flex h-full w-full max-w-md flex-col gap-6 border-l border-border/60 bg-surface-1/95 p-6 shadow-xl backdrop-blur">
-        <header className="flex items-start justify-between gap-4">
-          <div className="min-w-0">
-            <p className="text-xs font-semibold uppercase tracking-wide text-muted">Catat Pembayaran</p>
-            <h2 className="mt-1 text-lg font-semibold text-text">{debt.title}</h2>
-            <p className="text-sm text-muted">
-              {debt.party_name} • {dateFormatter.format(new Date(debt.date))}
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-surface-1 text-text hover:bg-border/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-            aria-label="Tutup panel pembayaran"
+    <>
+      <div
+        className="fixed inset-0 z-[60] bg-black/40 backdrop-blur supports-[backdrop-filter]:bg-black/30"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        ref={panelRef}
+        className="fixed inset-y-0 right-0 z-[70] h-[100dvh] w-full bg-card shadow-2xl sm:w-[480px] md:w-[520px]"
+        role="dialog"
+        aria-modal="true"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex h-full min-w-0 flex-col overflow-hidden">
+          <div
+            className="flex h-full min-h-0 flex-col overflow-y-auto overscroll-contain"
+            style={{ scrollbarGutter: 'stable' }}
           >
-            <X className="h-5 w-5" aria-hidden="true" />
-          </button>
-        </header>
+            <header className="sticky top-0 z-10 shrink-0 border-b border-border/60 bg-card/95 px-4 py-3 backdrop-blur">
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted">Catat Pembayaran</p>
+                  <h2 className="mt-1 truncate text-lg font-semibold text-text">{debt.title}</h2>
+                  <p className="text-sm text-muted">
+                    {debt.party_name} • {dateFormatter.format(new Date(debt.date))}
+                  </p>
+                </div>
+                <button
+                  ref={closeButtonRef}
+                  type="button"
+                  onClick={onClose}
+                  className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-surface-1 text-text transition hover:bg-border/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+                  aria-label="Tutup panel pembayaran"
+                >
+                  <X className="h-5 w-5" aria-hidden="true" />
+                </button>
+              </div>
+            </header>
 
-        <section className="grid grid-cols-2 gap-3 rounded-2xl border border-border/60 bg-surface-1/80 p-4">
-          <div className="min-w-0">
-            <p className="text-xs font-semibold uppercase tracking-wide text-muted">Sisa Tagihan</p>
-            <p className="mt-1 text-lg font-semibold text-text tabular-nums">{remainingLabel}</p>
-          </div>
-          <div className="min-w-0">
-            <p className="text-xs font-semibold uppercase tracking-wide text-muted">Total Terbayar</p>
-            <p className="mt-1 text-lg font-semibold text-text tabular-nums">{totalPaidLabel}</p>
-          </div>
-          <div className="min-w-0">
-            <p className="text-xs font-semibold uppercase tracking-wide text-muted">Status</p>
-            <p className="mt-1 text-sm font-medium text-text">
-              {debt.status === 'paid' ? 'Lunas' : debt.status === 'overdue' ? 'Jatuh Tempo' : 'Berjalan'}
-            </p>
-          </div>
-          <div className="min-w-0">
-            <p className="text-xs font-semibold uppercase tracking-wide text-muted">Jatuh Tempo</p>
-            <p className="mt-1 text-sm text-text/80">{debt.due_date ? dateFormatter.format(new Date(debt.due_date)) : '-'}</p>
-          </div>
-        </section>
+            <div className="flex-1 min-h-0 space-y-4 px-4 py-4 touch-manipulation">
+              <section className="grid min-w-0 gap-3 rounded-2xl border border-border/60 bg-surface-1/80 p-4 sm:grid-cols-2">
+                <div className="min-w-0">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted">Sisa Tagihan</p>
+                  <p className="mt-1 text-lg font-semibold text-text tabular-nums">{remainingLabel}</p>
+                </div>
+                <div className="min-w-0">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted">Total Terbayar</p>
+                  <p className="mt-1 text-lg font-semibold text-text tabular-nums">{totalPaidLabel}</p>
+                </div>
+                <div className="min-w-0">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted">Status</p>
+                  <p className="mt-1 text-sm font-medium text-text">
+                    {debt.status === 'paid' ? 'Lunas' : debt.status === 'overdue' ? 'Jatuh Tempo' : 'Berjalan'}
+                  </p>
+                </div>
+                <div className="min-w-0">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted">Jatuh Tempo</p>
+                  <p className="mt-1 text-sm text-text/80">
+                    {debt.due_date ? dateFormatter.format(new Date(debt.due_date)) : '-'}
+                  </p>
+                </div>
+              </section>
 
-        <form onSubmit={handleSubmit} className="space-y-3">
-          <div className="flex flex-col gap-1 text-sm font-medium text-text">
-            <label htmlFor="payment-amount">Nominal pembayaran</label>
-            <input
-              id="payment-amount"
-              value={amount}
-              onChange={(event) => setAmount(event.target.value)}
-              inputMode="decimal"
-              placeholder="Masukkan nominal"
-              className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-            />
-            {error ? <span className="text-xs text-danger">{error}</span> : null}
-          </div>
+              <form id="payment-form" onSubmit={handleSubmit} className="space-y-3">
+                <div className="flex flex-col gap-1 text-sm font-medium text-text">
+                  <label htmlFor="payment-amount">Nominal pembayaran</label>
+                  <input
+                    id="payment-amount"
+                    value={amount}
+                    onChange={(event) => setAmount(event.target.value)}
+                    inputMode="decimal"
+                    placeholder="Masukkan nominal"
+                    className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+                  />
+                  {error ? <span className="text-xs text-danger">{error}</span> : null}
+                </div>
 
-          <div className="flex flex-col gap-1 text-sm font-medium text-text">
-            <label htmlFor="payment-date">Tanggal pembayaran</label>
-            <input
-              id="payment-date"
-              type="date"
-              value={date}
-              onChange={(event) => setDate(event.target.value)}
-              className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-            />
-          </div>
+                <div className="flex flex-col gap-1 text-sm font-medium text-text">
+                  <label htmlFor="payment-date">Tanggal pembayaran</label>
+                  <input
+                    id="payment-date"
+                    type="date"
+                    value={date}
+                    onChange={(event) => setDate(event.target.value)}
+                    className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+                  />
+                </div>
 
-          <div className="flex flex-col gap-1 text-sm font-medium text-text">
-            <label htmlFor="payment-notes">Catatan</label>
-            <textarea
-              id="payment-notes"
-              value={notes}
-              onChange={(event) => setNotes(event.target.value)}
-              rows={3}
-              className="rounded-xl border border-border bg-surface-1 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-              placeholder="Catatan (opsional)"
-            />
-          </div>
+                <div className="flex flex-col gap-1 text-sm font-medium text-text">
+                  <label htmlFor="payment-notes">Catatan</label>
+                  <textarea
+                    id="payment-notes"
+                    value={notes}
+                    onChange={(event) => setNotes(event.target.value)}
+                    rows={3}
+                    className="min-h-[96px] rounded-xl border border-border bg-surface-1 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+                    placeholder="Catatan (opsional)"
+                  />
+                </div>
+              </form>
 
-          <div className="flex flex-col gap-3 pt-2 sm:flex-row sm:justify-end">
-            <button
-              type="button"
-              onClick={onClose}
-              className="inline-flex h-[42px] items-center justify-center rounded-xl border border-border bg-surface-1 px-5 text-sm font-medium text-text transition hover:bg-border/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-            >
-              Tutup
-            </button>
-            <button
-              type="submit"
-              disabled={Boolean(submitting)}
-              className="inline-flex h-[42px] items-center justify-center rounded-xl bg-brand px-6 text-sm font-semibold text-brand-foreground transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)] disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {submitting ? 'Menyimpan…' : 'Catat Pembayaran'}
-            </button>
-          </div>
-        </form>
+              <section className="min-h-[160px] min-w-0">
+                {loading ? (
+                  <p className="rounded-2xl border border-dashed border-border/70 bg-surface-1/40 px-4 py-6 text-center text-sm text-muted">
+                    Memuat riwayat pembayaran…
+                  </p>
+                ) : (
+                  <PaymentsList payments={payments} onDelete={onDeletePayment} deletingId={deletingId} />
+                )}
+              </section>
+            </div>
 
-        <section className="flex-1 overflow-y-auto">
-          {loading ? (
-            <p className="rounded-2xl border border-dashed border-border/70 bg-surface-1/40 px-4 py-6 text-center text-sm text-muted">
-              Memuat riwayat pembayaran…
-            </p>
-          ) : (
-            <PaymentsList payments={payments} onDelete={onDeletePayment} deletingId={deletingId} />
-          )}
-        </section>
+            <footer className="sticky bottom-0 z-10 shrink-0 border-t border-border/60 bg-card/95 px-4 py-3 pt-2 backdrop-blur pb-[env(safe-area-inset-bottom)]">
+              <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="inline-flex h-[42px] items-center justify-center rounded-xl border border-border bg-surface-1 px-5 text-sm font-medium text-text transition hover:bg-border/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+                >
+                  Tutup
+                </button>
+                <button
+                  type="submit"
+                  form="payment-form"
+                  disabled={Boolean(submitting)}
+                  className="inline-flex h-[42px] items-center justify-center rounded-xl bg-brand px-6 text-sm font-semibold text-brand-foreground transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)] disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {submitting ? 'Menyimpan…' : 'Catat Pembayaran'}
+                </button>
+              </div>
+            </footer>
+          </div>
+        </div>
       </div>
-    </div>,
+    </>,
     document.body,
   );
 }

--- a/src/components/debts/SummaryCards.tsx
+++ b/src/components/debts/SummaryCards.tsx
@@ -48,18 +48,18 @@ const CARDS = [
 
 export default function SummaryCards({ summary }: SummaryCardsProps) {
   return (
-    <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+    <section className="grid min-w-0 grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
       {CARDS.map((card) => {
         const value = summary ? summary[card.key] : 0;
         return (
           <article
             key={card.key}
-            className="card min-w-0 space-y-2 border border-border/60 bg-surface-1/90 text-left"
+            className="card min-w-0 space-y-2 border border-border/60 bg-surface-1/90 p-4 text-left md:p-5"
           >
             <p className="text-xs font-semibold uppercase tracking-wide text-muted">
               {card.label}
             </p>
-            <p className={`text-2xl font-bold tabular-nums ${card.tone}`}>
+            <p className={`text-xl font-bold tracking-tight tabular-nums md:text-2xl ${card.tone}`}>
               {formatCurrency(value)}
             </p>
             <p className="text-xs text-muted">{card.description}</p>

--- a/src/layout/Page.jsx
+++ b/src/layout/Page.jsx
@@ -5,7 +5,7 @@
 export default function Page({ children }) {
   return (
     <main
-      className="mx-auto max-w-5xl px-4"
+      className="mx-auto w-full max-w-5xl min-w-0 px-4"
       style={{ paddingTop: "var(--page-y)", paddingBottom: "var(--page-y)" }}
     >
       {children}

--- a/src/layout/PageHeader.jsx
+++ b/src/layout/PageHeader.jsx
@@ -2,10 +2,10 @@ import Breadcrumbs from "./Breadcrumbs";
 
 export default function PageHeader({ title, description, children }) {
   return (
-    <div className="mb-[var(--section-y)]">
+    <div className="mb-[var(--section-y)] min-w-0">
       <Breadcrumbs />
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <div>
+      <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
           <h1 className="text-xl font-bold text-text">
             {title}
           </h1>
@@ -15,7 +15,7 @@ export default function PageHeader({ title, description, children }) {
             </p>
           )}
         </div>
-        {children && <div className="flex gap-2">{children}</div>}
+        {children && <div className="flex flex-wrap justify-end gap-2">{children}</div>}
       </div>
     </div>
   );

--- a/src/pages/Debts.tsx
+++ b/src/pages/Debts.tsx
@@ -391,7 +391,7 @@ export default function Debts() {
 
   return (
     <Page>
-      <div className="space-y-6">
+      <div className="space-y-6 min-w-0">
         <PageHeader title="Hutang" description={pageDescription}>
           <button
             type="button"

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -17,6 +17,7 @@ module.exports = {
         danger: 'var(--danger)',
         info: 'var(--info)',
         bg: 'var(--bg)',
+        card: 'var(--surface)',
         'surface-1': 'var(--surface)',
         'surface-2': 'var(--surface-2)',
         border: 'var(--border)',


### PR DESCRIPTION
## Summary
- tighten layout containers to avoid horizontal overflow and keep page headers responsive
- refresh debts summary, filter bar, and table styling for better responsive behavior
- rebuild payment drawer with scrollable content, sticky regions, body locking, and focus trap

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cdf8d1d1708332b850f3d95d7c2ba8