### PR TITLE
Improve debts payment drawer layout and scrolling

### DIFF
--- a/src/components/debts/DebtsTableResponsive.tsx
+++ b/src/components/debts/DebtsTableResponsive.tsx
@@ -109,9 +109,9 @@ export default function DebtsTableResponsive({
 
   return (
     <div className="min-w-0 space-y-4">
-      <div className="hidden sm:block">
-        <div className="rounded-2xl border border-border bg-card/80 shadow-sm">
-          <div className="-mx-3 px-3 md:mx-0 md:px-0 overflow-x-auto">
+      <div className="hidden min-w-0 sm:block">
+        <div className="min-w-0 rounded-2xl border border-border bg-card/80 shadow-sm">
+          <div className="-mx-3 md:mx-0 px-3 md:px-0 overflow-x-auto">
             <table className="table-auto md:table-fixed w-full text-sm">
               <thead className="sticky top-0 z-10 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/75">
                 <tr>

--- a/src/components/debts/PaymentsList.tsx
+++ b/src/components/debts/PaymentsList.tsx
@@ -31,13 +31,13 @@ export default function PaymentsList({ payments, onDelete, deletingId }: Payment
         return (
           <li
             key={payment.id}
-            className="flex items-start justify-between gap-3 rounded-2xl border border-border/70 bg-surface-1/80 px-4 py-3 shadow-sm"
+            className="flex min-w-0 items-start justify-between gap-3 rounded-2xl border border-border/70 bg-surface-1/80 px-4 py-3 shadow-sm"
           >
             <div className="min-w-0">
               <p className="text-sm font-semibold text-text">{amountLabel}</p>
               <p className="text-xs text-muted">{dateLabel}</p>
               {payment.notes ? (
-                <p className="mt-2 truncate text-sm text-text/80" title={payment.notes}>
+                <p className="mt-2 break-words text-sm text-text/80" title={payment.notes}>
                   {payment.notes}
                 </p>
               ) : null}


### PR DESCRIPTION
## Summary
- refactor the debts payment drawer into a sticky header/scrollable body/sticky footer layout and harden validation, focus, and form control ergonomics
- update payments list styling to avoid overflow and keep notes readable on small screens
- ensure the debts table wrapper respects min-width constraints and confines horizontal scrolling to the table itself

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ce50a3118883329614290fbdf7f0ab