### PR TITLE
feat: overhaul data management page

### DIFF
--- a/src/components/data/BackupRestore.tsx
+++ b/src/components/data/BackupRestore.tsx
@@ -1,0 +1,199 @@
+// @ts-nocheck
+import { useMemo, useState } from 'react';
+import { DownloadCloud, Loader2, RefreshCw, UploadCloud } from 'lucide-react';
+import { supabase } from '../../lib/supabase';
+import { getCurrentUserId } from '../../lib/session';
+
+const ENTITY_TABLES = {
+  transactions: 'transactions',
+  categories: 'categories',
+  subscriptions: 'subscriptions',
+  goals: 'goals',
+  debts: 'debts',
+};
+
+async function downloadJSON(filename: string, data: unknown) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+  return blob;
+}
+
+export default function BackupRestore({ activeTab, onRestoreComplete }) {
+  const [busy, setBusy] = useState(false);
+  const [persistHistory, setPersistHistory] = useState(false);
+  const [error, setError] = useState('');
+  const [restorePreview, setRestorePreview] = useState(null);
+  const [restoring, setRestoring] = useState(false);
+
+  const allowedEntities = useMemo(() => {
+    if (activeTab && ENTITY_TABLES[activeTab]) {
+      return [activeTab];
+    }
+    return Object.keys(ENTITY_TABLES);
+  }, [activeTab]);
+
+  const handleBackup = async () => {
+    setBusy(true);
+    setError('');
+    try {
+      const userId = await getCurrentUserId();
+      if (!userId) throw new Error('User belum masuk');
+      const payload: Record<string, unknown> = {
+        generated_at: new Date().toISOString(),
+        entities: {},
+      };
+      for (const key of allowedEntities) {
+        const table = ENTITY_TABLES[key];
+        if (!table) continue;
+        const { data, error: queryError } = await supabase.from(table).select('*').eq('user_id', userId);
+        if (queryError) throw queryError;
+        payload.entities[key] = data || [];
+      }
+      const timestamp = new Date();
+      const formatted = `${timestamp.getFullYear()}${String(timestamp.getMonth() + 1).padStart(2, '0')}${String(timestamp.getDate()).padStart(2, '0')}-${String(timestamp.getHours()).padStart(2, '0')}${String(timestamp.getMinutes()).padStart(2, '0')}`;
+      const fileName = `hematwoi-${allowedEntities.length === 1 ? allowedEntities[0] : 'backup'}-${formatted}.json`;
+      const blob = await downloadJSON(fileName, payload);
+      if (persistHistory) {
+        const path = `${userId}/${fileName}`;
+        const { error: storageError } = await supabase.storage.from('backups').upload(path, blob, {
+          contentType: 'application/json',
+          upsert: true,
+        });
+        if (storageError) throw storageError;
+      }
+    } catch (err) {
+      setError(err.message || 'Gagal melakukan backup');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleRestoreFile = async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setError('');
+    try {
+      const text = await file.text();
+      const parsed = JSON.parse(text);
+      if (!parsed || typeof parsed !== 'object') {
+        throw new Error('Format file tidak dikenali');
+      }
+      const entities = parsed.entities || parsed.data || parsed;
+      const summary = Object.entries(entities || {}).reduce(
+        (acc, [key, value]) => {
+          if (Array.isArray(value)) {
+            acc[key] = value.length;
+          }
+          return acc;
+        },
+        {},
+      );
+      setRestorePreview({ file, entities, summary });
+    } catch (err) {
+      setError(err.message || 'File tidak valid');
+    }
+  };
+
+  const handleRestore = async () => {
+    if (!restorePreview) return;
+    setRestoring(true);
+    setError('');
+    try {
+      const userId = await getCurrentUserId();
+      if (!userId) throw new Error('User belum masuk');
+      for (const [key, rows] of Object.entries(restorePreview.entities || {})) {
+        if (!ENTITY_TABLES[key] || !Array.isArray(rows) || rows.length === 0) continue;
+        const table = ENTITY_TABLES[key];
+        for (let i = 0; i < rows.length; i += 500) {
+          const chunk = rows.slice(i, i + 500).map((row) => ({ ...row, user_id: row.user_id || userId }));
+          const { error: upsertError } = await supabase.from(table).upsert(chunk, { onConflict: 'id' });
+          if (upsertError) throw upsertError;
+        }
+      }
+      setRestorePreview(null);
+      onRestoreComplete?.();
+    } catch (err) {
+      setError(err.message || 'Gagal melakukan restore');
+    } finally {
+      setRestoring(false);
+    }
+  };
+
+  return (
+    <div className="rounded-3xl border border-border bg-card/70 p-4 shadow-sm">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h3 className="text-base font-semibold text-foreground">Backup &amp; Restore</h3>
+          <p className="text-xs text-muted-foreground">Simpan data lokal dan pulihkan kapan saja.</p>
+        </div>
+        <label className="flex items-center gap-2 text-xs text-muted-foreground">
+          <input
+            type="checkbox"
+            className="h-4 w-4 rounded border-muted"
+            checked={persistHistory}
+            onChange={(event) => setPersistHistory(event.target.checked)}
+          />
+          Simpan ke Supabase Storage
+        </label>
+      </div>
+      <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
+        <button
+          type="button"
+          onClick={handleBackup}
+          disabled={busy}
+          className="inline-flex h-[48px] items-center justify-center gap-2 rounded-2xl border border-border bg-background text-sm font-semibold shadow-sm disabled:opacity-50"
+        >
+          {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <DownloadCloud className="h-4 w-4" />}
+          Backup {allowedEntities.length === 1 ? allowedEntities[0] : 'semua'}
+        </button>
+        <label className="flex h-[48px] cursor-pointer items-center justify-center gap-2 rounded-2xl border border-border bg-background text-sm font-semibold shadow-sm">
+          <UploadCloud className="h-4 w-4" />
+          Pilih file JSON
+          <input type="file" accept="application/json" className="sr-only" onChange={handleRestoreFile} />
+        </label>
+      </div>
+      {restorePreview && (
+        <div className="mt-4 rounded-2xl border border-border bg-muted/30 p-4 text-sm">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="font-semibold text-foreground">Pratinjau Restore</p>
+              <p className="text-xs text-muted-foreground">{restorePreview.file.name}</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setRestorePreview(null)}
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+            >
+              <RefreshCw className="h-3 w-3" /> Reset
+            </button>
+          </div>
+          <ul className="mt-3 space-y-1 text-muted-foreground">
+            {Object.entries(restorePreview.summary || {}).map(([key, count]) => (
+              <li key={key} className="flex items-center justify-between">
+                <span className="capitalize">{key}</span>
+                <span className="font-semibold text-foreground">{count}</span>
+              </li>
+            ))}
+          </ul>
+          <button
+            type="button"
+            onClick={handleRestore}
+            disabled={restoring}
+            className="mt-4 inline-flex h-[44px] items-center justify-center rounded-full bg-primary px-6 text-sm font-semibold text-primary-foreground shadow-sm disabled:opacity-50"
+          >
+            {restoring ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            Restore Sekarang
+          </button>
+        </div>
+      )}
+      {error && <p className="mt-3 text-sm text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/data/BulkActionsBar.tsx
+++ b/src/components/data/BulkActionsBar.tsx
@@ -1,0 +1,72 @@
+// @ts-nocheck
+import { useState } from 'react';
+import { Loader2, Trash2 } from 'lucide-react';
+
+export default function BulkActionsBar({
+  selectedCount,
+  categories,
+  onDelete,
+  onUpdateCategory,
+  onClear,
+  busy,
+}) {
+  const [categoryId, setCategoryId] = useState('');
+
+  const handleUpdate = async () => {
+    if (!categoryId) return;
+    try {
+      await onUpdateCategory?.(categoryId);
+      setCategoryId('');
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        console.error('[HW][data:bulk-update]', error);
+      }
+    }
+  };
+
+  return (
+    <div className="sticky bottom-3 z-30 w-full rounded-2xl border border-border bg-card/95 px-4 py-3 shadow-lg backdrop-blur">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="text-sm font-medium text-foreground">
+          {selectedCount} dipilih
+          <button type="button" className="ml-3 text-xs text-muted-foreground underline" onClick={onClear}>
+            kosongkan
+          </button>
+        </div>
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
+          <div className="flex items-center gap-2">
+            <select
+              value={categoryId}
+              onChange={(event) => setCategoryId(event.target.value)}
+              className="h-[40px] min-w-[160px] rounded-xl border border-border bg-background px-3 text-sm"
+            >
+              <option value="">Ubah kategori...</option>
+              {categories?.map((category) => (
+                <option key={category.id} value={category.id}>
+                  {category.name}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              className="inline-flex h-[40px] items-center justify-center rounded-xl border border-border bg-background px-4 text-sm font-medium shadow-sm"
+              onClick={handleUpdate}
+              disabled={!categoryId || busy}
+            >
+              {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Terapkan'}
+            </button>
+          </div>
+          <button
+            type="button"
+            className="inline-flex h-[40px] items-center justify-center gap-2 rounded-xl bg-destructive px-4 text-sm font-semibold text-destructive-foreground shadow-sm disabled:opacity-50"
+            onClick={onDelete}
+            disabled={busy}
+          >
+            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+            Hapus
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/data/ColumnVisibility.tsx
+++ b/src/components/data/ColumnVisibility.tsx
@@ -1,0 +1,68 @@
+// @ts-nocheck
+import { useState } from 'react';
+import { EyeOff, SlidersHorizontal } from 'lucide-react';
+
+export default function ColumnVisibility({ columns, hidden, onChange }) {
+  const [open, setOpen] = useState(false);
+  const hiddenSet = hidden || new Set();
+
+  const toggleColumn = (id: string) => {
+    const next = new Set(hiddenSet);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    onChange?.(next);
+  };
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        className="inline-flex h-[40px] items-center gap-2 rounded-xl border border-border bg-card px-3 text-sm shadow-sm"
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        <SlidersHorizontal className="h-4 w-4" />
+        Kolom
+      </button>
+      {open && (
+        <div className="absolute right-0 z-20 mt-2 w-56 rounded-xl border border-border bg-background p-3 shadow-lg">
+          <div className="mb-2 flex items-center justify-between text-xs font-semibold uppercase text-muted-foreground">
+            Kolom
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground hover:text-foreground"
+                onClick={() => onChange?.(new Set())}
+              >
+                Semua on
+              </button>
+              <button
+                type="button"
+                className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground hover:text-foreground"
+                onClick={() => onChange?.(new Set(columns.map((c) => c.id)))}
+              >
+                <EyeOff className="h-3 w-3" />
+                Semua off
+              </button>
+            </div>
+          </div>
+          <div className="max-h-64 space-y-2 overflow-y-auto pr-1 text-sm">
+            {columns.map((column) => (
+              <label key={column.id} className="flex items-center justify-between gap-2 rounded-lg px-2 py-1 hover:bg-muted/60">
+                <span className="truncate text-sm">{column.label}</span>
+                <input
+                  type="checkbox"
+                  checked={!hiddenSet.has(column.id)}
+                  onChange={() => toggleColumn(column.id)}
+                  className="h-4 w-4 rounded border-muted"
+                />
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/data/DataCardList.tsx
+++ b/src/components/data/DataCardList.tsx
@@ -1,0 +1,107 @@
+// @ts-nocheck
+import { useState } from 'react';
+import { MoreHorizontal, Trash2 } from 'lucide-react';
+import clsx from 'clsx';
+
+export default function DataCardList({
+  rows,
+  columns,
+  hiddenColumns,
+  selectedIds,
+  onToggleSelect,
+  onAction,
+  loading,
+}) {
+  const hidden = hiddenColumns || new Set();
+  const [openMenu, setOpenMenu] = useState<string | null>(null);
+
+  if (loading) {
+    return (
+      <div className="space-y-3">
+        {Array.from({ length: 3 }).map((_, idx) => (
+          <div key={idx} className="rounded-2xl border bg-card/80 shadow-sm p-4 space-y-2 animate-pulse">
+            <div className="h-4 w-2/3 rounded bg-muted" />
+            <div className="grid grid-cols-2 gap-2">
+              <div className="h-3 rounded bg-muted/80" />
+              <div className="h-3 rounded bg-muted/80" />
+            </div>
+            <div className="flex justify-end">
+              <div className="h-8 w-20 rounded bg-muted/80" />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (!rows.length) {
+    return <p className="text-center text-sm text-muted-foreground">Tidak ada data.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {rows.map((row, index) => {
+        const rowKey = row.id || `row-${index}`;
+        return (
+          <div key={rowKey} className="rounded-2xl border bg-card/80 shadow-sm p-4 space-y-2">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-muted"
+                    checked={selectedIds?.has(row.id)}
+                    onChange={() => onToggleSelect?.(row)}
+                  />
+                  <div className="min-w-0">
+                    <h3 className="font-semibold text-sm truncate">{row.title || row.name || row.id}</h3>
+                    {row.subtitle && <p className="text-xs text-muted-foreground truncate">{row.subtitle}</p>}
+                  </div>
+                </div>
+              </div>
+              <div className="relative flex items-center gap-1">
+                <button
+                  type="button"
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-full border text-muted-foreground"
+                  onClick={() => setOpenMenu(openMenu === rowKey ? null : rowKey)}
+                >
+                  <MoreHorizontal className="h-4 w-4" />
+                </button>
+                {openMenu === rowKey && (
+                  <div className="absolute right-0 top-10 z-20 w-40 rounded-lg border bg-background p-2 shadow-lg">
+                    <button
+                      type="button"
+                      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted"
+                      onClick={() => {
+                        setOpenMenu(null);
+                        onAction?.('delete', row);
+                      }}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      Hapus
+                    </button>
+                  </div>
+                )}
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-2 text-xs">
+              {columns.map((column) => {
+                if (hidden.has(column.id)) return null;
+                const value = column.render ? column.render(row) : column.accessor ? column.accessor(row) : row[column.id];
+                if (value == null || value === '') return null;
+                return (
+                  <div key={column.id} className="min-w-0">
+                    <p className="text-[11px] uppercase text-muted-foreground">{column.label}</p>
+                    <p className={clsx('text-sm font-medium text-foreground', column.align === 'right' && 'text-right tabular-nums')}>
+                      {value}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/data/DataTable.tsx
+++ b/src/components/data/DataTable.tsx
@@ -1,0 +1,142 @@
+// @ts-nocheck
+import clsx from 'clsx';
+import { Fragment } from 'react';
+
+function HeaderCell({ column, hidden, onSortChange, sort }) {
+  if (hidden) return null;
+  const [sortField, sortDir] = sort?.split('-') ?? [];
+  const active = sortField === column.id;
+  const nextDir = active && sortDir === 'asc' ? 'desc' : 'asc';
+  const handleSort = () => {
+    if (!onSortChange) return;
+    const field = column.sortField ?? column.id;
+    if (!field) return;
+    const prefix = column.sortField ? column.sortField : column.id;
+    onSortChange(`${prefix}-${nextDir}`);
+  };
+  return (
+    <th
+      key={column.id}
+      scope="col"
+      className={clsx(
+        'px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground',
+        column.align === 'right' && 'text-right',
+        column.align === 'center' && 'text-center',
+        column.headerClassName,
+        'whitespace-nowrap'
+      )}
+    >
+      <button
+        type="button"
+        onClick={column.sortable ? handleSort : undefined}
+        className={clsx('flex items-center gap-1', column.align === 'right' && 'justify-end', column.align === 'center' && 'justify-center', !column.sortable && 'cursor-default')}
+        disabled={!column.sortable}
+      >
+        <span className="truncate">{column.label}</span>
+        {column.sortable && active && (
+          <span className="text-xs font-normal text-muted-foreground">{sortDir === 'asc' ? '▲' : '▼'}</span>
+        )}
+      </button>
+    </th>
+  );
+}
+
+export default function DataTable({
+  columns,
+  rows,
+  hiddenColumns,
+  selectedIds,
+  onToggleSelect,
+  onToggleAll,
+  sort,
+  onSortChange,
+  loading,
+}) {
+  const hidden = hiddenColumns || new Set();
+  const isAllSelected = rows.length > 0 && rows.every((row) => selectedIds?.has(row.id));
+  const isIndeterminate = rows.some((row) => selectedIds?.has(row.id)) && !isAllSelected;
+
+  return (
+    <div className="-mx-3 md:mx-0 px-3 md:px-0 overflow-x-auto">
+      <table className="table-auto md:table-fixed w-full text-sm">
+        <thead className="sticky top-0 z-10 bg-background/95 backdrop-blur">
+          <tr className="text-left">
+            <th scope="col" className="w-12 px-3 py-2">
+              <label className="flex h-4 items-center justify-center">
+                <input
+                  type="checkbox"
+                  checked={isAllSelected}
+                  ref={(el) => {
+                    if (el) el.indeterminate = isIndeterminate;
+                  }}
+                  onChange={() => onToggleAll?.()}
+                  className="h-4 w-4 rounded border-muted"
+                />
+              </label>
+            </th>
+            {columns.map((column) => (
+              <HeaderCell
+                key={column.id}
+                column={column}
+                hidden={hidden.has(column.id)}
+                onSortChange={onSortChange}
+                sort={sort}
+              />
+            ))}
+            <th className="w-12 px-3 py-2" />
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border/60">
+          {loading ? (
+            <tr>
+              <td colSpan={columns.length + 2} className="px-3 py-10 text-center text-muted-foreground">
+                Memuat data...
+              </td>
+            </tr>
+          ) : rows.length === 0 ? (
+            <tr>
+              <td colSpan={columns.length + 2} className="px-3 py-10 text-center text-muted-foreground">
+                Tidak ada data
+              </td>
+            </tr>
+          ) : (
+            rows.map((row, index) => (
+              <tr key={row.id || index} className="odd:bg-muted/30 hover:bg-muted/50">
+                <td className="w-12 px-3 py-2 align-middle">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-muted"
+                    checked={selectedIds?.has(row.id)}
+                    onChange={() => onToggleSelect?.(row)}
+                  />
+                </td>
+                {columns.map((column) => {
+                  if (hidden.has(column.id)) return <Fragment key={column.id} />;
+                  const value = column.render ? column.render(row) : column.accessor ? column.accessor(row) : row[column.id];
+                  return (
+                    <td
+                      key={column.id}
+                      className={clsx(
+                        'px-3 py-2 align-middle text-sm text-foreground',
+                        column.align === 'right' && 'text-right tabular-nums',
+                        column.align === 'center' && 'text-center',
+                        column.className,
+                        'max-w-[220px] truncate'
+                      )}
+                      title={typeof value === 'string' ? value : undefined}
+                    >
+                      {value ?? '-'}
+                    </td>
+                  );
+                })}
+                <td className="w-12 px-3 py-2 text-right">
+                  {row.__actions || null}
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/data/DedupTool.tsx
+++ b/src/components/data/DedupTool.tsx
@@ -1,0 +1,102 @@
+// @ts-nocheck
+import { useState } from 'react';
+import { Loader2, Trash2 } from 'lucide-react';
+
+export default function DedupTool({ duplicates = [], onDelete, loading, onRefresh }) {
+  const [selectedIds, setSelectedIds] = useState(new Set());
+  const [busy, setBusy] = useState(false);
+  const hasSelection = selectedIds.size > 0;
+
+  const toggleSelection = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const handleDelete = async () => {
+    if (!hasSelection) return;
+    setBusy(true);
+    try {
+      await onDelete?.(Array.from(selectedIds));
+      setSelectedIds(new Set());
+      onRefresh?.();
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        console.error('[HW][data:dedup]', error);
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="rounded-3xl border border-border bg-card/70 p-4 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-base font-semibold text-foreground">Deteksi Duplikat</h3>
+          <p className="text-xs text-muted-foreground">Pilih catatan yang ingin dihapus.</p>
+        </div>
+        <button
+          type="button"
+          onClick={onRefresh}
+          className="text-xs text-muted-foreground underline"
+        >
+          Muat ulang
+        </button>
+      </div>
+      {loading ? (
+        <div className="mt-4 flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Memuat kandidat duplikat...
+        </div>
+      ) : duplicates.length === 0 ? (
+        <p className="mt-4 text-sm text-muted-foreground">Tidak ditemukan duplikat.</p>
+      ) : (
+        <div className="mt-4 space-y-4">
+          {duplicates.map((group, index) => (
+            <div key={index} className="rounded-2xl border border-border bg-background/60 p-3">
+              <p className="text-xs font-semibold uppercase text-muted-foreground">{group.length} entri mirip</p>
+              <div className="mt-2 space-y-2">
+                {group.map((item) => (
+                  <label
+                    key={item.id}
+                    className="flex items-center justify-between gap-3 rounded-xl border border-border bg-card px-3 py-2 text-sm hover:bg-muted/50"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate font-medium">{item.title || item.notes || 'Tanpa catatan'}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {new Date(item.date).toLocaleDateString('id-ID')} • {item.amount?.toLocaleString?.('id-ID')}
+                      </p>
+                    </div>
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4 rounded border-muted"
+                      checked={selectedIds.has(item.id)}
+                      onChange={() => toggleSelection(item.id)}
+                    />
+                  </label>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="mt-4 flex justify-end">
+        <button
+          type="button"
+          onClick={handleDelete}
+          disabled={!hasSelection || busy}
+          className="inline-flex h-[40px] items-center justify-center gap-2 rounded-full bg-destructive px-5 text-sm font-semibold text-destructive-foreground shadow-sm disabled:opacity-50"
+        >
+          {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+          Hapus Terpilih
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/data/ImportModal.tsx
+++ b/src/components/data/ImportModal.tsx
@@ -1,0 +1,446 @@
+// @ts-nocheck
+import { useEffect, useMemo, useState } from 'react';
+import { ArrowLeft, CheckCircle2, FileUp, Loader2, TriangleAlert, Upload } from 'lucide-react';
+import {
+  parseCsv,
+  mapRowsToTransactions,
+  ensureCategories,
+  insertTransactionsChunked,
+} from '../../lib/api-data';
+
+const PRESETS = {
+  wallet: {
+    label: 'Wallet',
+    mapping: { date: 'Date', amount: 'Amount', type: 'Type', category: 'Category', note: 'Description' },
+  },
+  monarch: {
+    label: 'Monarch',
+    mapping: { date: 'Date', amount: 'Amount', type: 'Transaction Type', category: 'Category', note: 'Memo' },
+  },
+  ynab: {
+    label: 'YNAB',
+    mapping: { date: 'Date', amount: 'Amount', type: 'Type', category: 'Category', note: 'Memo', account: 'Account' },
+  },
+};
+
+function ModalShell({ open, title, onClose, children }) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 py-8">
+      <div className="flex h-full w-full max-w-4xl flex-col overflow-hidden rounded-3xl border border-border bg-background shadow-xl">
+        <div className="sticky top-0 z-10 flex items-center justify-between border-b border-border bg-background/95 px-6 py-4 backdrop-blur">
+          <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-9 items-center justify-center rounded-full border border-border px-3 text-sm"
+          >
+            Tutup
+          </button>
+        </div>
+        <div className="flex-1 min-h-0 overflow-y-auto px-6 py-6">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }) {
+  if (status === 'ok') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-semibold text-emerald-700">
+        <CheckCircle2 className="h-3 w-3" /> OK
+      </span>
+    );
+  }
+  if (status === 'warning') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-semibold text-amber-800">
+        <TriangleAlert className="h-3 w-3" /> Warning
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-rose-100 px-2 py-0.5 text-[11px] font-semibold text-rose-700">
+      <TriangleAlert className="h-3 w-3" /> Error
+    </span>
+  );
+}
+
+export default function ImportModal({
+  open,
+  onClose,
+  onImported,
+  existingCategories,
+  existingAccounts,
+  existingHashes,
+  userId,
+}) {
+  const [step, setStep] = useState(0);
+  const [fileInfo, setFileInfo] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [rows, setRows] = useState([]);
+  const [headers, setHeaders] = useState([]);
+  const [mapping, setMapping] = useState({ date: '', amount: '', type: '', category: '', account: '', note: '', tags: '' });
+  const [preview, setPreview] = useState(null);
+  const [autoCreateCategory, setAutoCreateCategory] = useState(true);
+  const [skipDuplicates, setSkipDuplicates] = useState(true);
+  const [progress, setProgress] = useState({ processed: 0, total: 0, inserted: 0, failed: 0 });
+  const [importing, setImporting] = useState(false);
+  const [resultSummary, setResultSummary] = useState(null);
+
+  useEffect(() => {
+    if (!open) {
+      setStep(0);
+      setFileInfo(null);
+      setRows([]);
+      setHeaders([]);
+      setMapping({ date: '', amount: '', type: '', category: '', account: '', note: '', tags: '' });
+      setPreview(null);
+      setError('');
+      setProgress({ processed: 0, total: 0, inserted: 0, failed: 0 });
+      setImporting(false);
+      setResultSummary(null);
+    }
+  }, [open]);
+
+  const hasValidMapping = useMemo(() => {
+    return Boolean(mapping.date && mapping.amount && mapping.type && mapping.note);
+  }, [mapping]);
+
+  const handleFile = async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setError('');
+    setLoading(true);
+    try {
+      const parsed = await parseCsv(file);
+      setFileInfo({
+        name: file.name,
+        size: file.size,
+        delimiter: parsed.delimiter,
+        encoding: parsed.encoding,
+      });
+      setRows(parsed.rows);
+      setHeaders(parsed.headers);
+      const guess = inferMapping(parsed.headers);
+      setMapping((prev) => ({ ...prev, ...guess }));
+      setStep(1);
+    } catch (err) {
+      setError(err.message || 'Gagal membaca file');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (step !== 2) return;
+    if (!hasValidMapping) return;
+    try {
+      const categoryMap = new Map(existingCategories?.map((cat) => [cat.name.toLowerCase(), cat]));
+      const accountMap = new Map(existingAccounts?.map((acc) => [acc.name.toLowerCase(), acc]));
+      const previewResult = mapRowsToTransactions(rows, mapping, {
+        existingCategories: categoryMap,
+        existingAccounts: accountMap,
+        skipDuplicates,
+        existingHashes,
+        userId,
+      });
+      setPreview(previewResult);
+    } catch (err) {
+      setError(err.message || 'Gagal melakukan mapping data');
+    }
+  }, [step, hasValidMapping, rows, mapping, existingCategories, existingAccounts, skipDuplicates, existingHashes, userId]);
+
+  const handleNext = () => {
+    if (step === 1) {
+      setStep(2);
+    }
+  };
+
+  const handlePreset = (presetKey: string) => {
+    const preset = PRESETS[presetKey];
+    if (!preset) return;
+    const newMapping = { ...mapping };
+    Object.entries(preset.mapping).forEach(([field, header]) => {
+      if (headers.includes(header)) {
+        newMapping[field] = header;
+      }
+    });
+    setMapping(newMapping);
+  };
+
+  const handleImport = async () => {
+    if (!preview) return;
+    setImporting(true);
+    setError('');
+    try {
+      let categoryMap = new Map((existingCategories || []).map((cat) => [cat.name.toLowerCase(), cat]));
+      let workingPreview = preview;
+      if (autoCreateCategory && preview.missingCategories.size) {
+        const created = await ensureCategories(preview.missingCategories, 'mixed');
+        created.forEach((cat) => {
+          categoryMap.set(cat.name.toLowerCase(), cat);
+        });
+        const rerun = mapRowsToTransactions(rows, mapping, {
+          existingCategories: categoryMap,
+          existingAccounts: new Map((existingAccounts || []).map((acc) => [acc.name.toLowerCase(), acc])),
+          skipDuplicates,
+          existingHashes,
+          userId,
+        });
+        workingPreview = rerun;
+        setPreview(rerun);
+      }
+      const validRows = (workingPreview.valid || []).map(({ hash, ...rest }) => rest);
+      if (!validRows.length) {
+        setError('Tidak ada baris yang valid untuk diimpor.');
+        setImporting(false);
+        return;
+      }
+      setProgress({ processed: 0, total: validRows.length, inserted: 0, failed: 0 });
+      const summary = await insertTransactionsChunked(validRows, {
+        onProgress: (payload) => {
+          setProgress(payload);
+        },
+      });
+      setResultSummary({
+        inserted: summary.inserted,
+        skipped: workingPreview.duplicateHashes.size,
+        failed: summary.failed,
+      });
+      onImported?.(summary.inserted);
+    } catch (err) {
+      setError(err.message || 'Gagal mengimpor data');
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  return (
+    <ModalShell open={open} title="Import CSV" onClose={onClose}>
+      {step === 0 && (
+        <div className="space-y-6">
+          <div className="rounded-2xl border border-dashed border-border bg-card/70 p-8 text-center">
+            <FileUp className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              Unggah file CSV dari Wallet, Monarch, YNAB, atau sumber lain. Kami akan mendeteksi pemisah otomatis.
+            </p>
+            <label className="mt-4 inline-flex h-[44px] cursor-pointer items-center justify-center rounded-full bg-primary px-6 text-sm font-semibold text-primary-foreground shadow-sm">
+              {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Pilih File CSV'}
+              <input type="file" accept=".csv,text/csv" className="sr-only" onChange={handleFile} />
+            </label>
+            {error && <p className="mt-4 text-sm text-destructive">{error}</p>}
+          </div>
+        </div>
+      )}
+
+      {step === 1 && (
+        <div className="space-y-6">
+          <div className="flex items-center justify-between">
+            <button type="button" className="inline-flex items-center gap-2 text-sm text-muted-foreground" onClick={() => setStep(0)}>
+              <ArrowLeft className="h-4 w-4" />
+              Kembali
+            </button>
+            <div className="text-xs text-muted-foreground">
+              Delimiter: <span className="font-semibold">{fileInfo?.delimiter || ','}</span> • Encoding: <span className="font-semibold">{fileInfo?.encoding || 'utf-8'}</span>
+            </div>
+          </div>
+          <div className="rounded-2xl border bg-card/80 p-4">
+            <p className="text-sm font-medium">Mapping Kolom</p>
+            <p className="text-xs text-muted-foreground">Sesuaikan kolom CSV ke field HematWoi.</p>
+            <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2">
+              {['date', 'type', 'category', 'account', 'amount', 'note', 'tags'].map((field) => (
+                <div key={field} className="space-y-1">
+                  <label className="text-xs font-medium text-muted-foreground">{labelForField(field)}</label>
+                  <select
+                    value={mapping[field] || ''}
+                    onChange={(event) => setMapping((prev) => ({ ...prev, [field]: event.target.value }))}
+                    className="h-[40px] w-full rounded-xl border border-border bg-background px-3 text-sm"
+                  >
+                    <option value="">Pilih kolom</option>
+                    {headers.map((header) => (
+                      <option key={header} value={header}>
+                        {header}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              ))}
+            </div>
+            <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              Preset:
+              {Object.entries(PRESETS).map(([key, preset]) => (
+                <button
+                  key={key}
+                  type="button"
+                  className="inline-flex items-center rounded-full border border-border px-3 py-1 text-xs font-medium hover:bg-muted"
+                  onClick={() => handlePreset(key)}
+                >
+                  {preset.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="flex items-center justify-between">
+            <button type="button" className="inline-flex items-center gap-2 text-sm text-muted-foreground" onClick={() => setStep(0)}>
+              <ArrowLeft className="h-4 w-4" />
+              Kembali
+            </button>
+            <button
+              type="button"
+              className="inline-flex h-[44px] items-center justify-center rounded-full bg-primary px-6 text-sm font-semibold text-primary-foreground shadow-sm disabled:opacity-50"
+              onClick={handleNext}
+              disabled={!hasValidMapping}
+            >
+              Lanjut
+            </button>
+          </div>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+      )}
+
+      {step === 2 && (
+        <div className="space-y-6">
+          <div className="flex flex-col gap-2 rounded-2xl border bg-card/80 p-4 text-sm text-foreground">
+            <div className="flex flex-wrap items-center gap-4">
+              <button type="button" className="inline-flex items-center gap-2 text-sm text-muted-foreground" onClick={() => setStep(1)}>
+                <ArrowLeft className="h-4 w-4" />
+                Ubah mapping
+              </button>
+              <label className="flex items-center gap-2 text-xs">
+                <input
+                  type="checkbox"
+                  checked={autoCreateCategory}
+                  onChange={(event) => setAutoCreateCategory(event.target.checked)}
+                  className="h-4 w-4 rounded border-muted"
+                />
+                Buat kategori baru otomatis
+              </label>
+              <label className="flex items-center gap-2 text-xs">
+                <input
+                  type="checkbox"
+                  checked={skipDuplicates}
+                  onChange={(event) => setSkipDuplicates(event.target.checked)}
+                  className="h-4 w-4 rounded border-muted"
+                />
+                Lewati duplikat
+              </label>
+            </div>
+            {preview && (
+              <div className="grid grid-cols-2 gap-4 text-xs text-muted-foreground md:grid-cols-4">
+                <div>Baris valid: <span className="font-semibold text-foreground">{preview.valid.length}</span></div>
+                <div>Duplikat: <span className="font-semibold text-foreground">{preview.duplicateHashes.size}</span></div>
+                <div>Butuh kategori baru: <span className="font-semibold text-foreground">{preview.missingCategories.size}</span></div>
+                <div>Total baris: <span className="font-semibold text-foreground">{rows.length}</span></div>
+              </div>
+            )}
+          </div>
+          <div className="rounded-2xl border bg-card/60">
+            <table className="w-full table-auto text-sm">
+              <thead className="sticky top-0 bg-background/95 backdrop-blur">
+                <tr className="text-left text-xs uppercase text-muted-foreground">
+                  <th className="px-3 py-2">Status</th>
+                  <th className="px-3 py-2">Tanggal</th>
+                  <th className="px-3 py-2">Tipe</th>
+                  <th className="px-3 py-2">Kategori</th>
+                  <th className="px-3 py-2 text-right">Jumlah</th>
+                  <th className="px-3 py-2">Catatan</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(preview?.rows || []).slice(0, 20).map((row, index) => (
+                  <tr key={index} className="odd:bg-muted/30">
+                    <td className="px-3 py-2"><StatusBadge status={row.status} /></td>
+                    <td className="px-3 py-2 text-xs">{row.mapped?.date?.slice(0, 10) || '-'}</td>
+                    <td className="px-3 py-2 text-xs capitalize">{row.mapped?.type || '-'}</td>
+                    <td className="px-3 py-2 text-xs">{row.original?.[mapping.category] || '-'}</td>
+                    <td className="px-3 py-2 text-right text-xs tabular-nums">{row.mapped?.amount?.toLocaleString?.('id-ID') || '-'}</td>
+                    <td className="px-3 py-2 text-xs">{row.mapped?.title || row.original?.[mapping.note] || '-'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <div className="flex flex-col gap-4">
+            {importing && (
+              <div>
+                <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full rounded-full bg-primary transition-all"
+                    style={{ width: progress.total ? `${Math.min(100, Math.round((progress.processed / progress.total) * 100))}%` : '0%' }}
+                  />
+                </div>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  Diproses {progress.processed}/{progress.total} • Berhasil {progress.inserted} • Gagal {progress.failed}
+                </p>
+              </div>
+            )}
+            {resultSummary && (
+              <div className="rounded-xl border border-border bg-muted/30 p-4 text-sm">
+                <p className="font-semibold text-foreground">Import selesai</p>
+                <ul className="mt-2 space-y-1 text-muted-foreground">
+                  <li>Berhasil: <span className="font-semibold text-emerald-600">{resultSummary.inserted}</span></li>
+                  <li>Duplikat dilewati: <span className="font-semibold text-amber-600">{resultSummary.skipped}</span></li>
+                  {resultSummary.failed > 0 && (
+                    <li>Gagal: <span className="font-semibold text-destructive">{resultSummary.failed}</span></li>
+                  )}
+                </ul>
+              </div>
+            )}
+            <div className="flex items-center justify-end gap-3">
+              <button type="button" className="inline-flex items-center gap-2 text-sm text-muted-foreground" onClick={onClose}>
+                Batal
+              </button>
+              <button
+                type="button"
+                className="inline-flex h-[44px] items-center justify-center rounded-full bg-primary px-6 text-sm font-semibold text-primary-foreground shadow-sm disabled:opacity-50"
+                onClick={handleImport}
+                disabled={importing || !preview || !preview.valid.length}
+              >
+                {importing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Upload className="mr-2 h-4 w-4" />}
+                Import
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </ModalShell>
+  );
+}
+
+function labelForField(field: string) {
+  switch (field) {
+    case 'date':
+      return 'Tanggal';
+    case 'type':
+      return 'Tipe';
+    case 'category':
+      return 'Kategori';
+    case 'account':
+      return 'Akun';
+    case 'amount':
+      return 'Jumlah';
+    case 'note':
+      return 'Catatan';
+    case 'tags':
+      return 'Tag';
+    default:
+      return field;
+  }
+}
+
+function inferMapping(headers: string[]) {
+  const lower = headers.map((header) => header.toLowerCase());
+  const find = (candidates: string[]) => headers[lower.findIndex((value) => candidates.includes(value))] || '';
+  return {
+    date: find(['date', 'tanggal', 'time', 'posted at']),
+    amount: find(['amount', 'jumlah', 'nilai', 'nominal']),
+    type: find(['type', 'tipe', 'jenis', 'transaction type']),
+    category: find(['category', 'kategori', 'group']),
+    account: find(['account', 'akun', 'wallet']),
+    note: find(['note', 'catatan', 'memo', 'description', 'title']),
+    tags: find(['tags', 'label']),
+  };
+}

--- a/src/components/data/NormalizeCategories.tsx
+++ b/src/components/data/NormalizeCategories.tsx
@@ -1,0 +1,209 @@
+// @ts-nocheck
+import { useEffect, useState } from 'react';
+import { ArrowRight, Loader2, Sparkles, Trash2 } from 'lucide-react';
+import { supabase } from '../../lib/supabase';
+import { getCurrentUserId } from '../../lib/session';
+
+export default function NormalizeCategories({ categories = [], onComplete }) {
+  const [mode, setMode] = useState<'rename' | 'merge'>('rename');
+  const [sourceId, setSourceId] = useState('');
+  const [targetId, setTargetId] = useState('');
+  const [newName, setNewName] = useState('');
+  const [deleteSource, setDeleteSource] = useState(true);
+  const [impact, setImpact] = useState({ total: 0, loading: false });
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!sourceId) {
+      setImpact({ total: 0, loading: false });
+      return;
+    }
+    let cancelled = false;
+    const fetchImpact = async () => {
+      setImpact({ total: 0, loading: true });
+      try {
+        const userId = await getCurrentUserId();
+        if (!userId) throw new Error('User belum masuk');
+        const { count, error: countError } = await supabase
+          .from('transactions')
+          .select('id', { count: 'exact', head: true })
+          .eq('user_id', userId)
+          .eq('category_id', sourceId);
+        if (countError) throw countError;
+        if (!cancelled) {
+          setImpact({ total: count || 0, loading: false });
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setImpact({ total: 0, loading: false });
+          if (import.meta.env.DEV) {
+            console.error('[HW][data:normalize]', err);
+          }
+        }
+      }
+    };
+    fetchImpact();
+    return () => {
+      cancelled = true;
+    };
+  }, [sourceId]);
+
+  const handleApply = async () => {
+    if (!sourceId) {
+      setError('Pilih kategori sumber terlebih dahulu.');
+      return;
+    }
+    setBusy(true);
+    setError('');
+    try {
+      const userId = await getCurrentUserId();
+      if (!userId) throw new Error('User belum masuk');
+      if (mode === 'rename') {
+        if (!newName.trim()) {
+          throw new Error('Nama baru tidak boleh kosong');
+        }
+        const { error: renameError } = await supabase
+          .from('categories')
+          .update({ name: newName.trim() })
+          .eq('id', sourceId)
+          .eq('user_id', userId);
+        if (renameError) throw renameError;
+      } else {
+        if (!targetId) {
+          throw new Error('Pilih kategori target.');
+        }
+        const { error: updateError } = await supabase
+          .from('transactions')
+          .update({ category_id: targetId })
+          .eq('user_id', userId)
+          .eq('category_id', sourceId);
+        if (updateError) throw updateError;
+        if (deleteSource) {
+          await supabase.from('categories').delete().eq('id', sourceId).eq('user_id', userId);
+        }
+      }
+      onComplete?.();
+      setSourceId('');
+      setTargetId('');
+      setNewName('');
+    } catch (err) {
+      setError(err.message || 'Gagal menyimpan perubahan');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="rounded-3xl border border-border bg-card/70 p-4 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-base font-semibold text-foreground">Normalisasi Kategori</h3>
+          <p className="text-xs text-muted-foreground">Gabungkan atau ubah nama kategori untuk rapihkan data.</p>
+        </div>
+        <Sparkles className="h-5 w-5 text-primary" />
+      </div>
+      <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-3">
+        <div className="space-y-1">
+          <label className="text-xs font-semibold text-muted-foreground">Mode</label>
+          <select
+            value={mode}
+            onChange={(event) => setMode(event.target.value as 'rename' | 'merge')}
+            className="h-[40px] w-full rounded-xl border border-border bg-background px-3 text-sm"
+          >
+            <option value="rename">Rename</option>
+            <option value="merge">Merge</option>
+          </select>
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs font-semibold text-muted-foreground">Kategori sumber</label>
+          <select
+            value={sourceId}
+            onChange={(event) => setSourceId(event.target.value)}
+            className="h-[40px] w-full rounded-xl border border-border bg-background px-3 text-sm"
+          >
+            <option value="">Pilih kategori</option>
+            {categories.map((cat) => (
+              <option key={cat.id} value={cat.id}>
+                {cat.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        {mode === 'merge' ? (
+          <div className="space-y-1">
+            <label className="text-xs font-semibold text-muted-foreground">Kategori target</label>
+            <select
+              value={targetId}
+              onChange={(event) => setTargetId(event.target.value)}
+              className="h-[40px] w-full rounded-xl border border-border bg-background px-3 text-sm"
+            >
+              <option value="">Pilih kategori</option>
+              {categories
+                .filter((cat) => cat.id !== sourceId)
+                .map((cat) => (
+                  <option key={cat.id} value={cat.id}>
+                    {cat.name}
+                  </option>
+                ))}
+            </select>
+          </div>
+        ) : (
+          <div className="space-y-1">
+            <label className="text-xs font-semibold text-muted-foreground">Nama baru</label>
+            <input
+              value={newName}
+              onChange={(event) => setNewName(event.target.value)}
+              className="h-[40px] w-full rounded-xl border border-border bg-background px-3 text-sm"
+              placeholder="Nama kategori baru"
+            />
+          </div>
+        )}
+      </div>
+      {mode === 'merge' && (
+        <label className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
+          <input
+            type="checkbox"
+            className="h-4 w-4 rounded border-muted"
+            checked={deleteSource}
+            onChange={(event) => setDeleteSource(event.target.checked)}
+          />
+          Hapus kategori sumber setelah pemindahan
+        </label>
+      )}
+      <div className="mt-4 rounded-2xl border border-border bg-muted/20 p-4 text-sm text-muted-foreground">
+        {impact.loading ? (
+          <div className="flex items-center gap-2">
+            <Loader2 className="h-4 w-4 animate-spin" /> Menghitung dampak...
+          </div>
+        ) : sourceId ? (
+          <div className="flex items-center gap-2">
+            <ArrowRight className="h-4 w-4 text-primary" />
+            <span>
+              {impact.total} transaksi akan {mode === 'merge' ? 'dipindahkan' : 'diupdate nama kategorinya'}
+            </span>
+          </div>
+        ) : (
+          <span>Pilih kategori untuk melihat dampaknya.</span>
+        )}
+      </div>
+      {error && <p className="mt-3 text-sm text-destructive">{error}</p>}
+      <div className="mt-4 flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={handleApply}
+          disabled={busy || !sourceId || (mode === 'merge' && !targetId)}
+          className="inline-flex h-[42px] items-center justify-center gap-2 rounded-full bg-primary px-6 text-sm font-semibold text-primary-foreground shadow-sm disabled:opacity-50"
+        >
+          {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
+          Terapkan
+        </button>
+        {mode === 'merge' && deleteSource && (
+          <div className="flex items-center gap-1 text-xs text-muted-foreground">
+            <Trash2 className="h-3 w-3" /> kategori sumber akan dihapus
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/api-data.ts
+++ b/src/lib/api-data.ts
@@ -1,0 +1,545 @@
+import { supabase } from './supabase';
+import { listTransactions as legacyListTransactions, getTransactionsSummary as legacySummary } from './api';
+import { getCurrentUserId } from './session';
+
+interface ListTransactionParams {
+  q?: string;
+  type?: string;
+  categoryId?: string | null;
+  dateFrom?: string | null;
+  dateTo?: string | null;
+  sort?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+interface BulkUpdateParams {
+  ids: string[];
+  patch: Record<string, unknown>;
+}
+
+interface CsvParseResult {
+  headers: string[];
+  rows: Array<Record<string, string>>;
+  delimiter: string;
+  encoding: string;
+}
+
+interface MappingOptions {
+  date: string;
+  type?: string;
+  category?: string;
+  account?: string;
+  amount: string;
+  note?: string;
+  tags?: string;
+}
+
+type ImportRow = Record<string, any>;
+
+interface MapOptions {
+  autoCreateCategories?: boolean;
+  skipDuplicates?: boolean;
+  existingCategories?: Map<string, { id: string; type?: string | null }>; // normalized by lowercase name
+  existingAccounts?: Map<string, { id: string }>; // normalized by lowercase name
+  existingHashes?: Set<string>;
+  userId?: string | null;
+}
+
+interface MapResultRow {
+  original: Record<string, string>;
+  status: 'ok' | 'warning' | 'error';
+  message?: string;
+  mapped?: ImportRow & { hash: string };
+  hash?: string;
+}
+
+interface MapRowsResult {
+  rows: MapResultRow[];
+  valid: (ImportRow & { hash: string })[];
+  missingCategories: Set<string>;
+  duplicateHashes: Set<string>;
+}
+
+interface ChunkInsertOptions {
+  chunkSize?: number;
+  onProgress?: (payload: {
+    processed: number;
+    total: number;
+    inserted: number;
+    failed: number;
+  }) => void;
+}
+
+function logDevError(scope: string, error: unknown) {
+  if (import.meta.env.DEV) {
+    console.error(`[HW][data:${scope}]`, error);
+  }
+}
+
+function wrapError(scope: string, error: unknown) {
+  const message =
+    error instanceof Error ? error.message : typeof error === 'string' ? error : 'Terjadi kesalahan';
+  return new Error(`${scope}: ${message}`);
+}
+
+function normalizeSort(sort?: string) {
+  if (!sort) return 'date-desc';
+  const allowed = new Set(['date-desc', 'date-asc', 'amount-desc', 'amount-asc']);
+  return allowed.has(sort) ? sort : 'date-desc';
+}
+
+function readFileAsText(file: File, encoding: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => {
+      reader.abort();
+      reject(new Error('Gagal membaca file'));
+    };
+    reader.onload = () => {
+      resolve(String(reader.result || ''));
+    };
+    try {
+      reader.readAsText(file, encoding as BufferEncoding);
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+function detectEncoding(file: File) {
+  const type = file.type || '';
+  if (/charset=([^;]+)/i.test(type)) {
+    const match = type.match(/charset=([^;]+)/i);
+    if (match) return match[1];
+  }
+  return 'utf-8';
+}
+
+function detectDelimiter(sample: string) {
+  const candidates = [',', ';', '\t'];
+  const lines = sample.split(/\r?\n/).filter(Boolean);
+  const target = lines.slice(0, 5);
+  let best = ',';
+  let bestScore = -Infinity;
+  for (const delimiter of candidates) {
+    let variance = 0;
+    let lastLength: number | null = null;
+    for (const line of target) {
+      const length = line.split(delimiter).length;
+      if (lastLength != null) {
+        variance += Math.abs(length - lastLength);
+      }
+      lastLength = length;
+    }
+    const score = (target[0]?.split(delimiter).length || 0) - variance;
+    if (score > bestScore) {
+      bestScore = score;
+      best = delimiter;
+    }
+  }
+  return best;
+}
+
+function normalizeType(value: string | undefined) {
+  if (!value) return null;
+  const normalized = value.toLowerCase().trim();
+  if (['income', 'in', 'pemasukan', 'masuk', 'credit'].includes(normalized)) return 'income';
+  if (['expense', 'out', 'pengeluaran', 'keluar', 'debit'].includes(normalized)) return 'expense';
+  if (['transfer', 'tf', 'pindah', 'mutasi'].includes(normalized)) return 'transfer';
+  return null;
+}
+
+function parseNumber(value: string | undefined) {
+  if (!value) return Number.NaN;
+  const trimmed = value.trim();
+  if (!trimmed) return Number.NaN;
+  const normalized = trimmed
+    .replace(/\s+/g, '')
+    .replace(/IDR|Rp|idr|rp|\.00/g, '')
+    .replace(/[^0-9.,-]/g, '');
+  const hasComma = normalized.includes(',');
+  const hasDot = normalized.includes('.');
+  let candidate = normalized;
+  if (hasComma && hasDot) {
+    if (normalized.lastIndexOf(',') > normalized.lastIndexOf('.')) {
+      candidate = normalized.replace(/\./g, '').replace(',', '.');
+    } else {
+      candidate = normalized.replace(/,/g, '');
+    }
+  } else if (hasComma && !hasDot) {
+    candidate = normalized.replace(/\./g, '').replace(',', '.');
+  } else {
+    candidate = normalized.replace(/,/g, '');
+  }
+  const parsed = Number.parseFloat(candidate);
+  return Number.isFinite(parsed) ? parsed : Number.NaN;
+}
+
+function normalizeDate(value: string | undefined) {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const candidates = [trimmed];
+  if (/^\d{1,2}[\/-]\d{1,2}[\/-]\d{2,4}$/.test(trimmed)) {
+    const parts = trimmed.split(/[\/-]/);
+    if (parts.length === 3) {
+      const [a, b, c] = parts;
+      const year = c.length === 2 ? Number.parseInt(`20${c}`, 10) : Number.parseInt(c, 10);
+      const monthFirst = `${year}-${a.padStart(2, '0')}-${b.padStart(2, '0')}`;
+      const dayFirst = `${year}-${b.padStart(2, '0')}-${a.padStart(2, '0')}`;
+      candidates.push(monthFirst, dayFirst);
+    }
+  }
+  for (const candidate of candidates) {
+    const date = new Date(candidate);
+    if (!Number.isNaN(date.getTime())) {
+      const iso = new Date(date.getTime());
+      iso.setHours(0, 0, 0, 0);
+      return iso.toISOString();
+    }
+  }
+  return null;
+}
+
+function safeTrim(value: string | undefined) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export async function listTransactions(params: ListTransactionParams = {}) {
+  try {
+    const { q, type, categoryId, dateFrom, dateTo, sort, page, pageSize } = params;
+    const filters: Record<string, unknown> = {
+      search: q || '',
+      sort: normalizeSort(sort),
+      page: page || 1,
+      pageSize: pageSize || 20,
+    };
+    if (type && type !== 'all') filters.type = type;
+    if (categoryId) filters.categories = [categoryId];
+    if (dateFrom) filters.startDate = dateFrom;
+    if (dateTo) filters.endDate = dateTo;
+
+    const [{ rows, total, page: currentPage, pageSize: limit }, summary] = await Promise.all([
+      legacyListTransactions(filters),
+      legacySummary(filters),
+    ]);
+    return { rows, total, page: currentPage, pageSize: limit, summary };
+  } catch (error) {
+    logDevError('listTransactions', error);
+    throw wrapError('Gagal memuat transaksi', error);
+  }
+}
+
+export async function bulkDeleteTransactions(ids: string[]) {
+  try {
+    if (!ids || ids.length === 0) {
+      return { deleted: 0 };
+    }
+    const userId = await getCurrentUserId();
+    if (!userId) {
+      throw new Error('User belum masuk');
+    }
+    const { data, error } = await supabase
+      .from('transactions')
+      .delete()
+      .eq('user_id', userId)
+      .in('id', ids)
+      .select('id');
+    if (error) throw error;
+    return { deleted: data?.length ?? 0 };
+  } catch (error) {
+    logDevError('bulkDeleteTransactions', error);
+    throw wrapError('Gagal menghapus transaksi', error);
+  }
+}
+
+export async function bulkUpdateTransactions({ ids, patch }: BulkUpdateParams) {
+  try {
+    if (!ids || ids.length === 0) {
+      return { updated: 0 };
+    }
+    const sanitized: Record<string, unknown> = {};
+    Object.entries(patch || {}).forEach(([key, value]) => {
+      if (value !== undefined && value !== null && value !== '') {
+        sanitized[key] = value;
+      }
+    });
+    if (Object.keys(sanitized).length === 0) {
+      return { updated: 0 };
+    }
+    const userId = await getCurrentUserId();
+    if (!userId) {
+      throw new Error('User belum masuk');
+    }
+    const { data, error } = await supabase
+      .from('transactions')
+      .update(sanitized)
+      .eq('user_id', userId)
+      .in('id', ids)
+      .select('id');
+    if (error) throw error;
+    return { updated: data?.length ?? 0 };
+  } catch (error) {
+    logDevError('bulkUpdateTransactions', error);
+    throw wrapError('Gagal memperbarui transaksi', error);
+  }
+}
+
+function toCsvValue(value: unknown) {
+  if (value == null) return '';
+  const str = String(value);
+  if (str.includes(',') || str.includes('\n') || str.includes('"')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+export async function exportTransactionsCSV(params: ListTransactionParams = {}) {
+  try {
+    const result = await listTransactions(params);
+    const headers = ['Tanggal', 'Tipe', 'Kategori', 'Akun', 'Jumlah', 'Catatan'];
+    const rows = result.rows.map((row: any) => [
+      row.date ? new Date(row.date).toISOString().slice(0, 10) : '',
+      row.type || '',
+      row.category?.name || '',
+      row.account?.name || '',
+      row.amount ?? '',
+      row.title || row.notes || '',
+    ]);
+    const csv = [headers.map(toCsvValue).join(','), ...rows.map((cells) => cells.map(toCsvValue).join(','))].join('\n');
+    return new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  } catch (error) {
+    logDevError('exportTransactionsCSV', error);
+    throw wrapError('Gagal mengekspor CSV', error);
+  }
+}
+
+export async function parseCsv(file: File): Promise<CsvParseResult> {
+  try {
+    const encoding = detectEncoding(file);
+    const text = await readFileAsText(file, encoding);
+    const delimiter = detectDelimiter(text);
+    const lines = text.split(/\r?\n/).filter((line) => line.trim() !== '');
+    if (lines.length === 0) {
+      return { headers: [], rows: [], delimiter, encoding };
+    }
+    const headers = lines[0].split(delimiter).map((h) => h.trim());
+    const rows: Array<Record<string, string>> = [];
+    for (let i = 1; i < lines.length; i += 1) {
+      const values = lines[i].split(delimiter);
+      const record: Record<string, string> = {};
+      headers.forEach((header, index) => {
+        record[header] = values[index]?.trim() ?? '';
+      });
+      rows.push(record);
+    }
+    return { headers, rows, delimiter, encoding };
+  } catch (error) {
+    logDevError('parseCsv', error);
+    throw wrapError('Gagal membaca CSV', error);
+  }
+}
+
+export function computeHash(tx: { user_id?: string | null; date?: string | null; amount?: number | string; title?: string | null }) {
+  const user = tx.user_id ?? '';
+  const date = tx.date ?? '';
+  const amount = typeof tx.amount === 'number' ? tx.amount.toFixed(2) : safeTrim(String(tx.amount ?? ''));
+  const note = tx.title ?? '';
+  return `${user}|${date}|${amount}|${note}`;
+}
+
+export function dedupeCandidates(rows: Array<{ id: string; user_id?: string | null; date?: string | null; amount?: number; title?: string | null }>) {
+  try {
+    const buckets = new Map<string, Array<typeof rows[number]>>();
+    rows.forEach((row) => {
+      const hash = computeHash(row);
+      if (!buckets.has(hash)) {
+        buckets.set(hash, []);
+      }
+      buckets.get(hash)!.push(row);
+    });
+    return Array.from(buckets.values()).filter((bucket) => bucket.length > 1);
+  } catch (error) {
+    logDevError('dedupeCandidates', error);
+    throw wrapError('Gagal mengelompokkan duplikat', error);
+  }
+}
+
+function normalizeTags(value: string | undefined) {
+  if (!value) return null;
+  const parts = value
+    .split(/[,;#]+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (parts.length === 0) return null;
+  return parts.join(',');
+}
+
+export function mapRowsToTransactions(
+  rows: Array<Record<string, string>>,
+  mapping: MappingOptions,
+  options: MapOptions = {},
+): MapRowsResult {
+  const results: MapResultRow[] = [];
+  const valid: (ImportRow & { hash: string })[] = [];
+  const missingCategories = new Set<string>();
+  const duplicateHashes = new Set<string>();
+  const normalizedCategories = options.existingCategories || new Map();
+  const normalizedAccounts = options.existingAccounts || new Map();
+  const seenHashes = new Set(options.existingHashes || []);
+  const userId = options.userId ?? null;
+
+  rows.forEach((original) => {
+    try {
+      const dateValue = mapping.date ? original[mapping.date] : undefined;
+      const amountValue = mapping.amount ? original[mapping.amount] : undefined;
+      const typeValue = mapping.type ? original[mapping.type] : undefined;
+      const categoryValue = mapping.category ? original[mapping.category] : undefined;
+      const accountValue = mapping.account ? original[mapping.account] : undefined;
+      const noteValue = mapping.note ? original[mapping.note] : undefined;
+      const tagsValue = mapping.tags ? original[mapping.tags] : undefined;
+
+      const normalizedDate = normalizeDate(dateValue || undefined);
+      if (!normalizedDate) {
+        results.push({ original, status: 'error', message: 'Tanggal tidak valid' });
+        return;
+      }
+      const parsedAmount = parseNumber(amountValue);
+      if (!Number.isFinite(parsedAmount) || parsedAmount === 0) {
+        results.push({ original, status: 'error', message: 'Jumlah tidak valid' });
+        return;
+      }
+      const normalizedType = normalizeType(typeValue || '');
+      if (!normalizedType) {
+        results.push({ original, status: 'error', message: 'Tipe tidak dikenal' });
+        return;
+      }
+      const mapped: ImportRow & { hash: string } = {
+        user_id: userId || undefined,
+        date: normalizedDate,
+        type: normalizedType as 'income' | 'expense' | 'transfer',
+        amount: Number(parsedAmount.toFixed(2)),
+        title: safeTrim(noteValue) || undefined,
+        notes: safeTrim(noteValue) || undefined,
+        tags: normalizeTags(tagsValue) || undefined,
+        account_id: undefined,
+        category_id: undefined,
+      } as ImportRow & { hash: string };
+
+      if (categoryValue) {
+        const key = categoryValue.toLowerCase().trim();
+        if (key && normalizedCategories.has(key)) {
+          mapped.category_id = normalizedCategories.get(key)!.id as any;
+        } else if (key) {
+          missingCategories.add(categoryValue.trim());
+        }
+      }
+
+      if (accountValue) {
+        const key = accountValue.toLowerCase().trim();
+        if (key && normalizedAccounts.has(key)) {
+          mapped.account_id = normalizedAccounts.get(key)!.id as any;
+        }
+      }
+
+      const hash = computeHash({ user_id: userId ?? undefined, date: mapped.date, amount: mapped.amount, title: mapped.title || '' });
+      mapped.hash = hash;
+
+      if (options.skipDuplicates && seenHashes.has(hash)) {
+        duplicateHashes.add(hash);
+        results.push({ original, status: 'warning', message: 'Duplikat dilewati', hash });
+        return;
+      }
+
+      seenHashes.add(hash);
+      valid.push(mapped);
+      results.push({ original, status: 'ok', mapped, hash });
+    } catch (error) {
+      logDevError('mapRowsToTransactions.row', error);
+      results.push({ original, status: 'error', message: 'Gagal memproses baris' });
+    }
+  });
+
+  return { rows: results, valid, missingCategories, duplicateHashes };
+}
+
+export async function insertTransactionsChunked(
+  rows: (ImportRow & { hash?: string })[],
+  options: ChunkInsertOptions = {},
+) {
+  try {
+    const chunkSize = options.chunkSize && options.chunkSize > 0 ? options.chunkSize : 500;
+    const userId = await getCurrentUserId();
+    if (!userId) {
+      throw new Error('User belum masuk');
+    }
+    const total = rows.length;
+    let processed = 0;
+    let inserted = 0;
+    let failed = 0;
+    for (let i = 0; i < rows.length; i += chunkSize) {
+      const chunk = rows.slice(i, i + chunkSize).map((row) => ({
+        ...row,
+        user_id: userId,
+      }));
+      try {
+        const { data, error } = await supabase.from('transactions').insert(chunk).select('id');
+        if (error) throw error;
+        inserted += data?.length ?? chunk.length;
+      } catch (error) {
+        failed += chunk.length;
+        logDevError('insertTransactionsChunked.chunk', error);
+      }
+      processed += chunk.length;
+      options.onProgress?.({ processed, total, inserted, failed });
+    }
+    if (failed > 0) {
+      throw new Error(`Sebagian data gagal diimpor (${failed} baris)`);
+    }
+    return { inserted, failed };
+  } catch (error) {
+    logDevError('insertTransactionsChunked', error);
+    throw wrapError('Gagal mengimpor transaksi', error);
+  }
+}
+
+export async function ensureCategories(
+  names: Iterable<string>,
+  type: 'income' | 'expense' | 'transfer' | 'mixed' = 'expense',
+) {
+  try {
+    const userId = await getCurrentUserId();
+    if (!userId) throw new Error('User belum masuk');
+    const normalized = Array.from(new Set(Array.from(names).map((name) => name.trim()).filter(Boolean)));
+    if (normalized.length === 0) {
+      return [];
+    }
+    const { data: existing, error: existingError } = await supabase
+      .from('categories')
+      .select('id, name, type')
+      .eq('user_id', userId)
+      .in('name', normalized);
+    if (existingError) throw existingError;
+    const existingNames = new Set(existing?.map((item) => item.name) ?? []);
+    const toCreate = normalized.filter((name) => !existingNames.has(name));
+    if (toCreate.length === 0) {
+      return existing || [];
+    }
+    const payload = toCreate.map((name) => ({
+      name,
+      type: type === 'mixed' ? 'expense' : type,
+      user_id: userId,
+    }));
+    const { data: inserted, error: insertError } = await supabase
+      .from('categories')
+      .insert(payload)
+      .select('id, name, type');
+    if (insertError) throw insertError;
+    return [...(existing || []), ...(inserted || [])];
+  } catch (error) {
+    logDevError('ensureCategories', error);
+    throw wrapError('Gagal membuat kategori', error);
+  }
+}
+

--- a/src/pages/DataPage.tsx
+++ b/src/pages/DataPage.tsx
@@ -1,0 +1,767 @@
+// @ts-nocheck
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  Database,
+  Download,
+  RefreshCw,
+  Search,
+  Upload,
+} from 'lucide-react';
+import DataTable from '../components/data/DataTable';
+import DataCardList from '../components/data/DataCardList';
+import ColumnVisibility from '../components/data/ColumnVisibility';
+import BulkActionsBar from '../components/data/BulkActionsBar';
+import ImportModal from '../components/data/ImportModal';
+import BackupRestore from '../components/data/BackupRestore';
+import DedupTool from '../components/data/DedupTool';
+import NormalizeCategories from '../components/data/NormalizeCategories';
+import {
+  listTransactions as apiListTransactions,
+  bulkDeleteTransactions,
+  bulkUpdateTransactions,
+  exportTransactionsCSV,
+  dedupeCandidates,
+  computeHash,
+} from '../lib/api-data';
+import { supabase } from '../lib/supabase';
+import { getCurrentUserId } from '../lib/session';
+import { useToast } from '../context/ToastContext';
+
+const TAB_KEYS = ['transactions', 'categories', 'debts', 'goals'];
+const TAB_LABELS = {
+  transactions: 'Transaksi',
+  categories: 'Kategori',
+  debts: 'Hutang',
+  goals: 'Goals',
+};
+
+const DEFAULT_FILTER = {
+  q: '',
+  type: 'all',
+  dateFrom: '',
+  dateTo: '',
+  sort: 'date-desc',
+  page: 1,
+  pageSize: 20,
+};
+
+function buildColumns(tab: string) {
+  switch (tab) {
+    case 'transactions':
+      return [
+        { id: 'date', label: 'Tanggal', accessor: (row) => new Date(row.date).toLocaleDateString('id-ID'), sortable: true, sortField: 'date' },
+        { id: 'title', label: 'Catatan', accessor: (row) => row.title || row.notes || '-', className: 'truncate' },
+        { id: 'type', label: 'Tipe', accessor: (row) => row.type, className: 'capitalize' },
+        { id: 'category', label: 'Kategori', accessor: (row) => row.category?.name || '-', className: 'truncate' },
+        { id: 'account', label: 'Akun', accessor: (row) => row.account?.name || '-', className: 'truncate' },
+        { id: 'amount', label: 'Nominal', accessor: (row) => Number(row.amount || 0).toLocaleString('id-ID'), align: 'right', sortable: true, sortField: 'amount' },
+      ];
+    case 'categories':
+      return [
+        { id: 'name', label: 'Nama', accessor: (row) => row.name, className: 'truncate', sortable: true, sortField: 'name' },
+        { id: 'type', label: 'Tipe', accessor: (row) => row.type || '-', className: 'capitalize' },
+        { id: 'created_at', label: 'Dibuat', accessor: (row) => row.created_at ? new Date(row.created_at).toLocaleDateString('id-ID') : '-', sortable: true, sortField: 'created_at' },
+      ];
+    case 'debts':
+      return [
+        { id: 'title', label: 'Judul', accessor: (row) => row.title || '-', className: 'truncate' },
+        { id: 'amount', label: 'Jumlah', accessor: (row) => Number(row.amount || 0).toLocaleString('id-ID'), align: 'right', sortable: true, sortField: 'amount' },
+        { id: 'status', label: 'Status', accessor: (row) => row.status || '-', className: 'capitalize' },
+        { id: 'due_date', label: 'Jatuh Tempo', accessor: (row) => row.due_date ? new Date(row.due_date).toLocaleDateString('id-ID') : '-', sortable: true, sortField: 'due_date' },
+      ];
+    case 'goals':
+      return [
+        { id: 'name', label: 'Nama', accessor: (row) => row.name || row.title || '-', className: 'truncate' },
+        { id: 'target', label: 'Target', accessor: (row) => Number(row.target || 0).toLocaleString('id-ID'), align: 'right', sortable: true, sortField: 'target' },
+        { id: 'saved', label: 'Tersimpan', accessor: (row) => Number(row.saved || 0).toLocaleString('id-ID'), align: 'right', sortable: true, sortField: 'saved' },
+        { id: 'deadline', label: 'Deadline', accessor: (row) => row.deadline ? new Date(row.deadline).toLocaleDateString('id-ID') : '-', sortable: true, sortField: 'deadline' },
+      ];
+    default:
+      return [];
+  }
+}
+
+function sortOptionsFor(tab: string) {
+  switch (tab) {
+    case 'transactions':
+      return [
+        { value: 'date-desc', label: 'Tanggal terbaru' },
+        { value: 'date-asc', label: 'Tanggal terlama' },
+        { value: 'amount-desc', label: 'Nominal terbesar' },
+        { value: 'amount-asc', label: 'Nominal terkecil' },
+      ];
+    case 'categories':
+      return [
+        { value: 'name-asc', label: 'Nama A-Z' },
+        { value: 'name-desc', label: 'Nama Z-A' },
+        { value: 'created_at-desc', label: 'Terbaru dibuat' },
+        { value: 'created_at-asc', label: 'Terlama dibuat' },
+      ];
+    case 'debts':
+      return [
+        { value: 'due_date-asc', label: 'Jatuh tempo terdekat' },
+        { value: 'due_date-desc', label: 'Jatuh tempo terjauh' },
+        { value: 'amount-desc', label: 'Nominal terbesar' },
+        { value: 'amount-asc', label: 'Nominal terkecil' },
+      ];
+    case 'goals':
+      return [
+        { value: 'deadline-asc', label: 'Deadline terdekat' },
+        { value: 'deadline-desc', label: 'Deadline terjauh' },
+        { value: 'target-desc', label: 'Target terbesar' },
+        { value: 'target-asc', label: 'Target terkecil' },
+        { value: 'saved-desc', label: 'Tersimpan terbanyak' },
+        { value: 'saved-asc', label: 'Tersimpan tersedikit' },
+      ];
+    default:
+      return [];
+  }
+}
+
+async function fetchCategories(filter, userId) {
+  let query = supabase
+    .from('categories')
+    .select('*', { count: 'exact' })
+    .eq('user_id', userId);
+  if (filter.q) {
+    query = query.ilike('name', `%${filter.q}%`);
+  }
+  const [sortField, sortDir] = (filter.sort || 'name-asc').split('-');
+  const ascending = sortDir !== 'desc';
+  const orderField = sortField === 'created_at' ? 'created_at' : 'name';
+  query = query.order(orderField, { ascending });
+  const from = (filter.page - 1) * filter.pageSize;
+  const to = from + filter.pageSize - 1;
+  const { data, error, count } = await query.range(from, to);
+  if (error) throw error;
+  return { rows: data || [], total: count || 0 };
+}
+
+async function fetchDebts(filter, userId) {
+  let query = supabase
+    .from('debts')
+    .select('*', { count: 'exact' })
+    .eq('user_id', userId);
+  if (filter.q) {
+    query = query.ilike('title', `%${filter.q}%`);
+  }
+  const [sortField, sortDir] = (filter.sort || 'due_date-desc').split('-');
+  const ascending = sortDir !== 'desc';
+  const orderField = sortField === 'amount' ? 'amount' : sortField === 'due_date' ? 'due_date' : 'created_at';
+  query = query.order(orderField, { ascending });
+  const from = (filter.page - 1) * filter.pageSize;
+  const to = from + filter.pageSize - 1;
+  const { data, error, count } = await query.range(from, to);
+  if (error) throw error;
+  return { rows: data || [], total: count || 0 };
+}
+
+async function fetchGoals(filter, userId) {
+  let query = supabase
+    .from('goals')
+    .select('*', { count: 'exact' })
+    .eq('user_id', userId);
+  if (filter.q) {
+    query = query.ilike('name', `%${filter.q}%`);
+  }
+  const [sortField, sortDir] = (filter.sort || 'deadline-asc').split('-');
+  const ascending = sortDir !== 'desc';
+  let orderField = 'created_at';
+  if (sortField === 'deadline') orderField = 'deadline';
+  if (sortField === 'target') orderField = 'target';
+  if (sortField === 'saved') orderField = 'saved';
+  query = query.order(orderField, { ascending });
+  const from = (filter.page - 1) * filter.pageSize;
+  const to = from + filter.pageSize - 1;
+  const { data, error, count } = await query.range(from, to);
+  if (error) throw error;
+  return { rows: data || [], total: count || 0 };
+}
+
+function toFilename(entity: string, extension: string) {
+  const now = new Date();
+  const stamp = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}-${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}`;
+  return `hematwoi-${entity}-${stamp}.${extension}`;
+}
+
+export default function DataPage() {
+  const [activeTab, setActiveTab] = useState('transactions');
+  const [filters, setFilters] = useState(() => {
+    const base = TAB_KEYS.reduce((acc, key) => {
+      acc[key] = { ...DEFAULT_FILTER };
+      return acc;
+    }, {} as Record<string, typeof DEFAULT_FILTER>);
+    base.categories.sort = 'name-asc';
+    base.debts.sort = 'due_date-desc';
+    base.goals.sort = 'deadline-asc';
+    return base;
+  });
+  const [dataState, setDataState] = useState(() =>
+    TAB_KEYS.reduce((acc, key) => {
+      acc[key] = { rows: [], total: 0, loading: false, error: '' };
+      return acc;
+    }, {}),
+  );
+  const [summary, setSummary] = useState({ total: 0, income: 0, expense: 0, net: 0 });
+  const [hiddenColumns, setHiddenColumns] = useState(() =>
+    TAB_KEYS.reduce((acc, key) => {
+      acc[key] = new Set();
+      return acc;
+    }, {}),
+  );
+  const [selectedRows, setSelectedRows] = useState(() =>
+    TAB_KEYS.reduce((acc, key) => {
+      acc[key] = new Set();
+      return acc;
+    }, {}),
+  );
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth < 768 : false,
+  );
+  const [importOpen, setImportOpen] = useState(false);
+  const [categories, setCategories] = useState([]);
+  const [accounts, setAccounts] = useState([]);
+  const [duplicates, setDuplicates] = useState([]);
+  const [loadingDuplicates, setLoadingDuplicates] = useState(false);
+  const [userId, setUserId] = useState(null);
+  const { addToast } = useToast();
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (typeof window === 'undefined') return;
+      setIsMobile(window.innerWidth < 768);
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const uid = await getCurrentUserId();
+        setUserId(uid);
+        if (!uid) return;
+        const [catRes, accountRes] = await Promise.all([
+          supabase.from('categories').select('id, name, type').eq('user_id', uid).order('name'),
+          supabase.from('accounts').select('id, name').eq('user_id', uid).order('name'),
+        ]);
+        if (catRes.error) throw catRes.error;
+        if (accountRes.error) throw accountRes.error;
+        setCategories(catRes.data || []);
+        setAccounts(accountRes.data || []);
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.error('[HW][data:init]', err);
+        }
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    const currentFilter = filters[activeTab];
+    let cancelled = false;
+    const load = async () => {
+      setDataState((prev) => ({
+        ...prev,
+        [activeTab]: { ...prev[activeTab], loading: true, error: '' },
+      }));
+      try {
+        if (!userId) {
+          setDataState((prev) => ({
+            ...prev,
+            [activeTab]: { ...prev[activeTab], rows: [], total: 0, loading: false },
+          }));
+          return;
+        }
+        let result;
+        if (activeTab === 'transactions') {
+          const response = await apiListTransactions(currentFilter);
+          result = { rows: response.rows, total: response.total };
+          setSummary({
+            total: response.total,
+            income: Number(response.summary?.income || 0),
+            expense: Number(response.summary?.expense || 0),
+            net: Number(response.summary?.net || 0),
+          });
+        } else if (activeTab === 'categories') {
+          result = await fetchCategories(currentFilter, userId);
+        } else if (activeTab === 'debts') {
+          result = await fetchDebts(currentFilter, userId);
+        } else if (activeTab === 'goals') {
+          result = await fetchGoals(currentFilter, userId);
+        }
+        if (!cancelled && result) {
+          setDataState((prev) => ({
+            ...prev,
+            [activeTab]: { ...prev[activeTab], rows: result.rows, total: result.total, loading: false, error: '' },
+          }));
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setDataState((prev) => ({
+            ...prev,
+            [activeTab]: { ...prev[activeTab], loading: false, error: err.message || 'Gagal memuat data' },
+          }));
+        }
+        if (import.meta.env.DEV) {
+          console.error('[HW][data:load]', err);
+        }
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, filters, userId]);
+
+  useEffect(() => {
+    if (activeTab !== 'transactions') return;
+    const rows = dataState.transactions.rows || [];
+    if (!rows.length) {
+      setDuplicates([]);
+      return;
+    }
+    try {
+      setLoadingDuplicates(true);
+      const groups = dedupeCandidates(rows.filter((row) => row.id));
+      setDuplicates(groups);
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.error('[HW][data:dedupe-calc]', err);
+      }
+    } finally {
+      setLoadingDuplicates(false);
+    }
+  }, [dataState.transactions.rows, activeTab]);
+
+  const handleFilterChange = (tab, key, value) => {
+    setFilters((prev) => {
+      const next = { ...prev };
+      next[tab] = { ...next[tab], [key]: value };
+      if (key !== 'page' && key !== 'pageSize') {
+        next[tab].page = 1;
+      }
+      return next;
+    });
+  };
+
+  const columns = useMemo(() => buildColumns(activeTab), [activeTab]);
+  const rows = dataState[activeTab]?.rows || [];
+  const total = dataState[activeTab]?.total || 0;
+  const page = filters[activeTab]?.page || 1;
+  const pageSize = filters[activeTab]?.pageSize || 20;
+  const pageCount = Math.max(1, Math.ceil(total / pageSize));
+
+  const selected = selectedRows[activeTab] || new Set();
+  const hidden = hiddenColumns[activeTab] || new Set();
+
+  const toggleRow = (row) => {
+    setSelectedRows((prev) => {
+      const copy = { ...prev };
+      const next = new Set(copy[activeTab]);
+      if (next.has(row.id)) {
+        next.delete(row.id);
+      } else {
+        next.add(row.id);
+      }
+      copy[activeTab] = next;
+      return copy;
+    });
+  };
+
+  const toggleAll = () => {
+    setSelectedRows((prev) => {
+      const copy = { ...prev };
+      if (selected.size === rows.length) {
+        copy[activeTab] = new Set();
+      } else {
+        copy[activeTab] = new Set(rows.map((row) => row.id));
+      }
+      return copy;
+    });
+  };
+
+  const handleDeleteSelected = async () => {
+    if (activeTab !== 'transactions' || selected.size === 0) return;
+    try {
+      await bulkDeleteTransactions(Array.from(selected));
+      addToast({ title: 'Transaksi dihapus', status: 'success' });
+      setSelectedRows((prev) => ({ ...prev, transactions: new Set() }));
+      refreshCurrentTab();
+    } catch (err) {
+      addToast({ title: 'Gagal menghapus transaksi', status: 'error', description: err.message });
+    }
+  };
+
+  const handleBulkUpdateCategory = async (categoryId: string) => {
+    if (!categoryId) return;
+    try {
+      await bulkUpdateTransactions({ ids: Array.from(selected), patch: { category_id: categoryId } });
+      addToast({ title: 'Kategori diperbarui', status: 'success' });
+      refreshCurrentTab();
+      setSelectedRows((prev) => ({ ...prev, transactions: new Set() }));
+    } catch (err) {
+      addToast({ title: 'Gagal mengubah kategori', status: 'error', description: err.message });
+    }
+  };
+
+  const refreshCurrentTab = () => {
+    setFilters((prev) => ({ ...prev, [activeTab]: { ...prev[activeTab] } }));
+  };
+
+  const handleExportCSV = async () => {
+    try {
+      const blob = await exportTransactionsCSV(filters.transactions);
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = toFilename('transactions', 'csv');
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      addToast({ title: 'Gagal export CSV', status: 'error', description: err.message });
+    }
+  };
+
+  const handleExportJSON = async () => {
+    try {
+      const rows = await fetchAllTransactions(filters.transactions);
+      await triggerDownloadJSON(rows, toFilename('transactions', 'json'));
+    } catch (err) {
+      addToast({ title: 'Gagal export JSON', status: 'error', description: err.message });
+    }
+  };
+
+  const existingHashes = useMemo(() => {
+    if (activeTab !== 'transactions') return new Set();
+    return new Set(
+      (dataState.transactions.rows || []).map((row) =>
+        computeHash({ user_id: row.user_id || userId, date: row.date, amount: row.amount, title: row.title || '' }),
+      ),
+    );
+  }, [dataState.transactions.rows, userId, activeTab]);
+
+  const cardSummary = [
+    {
+      label: 'Total Transaksi',
+      value: summary.total,
+      icon: Database,
+    },
+    {
+      label: 'Total Pemasukan',
+      value: summary.income,
+      icon: ArrowDownToLine,
+    },
+    {
+      label: 'Total Pengeluaran',
+      value: summary.expense,
+      icon: ArrowUpFromLine,
+    },
+    {
+      label: 'Saldo Terhitung',
+      value: summary.net,
+      icon: RefreshCw,
+    },
+  ];
+
+  return (
+    <main className="min-w-0 w-full px-4 md:px-6 py-5 space-y-6">
+      <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        {cardSummary.map((card) => (
+          <div key={card.label} className="rounded-3xl border border-border bg-card/80 p-4 shadow-sm">
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-muted-foreground">{card.label}</p>
+              <card.icon className="h-5 w-5 text-primary" />
+            </div>
+            <p className="mt-3 text-2xl font-semibold text-foreground">
+              {typeof card.value === 'number' ? card.value.toLocaleString('id-ID') : card.value}
+            </p>
+          </div>
+        ))}
+      </section>
+
+      <section className="rounded-3xl border border-border bg-card/70 p-4 shadow-sm">
+        <div className="flex flex-wrap items-center gap-2">
+          {TAB_KEYS.map((key) => (
+            <button
+              key={key}
+              type="button"
+              className={`inline-flex h-9 items-center rounded-full px-4 text-sm font-medium transition ${
+                activeTab === key ? 'bg-primary text-primary-foreground' : 'bg-muted/50 text-muted-foreground hover:bg-muted'
+              }`}
+              onClick={() => setActiveTab(key)}
+            >
+              {TAB_LABELS[key]}
+            </button>
+          ))}
+          <div className="ml-auto flex items-center gap-2">
+            {activeTab === 'transactions' && (
+              <>
+                <button
+                  type="button"
+                  className="inline-flex h-[40px] items-center gap-2 rounded-xl border border-border bg-background px-3 text-sm"
+                  onClick={handleExportCSV}
+                >
+                  <Download className="h-4 w-4" /> CSV
+                </button>
+                <button
+                  type="button"
+                  className="inline-flex h-[40px] items-center gap-2 rounded-xl border border-border bg-background px-3 text-sm"
+                  onClick={handleExportJSON}
+                >
+                  <Download className="h-4 w-4" /> JSON
+                </button>
+                <button
+                  type="button"
+                  className="inline-flex h-[40px] items-center gap-2 rounded-xl bg-primary px-4 text-sm font-semibold text-primary-foreground"
+                  onClick={() => setImportOpen(true)}
+                >
+                  <Upload className="h-4 w-4" /> Import CSV
+                </button>
+              </>
+            )}
+            <ColumnVisibility
+              columns={columns}
+              hidden={hidden}
+              onChange={(set) =>
+                setHiddenColumns((prev) => ({
+                  ...prev,
+                  [activeTab]: new Set(Array.from(set).filter(Boolean)),
+                }))
+              }
+            />
+          </div>
+        </div>
+
+        <div className="mt-4 grid grid-cols-2 md:grid-cols-8 gap-3 items-center">
+          <div className="col-span-2 md:col-span-3">
+            <div className="flex h-[40px] items-center gap-2 rounded-xl border border-border bg-background px-3">
+              <Search className="h-4 w-4 text-muted-foreground" />
+              <input
+                value={filters[activeTab].q}
+                onChange={(event) => handleFilterChange(activeTab, 'q', event.target.value)}
+                placeholder="Cari..."
+                className="h-full flex-1 bg-transparent text-sm outline-none"
+              />
+            </div>
+          </div>
+          {activeTab === 'transactions' && (
+            <>
+              <select
+                value={filters.transactions.type}
+                onChange={(event) => handleFilterChange('transactions', 'type', event.target.value)}
+                className="h-[40px] w-full rounded-xl border border-border bg-background px-3 text-sm"
+              >
+                <option value="all">Semua Tipe</option>
+                <option value="income">Pemasukan</option>
+                <option value="expense">Pengeluaran</option>
+                <option value="transfer">Transfer</option>
+              </select>
+              <input
+                type="date"
+                value={filters.transactions.dateFrom || ''}
+                onChange={(event) => handleFilterChange('transactions', 'dateFrom', event.target.value)}
+                className="h-[40px] w-full rounded-xl border border-border bg-background px-3 text-sm"
+              />
+              <input
+                type="date"
+                value={filters.transactions.dateTo || ''}
+                onChange={(event) => handleFilterChange('transactions', 'dateTo', event.target.value)}
+                className="h-[40px] w-full rounded-xl border border-border bg-background px-3 text-sm"
+              />
+            </>
+          )}
+          <div className="col-span-2 md:col-span-2">
+            <select
+              value={filters[activeTab].sort}
+              onChange={(event) => handleFilterChange(activeTab, 'sort', event.target.value)}
+              className="h-[40px] w-full rounded-xl border border-border bg-background px-3 text-sm"
+            >
+              {sortOptionsFor(activeTab).map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-span-2 md:col-span-1 md:ml-auto">
+            <select
+              value={filters[activeTab].pageSize}
+              onChange={(event) => handleFilterChange(activeTab, 'pageSize', Number(event.target.value))}
+              className="h-[40px] w-full rounded-xl border border-border bg-background px-3 text-sm"
+            >
+              {[20, 50, 100].map((size) => (
+                <option key={size} value={size}>
+                  {size}/halaman
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="mt-4 space-y-4">
+          {dataState[activeTab].error && (
+            <div className="rounded-2xl border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+              {dataState[activeTab].error}
+            </div>
+          )}
+          {isMobile ? (
+            <DataCardList
+              rows={rows}
+              columns={columns}
+              hiddenColumns={hidden}
+              selectedIds={selected}
+              onToggleSelect={toggleRow}
+              loading={dataState[activeTab].loading}
+              onAction={(action, row) => {
+                if (action === 'delete' && activeTab === 'transactions') {
+                  bulkDeleteTransactions([row.id])
+                    .then(() => {
+                      addToast({ title: 'Transaksi dihapus', status: 'success' });
+                      refreshCurrentTab();
+                    })
+                    .catch((err) => {
+                      addToast({ title: 'Gagal menghapus', status: 'error', description: err.message });
+                    });
+                }
+              }}
+            />
+          ) : (
+            <DataTable
+              columns={columns}
+              rows={rows}
+              hiddenColumns={hidden}
+              selectedIds={selected}
+              onToggleSelect={toggleRow}
+              onToggleAll={toggleAll}
+              sort={filters[activeTab].sort}
+              onSortChange={(value) => handleFilterChange(activeTab, 'sort', value)}
+              loading={dataState[activeTab].loading}
+            />
+          )}
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>
+              Menampilkan {(page - 1) * pageSize + 1}-{Math.min(page * pageSize, total)} dari {total}
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                className="inline-flex h-8 items-center justify-center rounded-full border border-border px-3"
+                onClick={() => handleFilterChange(activeTab, 'page', Math.max(1, page - 1))}
+                disabled={page <= 1}
+              >
+                Prev
+              </button>
+              <span>
+                {page}/{pageCount}
+              </span>
+              <button
+                type="button"
+                className="inline-flex h-8 items-center justify-center rounded-full border border-border px-3"
+                onClick={() => handleFilterChange(activeTab, 'page', Math.min(pageCount, page + 1))}
+                disabled={page >= pageCount}
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {activeTab === 'transactions' && selected.size > 0 && (
+        <BulkActionsBar
+          selectedCount={selected.size}
+          categories={categories}
+          onDelete={handleDeleteSelected}
+          onUpdateCategory={handleBulkUpdateCategory}
+          onClear={() => setSelectedRows((prev) => ({ ...prev, transactions: new Set() }))}
+        />
+      )}
+
+      {activeTab === 'transactions' && (
+        <div className="space-y-4">
+          <DedupTool
+            duplicates={duplicates}
+            loading={loadingDuplicates}
+            onDelete={async (ids) => {
+              try {
+                await bulkDeleteTransactions(ids);
+                addToast({ title: 'Duplikat dihapus', status: 'success' });
+                refreshCurrentTab();
+              } catch (err) {
+                addToast({ title: 'Gagal menghapus duplikat', status: 'error', description: err.message });
+              }
+            }}
+            onRefresh={refreshCurrentTab}
+          />
+          <NormalizeCategories
+            categories={categories}
+            onComplete={() => {
+              refreshCurrentTab();
+              if (userId) {
+                supabase
+                  .from('categories')
+                  .select('id, name, type')
+                  .eq('user_id', userId)
+                  .order('name')
+                  .then((res) => {
+                    if (!res.error) setCategories(res.data || []);
+                  });
+              }
+            }}
+          />
+        </div>
+      )}
+
+      <BackupRestore
+        activeTab={activeTab === 'transactions' ? 'transactions' : undefined}
+        onRestoreComplete={refreshCurrentTab}
+      />
+
+      <ImportModal
+        open={importOpen}
+        onClose={() => setImportOpen(false)}
+        onImported={() => {
+          setImportOpen(false);
+          refreshCurrentTab();
+        }}
+        existingCategories={categories}
+        existingAccounts={accounts}
+        existingHashes={existingHashes}
+        userId={userId}
+      />
+    </main>
+  );
+}
+
+async function fetchAllTransactions(filter) {
+  const pageSize = 500;
+  let page = 1;
+  let fetched = [];
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const response = await apiListTransactions({ ...filter, page, pageSize });
+    fetched = fetched.concat(response.rows);
+    if (!response.rows.length || fetched.length >= response.total) {
+      break;
+    }
+    page += 1;
+  }
+  return fetched;
+}
+
+async function triggerDownloadJSON(data, filename) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -24,7 +24,7 @@ function loadComponent(path: string) {
     case '/categories':
       return lazy(() => import('../pages/Categories'));
     case '/data':
-      return lazy(() => import('../pages/DataToolsPage'));
+      return lazy(() => import('../pages/DataPage'));
     case '/subscriptions':
       return lazy(() => import('../pages/Subscriptions'));
     case '/settings':


### PR DESCRIPTION
## Summary
- replace the legacy /data experience with a tabbed DataPage that surfaces per-entity filters, sortable tables, responsive card views, and at-a-glance transaction summaries
- add transactional data utilities for listing, exporting, importing, deduplicating, and batch inserting transactions to simplify bulk management workflows
- implement dedicated tools for CSV import, backup & restore, duplicate cleanup, and category normalization alongside reusable column/bulk action controls

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1517cab8c83328ad509e11bf832c5