### PR TITLE
feat: enable inline transaction editing

### DIFF
--- a/src/components/data/DataCardList.tsx
+++ b/src/components/data/DataCardList.tsx
@@ -1,7 +1,28 @@
 // @ts-nocheck
-import { useState } from 'react';
-import { MoreHorizontal, Trash2 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { MoreHorizontal, Trash2, X as CloseIcon } from 'lucide-react';
 import clsx from 'clsx';
+import {
+  TransactionAccountEditor,
+  TransactionAmountEditor,
+  TransactionCategoryEditor,
+  TransactionDateEditor,
+  TransactionTagsEditor,
+  TransactionTitleEditor,
+  TransactionTypeEditor,
+} from './TransactionFieldEditors';
+
+const INTERACTIVE_FIELDS = new Set(['date', 'title', 'type', 'category', 'account', 'amount', 'tags']);
+
+const SHEET_COMPONENTS = {
+  date: TransactionDateEditor,
+  title: TransactionTitleEditor,
+  type: TransactionTypeEditor,
+  category: TransactionCategoryEditor,
+  account: TransactionAccountEditor,
+  amount: TransactionAmountEditor,
+  tags: TransactionTagsEditor,
+};
 
 export default function DataCardList({
   rows,
@@ -11,9 +32,39 @@ export default function DataCardList({
   onToggleSelect,
   onAction,
   loading,
+  editing,
 }) {
   const hidden = hiddenColumns || new Set();
   const [openMenu, setOpenMenu] = useState<string | null>(null);
+  const [sheet, setSheet] = useState<{ rowId: string; field: string } | null>(null);
+
+  const interactiveColumns = useMemo(() => {
+    if (!editing) return new Set();
+    return new Set(
+      columns.filter((column) => INTERACTIVE_FIELDS.has(column.id) && !hidden.has(column.id)).map((column) => column.id),
+    );
+  }, [columns, editing, hidden]);
+
+  const handleOpenSheet = (row, column) => {
+    if (!editing) return;
+    if (!INTERACTIVE_FIELDS.has(column.id)) return;
+    setSheet({ rowId: row.id, field: column.id });
+  };
+
+  const handleCloseSheet = () => {
+    setSheet(null);
+  };
+
+  useEffect(() => {
+    if (!sheet) return;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        handleCloseSheet();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [sheet]);
 
   if (loading) {
     return (
@@ -38,70 +89,134 @@ export default function DataCardList({
     return <p className="text-center text-sm text-muted-foreground">Tidak ada data.</p>;
   }
 
+  const activeRow = sheet ? rows.find((row) => row.id === sheet.rowId) : null;
+  const SheetComponent = sheet ? SHEET_COMPONENTS[sheet.field] : null;
+  const sheetColumn = sheet ? columns.find((column) => column.id === sheet.field) : null;
+
   return (
-    <div className="space-y-3">
-      {rows.map((row, index) => {
-        const rowKey = row.id || `row-${index}`;
-        return (
-          <div key={rowKey} className="rounded-2xl border bg-card/80 shadow-sm p-4 space-y-2">
-            <div className="flex items-start justify-between gap-3">
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    className="h-4 w-4 rounded border-muted"
-                    checked={selectedIds?.has(row.id)}
-                    onChange={() => onToggleSelect?.(row)}
-                  />
-                  <div className="min-w-0">
-                    <h3 className="font-semibold text-sm truncate">{row.title || row.name || row.id}</h3>
-                    {row.subtitle && <p className="text-xs text-muted-foreground truncate">{row.subtitle}</p>}
+    <>
+      <div className="space-y-3">
+        {rows.map((row, index) => {
+          const rowKey = row.id || `row-${index}`;
+          return (
+            <div key={rowKey} className="rounded-2xl border bg-card/80 shadow-sm p-4 space-y-2">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4 rounded border-muted"
+                      checked={selectedIds?.has(row.id)}
+                      onChange={() => onToggleSelect?.(row)}
+                    />
+                    <div className="min-w-0">
+                      <h3 className="font-semibold text-sm truncate">
+                        {row.title || row.name || row.id}
+                      </h3>
+                      {row.subtitle && <p className="text-xs text-muted-foreground truncate">{row.subtitle}</p>}
+                    </div>
                   </div>
                 </div>
+                <div className="relative flex items-center gap-1">
+                  <button
+                    type="button"
+                    className="inline-flex h-8 w-8 items-center justify-center rounded-full border text-muted-foreground"
+                    onClick={() => setOpenMenu(openMenu === rowKey ? null : rowKey)}
+                  >
+                    <MoreHorizontal className="h-4 w-4" />
+                  </button>
+                  {openMenu === rowKey && (
+                    <div className="absolute right-0 top-10 z-20 w-40 rounded-lg border bg-background p-2 shadow-lg">
+                      <button
+                        type="button"
+                        className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted"
+                        onClick={() => {
+                          setOpenMenu(null);
+                          onAction?.('delete', row);
+                        }}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                        Hapus
+                      </button>
+                    </div>
+                  )}
+                </div>
               </div>
-              <div className="relative flex items-center gap-1">
-                <button
-                  type="button"
-                  className="inline-flex h-8 w-8 items-center justify-center rounded-full border text-muted-foreground"
-                  onClick={() => setOpenMenu(openMenu === rowKey ? null : rowKey)}
-                >
-                  <MoreHorizontal className="h-4 w-4" />
-                </button>
-                {openMenu === rowKey && (
-                  <div className="absolute right-0 top-10 z-20 w-40 rounded-lg border bg-background p-2 shadow-lg">
-                    <button
-                      type="button"
-                      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted"
-                      onClick={() => {
-                        setOpenMenu(null);
-                        onAction?.('delete', row);
-                      }}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                      Hapus
-                    </button>
-                  </div>
-                )}
+              <div className="grid grid-cols-2 gap-2 text-xs">
+                {columns.map((column) => {
+                  if (hidden.has(column.id)) return null;
+                  if (column.id === '__actions') return null;
+                  const displayValue = column.display
+                    ? column.display(row)
+                    : column.accessor
+                    ? column.accessor(row)
+                    : row[column.id];
+                  if (displayValue == null || displayValue === '') return null;
+                  const interactive = interactiveColumns.has(column.id);
+                  const status = interactive && editing ? editing.getStatus(row.id, column.id) : null;
+
+                  if (interactive && editing) {
+                    return (
+                      <button
+                        key={column.id}
+                        type="button"
+                        onClick={() => handleOpenSheet(row, column)}
+                        className="flex min-w-0 flex-col rounded-xl border border-transparent bg-muted/40 px-3 py-2 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                      >
+                        <span className="text-[11px] uppercase text-muted-foreground">{column.label}</span>
+                        <span className={clsx('mt-1 flex items-center gap-2 text-sm font-medium text-foreground')}>
+                          <span className="truncate">{displayValue}</span>
+                          {status?.state === 'saving' ? (
+                            <span className="text-xs text-muted-foreground">⋯</span>
+                          ) : status?.state === 'error' ? (
+                            <span className="text-xs text-red-500">!</span>
+                          ) : null}
+                        </span>
+                      </button>
+                    );
+                  }
+
+                  return (
+                    <div key={column.id} className="min-w-0">
+                      <p className="text-[11px] uppercase text-muted-foreground">{column.label}</p>
+                      <p className={clsx('text-sm font-medium text-foreground', column.align === 'right' && 'text-right tabular-nums')}>
+                        {displayValue}
+                      </p>
+                    </div>
+                  );
+                })}
               </div>
             </div>
-            <div className="grid grid-cols-2 gap-2 text-xs">
-              {columns.map((column) => {
-                if (hidden.has(column.id)) return null;
-                const value = column.render ? column.render(row) : column.accessor ? column.accessor(row) : row[column.id];
-                if (value == null || value === '') return null;
-                return (
-                  <div key={column.id} className="min-w-0">
-                    <p className="text-[11px] uppercase text-muted-foreground">{column.label}</p>
-                    <p className={clsx('text-sm font-medium text-foreground', column.align === 'right' && 'text-right tabular-nums')}>
-                      {value}
-                    </p>
-                  </div>
-                );
-              })}
+          );
+        })}
+      </div>
+      {sheet && SheetComponent && activeRow && (
+        <div
+          className="fixed inset-0 z-40 flex flex-col justify-end bg-black/50"
+          onClick={handleCloseSheet}
+          role="presentation"
+        >
+          <div
+            className="min-h-0 overflow-y-auto rounded-t-3xl bg-background p-4 shadow-2xl"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="mb-3 flex items-center justify-between">
+              <div>
+                <p className="text-xs uppercase text-muted-foreground">Edit</p>
+                <h3 className="text-base font-semibold text-foreground">{sheetColumn?.label || 'Field'}</h3>
+              </div>
+              <button
+                type="button"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border"
+                onClick={handleCloseSheet}
+              >
+                <CloseIcon className="h-4 w-4" />
+              </button>
             </div>
+            <SheetComponent row={activeRow} editing={editing} variant="sheet" autoFocus />
           </div>
-        );
-      })}
-    </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/src/components/data/DataTable.tsx
+++ b/src/components/data/DataTable.tsx
@@ -113,19 +113,16 @@ export default function DataTable({
                 {columns.map((column) => {
                   if (hidden.has(column.id)) return <Fragment key={column.id} />;
                   const value = column.render ? column.render(row) : column.accessor ? column.accessor(row) : row[column.id];
+                  const cellClass = clsx(
+                    'px-3 py-2 align-middle text-sm text-foreground',
+                    column.align === 'right' && 'text-right tabular-nums',
+                    column.align === 'center' && 'text-center',
+                    column.className,
+                    !column.render && 'max-w-[220px] truncate',
+                  );
                   return (
-                    <td
-                      key={column.id}
-                      className={clsx(
-                        'px-3 py-2 align-middle text-sm text-foreground',
-                        column.align === 'right' && 'text-right tabular-nums',
-                        column.align === 'center' && 'text-center',
-                        column.className,
-                        'max-w-[220px] truncate'
-                      )}
-                      title={typeof value === 'string' ? value : undefined}
-                    >
-                      {value ?? '-'}
+                    <td key={column.id} className={cellClass} title={!column.render && typeof value === 'string' ? value : undefined}>
+                      {value ?? (column.render ? null : '-')}
                     </td>
                   );
                 })}

--- a/src/components/data/TransactionFieldEditors.tsx
+++ b/src/components/data/TransactionFieldEditors.tsx
@@ -1,0 +1,560 @@
+// @ts-nocheck
+import { useEffect, useMemo, useRef, useState } from 'react';
+import clsx from 'clsx';
+import {
+  Check,
+  ChevronDown,
+  CircleAlert,
+  Loader2,
+  Tag,
+  X,
+} from 'lucide-react';
+
+const TYPE_OPTIONS = [
+  { value: 'income', label: 'Pemasukan' },
+  { value: 'expense', label: 'Pengeluaran' },
+  { value: 'transfer', label: 'Transfer' },
+];
+
+function toInputDate(value?: string) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function parseTags(value?: string) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  return String(value)
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+}
+
+function StatusIcon({ status }) {
+  if (!status || status.state === 'idle') return null;
+  if (status.state === 'saving') {
+    return <Loader2 className="ml-2 h-4 w-4 animate-spin text-muted-foreground" aria-hidden="true" />;
+  }
+  if (status.state === 'saved') {
+    return <Check className="ml-2 h-4 w-4 text-emerald-500" aria-hidden="true" />;
+  }
+  if (status.state === 'error') {
+    return <CircleAlert className="ml-2 h-4 w-4 text-red-500" aria-hidden="true" />;
+  }
+  return null;
+}
+
+function FieldWrapper({
+  children,
+  status,
+  className,
+  variant = 'table',
+}: {
+  children: React.ReactNode;
+  status: { state: string; message?: string };
+  className?: string;
+  variant?: 'table' | 'sheet';
+}) {
+  return (
+    <div
+      className={clsx(
+        'group/field flex min-w-0 items-center gap-2',
+        variant === 'sheet' ? 'rounded-2xl border border-border bg-background/80 px-3 py-2' : 'rounded-lg px-2 py-1.5',
+        className,
+      )}
+    >
+      <div className="min-w-0 flex-1">{children}</div>
+      <span className="sr-only" aria-live="polite">
+        {status?.state === 'saving'
+          ? 'Menyimpan'
+          : status?.state === 'saved'
+          ? 'Tersimpan'
+          : status?.state === 'error'
+          ? status?.message || 'Gagal menyimpan'
+          : 'Siap'}
+      </span>
+      <StatusIcon status={status} />
+    </div>
+  );
+}
+
+export function TransactionDateEditor({ row, editing, variant = 'table', autoFocus = false }) {
+  const status = editing.getStatus(row.id, 'date');
+  const [value, setValue] = useState(() => toInputDate(row.date));
+
+  useEffect(() => {
+    if (status.state !== 'saving') {
+      setValue(toInputDate(row.date));
+    }
+  }, [row.date, status.state]);
+
+  const handleChange = (event) => {
+    setValue(event.target.value);
+    editing.queueUpdate(row.id, 'date', event.target.value, { debounceMs: 0 });
+  };
+
+  const handleBlur = () => {
+    editing.flushUpdate(row.id, 'date');
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      editing.flushUpdate(row.id, 'date');
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      editing.cancelUpdate(row.id, 'date');
+      setValue(toInputDate(row.date));
+    }
+  };
+
+  return (
+    <FieldWrapper status={status} variant={variant}>
+      <input
+        type="date"
+        value={value}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        autoFocus={autoFocus}
+        className="w-full rounded-md border border-border bg-transparent px-2 py-1 text-sm text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+      />
+    </FieldWrapper>
+  );
+}
+
+export function TransactionTitleEditor({ row, editing, variant = 'table', autoFocus = false }) {
+  const status = editing.getStatus(row.id, 'title');
+  const display = row.title ?? row.notes ?? '';
+  const [value, setValue] = useState(display);
+
+  useEffect(() => {
+    if (status.state !== 'saving') {
+      setValue(row.title ?? row.notes ?? '');
+    }
+  }, [row.title, row.notes, status.state]);
+
+  const handleChange = (event) => {
+    setValue(event.target.value);
+    editing.queueUpdate(row.id, 'title', event.target.value, { debounceMs: 400 });
+  };
+
+  const handleBlur = () => {
+    editing.flushUpdate(row.id, 'title');
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      editing.flushUpdate(row.id, 'title');
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      editing.cancelUpdate(row.id, 'title');
+      setValue(row.title ?? row.notes ?? '');
+    }
+  };
+
+  return (
+    <FieldWrapper status={status} variant={variant}>
+      <input
+        type="text"
+        value={value}
+        placeholder="Catatan"
+        onChange={handleChange}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        autoFocus={autoFocus}
+        className="w-full rounded-md border border-transparent bg-transparent px-2 py-1 text-sm text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+      />
+    </FieldWrapper>
+  );
+}
+
+export function TransactionTypeEditor({ row, editing, variant = 'table' }) {
+  const status = editing.getStatus(row.id, 'type');
+  const handleChange = (event) => {
+    editing.commitUpdate(row.id, 'type', event.target.value);
+  };
+
+  return (
+    <FieldWrapper status={status} variant={variant}>
+      <select
+        value={row.type || 'expense'}
+        onChange={handleChange}
+        className="w-full rounded-md border border-border bg-background px-2 py-1 text-sm capitalize text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+      >
+        {TYPE_OPTIONS.map((option) => (
+          <option key={option.value} value={option.value} className="capitalize">
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </FieldWrapper>
+  );
+}
+
+function useSearchableOptions(options, open) {
+  const inputRef = useRef(null);
+  useEffect(() => {
+    if (open && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [open]);
+  return inputRef;
+}
+
+function SearchableSelect({
+  row,
+  editing,
+  field,
+  options,
+  placeholder,
+  variant,
+}) {
+  const status = editing.getStatus(row.id, field);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const buttonRef = useRef(null);
+  const currentName = useMemo(() => {
+    if (field === 'category') {
+      return row.category?.name ?? row.category ?? '';
+    }
+    if (field === 'account') {
+      return row.account?.name ?? row.account ?? '';
+    }
+    return '';
+  }, [row, field]);
+  const currentId = field === 'category' ? row.category_id : row.account_id;
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('');
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open && status.state !== 'saving') {
+      setQuery('');
+    }
+  }, [status.state, open]);
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return options;
+    const lower = query.trim().toLowerCase();
+    return options.filter((option) => option.name.toLowerCase().includes(lower));
+  }, [options, query]);
+
+  const handleSelect = (option) => {
+    editing.commitUpdate(row.id, field, option?.id || null);
+    setOpen(false);
+  };
+
+  const handleClear = () => {
+    editing.commitUpdate(row.id, field, null);
+    setOpen(false);
+  };
+
+  const inputRef = useSearchableOptions(options, open);
+
+  return (
+    <FieldWrapper status={status} variant={variant} className="relative">
+      <button
+        type="button"
+        ref={buttonRef}
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex w-full items-center justify-between rounded-md border border-border bg-background px-2 py-1 text-sm text-left text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+      >
+        <span className={clsx('truncate', !currentId && !currentName && 'text-muted-foreground')}>
+          {currentName || placeholder}
+        </span>
+        <ChevronDown className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+      </button>
+      {open && (
+        <div className="absolute left-0 top-full z-30 mt-1 w-56 rounded-xl border border-border bg-popover p-2 shadow-xl">
+          <div className="flex items-center gap-2 rounded-lg border border-border bg-background px-2 py-1">
+            <input
+              ref={inputRef}
+              type="text"
+              placeholder={`Cari ${placeholder.toLowerCase()}`}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              className="w-full bg-transparent text-sm text-foreground focus:outline-none"
+            />
+            {query && (
+              <button
+                type="button"
+                className="text-xs text-muted-foreground"
+                onClick={() => setQuery('')}
+              >
+                Hapus
+              </button>
+            )}
+          </div>
+          <div className="mt-2 max-h-48 min-h-[40px] overflow-y-auto">
+            {filtered.length === 0 ? (
+              <p className="px-2 py-1 text-xs text-muted-foreground">Tidak ada hasil</p>
+            ) : (
+              filtered.map((option) => (
+                <button
+                  key={option.id}
+                  type="button"
+                  onClick={() => handleSelect(option)}
+                  className={clsx(
+                    'flex w-full items-center justify-between rounded-md px-2 py-1 text-sm',
+                    option.id === currentId ? 'bg-primary/10 text-primary' : 'hover:bg-muted/60',
+                  )}
+                >
+                  <span className="truncate">{option.name}</span>
+                  {option.id === currentId ? <Check className="h-4 w-4" aria-hidden="true" /> : null}
+                </button>
+              ))
+            )}
+          </div>
+          <div className="mt-2 flex justify-between">
+            <button
+              type="button"
+              className="text-xs text-muted-foreground"
+              onClick={() => setOpen(false)}
+            >
+              Tutup
+            </button>
+            <button type="button" className="text-xs text-primary" onClick={handleClear}>
+              Kosongkan
+            </button>
+          </div>
+        </div>
+      )}
+    </FieldWrapper>
+  );
+}
+
+export function TransactionCategoryEditor({ row, editing, variant = 'table' }) {
+  return (
+    <SearchableSelect
+      row={row}
+      editing={editing}
+      field="category"
+      options={editing.categories || []}
+      placeholder="Pilih kategori"
+      variant={variant}
+    />
+  );
+}
+
+export function TransactionAccountEditor({ row, editing, variant = 'table' }) {
+  return (
+    <SearchableSelect
+      row={row}
+      editing={editing}
+      field="account"
+      options={editing.accounts || []}
+      placeholder="Pilih akun"
+      variant={variant}
+    />
+  );
+}
+
+function normalizeAmountInput(value: string) {
+  if (!value) return '';
+  const cleaned = value.replace(/[^0-9,-.]/g, '').replace(/,/g, '.');
+  return cleaned;
+}
+
+function formatCurrency(value: number | string | null | undefined) {
+  if (value == null || value === '') return '';
+  const number = Number(value);
+  if (!Number.isFinite(number)) return '';
+  return new Intl.NumberFormat('id-ID').format(number);
+}
+
+export function TransactionAmountEditor({ row, editing, variant = 'table', autoFocus = false }) {
+  const status = editing.getStatus(row.id, 'amount');
+  const [focused, setFocused] = useState(false);
+  const [value, setValue] = useState(() => (row.amount != null ? String(row.amount) : ''));
+
+  useEffect(() => {
+    if (!focused && status.state !== 'saving') {
+      setValue(row.amount != null ? String(row.amount) : '');
+    }
+  }, [row.amount, focused, status.state]);
+
+  const handleChange = (event) => {
+    const next = normalizeAmountInput(event.target.value);
+    setValue(next);
+  };
+
+  const commit = () => {
+    editing.commitUpdate(row.id, 'amount', value || null);
+  };
+
+  const handleBlur = () => {
+    setFocused(false);
+    commit();
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commit();
+      setFocused(false);
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      editing.cancelUpdate(row.id, 'amount');
+      setValue(row.amount != null ? String(row.amount) : '');
+      setFocused(false);
+    }
+  };
+
+  return (
+    <FieldWrapper status={status} variant={variant}>
+      <input
+        type="text"
+        inputMode="decimal"
+        autoFocus={autoFocus}
+        onFocus={() => setFocused(true)}
+        onBlur={handleBlur}
+        value={focused ? value : formatCurrency(row.amount)}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        className="w-full rounded-md border border-border bg-background px-2 py-1 text-right text-sm text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+      />
+    </FieldWrapper>
+  );
+}
+
+export function TransactionTagsEditor({ row, editing, variant = 'table', autoFocus = false }) {
+  const status = editing.getStatus(row.id, 'tags');
+  const [tags, setTags] = useState(() => parseTags(row.tags));
+  const [value, setValue] = useState('');
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    setTags(parseTags(row.tags));
+  }, [row.tags]);
+
+  useEffect(() => {
+    if (autoFocus && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [autoFocus]);
+
+  const commit = (nextTags) => {
+    setTags(nextTags);
+    editing.commitUpdate(row.id, 'tags', nextTags.join(','));
+  };
+
+  const handleRemove = (index) => {
+    const next = tags.filter((_, i) => i !== index);
+    commit(next);
+  };
+
+  const pushTag = (tag) => {
+    const cleaned = tag.trim();
+    if (!cleaned) return;
+    if (tags.includes(cleaned)) {
+      setValue('');
+      return;
+    }
+    const next = [...tags, cleaned];
+    setTags(next);
+    setValue('');
+    editing.queueUpdate(row.id, 'tags', next.join(','), { debounceMs: 400 });
+  };
+
+  const handleChange = (event) => {
+    const input = event.target.value;
+    if (input.includes(',')) {
+      const parts = input.split(',');
+      parts.forEach((part, index) => {
+        if (index === parts.length - 1) {
+          setValue(part);
+        } else {
+          pushTag(part);
+        }
+      });
+      return;
+    }
+    setValue(input);
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      pushTag(value);
+      editing.flushUpdate(row.id, 'tags');
+    } else if (event.key === 'Backspace' && !value) {
+      setTags((prev) => {
+        if (!prev.length) return prev;
+        const next = prev.slice(0, -1);
+        editing.queueUpdate(row.id, 'tags', next.join(','), { debounceMs: 400 });
+        return next;
+      });
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      editing.cancelUpdate(row.id, 'tags');
+      setTags(parseTags(row.tags));
+      setValue('');
+    }
+  };
+
+  const handleBlur = () => {
+    if (value.trim()) {
+      pushTag(value);
+      setValue('');
+    }
+    editing.flushUpdate(row.id, 'tags');
+  };
+
+  return (
+    <FieldWrapper status={status} variant={variant}>
+      <div className="flex flex-wrap items-center gap-1">
+        {tags.length === 0 && !value ? (
+          <span className="flex items-center gap-1 rounded-full bg-muted/60 px-2 py-0.5 text-xs text-muted-foreground">
+            <Tag className="h-3 w-3" /> Tag
+          </span>
+        ) : null}
+        {tags.map((tag, index) => (
+          <span
+            key={tag}
+            className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs text-primary"
+          >
+            {tag}
+            <button
+              type="button"
+              onClick={() => handleRemove(index)}
+              className="text-primary hover:text-primary/70"
+              aria-label={`Hapus tag ${tag}`}
+            >
+              <X className="h-3 w-3" aria-hidden="true" />
+            </button>
+          </span>
+        ))}
+        <input
+          ref={inputRef}
+          type="text"
+          value={value}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          onBlur={handleBlur}
+          placeholder={tags.length ? '' : 'Tambah tag'}
+          className="min-w-[60px] flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        />
+      </div>
+    </FieldWrapper>
+  );
+}
+
+export const TransactionEditors = {
+  TransactionDateEditor,
+  TransactionTitleEditor,
+  TransactionTypeEditor,
+  TransactionCategoryEditor,
+  TransactionAccountEditor,
+  TransactionAmountEditor,
+  TransactionTagsEditor,
+};

--- a/src/hooks/useTransactionInlineEditing.ts
+++ b/src/hooks/useTransactionInlineEditing.ts
@@ -1,0 +1,550 @@
+// @ts-nocheck
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { patchTransaction } from '../lib/api-data';
+
+const FIELD_LABELS = {
+  date: 'Tanggal',
+  title: 'Catatan',
+  type: 'Tipe',
+  category: 'Kategori',
+  account: 'Akun',
+  amount: 'Nominal',
+  tags: 'Tag',
+};
+
+const TYPE_OPTIONS = new Set(['income', 'expense', 'transfer']);
+
+function toInputDate(value?: string | null) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function toIsoDate(value?: string | null) {
+  if (!value) return null;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    const [y, m, d] = value.split('-').map((part) => Number.parseInt(part, 10));
+    if (Number.isNaN(y) || Number.isNaN(m) || Number.isNaN(d)) return null;
+    const local = new Date(y, m - 1, d, 12, 0, 0);
+    if (Number.isNaN(local.getTime())) return null;
+    local.setHours(0, 0, 0, 0);
+    const withTimezone = new Date(local.getTime() - local.getTimezoneOffset() * 60 * 1000);
+    return withTimezone.toISOString();
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString();
+}
+
+function normalizeAmountInput(value: string | number | null | undefined) {
+  if (value == null) return null;
+  const candidate = String(value).replace(/[^0-9.,-]/g, '').replace(/,/g, '.');
+  const parsed = Number.parseFloat(candidate);
+  if (!Number.isFinite(parsed)) return null;
+  return Number(parsed.toFixed(2));
+}
+
+function normalizeTags(value: string | null | undefined) {
+  if (!value) return null;
+  const normalized = value
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+  if (!normalized.length) return null;
+  const unique = Array.from(new Set(normalized));
+  return unique.join(',');
+}
+
+function findCategory(categories, id) {
+  if (!id) return null;
+  return categories.find((category) => category.id === id) || null;
+}
+
+function findAccount(accounts, id) {
+  if (!id) return null;
+  return accounts.find((account) => account.id === id) || null;
+}
+
+export function useTransactionInlineEditing({ rows, categories, accounts, addToast }) {
+  const [displayRows, setDisplayRows] = useState(rows || []);
+  const baseMapRef = useRef(new Map());
+  const optimisticRef = useRef(new Map());
+  const queuedRef = useRef(new Map());
+  const timersRef = useRef(new Map());
+  const statusRef = useRef(new Map());
+  const [, forceStatus] = useState(0);
+  const displayRowsRef = useRef(displayRows);
+  const categoriesRef = useRef(categories || []);
+  const accountsRef = useRef(accounts || []);
+  const undoRef = useRef(null);
+  const undoTimerRef = useRef(null);
+  const [undoState, setUndoState] = useState(null);
+  const [conflict, setConflict] = useState(null);
+
+  useEffect(() => {
+    categoriesRef.current = categories || [];
+  }, [categories]);
+
+  useEffect(() => {
+    accountsRef.current = accounts || [];
+  }, [accounts]);
+
+  const syncBaseRows = useCallback(
+    (nextRows: any[]) => {
+      const baseMap = new Map();
+      nextRows.forEach((row) => {
+        if (!row?.id) return;
+        baseMap.set(row.id, row);
+      });
+      baseMapRef.current = baseMap;
+      setDisplayRows((prev) =>
+        nextRows.map((row) => {
+          const optimistic = optimisticRef.current.get(row.id);
+          return optimistic ? { ...row, ...optimistic } : row;
+        }),
+      );
+    },
+    [],
+  );
+
+  useEffect(() => {
+    syncBaseRows(rows || []);
+  }, [rows, syncBaseRows]);
+
+  useEffect(() => {
+    displayRowsRef.current = displayRows;
+  }, [displayRows]);
+
+  const setStatus = useCallback((rowId: string, field: string, status?: { state: string; message?: string }) => {
+    const key = `${rowId}:${field}`;
+    const next = new Map(statusRef.current);
+    if (!status || status.state === 'idle') {
+      next.delete(key);
+    } else {
+      next.set(key, status);
+    }
+    statusRef.current = next;
+    forceStatus((value) => value + 1);
+  }, []);
+
+  const getStatus = useCallback((rowId: string, field: string) => {
+    const key = `${rowId}:${field}`;
+    return statusRef.current.get(key) || { state: 'idle' };
+  }, []);
+
+  const formatValue = useCallback((row, field: string) => {
+    switch (field) {
+      case 'date':
+        return row.date ? new Date(row.date).toLocaleDateString('id-ID') : '-';
+      case 'title':
+        return row.title || row.notes || '-';
+      case 'type':
+        return row.type ? row.type.charAt(0).toUpperCase() + row.type.slice(1) : '-';
+      case 'category':
+        return row.category?.name || row.category || '-';
+      case 'account':
+        return row.account?.name || row.account || '-';
+      case 'amount':
+        return row.amount != null ? new Intl.NumberFormat('id-ID').format(Number(row.amount)) : '-';
+      case 'tags':
+        return row.tags ? row.tags.split(',').join(', ') : '-';
+      default:
+        return row[field] ?? '-';
+    }
+  }, []);
+
+  const clearUndo = useCallback(() => {
+    if (undoTimerRef.current) {
+      clearTimeout(undoTimerRef.current);
+      undoTimerRef.current = null;
+    }
+    undoRef.current = null;
+    setUndoState(null);
+  }, []);
+
+  const scheduleUndo = useCallback((payload) => {
+    clearUndo();
+    undoRef.current = payload;
+    setUndoState({ field: payload.field, rowId: payload.rowId, label: FIELD_LABELS[payload.field] || payload.field });
+    undoTimerRef.current = window.setTimeout(() => {
+      undoRef.current = null;
+      setUndoState(null);
+    }, 6000);
+  }, [clearUndo]);
+
+  const applyPatch = useCallback(
+    async (rowId: string, field: string, rawValue, options: any = {}) => {
+      const key = `${rowId}:${field}`;
+      if (timersRef.current.has(key)) {
+        clearTimeout(timersRef.current.get(key));
+        timersRef.current.delete(key);
+      }
+      queuedRef.current.delete(key);
+
+      const baseRow = options.prevOverride || baseMapRef.current.get(rowId) || displayRowsRef.current.find((row) => row.id === rowId);
+      if (!baseRow) return;
+
+      const categoriesList = categoriesRef.current;
+      const accountsList = accountsRef.current;
+
+      let patch: Record<string, unknown> | null = null;
+      let optimistic: Record<string, unknown> = {};
+      let revertPatch: Record<string, unknown> = {};
+      let errorMessage: string | null = null;
+
+      const nextRow = { ...baseRow };
+
+      const applyOptimistic = (updates) => {
+        optimistic = { ...optimistic, ...updates };
+        Object.assign(nextRow, updates);
+      };
+
+      switch (field) {
+        case 'date': {
+          const normalized = toIsoDate(typeof rawValue === 'string' ? rawValue : toInputDate(rawValue));
+          if (!normalized) {
+            errorMessage = 'Tanggal tidak valid';
+            break;
+          }
+          if (baseRow.date === normalized) {
+            patch = null;
+            break;
+          }
+          patch = { date: normalized };
+          applyOptimistic({ date: normalized });
+          revertPatch = { date: baseRow.date || null };
+          break;
+        }
+        case 'title': {
+          const value = typeof rawValue === 'string' ? rawValue.trim() : '';
+          const normalized = value || null;
+          if ((baseRow.title || baseRow.notes || null) === normalized) {
+            patch = null;
+            break;
+          }
+          patch = { title: normalized, notes: normalized };
+          applyOptimistic({ title: normalized, notes: normalized, note: normalized });
+          revertPatch = { title: baseRow.title || null, notes: baseRow.notes || null };
+          break;
+        }
+        case 'type': {
+          const value = typeof rawValue === 'string' ? rawValue.toLowerCase() : '';
+          if (!TYPE_OPTIONS.has(value)) {
+            errorMessage = 'Tipe tidak valid';
+            break;
+          }
+          if (baseRow.type === value) {
+            patch = null;
+            break;
+          }
+          patch = { type: value };
+          applyOptimistic({ type: value });
+          revertPatch = { type: baseRow.type || null };
+          break;
+        }
+        case 'category': {
+          const id = rawValue || null;
+          if (id) {
+            const found = findCategory(categoriesList, id);
+            if (!found) {
+              errorMessage = 'Kategori tidak ditemukan';
+              break;
+            }
+            if (baseRow.category_id === id) {
+              patch = null;
+              break;
+            }
+            patch = { category_id: id };
+            applyOptimistic({
+              category_id: id,
+              category: { id, name: found.name, type: found.type },
+            });
+            revertPatch = { category_id: baseRow.category_id || null };
+          } else {
+            if (!baseRow.category_id) {
+              patch = null;
+              break;
+            }
+            patch = { category_id: null };
+            applyOptimistic({ category_id: null, category: null });
+            revertPatch = { category_id: baseRow.category_id || null };
+          }
+          break;
+        }
+        case 'account': {
+          const id = rawValue || null;
+          if (id) {
+            const found = findAccount(accountsList, id);
+            if (!found) {
+              errorMessage = 'Akun tidak ditemukan';
+              break;
+            }
+            if (baseRow.account_id === id) {
+              patch = null;
+              break;
+            }
+            patch = { account_id: id };
+            applyOptimistic({ account_id: id, account: { id, name: found.name } });
+            revertPatch = { account_id: baseRow.account_id || null };
+          } else {
+            if (!baseRow.account_id) {
+              patch = null;
+              break;
+            }
+            patch = { account_id: null };
+            applyOptimistic({ account_id: null, account: null });
+            revertPatch = { account_id: baseRow.account_id || null };
+          }
+          break;
+        }
+        case 'amount': {
+          const normalized = normalizeAmountInput(rawValue);
+          if (!normalized || normalized <= 0) {
+            errorMessage = 'Nominal harus lebih dari 0';
+            break;
+          }
+          if (Number(baseRow.amount) === normalized) {
+            patch = null;
+            break;
+          }
+          patch = { amount: normalized };
+          applyOptimistic({ amount: normalized });
+          revertPatch = { amount: baseRow.amount || null };
+          break;
+        }
+        case 'tags': {
+          const normalized = normalizeTags(typeof rawValue === 'string' ? rawValue : Array.isArray(rawValue) ? rawValue.join(',') : null);
+          if ((baseRow.tags || null) === (normalized || null)) {
+            patch = null;
+            break;
+          }
+          patch = { tags: normalized };
+          applyOptimistic({ tags: normalized });
+          revertPatch = { tags: baseRow.tags || null };
+          break;
+        }
+        default:
+          patch = null;
+      }
+
+      if (errorMessage) {
+        setStatus(rowId, field, { state: 'error', message: errorMessage });
+        return;
+      }
+
+      if (!patch) {
+        setStatus(rowId, field, { state: 'idle' });
+        return;
+      }
+
+      setStatus(rowId, field, { state: 'saving' });
+      optimisticRef.current.set(rowId, { ...(optimisticRef.current.get(rowId) || {}), ...optimistic });
+      setDisplayRows((prev) => prev.map((row) => (row.id === rowId ? { ...row, ...optimistic } : row)));
+
+      try {
+        const { next } = await patchTransaction(rowId, patch, { prev: baseRow, force: options.force });
+        optimisticRef.current.delete(rowId);
+        baseMapRef.current.set(rowId, next);
+        setDisplayRows((prev) => prev.map((row) => (row.id === rowId ? { ...row, ...next } : row)));
+        setStatus(rowId, field, { state: 'saved' });
+        window.setTimeout(() => {
+          const currentStatus = getStatus(rowId, field);
+          if (currentStatus.state === 'saved') {
+            setStatus(rowId, field, { state: 'idle' });
+          }
+        }, 1200);
+        if (!options.skipUndo) {
+          scheduleUndo({ rowId, field, prevRow: baseRow, revertPatch, value: rawValue });
+        }
+      } catch (error) {
+        optimisticRef.current.delete(rowId);
+        setDisplayRows((prev) => prev.map((row) => (row.id === rowId ? baseRow : row)));
+        if (error?.code === 'conflict') {
+          setConflict({ rowId, field, latest: error.latest, prevRow: baseRow, value: rawValue });
+          setStatus(rowId, field, { state: 'error', message: 'Data telah berubah' });
+        } else {
+          setStatus(rowId, field, { state: 'error', message: 'Tidak bisa menyimpan. Cek koneksi atau ulangi.' });
+          addToast?.({ message: 'Tidak bisa menyimpan. Cek koneksi atau ulangi.', type: 'danger' });
+        }
+      }
+    },
+    [addToast, getStatus, scheduleUndo, setStatus],
+  );
+
+  const queueUpdate = useCallback(
+    (rowId: string, field: string, value: any, options: { debounceMs?: number } = {}) => {
+      const key = `${rowId}:${field}`;
+      queuedRef.current.set(key, value);
+      if (timersRef.current.has(key)) {
+        clearTimeout(timersRef.current.get(key));
+        timersRef.current.delete(key);
+      }
+      const delay = options.debounceMs ?? 0;
+      if (delay > 0) {
+        const timer = window.setTimeout(() => {
+          timersRef.current.delete(key);
+          const queuedValue = queuedRef.current.get(key);
+          queuedRef.current.delete(key);
+          applyPatch(rowId, field, queuedValue);
+        }, delay);
+        timersRef.current.set(key, timer);
+      } else {
+        queuedRef.current.delete(key);
+        applyPatch(rowId, field, value);
+      }
+    },
+    [applyPatch],
+  );
+
+  const flushUpdate = useCallback(
+    (rowId: string, field: string) => {
+      const key = `${rowId}:${field}`;
+      const queuedValue = queuedRef.current.get(key);
+      if (timersRef.current.has(key)) {
+        clearTimeout(timersRef.current.get(key));
+        timersRef.current.delete(key);
+      }
+      queuedRef.current.delete(key);
+      if (queuedValue !== undefined) {
+        applyPatch(rowId, field, queuedValue);
+      }
+    },
+    [applyPatch],
+  );
+
+  const cancelUpdate = useCallback(
+    (rowId: string, field: string) => {
+      const key = `${rowId}:${field}`;
+      if (timersRef.current.has(key)) {
+        clearTimeout(timersRef.current.get(key));
+        timersRef.current.delete(key);
+      }
+      queuedRef.current.delete(key);
+      optimisticRef.current.delete(rowId);
+      const baseRow = baseMapRef.current.get(rowId);
+      if (baseRow) {
+        setDisplayRows((prev) => prev.map((row) => (row.id === rowId ? { ...baseRow } : row)));
+      }
+      setStatus(rowId, field, { state: 'idle' });
+    },
+    [setStatus],
+  );
+
+  const commitUpdate = useCallback(
+    (rowId: string, field: string, value: any, options = {}) => {
+      applyPatch(rowId, field, value, options);
+    },
+    [applyPatch],
+  );
+
+  const handleUndo = useCallback(() => {
+    const payload = undoRef.current;
+    if (!payload) return;
+    const baseRow = baseMapRef.current.get(payload.rowId);
+    const rawValue = (() => {
+      switch (payload.field) {
+        case 'date':
+          return toInputDate(payload.prevRow?.date);
+        case 'title':
+          return payload.prevRow?.title || payload.prevRow?.notes || '';
+        case 'type':
+          return payload.prevRow?.type || 'expense';
+        case 'category':
+          return payload.prevRow?.category_id || null;
+        case 'account':
+          return payload.prevRow?.account_id || null;
+        case 'amount':
+          return payload.prevRow?.amount || null;
+        case 'tags':
+          return payload.prevRow?.tags || '';
+        default:
+          return null;
+      }
+    })();
+    clearUndo();
+    applyPatch(payload.rowId, payload.field, rawValue, { prevOverride: baseRow, skipUndo: true, force: true });
+  }, [applyPatch, clearUndo]);
+
+  const applyRealtimeUpsert = useCallback((row) => {
+    if (!row?.id) return;
+    baseMapRef.current.set(row.id, row);
+    setDisplayRows((prev) => {
+      const index = prev.findIndex((item) => item.id === row.id);
+      const optimistic = optimisticRef.current.get(row.id);
+      const merged = optimistic ? { ...row, ...optimistic } : row;
+      if (index === -1) {
+        return [merged, ...prev];
+      }
+      const clone = [...prev];
+      clone[index] = merged;
+      return clone;
+    });
+  }, []);
+
+  const applyRealtimeDelete = useCallback((id: string) => {
+    baseMapRef.current.delete(id);
+    optimisticRef.current.delete(id);
+    setDisplayRows((prev) => prev.filter((row) => row.id !== id));
+  }, []);
+
+  const resolveConflictWithLatest = useCallback(() => {
+    if (!conflict) return;
+    baseMapRef.current.set(conflict.latest.id, conflict.latest);
+    optimisticRef.current.delete(conflict.latest.id);
+    setDisplayRows((prev) => prev.map((row) => (row.id === conflict.latest.id ? conflict.latest : row)));
+    setStatus(conflict.rowId, conflict.field, { state: 'idle' });
+    setConflict(null);
+  }, [conflict, setStatus]);
+
+  const resolveConflictForce = useCallback(() => {
+    if (!conflict) return;
+    const { rowId, field, latest, value } = conflict;
+    setConflict(null);
+    applyPatch(rowId, field, value, { prevOverride: latest, force: true });
+  }, [applyPatch, conflict]);
+
+  return useMemo(
+    () => ({
+      rows: displayRows,
+      queueUpdate,
+      flushUpdate,
+      cancelUpdate,
+      commitUpdate,
+      getStatus,
+      formatValue,
+      undoState,
+      onUndo: handleUndo,
+      clearUndo,
+      conflict,
+      resolveConflictWithLatest,
+      resolveConflictForce,
+      applyRealtimeUpsert,
+      applyRealtimeDelete,
+      categories,
+      accounts,
+    }),
+    [
+      displayRows,
+      queueUpdate,
+      flushUpdate,
+      cancelUpdate,
+      commitUpdate,
+      getStatus,
+      formatValue,
+      undoState,
+      handleUndo,
+      clearUndo,
+      conflict,
+      resolveConflictWithLatest,
+      resolveConflictForce,
+      applyRealtimeUpsert,
+      applyRealtimeDelete,
+      categories,
+      accounts,
+    ],
+  );
+}

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -228,6 +228,13 @@ export function mapTransactionRow(tx = {}) {
     tx.title ??
     "";
 
+  const tagsValue =
+    tx.tags ??
+    tx.tag_list ??
+    tx.labels ??
+    tx.label ??
+    null;
+
   return {
     id: tx.id,
     user_id: tx.user_id ?? null,
@@ -253,6 +260,7 @@ export function mapTransactionRow(tx = {}) {
     rev: tx.rev ?? null,
     updated_at: tx.updated_at ?? null,
     inserted_at: insertedAt,
+    tags: typeof tagsValue === 'string' ? tagsValue : Array.isArray(tagsValue) ? tagsValue.filter(Boolean).join(',') : null,
   };
 }
 
@@ -352,6 +360,7 @@ export async function listTransactions(options = {}) {
     amount,
     title,
     notes,
+    tags,
     account_id,
     to_account_id,
     category_id,


### PR DESCRIPTION
## Summary
- add inline editors for transaction fields on desktop and mobile, including status feedback, validation, and undo affordances
- introduce a shared transaction editing hook that performs optimistic saves, handles realtime updates, and surfaces conflicts
- extend data utilities with transaction PATCH support, realtime subscriptions, and normalized tag handling

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d158536b2c83329dd1fffc31852059