### PR TITLE
feat: modernize transactions table and mobile cards

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -174,6 +174,11 @@ export function mapTransactionRow(tx = {}) {
     tx.category_name ??
     tx.category ??
     null;
+  const categoryColor =
+    tx.category?.color ??
+    tx.categories?.color ??
+    tx.category_color ??
+    null;
   const categoryId =
     tx.category_id ??
     tx.category?.id ??
@@ -250,6 +255,7 @@ export function mapTransactionRow(tx = {}) {
     to_account_id: toAccountId,
     category: categoryName,
     category_id: categoryId,
+    category_color: categoryColor,
     merchant: merchantName,
     merchant_id: merchantId,
     receipts,


### PR DESCRIPTION
## Summary
- refresh the transactions list with a sticky modern table on desktop and elegant cards on mobile
- add active filter chips, sticky bulk selection toolbar, and bulk edit dialogs for category/account updates
- improve empty/loading states, amount formatting, and selection handling while keeping keyboard accessibility

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d167f78dd483328ae87c5094daef98