### PR TITLE
Route dashboard to root and default sessions to online mode

### DIFF
--- a/src/guards/BootGate.tsx
+++ b/src/guards/BootGate.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+import { useMode } from '../hooks/useMode';
+
+interface BootGateProps {
+  ready: boolean;
+  children: ReactNode;
+}
+
+export default function BootGate({ ready, children }: BootGateProps) {
+  const { mode } = useMode();
+
+  if (!ready || !mode) {
+    return (
+      <div className="grid min-h-screen place-items-center bg-bg text-text">
+        <div className="space-y-2 text-center">
+          <div className="text-2xl font-semibold">HematWoi</div>
+          <p className="text-sm text-muted">Menyiapkan dasbor…</p>
+        </div>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/hooks/useMode.jsx
+++ b/src/hooks/useMode.jsx
@@ -2,12 +2,17 @@ import { createContext, useContext, useEffect, useState } from "react";
 import * as apiOnline from "../lib/api.online";
 import * as apiLocal from "../lib/api.local";
 
+const STORAGE_KEY = "hw:connectionMode";
+
 const ModeContext = createContext(null);
 
 export function ModeProvider({ children }) {
   const [mode, setMode] = useState(() => {
     try {
-      return localStorage.getItem("hw:mode") || "online";
+      const stored =
+        localStorage.getItem(STORAGE_KEY) || localStorage.getItem("hw:mode");
+      if (stored === "cloud") return "online";
+      return stored || "online";
     } catch {
       return "online";
     }
@@ -15,6 +20,7 @@ export function ModeProvider({ children }) {
 
   useEffect(() => {
     try {
+      localStorage.setItem(STORAGE_KEY, mode);
       localStorage.setItem("hw:mode", mode);
     } catch {
       /* ignore */

--- a/src/hooks/useMode.test.jsx
+++ b/src/hooks/useMode.test.jsx
@@ -16,9 +16,9 @@ describe("useMode", () => {
     expect(result.current.mode).toBe("online");
     act(() => result.current.toggle());
     expect(result.current.mode).toBe("local");
-    expect(localStorage.getItem("hw:mode")).toBe("local");
+    expect(localStorage.getItem("hw:connectionMode")).toBe("local");
     act(() => result.current.toggle());
     expect(result.current.mode).toBe("online");
-    expect(localStorage.getItem("hw:mode")).toBe("online");
+    expect(localStorage.getItem("hw:connectionMode")).toBe("online");
   });
 });

--- a/src/pages/Auth.jsx
+++ b/src/pages/Auth.jsx
@@ -1,11 +1,10 @@
 import { useState, useEffect } from 'react';
 import clsx from 'clsx';
 import { supabase } from '../lib/supabase';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 export default function AuthPage() {
   const navigate = useNavigate();
-  const location = useLocation();
   const [tab, setTab] = useState('login');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -17,7 +16,7 @@ export default function AuthPage() {
   useEffect(() => {
     supabase.auth.getSession().then(({ data }) => {
       if (data.session) {
-        navigate('/dashboard');
+        navigate('/', { replace: true });
       }
     });
   }, [navigate]);
@@ -27,10 +26,10 @@ export default function AuthPage() {
     setLoading(true);
     setError('');
     const { error } = await supabase.auth.signInWithPassword({ email, password });
-    if (error) setError(error.message);
-    else {
-      const from = location.state?.from?.pathname || '/dashboard';
-      navigate(from);
+    if (error) {
+      setError(error.message);
+    } else {
+      navigate('/', { replace: true });
     }
     setLoading(false);
   };

--- a/src/pages/SettingsPage.test.tsx
+++ b/src/pages/SettingsPage.test.tsx
@@ -19,8 +19,8 @@ const store: Record<string, string> = {};
 
 beforeEach(() => localStorage.clear());
 
-const renderWithMode = (mode: 'cloud' | 'local') => {
-  localStorage.setItem('hw:mode', mode);
+const renderWithMode = (mode: 'online' | 'local') => {
+  localStorage.setItem('hw:connectionMode', mode);
   return render(
     <MemoryRouter>
       <DataProvider initialMode={mode}>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -141,10 +141,10 @@ export default function SettingsPage() {
           label="Mode"
           value={mode}
           options={[
-            { value: 'cloud', label: 'Cloud' },
+            { value: 'online', label: 'Online' },
             { value: 'local', label: 'Local' },
           ]}
-          onChange={(v) => setMode(v as 'cloud' | 'local')}
+          onChange={(v) => setMode(v as 'online' | 'local')}
         />
         {mode === 'local' && (
           <DangerZone>

--- a/src/providers/DataProvider.test.tsx
+++ b/src/providers/DataProvider.test.tsx
@@ -19,7 +19,7 @@ beforeEach(() => {
 });
 
 describe('useRepo', () => {
-  it('returns cloud repo by default', () => {
+  it('returns online repo by default', () => {
     const wrapper = ({ children }: any) => <DataProvider>{children}</DataProvider>;
     const { result } = renderHook(() => useRepo(), { wrapper });
     expect(result.current).toBeInstanceOf(CloudRepo);

--- a/src/providers/DataProvider.tsx
+++ b/src/providers/DataProvider.tsx
@@ -4,20 +4,35 @@ import { CloudRepo } from '../repo/CloudRepo';
 import { LocalRepo } from '../repo/LocalRepo';
 import { IRepo } from '../interfaces/IRepo';
 
+const STORAGE_KEY = 'hw:connectionMode';
+
+type DataMode = 'online' | 'local';
+
 interface Ctx {
-  mode: 'cloud' | 'local';
-  setMode: (m: 'cloud' | 'local') => void;
+  mode: DataMode;
+  setMode: (m: DataMode) => void;
   repo: IRepo;
 }
 
 const DataContext = createContext<Ctx | undefined>(undefined);
 
-export function DataProvider({ children, initialMode }: { children: ReactNode; initialMode?: 'cloud' | 'local'; }) {
-  const [mode, setMode] = useState<'cloud' | 'local'>(() => (localStorage.getItem('hw:mode') as 'cloud' | 'local') || initialMode || 'cloud');
+export function DataProvider({ children, initialMode }: { children: ReactNode; initialMode?: DataMode; }) {
+  const [mode, setMode] = useState<DataMode>(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY) ?? localStorage.getItem('hw:mode');
+      if (stored === 'cloud') return 'online';
+      if (stored === 'online' || stored === 'local') return stored;
+      if (initialMode) return initialMode;
+      return 'online';
+    } catch {
+      return initialMode || 'online';
+    }
+  });
 
-  const repo = useMemo<IRepo>(() => (mode === 'cloud' ? new CloudRepo(supabase) : new LocalRepo()), [mode]);
+  const repo = useMemo<IRepo>(() => (mode === 'online' ? new CloudRepo(supabase) : new LocalRepo()), [mode]);
 
   useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, mode);
     localStorage.setItem('hw:mode', mode);
   }, [mode]);
 


### PR DESCRIPTION
## Summary
- wrap the app router in a boot gate to await auth/mode resolution and expose the dashboard as the root index route while redirecting legacy /dashboard hits
- force new Supabase sessions to default the connection mode to online and persist the value via the updated mode/data providers
- ensure auth flows and settings use the root dashboard path and online/local terminology consistently

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d16f7e5a64833285c885a85957df7a