### PR TITLE
feat: redesign authentication experience

### DIFF
--- a/src/components/auth/LoginCard.tsx
+++ b/src/components/auth/LoginCard.tsx
@@ -1,0 +1,741 @@
+import clsx from 'clsx';
+import {
+  FormEvent,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  loginWithPassword,
+  sendMagicLink,
+  verifyMagicOtp,
+  resetPassword,
+  signInWithProvider,
+} from '../../lib/auth';
+import SocialButtons, { getAvailableSocialProviders } from './SocialButtons';
+
+type Provider = 'google' | 'github';
+
+type LoginCardProps = {
+  onSuccess: () => void;
+  initialEmail?: string;
+};
+
+type StatusState = {
+  type: 'success' | 'error' | 'info';
+  message: string;
+};
+
+const MIN_PASSWORD_LENGTH = 6;
+const MAGIC_LINK_COOLDOWN = 45;
+
+const emailPattern = /^(?:[a-zA-Z0-9_.'%+-]+)@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/;
+
+function validateEmail(email: string) {
+  return emailPattern.test(email.trim().toLowerCase());
+}
+
+function setConnectionModeOnline() {
+  try {
+    localStorage.setItem('hw:connectionMode', 'online');
+    localStorage.setItem('hw:mode', 'online');
+  } catch {
+    /* ignore */
+  }
+}
+
+export default function LoginCard({ onSuccess, initialEmail = '' }: LoginCardProps) {
+  const [activeTab, setActiveTab] = useState<'password' | 'magic'>('password');
+  const [view, setView] = useState<'login' | 'reset'>('login');
+  const [email, setEmail] = useState(initialEmail);
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [remember, setRemember] = useState(false);
+  const [status, setStatus] = useState<StatusState | null>(null);
+  const [loadingAction, setLoadingAction] = useState<
+    'login' | 'magic' | 'reset' | 'otp' | null
+  >(null);
+  const [magicLinkSent, setMagicLinkSent] = useState(false);
+  const [magicEmail, setMagicEmail] = useState('');
+  const [cooldown, setCooldown] = useState(0);
+  const [otpVisible, setOtpVisible] = useState(false);
+  const [otpCode, setOtpCode] = useState('');
+  const [loadingProvider, setLoadingProvider] = useState<Provider | null>(null);
+  const [resetEmail, setResetEmail] = useState(initialEmail);
+  const socialProviders = useMemo(() => getAvailableSocialProviders(), []);
+
+  const statusId = useId();
+  const otpInputId = useId();
+  const loginEmailId = useId();
+  const passwordInputId = useId();
+  const magicEmailId = useId();
+  const resetEmailId = useId();
+
+  const submitLockRef = useRef(false);
+  const submitLockTimeout = useRef<number>();
+  const cooldownTimer = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    setEmail(initialEmail);
+    setResetEmail(initialEmail);
+  }, [initialEmail]);
+
+  useEffect(() => {
+    try {
+      const remembered = localStorage.getItem('hw:rememberMe');
+      if (remembered) {
+        setRemember(remembered === 'true');
+      }
+    } catch {
+      setRemember(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (cooldown <= 0) {
+      if (cooldownTimer.current) {
+        window.clearInterval(cooldownTimer.current);
+        cooldownTimer.current = undefined;
+      }
+      return;
+    }
+
+    if (cooldownTimer.current) {
+      return;
+    }
+
+    cooldownTimer.current = window.setInterval(() => {
+      setCooldown((prev) => {
+        if (prev <= 1) {
+          if (cooldownTimer.current) {
+            window.clearInterval(cooldownTimer.current);
+            cooldownTimer.current = undefined;
+          }
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => {
+      if (cooldownTimer.current) {
+        window.clearInterval(cooldownTimer.current);
+        cooldownTimer.current = undefined;
+      }
+    };
+  }, [cooldown]);
+
+  useEffect(() => {
+    return () => {
+      if (submitLockTimeout.current) {
+        window.clearTimeout(submitLockTimeout.current);
+      }
+      if (cooldownTimer.current) {
+        window.clearInterval(cooldownTimer.current);
+        cooldownTimer.current = undefined;
+      }
+    };
+  }, []);
+
+  const resetStatus = useCallback(() => setStatus(null), []);
+
+  const preventRapidSubmit = () => {
+    if (submitLockRef.current) {
+      return true;
+    }
+    submitLockRef.current = true;
+    window.clearTimeout(submitLockTimeout.current);
+    submitLockTimeout.current = window.setTimeout(() => {
+      submitLockRef.current = false;
+    }, 300);
+    return false;
+  };
+
+  const handleRememberChange = (value: boolean, currentEmail: string) => {
+    setRemember(value);
+    try {
+      localStorage.setItem('hw:rememberMe', value ? 'true' : 'false');
+      if (!value) {
+        localStorage.removeItem('hw:lastEmail');
+      } else if (currentEmail) {
+        localStorage.setItem('hw:lastEmail', currentEmail);
+      }
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const persistLastEmail = (value: string) => {
+    try {
+      if (remember) {
+        localStorage.setItem('hw:lastEmail', value);
+      }
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const handleLogin = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (preventRapidSubmit() || loadingAction) {
+      return;
+    }
+
+    resetStatus();
+    const sanitizedEmail = email.trim().toLowerCase();
+
+    if (!validateEmail(sanitizedEmail)) {
+      setStatus({ type: 'error', message: 'Masukkan email yang valid.' });
+      return;
+    }
+
+    if (password.trim().length < MIN_PASSWORD_LENGTH) {
+      setStatus({
+        type: 'error',
+        message: `Kata sandi minimal ${MIN_PASSWORD_LENGTH} karakter.`,
+      });
+      return;
+    }
+
+    setLoadingAction('login');
+    try {
+      const { error } = await loginWithPassword({
+        email: sanitizedEmail,
+        password: password.trim(),
+      });
+      if (error) {
+        setStatus({ type: 'error', message: error });
+        return;
+      }
+
+      persistLastEmail(sanitizedEmail);
+      setConnectionModeOnline();
+      setStatus({ type: 'success', message: 'Berhasil masuk. Mengalihkan…' });
+      onSuccess();
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.error('[HW][auth] handleLogin', err);
+      }
+      setStatus({ type: 'error', message: 'Terjadi kesalahan. Coba lagi.' });
+    } finally {
+      setLoadingAction(null);
+    }
+  };
+
+  const executeMagicLink = async (sanitizedEmail: string) => {
+    setLoadingAction('magic');
+    try {
+      const { error } = await sendMagicLink({ email: sanitizedEmail });
+      if (error) {
+        setStatus({ type: 'error', message: error });
+        return;
+      }
+
+      persistLastEmail(sanitizedEmail);
+      setMagicLinkSent(true);
+      setMagicEmail(sanitizedEmail);
+      setStatus({
+        type: 'success',
+        message: 'Tautan login telah dikirim ke email kamu.',
+      });
+      setCooldown(MAGIC_LINK_COOLDOWN);
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.error('[HW][auth] executeMagicLink', err);
+      }
+      setStatus({ type: 'error', message: 'Terjadi kesalahan. Coba lagi.' });
+    } finally {
+      setLoadingAction(null);
+    }
+  };
+
+  const handleMagicLink = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (preventRapidSubmit() || loadingAction) {
+      return;
+    }
+
+    resetStatus();
+    const sanitizedEmail = email.trim().toLowerCase();
+
+    if (!validateEmail(sanitizedEmail)) {
+      setStatus({ type: 'error', message: 'Masukkan email yang valid.' });
+      return;
+    }
+
+    await executeMagicLink(sanitizedEmail);
+  };
+
+  const handleResendMagicLink = async () => {
+    if (preventRapidSubmit() || loadingAction) {
+      return;
+    }
+
+    resetStatus();
+    const targetEmail = email.trim().toLowerCase() || magicEmail;
+
+    if (!validateEmail(targetEmail)) {
+      setStatus({ type: 'error', message: 'Masukkan email yang valid sebelum mengirim ulang.' });
+      return;
+    }
+
+    await executeMagicLink(targetEmail);
+  };
+
+  const handleResetPassword = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (preventRapidSubmit() || loadingAction) {
+      return;
+    }
+
+    resetStatus();
+    const sanitizedEmail = resetEmail.trim().toLowerCase();
+
+    if (!validateEmail(sanitizedEmail)) {
+      setStatus({ type: 'error', message: 'Masukkan email yang valid.' });
+      return;
+    }
+
+    setLoadingAction('reset');
+    try {
+      const { error } = await resetPassword({ email: sanitizedEmail });
+      if (error) {
+        setStatus({ type: 'error', message: error });
+        return;
+      }
+
+      if (remember) {
+        persistLastEmail(sanitizedEmail);
+      }
+
+      setStatus({
+        type: 'success',
+        message:
+          'Kami telah mengirim tautan reset ke email kamu. Ikuti instruksinya untuk membuat kata sandi baru.',
+      });
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.error('[HW][auth] handleResetPassword', err);
+      }
+      setStatus({ type: 'error', message: 'Terjadi kesalahan. Coba lagi.' });
+    } finally {
+      setLoadingAction(null);
+    }
+  };
+
+  const handleVerifyOtp = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (preventRapidSubmit() || loadingAction) {
+      return;
+    }
+
+    resetStatus();
+
+    if (!magicEmail) {
+      setStatus({
+        type: 'error',
+        message: 'Kirim magic link terlebih dahulu sebelum memasukkan kode OTP.',
+      });
+      return;
+    }
+
+    if (otpCode.trim().length !== 6) {
+      setStatus({ type: 'error', message: 'Masukkan 6 digit kode OTP.' });
+      return;
+    }
+
+    setLoadingAction('otp');
+    try {
+      const { data, error } = await verifyMagicOtp({
+        email: magicEmail,
+        token: otpCode.trim(),
+        type: 'magiclink',
+      });
+
+      if (error) {
+        setStatus({ type: 'error', message: error });
+        return;
+      }
+
+      if (data?.session) {
+        setConnectionModeOnline();
+        setStatus({ type: 'success', message: 'Berhasil diverifikasi. Mengalihkan…' });
+        onSuccess();
+        return;
+      }
+
+      setStatus({
+        type: 'info',
+        message:
+          'Kode OTP berhasil diterima. Jika tidak otomatis masuk, buka tautan magic link dari email kamu.',
+      });
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.error('[HW][auth] handleVerifyOtp', err);
+      }
+      setStatus({ type: 'error', message: 'Terjadi kesalahan. Coba lagi.' });
+    } finally {
+      setLoadingAction(null);
+    }
+  };
+
+  const handleSocialSelect = useCallback(
+    async (provider: Provider) => {
+      if (loadingProvider || loadingAction) {
+        return;
+      }
+
+      resetStatus();
+      setLoadingProvider(provider);
+      try {
+        const { error } = await signInWithProvider(provider);
+        if (error) {
+          setStatus({ type: 'error', message: error });
+          return;
+        }
+
+        setStatus({
+          type: 'info',
+          message: 'Mengarahkan ke penyedia login… Jika tidak muncul, cek popup di browser.',
+        });
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.error('[HW][auth] handleSocialSelect', err);
+        }
+        setStatus({ type: 'error', message: 'Terjadi kesalahan. Coba lagi.' });
+      } finally {
+        setLoadingProvider(null);
+      }
+    },
+    [loadingAction, loadingProvider, resetStatus]
+  );
+
+  const isLoginBusy = loadingAction === 'login';
+  const isMagicBusy = loadingAction === 'magic';
+  const isResetBusy = loadingAction === 'reset';
+  const isOtpBusy = loadingAction === 'otp';
+
+  const statusClassName = useMemo(() => {
+    if (!status) return '';
+    if (status.type === 'success') {
+      return 'bg-success/10 text-success border border-success/30';
+    }
+    if (status.type === 'error') {
+      return 'bg-danger/10 text-danger border border-danger/30';
+    }
+    return 'bg-info/10 text-info border border-info/30';
+  }, [status]);
+
+  const togglePasswordLabel = showPassword ? 'Sembunyikan kata sandi' : 'Tampilkan kata sandi';
+
+  const renderLoginForm = () => (
+    <form
+      onSubmit={activeTab === 'password' ? handleLogin : handleMagicLink}
+      className="space-y-4"
+      noValidate
+    >
+      <div className="space-y-1">
+        <label htmlFor={activeTab === 'password' ? loginEmailId : magicEmailId} className="form-label">
+          Email
+        </label>
+        <input
+          id={activeTab === 'password' ? loginEmailId : magicEmailId}
+          type="email"
+          inputMode="email"
+          autoComplete="email"
+          value={email}
+          onChange={(event) => {
+            const value = event.target.value;
+            setEmail(value);
+            if (remember) {
+              try {
+                localStorage.setItem('hw:lastEmail', value.trim().toLowerCase());
+              } catch {
+                /* ignore */
+              }
+            }
+          }}
+          required
+          aria-invalid={status?.type === 'error' && status.message.toLowerCase().includes('email')}
+          aria-describedby={status ? statusId : undefined}
+          className="form-control"
+        />
+      </div>
+
+      {activeTab === 'password' ? (
+        <div className="space-y-1">
+          <label htmlFor={passwordInputId} className="form-label">
+            Kata sandi
+          </label>
+          <div className="relative">
+            <input
+              id={passwordInputId}
+              type={showPassword ? 'text' : 'password'}
+              autoComplete="current-password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              minLength={MIN_PASSWORD_LENGTH}
+              required
+              aria-invalid={
+                status?.type === 'error' && status.message.toLowerCase().includes('sandi')
+              }
+              aria-describedby={status ? statusId : undefined}
+              className="form-control pr-12"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((prev) => !prev)}
+              className="absolute inset-y-0 right-0 flex items-center px-3 text-sm font-medium text-muted hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/45"
+              aria-label={togglePasswordLabel}
+            >
+              {showPassword ? 'Sembunyi' : 'Tampil'}
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <label className="inline-flex items-center gap-2 text-sm text-text">
+          <input
+            type="checkbox"
+            checked={remember}
+            onChange={(event) => handleRememberChange(event.target.checked, email.trim().toLowerCase())}
+          />
+          <span>Ingat saya</span>
+        </label>
+        {view === 'login' ? (
+          <button
+            type="button"
+            onClick={() => {
+              setView('reset');
+              setStatus(null);
+            }}
+            className="text-sm font-semibold text-primary hover:underline"
+          >
+            Lupa kata sandi?
+          </button>
+        ) : null}
+      </div>
+
+      <button
+        type="submit"
+        disabled={
+          (activeTab === 'password' ? isLoginBusy : isMagicBusy) ||
+          loadingAction !== null
+        }
+        className="btn btn-primary w-full"
+      >
+        <span className="flex items-center justify-center gap-2">
+          {(activeTab === 'password' ? isLoginBusy : isMagicBusy) ? (
+            <span className="inline-flex h-4 w-4 animate-spin rounded-full border-2 border-text-inverse border-t-transparent" />
+          ) : null}
+          <span>{activeTab === 'password' ? 'Masuk' : 'Kirim Magic Link'}</span>
+        </span>
+      </button>
+
+      {magicLinkSent && activeTab === 'magic' ? (
+        <div className="space-y-3 rounded-2xl border border-border-subtle bg-surface-alt/50 p-4 text-sm text-muted">
+          <p>
+            Kami telah mengirim tautan login ke <span className="font-medium text-text">{magicEmail}</span>. Buka email dan ikuti
+            petunjuknya. Jika diminta kode OTP, masukkan 6 digit kode di bawah.
+          </p>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <button
+              type="button"
+              onClick={() => {
+                void handleResendMagicLink();
+              }}
+              disabled={isMagicBusy || cooldown > 0 || loadingAction !== null}
+              className="btn w-full sm:w-auto"
+            >
+              {isMagicBusy ? (
+                <span className="inline-flex h-4 w-4 animate-spin rounded-full border-2 border-border-subtle border-t-transparent" />
+              ) : null}
+              <span>{cooldown > 0 ? `Kirim ulang dalam ${cooldown}s` : 'Kirim ulang link'}</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setOtpVisible((prev) => {
+                  if (prev) {
+                    setOtpCode('');
+                  }
+                  return !prev;
+                });
+                resetStatus();
+              }}
+              className="text-sm font-semibold text-primary hover:underline"
+            >
+              {otpVisible ? 'Sembunyikan OTP' : 'Saya punya kode OTP'}
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </form>
+  );
+
+  const renderResetForm = () => (
+    <form onSubmit={handleResetPassword} className="space-y-4" noValidate>
+      <div className="space-y-1">
+        <label htmlFor={resetEmailId} className="form-label">
+          Email terdaftar
+        </label>
+        <input
+          id={resetEmailId}
+          type="email"
+          inputMode="email"
+          autoComplete="email"
+          value={resetEmail}
+          onChange={(event) => setResetEmail(event.target.value)}
+          required
+          aria-invalid={status?.type === 'error' && status.message.toLowerCase().includes('email')}
+          aria-describedby={status ? statusId : undefined}
+          className="form-control"
+        />
+      </div>
+      <p className="text-sm text-muted">
+        Kami akan mengirim tautan untuk mengatur ulang kata sandi. Tautan akan
+        mengarahkan kamu kembali ke HematWoi setelah selesai.
+      </p>
+      <button type="submit" disabled={isResetBusy || loadingAction !== null} className="btn btn-primary w-full">
+        <span className="flex items-center justify-center gap-2">
+          {isResetBusy ? (
+            <span className="inline-flex h-4 w-4 animate-spin rounded-full border-2 border-text-inverse border-t-transparent" />
+          ) : null}
+          <span>Kirim tautan reset</span>
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          setView('login');
+          setStatus(null);
+        }}
+        className="btn w-full"
+      >
+        Kembali ke login
+      </button>
+    </form>
+  );
+
+  return (
+    <div className="w-full max-w-md rounded-3xl border border-border-subtle bg-surface p-6 shadow-sm sm:p-8">
+      <div className="space-y-6">
+        <div className="space-y-2 text-center">
+          <h1 className="text-2xl font-semibold text-text">Masuk ke HematWoi</h1>
+          <p className="text-sm text-muted">
+            Kelola keuanganmu dengan lebih cerdas. Pilih metode login favoritmu.
+          </p>
+        </div>
+
+        {view === 'login' ? (
+          <div className="flex rounded-full border border-border-subtle bg-surface-alt p-1 text-sm font-medium text-muted">
+            <button
+              type="button"
+              onClick={() => {
+                setActiveTab('password');
+                setStatus(null);
+              }}
+              className={clsx(
+                'flex-1 rounded-full px-3 py-2 transition',
+                activeTab === 'password'
+                  ? 'bg-surface text-text shadow-sm'
+                  : 'hover:text-text'
+              )}
+            >
+              Email &amp; Password
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setActiveTab('magic');
+                setStatus(null);
+              }}
+              className={clsx(
+                'flex-1 rounded-full px-3 py-2 transition',
+                activeTab === 'magic' ? 'bg-surface text-text shadow-sm' : 'hover:text-text'
+              )}
+            >
+              Magic Link
+            </button>
+          </div>
+        ) : (
+          <div className="text-center text-sm font-semibold text-text">Reset Kata Sandi</div>
+        )}
+
+        {status ? (
+          <div
+            className={clsx(
+              'rounded-2xl px-4 py-3 text-sm',
+              statusClassName
+            )}
+            role="status"
+            aria-live="polite"
+            id={statusId}
+          >
+            {status.message}
+          </div>
+        ) : (
+          <div aria-live="polite" id={statusId} className="sr-only">
+            {''}
+          </div>
+        )}
+
+        {view === 'login' ? renderLoginForm() : renderResetForm()}
+
+        {otpVisible && view === 'login' ? (
+          <form onSubmit={handleVerifyOtp} className="space-y-3" noValidate>
+            <div className="space-y-1">
+              <label htmlFor={otpInputId} className="form-label">
+                Masukkan kode OTP (6 digit)
+              </label>
+              <input
+                id={otpInputId}
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                maxLength={6}
+                value={otpCode}
+                onChange={(event) => setOtpCode(event.target.value.replace(/\D/g, ''))}
+                aria-invalid={status?.type === 'error' && status.message.toLowerCase().includes('otp')}
+                aria-describedby={status ? statusId : undefined}
+                className="form-control tracking-widest"
+              />
+            </div>
+            <button type="submit" disabled={isOtpBusy || otpCode.length !== 6} className="btn btn-primary w-full">
+              <span className="flex items-center justify-center gap-2">
+                {isOtpBusy ? (
+                  <span className="inline-flex h-4 w-4 animate-spin rounded-full border-2 border-text-inverse border-t-transparent" />
+                ) : null}
+                <span>Verifikasi OTP</span>
+              </span>
+            </button>
+          </form>
+        ) : null}
+
+        {socialProviders.length > 0 ? (
+          <>
+            <div className="flex items-center gap-4 text-xs uppercase tracking-wide text-muted">
+              <span className="h-px flex-1 bg-border-subtle" aria-hidden />
+              <span>atau lanjut dengan</span>
+              <span className="h-px flex-1 bg-border-subtle" aria-hidden />
+            </div>
+
+            <SocialButtons
+              disabled={Boolean(loadingAction)}
+              loadingProvider={loadingProvider}
+              onSelect={handleSocialSelect}
+            />
+          </>
+        ) : null}
+
+        <p className="text-center text-xs text-muted">
+          Dengan masuk kamu menyetujui ketentuan layanan dan kebijakan privasi HematWoi.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/SocialButtons.tsx
+++ b/src/components/auth/SocialButtons.tsx
@@ -1,0 +1,154 @@
+import clsx from 'clsx';
+import type { MouseEventHandler, ReactNode } from 'react';
+
+type Provider = 'google' | 'github';
+
+type SocialButtonsProps = {
+  disabled?: boolean;
+  loadingProvider?: Provider | null;
+  onSelect?: (provider: Provider) => void;
+};
+
+type ProviderConfig = {
+  label: string;
+  provider: Provider;
+  icon: ReactNode;
+};
+
+const providerConfigs: ProviderConfig[] = [
+  {
+    label: 'Google',
+    provider: 'google',
+    icon: (
+      <svg
+        aria-hidden
+        viewBox="0 0 24 24"
+        className="h-5 w-5"
+        focusable="false"
+      >
+        <path
+          fill="#EA4335"
+          d="M12 10.2v3.8h5.3c-.2 1.4-.9 2.6-2 3.4l3.3 2.6c1.9-1.8 3-4.4 3-7.5 0-.7-.1-1.4-.2-2H12z"
+        />
+        <path
+          fill="#34A853"
+          d="M5.3 14.3l-.9.7-2.6 2c1.8 3.5 5.3 5.9 9.2 5.9 2.8 0 5.1-.9 6.8-2.4l-3.3-2.6c-.9.6-2.1 1-3.5 1-2.7 0-5-1.8-5.8-4.2z"
+        />
+        <path
+          fill="#4A90E2"
+          d="M2.7 7.7C2 9.1 1.6 10.5 1.6 12c0 1.5.4 2.9 1.1 4.3l3.9-3c-.2-.6-.3-1.2-.3-1.9s.1-1.3.3-1.9z"
+        />
+        <path
+          fill="#FBBC05"
+          d="M11 4.6c1.5 0 2.8.5 3.8 1.4l2.8-2.8C15.9 1.1 13.6 0 11 0 7.1 0 3.6 2.4 1.8 5.9l3.9 3c.8-2.4 3.1-4.3 5.3-4.3z"
+        />
+      </svg>
+    ),
+  },
+  {
+    label: 'GitHub',
+    provider: 'github',
+    icon: (
+      <svg
+        aria-hidden
+        viewBox="0 0 24 24"
+        className="h-5 w-5"
+        focusable="false"
+      >
+        <path
+          fill="currentColor"
+          d="M12 .5a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2c-3.4.7-4.2-1.7-4.2-1.7-.6-1.4-1.4-1.7-1.4-1.7-1.2-.8.1-.8.1-.8 1.3.1 2 1.3 2 1.3 1.2 2 3.2 1.5 4 .9.1-.9.4-1.5.7-1.9-2.7-.3-5.5-1.4-5.5-6.1 0-1.4.5-2.5 1.3-3.4-.1-.3-.6-1.7.1-3.5 0 0 1-.3 3.4 1.3a11.5 11.5 0 0 1 6.2 0c2.4-1.6 3.4-1.3 3.4-1.3.7 1.8.2 3.2.1 3.5.9.9 1.3 2 1.3 3.4 0 4.7-2.8 5.8-5.5 6.1.5.4.8 1.2.8 2.4v3.6c0 .3.2.7.8.6A12 12 0 0 0 12 .5z"
+        />
+      </svg>
+    ),
+  },
+];
+
+function isProviderEnabled(provider: Provider) {
+  const env =
+    (typeof import.meta !== 'undefined' && import.meta.env) ||
+    (typeof process !== 'undefined' ? (process.env as Record<string, string>) : {});
+
+  const flagKeys: Record<Provider, string[]> = {
+    google: [
+      'VITE_SUPABASE_GOOGLE',
+      'VITE_SUPABASE_OAUTH_GOOGLE',
+      'VITE_SUPABASE_GOOGLE_ENABLED',
+      'VITE_SUPABASE_GOOGLE_CLIENT_ID',
+    ],
+    github: [
+      'VITE_SUPABASE_GITHUB',
+      'VITE_SUPABASE_OAUTH_GITHUB',
+      'VITE_SUPABASE_GITHUB_ENABLED',
+    ],
+  };
+
+  return flagKeys[provider].some((key) => {
+    const value = env?.[key];
+    if (typeof value === 'string') {
+      return value.toLowerCase() === 'true' || value.length > 0;
+    }
+    return Boolean(value);
+  });
+}
+
+export default function SocialButtons({
+  disabled,
+  loadingProvider,
+  onSelect,
+}: SocialButtonsProps) {
+  const activeProviders = getAvailableSocialProviders();
+
+  if (activeProviders.length === 0) {
+    return null;
+  }
+
+  const handleClick = (provider: Provider): MouseEventHandler<HTMLButtonElement> =>
+    (event) => {
+      event.preventDefault();
+      if (disabled || loadingProvider) {
+        return;
+      }
+      onSelect?.(provider);
+    };
+
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row">
+      {activeProviders.map(({ provider, label, icon }) => {
+        const isLoading = loadingProvider === provider;
+        return (
+          <button
+            key={provider}
+            type="button"
+            onClick={handleClick(provider)}
+            disabled={disabled || isLoading}
+            className={clsx(
+              'btn w-full border border-border-subtle bg-surface-alt text-sm font-semibold text-text transition focus-visible:ring-2 focus-visible:ring-primary/45 sm:flex-1',
+              'hover:bg-surface-alt/70'
+            )}
+          >
+            {isLoading ? (
+              <span className="flex items-center justify-center gap-2">
+                <span className="inline-flex h-4 w-4 animate-spin rounded-full border-2 border-border-subtle border-t-transparent" />
+                <span>Menghubungkan…</span>
+              </span>
+            ) : (
+              <span className="flex items-center justify-center gap-2 text-sm">
+                <span aria-hidden className="text-lg text-text">
+                  {icon}
+                </span>
+                <span>Lanjut dengan {label}</span>
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function getAvailableSocialProviders(): Provider[] {
+  return providerConfigs
+    .filter((config) => isProviderEnabled(config.provider))
+    .map((config) => config.provider);
+}

--- a/src/components/system/ErrorBoundary.tsx
+++ b/src/components/system/ErrorBoundary.tsx
@@ -1,46 +1,59 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 
-type ErrorBoundaryProps = {
+interface ErrorBoundaryProps {
   children: ReactNode;
-  fallback?: ReactNode;
-};
+}
 
-type ErrorBoundaryState = {
+interface ErrorBoundaryState {
   hasError: boolean;
-  message: string;
-};
+  error?: Error | null;
+}
 
-export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
-  constructor(props: ErrorBoundaryProps) {
-    super(props);
-    this.state = {
-      hasError: false,
-      message: 'Terjadi kesalahan. Silakan muat ulang halaman.',
-    };
+export default class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = {
+    hasError: false,
+    error: null,
+  };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
   }
 
-  static getDerivedStateFromError(error: unknown): ErrorBoundaryState {
-    const message =
-      error instanceof Error && error.message
-        ? error.message
-        : 'Terjadi kesalahan. Silakan coba lagi nanti.';
-    return { hasError: true, message };
-  }
-
-  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+  componentDidCatch(error: Error, info: ErrorInfo) {
     if (import.meta.env.DEV) {
-      console.error('[HW][ErrorBoundary]', error, errorInfo);
+      console.error('[HW][ErrorBoundary]', error, info);
     }
   }
+
+  private handleReload = () => {
+    this.setState({ hasError: false, error: null });
+    if (typeof window !== 'undefined') {
+      window.location.reload();
+    }
+  };
 
   render() {
     if (this.state.hasError) {
       return (
-        this.props.fallback ?? (
-          <div className="p-6 text-center text-sm text-muted-foreground">
-            {this.state.message}
+        <div className="flex min-h-screen flex-col items-center justify-center bg-surface-alt px-6 py-12 text-center text-text">
+          <div className="max-w-md space-y-4">
+            <h1 className="text-2xl font-semibold">Terjadi kesalahan</h1>
+            <p className="text-sm text-muted">
+              Ups, ada sesuatu yang tidak berjalan semestinya. Silakan muat ulang
+              halaman ini dan coba lagi.
+            </p>
+            <button
+              type="button"
+              onClick={this.handleReload}
+              className="btn btn-primary w-full sm:w-auto"
+            >
+              Muat ulang
+            </button>
           </div>
-        )
+        </div>
       );
     }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,227 @@
+import type {
+  AuthError,
+  AuthResponse,
+  AuthTokenResponsePasswordless,
+  OAuthResponse,
+  Session,
+} from '@supabase/supabase-js';
+import { supabase } from './supabase';
+
+const AUTH_REDIRECT_URL =
+  typeof window !== 'undefined' && window.location?.origin
+    ? window.location.origin
+    : undefined;
+
+const resolveRedirectUrl = () =>
+  (typeof import.meta !== 'undefined' &&
+    import.meta.env &&
+    (import.meta.env.VITE_SUPABASE_REDIRECT_URL as string)) ||
+  AUTH_REDIRECT_URL ||
+  '';
+
+const NETWORK_ERROR_MESSAGE =
+  'Tidak dapat terhubung ke server. Periksa koneksi internet kamu.';
+
+const DEFAULT_ERROR_MESSAGE =
+  'Terjadi kesalahan tak terduga. Silakan coba lagi.';
+
+function normaliseMessage(message: string) {
+  return message.trim().toLowerCase();
+}
+
+function mapAuthError(error: unknown): string {
+  if (!error) return DEFAULT_ERROR_MESSAGE;
+
+  if (typeof error === 'string') {
+    return translateErrorMessage(error);
+  }
+
+  const authError = error as AuthError;
+  if (authError?.message) {
+    return translateErrorMessage(authError.message, authError.status);
+  }
+
+  if (error instanceof Error && error.message) {
+    return translateErrorMessage(error.message);
+  }
+
+  return DEFAULT_ERROR_MESSAGE;
+}
+
+function translateErrorMessage(message: string, status?: number) {
+  const text = normaliseMessage(message);
+
+  if (text.includes('invalid login credentials')) {
+    return 'Email atau kata sandi salah.';
+  }
+
+  if (text.includes('email not confirmed')) {
+    return 'Email kamu belum terverifikasi. Silakan cek kotak masuk untuk verifikasi.';
+  }
+
+  if (text.includes('user not found')) {
+    return 'Akun dengan email tersebut tidak ditemukan.';
+  }
+
+  if (text.includes('refresh token not found')) {
+    return 'Sesi kamu telah berakhir. Silakan login kembali.';
+  }
+
+  if (text.includes('network') || text.includes('fetch failed')) {
+    return NETWORK_ERROR_MESSAGE;
+  }
+
+  if (status === 429) {
+    return 'Terlalu banyak percobaan. Coba lagi beberapa saat nanti.';
+  }
+
+  if (status === 422) {
+    return 'Permintaan tidak valid. Periksa kembali data yang kamu masukkan.';
+  }
+
+  return message || DEFAULT_ERROR_MESSAGE;
+}
+
+export async function loginWithPassword(params: {
+  email: string;
+  password: string;
+}): Promise<{ data?: AuthResponse['data']; error?: string }> {
+  try {
+    const { data, error } = await supabase.auth.signInWithPassword({
+      email: params.email,
+      password: params.password,
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    return { data };
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.error('[HW][auth] loginWithPassword', err);
+    }
+    return { error: mapAuthError(err) };
+  }
+}
+
+export async function sendMagicLink(params: {
+  email: string;
+  redirectTo?: string;
+}): Promise<{
+  data?: AuthTokenResponsePasswordless['data'];
+  error?: string;
+}> {
+  try {
+    const redirectTo = params.redirectTo ?? resolveRedirectUrl();
+    const { data, error } = await supabase.auth.signInWithOtp({
+      email: params.email,
+      options: { emailRedirectTo: redirectTo },
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    return { data };
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.error('[HW][auth] sendMagicLink', err);
+    }
+    return { error: mapAuthError(err) };
+  }
+}
+
+export async function verifyMagicOtp(params: {
+  email: string;
+  token: string;
+  type?: 'magiclink' | 'email';
+}): Promise<{ data?: AuthResponse['data']; error?: string }> {
+  try {
+    const { data, error } = await supabase.auth.verifyOtp({
+      email: params.email,
+      token: params.token,
+      type: params.type ?? 'magiclink',
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    return { data };
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.error('[HW][auth] verifyMagicOtp', err);
+    }
+    return { error: mapAuthError(err) };
+  }
+}
+
+export async function resetPassword(params: {
+  email: string;
+  redirectTo?: string;
+}): Promise<{ error?: string }> {
+  try {
+    const redirectTo = params.redirectTo ?? resolveRedirectUrl();
+    const { error } = await supabase.auth.resetPasswordForEmail(params.email, {
+      redirectTo,
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    return {};
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.error('[HW][auth] resetPassword', err);
+    }
+    return { error: mapAuthError(err) };
+  }
+}
+
+export async function signInWithProvider(provider: 'google' | 'github', options?: {
+  redirectTo?: string;
+}): Promise<{ data?: OAuthResponse['data']; error?: string }> {
+  try {
+    const redirectTo = options?.redirectTo ?? resolveRedirectUrl();
+    const { data, error } = await supabase.auth.signInWithOAuth({
+      provider,
+      options: {
+        redirectTo,
+      },
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    return { data };
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.error('[HW][auth] signInWithProvider', err);
+    }
+    return { error: mapAuthError(err) };
+  }
+}
+
+export async function getSession(): Promise<{
+  session: Session | null;
+  error?: string;
+}> {
+  try {
+    const { data, error } = await supabase.auth.getSession();
+    if (error) {
+      throw error;
+    }
+
+    return { session: data.session ?? null };
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.error('[HW][auth] getSession', err);
+    }
+    return { session: null, error: mapAuthError(err) };
+  }
+}
+
+export { mapAuthError };

--- a/src/pages/AuthLogin.tsx
+++ b/src/pages/AuthLogin.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import LoginCard from '../components/auth/LoginCard';
+import ErrorBoundary from '../components/system/ErrorBoundary';
+import { getSession } from '../lib/auth';
+import { supabase } from '../lib/supabase';
+
+function setConnectionModeOnline() {
+  try {
+    localStorage.setItem('hw:connectionMode', 'online');
+    localStorage.setItem('hw:mode', 'online');
+  } catch {
+    /* ignore */
+  }
+}
+
+function AuthLoginContent() {
+  const navigate = useNavigate();
+  const [checkingSession, setCheckingSession] = useState(true);
+  const [sessionError, setSessionError] = useState<string | null>(null);
+  const [initialEmail, setInitialEmail] = useState('');
+
+  const tips = useMemo(
+    () => [
+      'Sinkron otomatis dengan akun bank dan dompet digital yang kamu percayai.',
+      'Pantau anggaran dan goals tabungan dengan visual yang mudah dipahami.',
+      'Dapatkan insight pintar setiap minggu agar keuanganmu makin sehat.',
+    ],
+    []
+  );
+
+  useEffect(() => {
+    let mounted = true;
+    async function checkSession() {
+      try {
+        const { session, error } = await getSession();
+        if (!mounted) return;
+
+        if (session) {
+          setConnectionModeOnline();
+          navigate('/', { replace: true });
+          return;
+        }
+
+        if (error) {
+          setSessionError(error);
+        }
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.error('[HW][auth] checkSession', err);
+        }
+        if (mounted) {
+          setSessionError('Tidak dapat memeriksa sesi login. Coba lagi.');
+        }
+      } finally {
+        if (mounted) {
+          setCheckingSession(false);
+        }
+      }
+    }
+
+    checkSession();
+
+    const { data: sub } = supabase.auth.onAuthStateChange((event, session) => {
+      if (!mounted) return;
+      if (event === 'SIGNED_IN' && session) {
+        setConnectionModeOnline();
+        navigate('/', { replace: true });
+      }
+    });
+
+    return () => {
+      mounted = false;
+      sub.subscription?.unsubscribe();
+    };
+  }, [navigate]);
+
+  useEffect(() => {
+    try {
+      const shouldPrefill = localStorage.getItem('hw:rememberMe') === 'true';
+      if (!shouldPrefill) return;
+      const savedEmail = localStorage.getItem('hw:lastEmail');
+      if (savedEmail) {
+        setInitialEmail(savedEmail);
+      }
+    } catch {
+      setInitialEmail('');
+    }
+  }, []);
+
+  const handleSuccess = () => {
+    setConnectionModeOnline();
+    navigate('/', { replace: true });
+  };
+
+  useEffect(() => {
+    const previousTitle = document.title;
+    document.title = 'Masuk | HematWoi';
+    return () => {
+      document.title = previousTitle;
+    };
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-surface-alt text-text">
+      <div className="flex min-h-screen flex-col lg:flex-row">
+        <section className="flex flex-1 items-center justify-center bg-gradient-to-br from-surface-alt via-surface-alt to-surface px-6 py-12">
+          <div className="max-w-xl space-y-6 text-center lg:text-left">
+            <span className="inline-flex items-center justify-center rounded-full bg-primary/10 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
+              HematWoi
+            </span>
+            <h1 className="text-3xl font-semibold sm:text-4xl">Selamat datang kembali 👋</h1>
+            <p className="text-sm leading-relaxed text-muted">
+              Masuk untuk melanjutkan perjalanan finansialmu. Data kamu aman, dan kami akan
+              menyesuaikan pengalaman sesuai gaya hidup hematmu.
+            </p>
+            <ul className="mx-auto flex max-w-md flex-col gap-3 text-left text-sm text-text lg:mx-0">
+              {tips.map((tip) => (
+                <li key={tip} className="flex items-start gap-3">
+                  <span className="mt-0.5 flex h-6 w-6 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">
+                    ✓
+                  </span>
+                  <span className="leading-relaxed">{tip}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        <section className="flex flex-1 items-center justify-center bg-surface px-6 py-12">
+          <div className="w-full max-w-md space-y-4">
+            {sessionError ? (
+              <div className="rounded-2xl border border-warning/30 bg-warning/10 px-4 py-3 text-sm text-warning" role="alert" aria-live="polite">
+                {sessionError}
+              </div>
+            ) : null}
+            {checkingSession ? (
+              <div className="w-full max-w-md animate-pulse rounded-3xl border border-border-subtle/70 bg-surface-alt/70 p-6 shadow-sm sm:p-8">
+                <div className="h-6 w-2/3 rounded-lg bg-border-subtle/80" />
+                <div className="mt-4 h-4 w-full rounded-lg bg-border-subtle/60" />
+                <div className="mt-6 space-y-3">
+                  <div className="h-11 w-full rounded-2xl bg-border-subtle/50" />
+                  <div className="h-11 w-full rounded-2xl bg-border-subtle/40" />
+                  <div className="h-11 w-full rounded-2xl bg-border-subtle/30" />
+                  <div className="h-11 w-full rounded-2xl bg-border-subtle/40" />
+                </div>
+              </div>
+            ) : (
+              <LoginCard onSuccess={handleSuccess} initialEmail={initialEmail} />
+            )}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+export default function AuthLogin() {
+  return (
+    <ErrorBoundary>
+      <AuthLoginContent />
+    </ErrorBoundary>
+  );
+}

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -32,7 +32,7 @@ function loadComponent(path: string) {
     case '/profile':
       return lazy(() => import('../pages/Profile'));
     case '/auth':
-      return lazy(() => import('../pages/Auth'));
+      return lazy(() => import('../pages/AuthLogin'));
     default:
       return lazy(() => import('../pages/Dashboard'));
   }


### PR DESCRIPTION
## Summary
- add dedicated Supabase auth helpers covering password, magic link, OTP, reset, and social providers
- build modern login card with tabs for password and magic link flows, inline OTP fallback, reset password step, and social logins
- create responsive /auth page with hero section, session guard, skeleton loader, and error boundary fallback

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d1dd935c8483328d44258cc56d0fb5