### PR TITLE
feat: allow username sign-in

### DIFF
--- a/src/pages/AuthLogin.tsx
+++ b/src/pages/AuthLogin.tsx
@@ -15,7 +15,7 @@ export default function AuthLogin() {
   const location = useLocation();
   const [checking, setChecking] = useState(true);
   const [sessionError, setSessionError] = useState<string | null>(null);
-  const [prefilledEmail] = useState(() => {
+  const [prefilledIdentifier] = useState(() => {
     try {
       return localStorage.getItem('hw:lastEmail') ?? '';
     } catch {
@@ -106,7 +106,7 @@ export default function AuthLogin() {
                 Masuk untuk menyinkronkan transaksi, meninjau anggaran, dan tetap on-track dengan tujuan finansialmu.
               </p>
             </div>
-            <ul className="w-full max-w-lg space-y-3 text-left text-sm text-text">
+            <ul className="hidden w-full max-w-lg space-y-3 text-left text-sm text-text md:block">
               {heroTips.map((tip) => (
                 <li key={tip} className="flex items-start gap-3 rounded-2xl border border-border-subtle/60 bg-surface px-4 py-3 shadow-sm">
                   <span className="mt-1 inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
@@ -128,7 +128,7 @@ export default function AuthLogin() {
               {checking ? (
                 skeleton
               ) : (
-                <LoginCard defaultEmail={prefilledEmail} onSuccess={handleSuccess} />
+                <LoginCard defaultIdentifier={prefilledIdentifier} onSuccess={handleSuccess} />
               )}
             </div>
           </section>

--- a/supabase/migrations/20250331000000_create_resolve_email_by_username.sql
+++ b/supabase/migrations/20250331000000_create_resolve_email_by_username.sql
@@ -1,0 +1,28 @@
+create or replace function public.resolve_email_by_username(username text)
+returns text
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  normalized_username text;
+  matched_email text;
+begin
+  normalized_username := lower(nullif(trim(username), ''));
+  if normalized_username is null then
+    return null;
+  end if;
+
+  select u.email
+    into matched_email
+  from auth.users u
+  join public.user_profiles p on p.id = u.id
+  where p.username is not null
+    and lower(p.username) = normalized_username
+  limit 1;
+
+  return matched_email;
+end;
+$$;
+
+grant execute on function public.resolve_email_by_username(text) to authenticated;


### PR DESCRIPTION
## Summary
- update the login form to accept either an email address or username, resolve usernames through Supabase RPC, and improve validation/state handling
- add a SECURITY DEFINER RPC and client helper to map usernames to emails safely
- hide the promotional bullet list on small screens while keeping the desktop layout intact

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d22dbbd8f88332b398b429abca9773