### PR TITLE
Enable username login and hide promo copy on mobile

### DIFF
--- a/src/pages/AuthLogin.tsx
+++ b/src/pages/AuthLogin.tsx
@@ -15,8 +15,10 @@ export default function AuthLogin() {
   const location = useLocation();
   const [checking, setChecking] = useState(true);
   const [sessionError, setSessionError] = useState<string | null>(null);
-  const [prefilledEmail] = useState(() => {
+  const [prefilledIdentifier] = useState(() => {
     try {
+      const stored = localStorage.getItem('hw:lastIdentifier');
+      if (stored) return stored;
       return localStorage.getItem('hw:lastEmail') ?? '';
     } catch {
       return '';
@@ -106,7 +108,7 @@ export default function AuthLogin() {
                 Masuk untuk menyinkronkan transaksi, meninjau anggaran, dan tetap on-track dengan tujuan finansialmu.
               </p>
             </div>
-            <ul className="w-full max-w-lg space-y-3 text-left text-sm text-text">
+            <ul className="hidden w-full max-w-lg space-y-3 text-left text-sm text-text md:block">
               {heroTips.map((tip) => (
                 <li key={tip} className="flex items-start gap-3 rounded-2xl border border-border-subtle/60 bg-surface px-4 py-3 shadow-sm">
                   <span className="mt-1 inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
@@ -128,7 +130,7 @@ export default function AuthLogin() {
               {checking ? (
                 skeleton
               ) : (
-                <LoginCard defaultEmail={prefilledEmail} onSuccess={handleSuccess} />
+                <LoginCard defaultIdentifier={prefilledIdentifier} onSuccess={handleSuccess} />
               )}
             </div>
           </section>

--- a/supabase/migrations/20250330000000_create_resolve_email_by_username.sql
+++ b/supabase/migrations/20250330000000_create_resolve_email_by_username.sql
@@ -1,0 +1,32 @@
+create or replace function public.resolve_email_by_username(username text)
+returns text
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  target_email text;
+begin
+  if username is null or length(trim(username)) = 0 then
+    return null;
+  end if;
+
+  select u.email
+    into target_email
+  from public.user_profiles p
+    join auth.users u on u.id = p.id
+  where p.username is not null
+    and lower(p.username) = lower(username)
+  limit 1;
+
+  if target_email is null then
+    return null;
+  end if;
+
+  return trim(target_email);
+end;
+$$;
+
+revoke all on function public.resolve_email_by_username(text) from public;
+grant execute on function public.resolve_email_by_username(text) to anon;
+grant execute on function public.resolve_email_by_username(text) to authenticated;


### PR DESCRIPTION
## Summary
- allow signing in with username or email by updating the login form validation and flow
- add a Supabase RPC to resolve usernames to emails securely
- hide the promo bullet list on small screens to simplify the mobile layout

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d22dbbd8f88332b398b429abca9773