### PR TITLE
Fix username login RPC payload and align error messaging

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -67,7 +67,7 @@ function translateMessage(code?: string | null, raw?: string | null): string | n
   if (normalized.includes('password') && normalized.includes('6'))
     return 'Kata sandi minimal 6 karakter.';
   if (normalized.includes('network') || normalized.includes('fetch') || normalized.includes('connection'))
-    return 'Periksa koneksi internet kamu.';
+    return 'Periksa koneksi internet.';
   if (normalized.includes('otp') && normalized.includes('expired'))
     return 'Kode OTP sudah kedaluwarsa. Kirim ulang tautan.';
   if (normalized.includes('otp') && normalized.includes('invalid'))
@@ -129,7 +129,7 @@ export async function resolveEmailByUsername(username: string): Promise<string |
 
   try {
     const { data, error } = await supabase.rpc('resolve_email_by_username', {
-      username: trimmed,
+      username_input: trimmed,
     });
     if (error) throw error;
     if (!data) return null;
@@ -142,9 +142,9 @@ export async function resolveEmailByUsername(username: string): Promise<string |
       console.error('[HW][auth-login]', error);
     }
     if (isNetworkError(error)) {
-      throw new Error('Tidak bisa terhubung. Periksa internet kamu.');
+      throw new Error('Periksa koneksi internet.');
     }
-    throw new Error('Username tidak ditemukan.');
+    throw new Error('Username atau email tidak ditemukan.');
   }
 }
 


### PR DESCRIPTION
## Summary
- update login RPC payload to use the expected `username_input` argument
- normalize network error messaging to "Periksa koneksi internet." for consistency
- surface username lookup failures as "Username atau email tidak ditemukan."

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d235d7b02c8332a2681479afe142c8