### PR TITLE
Add budget status highlights on dashboard

### DIFF
--- a/src/components/BudgetStatusHighlights.jsx
+++ b/src/components/BudgetStatusHighlights.jsx
@@ -1,0 +1,109 @@
+import SectionHeader from "./SectionHeader";
+
+function normalizeItems(items = []) {
+  return items
+    .map((item) => {
+      const pct = Number.isFinite(Number(item?.pct))
+        ? Number(item.pct)
+        : 0;
+      return {
+        category: item?.category || "Tanpa kategori",
+        planned: Number.isFinite(Number(item?.planned)) ? Number(item.planned) : 0,
+        actual: Number.isFinite(Number(item?.actual)) ? Number(item.actual) : 0,
+        pct,
+      };
+    })
+    .filter((item) => item.pct > 0);
+}
+
+const MAX_ITEMS = 5;
+
+function BudgetStatusGroup({ title, colorClass, items }) {
+  if (!items.length) return null;
+  return (
+    <div className="space-y-2">
+      <h3
+        className={
+          "text-xs font-semibold uppercase tracking-wide text-muted/80"
+        }
+      >
+        {title}
+      </h3>
+      <div className="flex flex-wrap gap-2">
+        {items.map((item) => (
+          <span
+            key={`${title}-${item.category}`}
+            className={`inline-flex max-w-full items-center gap-1 rounded-full border px-3 py-1 text-xs font-medium shadow-sm ${colorClass}`}
+          >
+            <span className="min-w-0 max-w-[10rem] overflow-hidden text-ellipsis whitespace-nowrap">
+              {item.category}
+            </span>
+            <span>{Math.round(item.pct)}%</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function BudgetStatusHighlights({ items = [] }) {
+  const normalized = normalizeItems(items);
+  if (!normalized.length) {
+    return (
+      <section className="rounded-xl border border-border/60 bg-card/60 p-4 shadow-sm backdrop-blur">
+        <SectionHeader
+          title="Status Anggaran"
+          description="Pantau kategori yang mendekati atau melebihi batas."
+        />
+        <p className="mt-3 text-sm text-muted">
+          Belum ada data anggaran untuk ditampilkan.
+        </p>
+      </section>
+    );
+  }
+
+  const over = normalized
+    .filter((item) => item.pct >= 100)
+    .sort((a, b) => b.pct - a.pct);
+  const near = normalized
+    .filter((item) => item.pct >= 80 && item.pct < 100)
+    .sort((a, b) => b.pct - a.pct);
+
+  const overDisplay = over.slice(0, MAX_ITEMS);
+  const nearDisplay = near.slice(0, Math.max(0, MAX_ITEMS - overDisplay.length));
+
+  if (!overDisplay.length && !nearDisplay.length) {
+    return (
+      <section className="rounded-xl border border-border/60 bg-card/60 p-4 shadow-sm backdrop-blur">
+        <SectionHeader
+          title="Status Anggaran"
+          description="Pantau kategori yang mendekati atau melebihi batas."
+        />
+        <p className="mt-3 text-sm text-muted">
+          Semua kategori masih aman di bawah 80% dari anggaran.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-xl border border-border/60 bg-card/60 p-4 shadow-sm backdrop-blur">
+      <SectionHeader
+        title="Status Anggaran"
+        description="Pantau kategori yang mendekati atau melebihi batas."
+      />
+      <div className="mt-4 space-y-4">
+        <BudgetStatusGroup
+          title="Over Budget"
+          colorClass="border-rose-500/30 bg-rose-500/10 text-rose-600 dark:border-rose-400/30 dark:text-rose-300"
+          items={overDisplay}
+        />
+        <BudgetStatusGroup
+          title="Near Budget"
+          colorClass="border-amber-500/30 bg-amber-500/10 text-amber-600 dark:border-amber-400/30 dark:text-amber-300"
+          items={nearDisplay}
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -4,6 +4,7 @@ import QuoteBoard from "../components/QuoteBoard";
 import SavingsProgress from "../components/SavingsProgress";
 import AchievementBadges from "../components/AchievementBadges";
 import QuickActions from "../components/QuickActions";
+import BudgetStatusHighlights from "../components/BudgetStatusHighlights";
 import SectionHeader from "../components/SectionHeader";
 import MonthlyTrendChart from "../components/MonthlyTrendChart";
 import CategoryDonut from "../components/CategoryDonut";
@@ -13,7 +14,7 @@ import useInsights from "../hooks/useInsights";
 import EventBus from "../lib/eventBus";
 
 // Each content block uses <Section> to maintain a single vertical rhythm.
-export default function Dashboard({ stats, txs }) {
+export default function Dashboard({ stats, txs, budgetStatus = [] }) {
   const streak = useMemo(() => {
     const dates = new Set(txs.map((t) => new Date(t.date).toDateString()));
     let count = 0;
@@ -64,6 +65,8 @@ export default function Dashboard({ stats, txs }) {
       </div>
 
       <QuickActions />
+
+      <BudgetStatusHighlights items={budgetStatus} />
 
       <section className="space-y-6 sm:space-y-8 lg:space-y-10">
         <SectionHeader title="Analisis Bulanan" />


### PR DESCRIPTION
## Summary
- persist budget status view data in app state when cloud mode is active
- surface near and over budget categories on the dashboard with responsive chips and grouping
- handle empty and safe states gracefully while keeping the section within the existing layout rhythm

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d235e802e48332a5f289dc752f227a