### PR TITLE
feat: surface quote signals from supabase views

### DIFF
--- a/src/components/QuoteBoard.jsx
+++ b/src/components/QuoteBoard.jsx
@@ -1,25 +1,14 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  generateQuotes,
-  highlightKeys,
-  loadQuoteEngine,
-} from '../lib/quoteEngine';
+import { generateQuotes, highlightKeys, loadQuoteEngine } from '../lib/quoteEngine';
 
 const GROUP_META = {
-  'over-budget': { label: 'Anggaran Jebol', emoji: '🚑' },
+  'over-budget': { label: 'Anggaran Jebol', emoji: '🚨' },
   'near-budget': { label: 'Hampir Batas', emoji: '🛑' },
   'weekly-repeats': { label: 'Belanja Berulang', emoji: '🧋' },
   'large-transaction': { label: 'Transaksi Besar', emoji: '💳' },
-  'low-balance': { label: 'Saldo Menipis', emoji: '⛽' },
-  subscription: { label: 'Langganan', emoji: '🔔' },
-  'net-cashflow': { label: 'Arus Kas', emoji: '📈' },
-  'weekly-summary': { label: 'Ringkasan Mingguan', emoji: '📝' },
-  streak: { label: 'Streak Pencatatan', emoji: '🔥' },
-  'no-spend': { label: 'No-Spend Day', emoji: '🙌' },
-  'quiet-category': { label: 'Kategori Sepi', emoji: '🌱' },
-  'round-up': { label: 'Sapu Receh', emoji: '💰' },
-  goal: { label: 'Goal Nabung', emoji: '🎯' },
-  fallback: { label: 'Santai Dulu', emoji: '☕' },
+  'net-cashflow': { label: 'Arus Kas Bulanan', emoji: '📈' },
+  'weekly-top': { label: 'Kategori Top Minggu Ini', emoji: '📝' },
+  fallback: { label: 'Santai Dulu', emoji: '☕️' },
 };
 
 const DEFAULT_META = { label: 'Quote Cerdas', emoji: '💡' };
@@ -64,7 +53,7 @@ function QuoteCard({ quote }) {
   );
 
   return (
-    <article className="min-w-[220px] shrink-0 rounded-3xl border border-border bg-surface shadow-sm p-4 md:min-w-0 md:p-5">
+    <article className="rounded-3xl border border-border bg-surface shadow-sm p-4 sm:p-5">
       <div className="mb-3 flex items-center gap-2 text-sm text-muted">
         <span aria-hidden className="text-xl leading-none">
           {meta.emoji}
@@ -78,7 +67,7 @@ function QuoteCard({ quote }) {
 
 function QuoteSkeleton() {
   return (
-    <div className="min-w-[220px] shrink-0 rounded-3xl border border-border bg-surface shadow-sm p-4 md:min-w-0 md:p-5">
+    <div className="rounded-3xl border border-border bg-surface shadow-sm p-4 sm:p-5">
       <div className="mb-3 h-4 w-24 animate-pulse rounded-full bg-border/70" />
       <div className="space-y-2">
         <div className="h-3.5 w-full animate-pulse rounded-full bg-border/70" />
@@ -106,9 +95,8 @@ export default function QuoteBoard() {
         setError(null);
         setLoading(false);
       })
-      .catch((err) => {
+      .catch(() => {
         if (cancelled) return;
-        console.error('[HW][quotes] gagal memuat QuoteBoard', err);
         setSignals(null);
         setQuotes(generateQuotes(null));
         setError('Tidak bisa memuat data terbaru.');
@@ -126,7 +114,7 @@ export default function QuoteBoard() {
   const cards = useMemo(() => {
     if (loading) {
       return (
-        <div className="flex gap-3 overflow-x-auto pb-2 md:grid md:grid-cols-2 md:gap-4 md:overflow-visible md:pb-0 lg:grid-cols-3">
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {[0, 1, 2].map((key) => (
             <QuoteSkeleton key={key} />
           ))}
@@ -135,13 +123,13 @@ export default function QuoteBoard() {
     }
     if (!quotes.length) {
       return (
-        <div className="rounded-3xl border border-border bg-surface shadow-sm p-4 text-sm text-muted md:p-5">
+        <div className="rounded-3xl border border-border bg-surface shadow-sm p-4 text-sm text-muted sm:p-5">
           Belum ada aktivitas yang bisa dianalisis. Coba catat transaksi dulu, ya!
         </div>
       );
     }
     return (
-      <div className="flex gap-3 overflow-x-auto pb-2 md:grid md:grid-cols-2 md:gap-4 md:overflow-visible md:pb-0 lg:grid-cols-3">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {quotes.map((quote) => (
           <QuoteCard key={`${quote.group}-${quote.text}`} quote={quote} />
         ))}
@@ -157,9 +145,7 @@ export default function QuoteBoard() {
           <p className="text-sm text-muted">Insight singkat dari transaksi teranyar.</p>
         </div>
         <div className="flex items-center gap-3">
-          {error && !loading && (
-            <span className="text-xs text-amber-500">{error}</span>
-          )}
+          {error && !loading && <span className="text-xs text-amber-500">{error}</span>}
           <button
             type="button"
             onClick={handleRefresh}

--- a/src/lib/dashboardSignals.ts
+++ b/src/lib/dashboardSignals.ts
@@ -1,0 +1,278 @@
+import { supabase } from './supabase';
+
+const MONTH_FORMAT = new Intl.DateTimeFormat('id-ID', { month: 'long', year: 'numeric' });
+const NUMBER_FORMAT = new Intl.NumberFormat('id-ID', { maximumFractionDigits: 0 });
+
+export interface MerchantRepeatSignal {
+  merchant: string;
+  count: number;
+  total: number;
+}
+
+export interface BudgetStatusSignal {
+  category: string;
+  pct: number;
+}
+
+export interface CashflowSignal {
+  month: string;
+  amount: number;
+}
+
+export interface WeeklyTopSignal {
+  category: string;
+  total: number;
+}
+
+export interface LargeTransactionSignal {
+  merchant: string;
+  amount: number;
+}
+
+export interface DashboardSignals {
+  weeklyRepeats: MerchantRepeatSignal[];
+  nearBudget: BudgetStatusSignal[];
+  overBudget: BudgetStatusSignal[];
+  largeTransaction: LargeTransactionSignal | null;
+  netCashflow: CashflowSignal | null;
+  weeklyTop: WeeklyTopSignal | null;
+}
+
+export const EMPTY_SIGNALS: DashboardSignals = {
+  weeklyRepeats: [],
+  nearBudget: [],
+  overBudget: [],
+  largeTransaction: null,
+  netCashflow: null,
+  weeklyTop: null,
+};
+
+interface FetchOptions {
+  limit?: number;
+  optional?: boolean;
+  orderBy?: string;
+  ascending?: boolean;
+}
+
+const LARGE_TX_THRESHOLD = 500_000;
+
+export async function getDashboardSignals(): Promise<DashboardSignals> {
+  try {
+    const [weeklyMerchantRows, largeExpenseRows, cashflowRows, weeklyTopRows, budgetStatusRows] =
+      await Promise.all([
+        fetchView('v_tx_weekly_merchant', { limit: 12 }),
+        fetchView('v_tx_large_expenses_month', { limit: 10 }),
+        fetchView('v_tx_monthly_cashflow', { limit: 6 }),
+        fetchView('v_tx_weekly_top_category', { limit: 6 }),
+        fetchView('v_budget_status_month', { limit: 20, optional: true }),
+      ]);
+
+    const weeklyRepeats = mapWeeklyRepeats(weeklyMerchantRows);
+    const largeTransaction = mapLargeTransaction(largeExpenseRows);
+    const netCashflow = mapCashflow(cashflowRows);
+    const weeklyTop = mapWeeklyTop(weeklyTopRows);
+    const { nearBudget, overBudget } = mapBudgetStatus(budgetStatusRows);
+
+    return {
+      weeklyRepeats,
+      nearBudget,
+      overBudget,
+      largeTransaction,
+      netCashflow,
+      weeklyTop,
+    };
+  } catch (error) {
+    return { ...EMPTY_SIGNALS };
+  }
+}
+
+async function fetchView(name: string, options: FetchOptions = {}): Promise<any[]> {
+  const { limit, optional = false, orderBy, ascending = false } = options;
+  try {
+    let query = supabase.from(name).select('*');
+    if (orderBy) {
+      query = query.order(orderBy, { ascending });
+    }
+    if (typeof limit === 'number') {
+      query = query.limit(limit);
+    }
+    const { data, error } = await query;
+    if (error) {
+      if (optional) return [];
+      throw error;
+    }
+    return Array.isArray(data) ? data : [];
+  } catch (err) {
+    if (optional) return [];
+    throw err;
+  }
+}
+
+function mapWeeklyRepeats(rows: any[]): MerchantRepeatSignal[] {
+  return rows
+    .map((row) => {
+      const merchant = pickString(row, ['merchant', 'merchant_name', 'name', 'title']);
+      const count = pickNumber(row, ['count', 'tx_count', 'transaction_count']);
+      const total = pickNumber(row, ['total', 'total_amount', 'amount', 'sum']);
+      if (!merchant || count < 2 || total <= 0) return null;
+      return { merchant, count, total };
+    })
+    .filter(Boolean)
+    .sort((a, b) => b!.total - a!.total)
+    .map((item) => ({
+      merchant: item!.merchant,
+      count: item!.count,
+      total: item!.total,
+    }));
+}
+
+function mapLargeTransaction(rows: any[]): LargeTransactionSignal | null {
+  const candidate = rows
+    .map((row) => {
+      const merchant = pickString(row, ['merchant', 'merchant_name', 'name', 'title']);
+      const amount = Math.abs(pickNumber(row, ['amount', 'total', 'total_amount', 'value']));
+      if (!merchant || amount < LARGE_TX_THRESHOLD) return null;
+      return { merchant, amount };
+    })
+    .filter(Boolean)
+    .sort((a, b) => b!.amount - a!.amount)[0];
+
+  return candidate
+    ? {
+        merchant: candidate.merchant,
+        amount: candidate.amount,
+      }
+    : null;
+}
+
+function mapCashflow(rows: any[]): CashflowSignal | null {
+  let best: { month: string; amount: number; timestamp: number } | null = null;
+  for (const row of rows) {
+    const amount = pickNumber(row, ['net', 'net_amount', 'amount', 'total', 'balance']);
+    const monthLabel = getMonthLabel(row);
+    if (!monthLabel) continue;
+    const ts = getMonthTimestamp(row);
+    if (!best || (ts !== null && ts > best.timestamp)) {
+      best = {
+        month: monthLabel,
+        amount,
+        timestamp: ts ?? Number.MIN_SAFE_INTEGER,
+      };
+    }
+  }
+  if (!best) return null;
+  return { month: best.month, amount: best.amount };
+}
+
+function mapWeeklyTop(rows: any[]): WeeklyTopSignal | null {
+  const candidate = rows
+    .map((row) => {
+      const category = pickString(row, ['category', 'category_name', 'name', 'label']);
+      const total = pickNumber(row, ['total', 'total_amount', 'amount', 'sum']);
+      if (!category || total <= 0) return null;
+      return { category, total };
+    })
+    .filter(Boolean)
+    .sort((a, b) => b!.total - a!.total)[0];
+
+  return candidate ? { category: candidate.category, total: candidate.total } : null;
+}
+
+function mapBudgetStatus(rows: any[]): { nearBudget: BudgetStatusSignal[]; overBudget: BudgetStatusSignal[] } {
+  const nearBudget: BudgetStatusSignal[] = [];
+  const overBudget: BudgetStatusSignal[] = [];
+
+  for (const row of rows) {
+    const category = pickString(row, ['category', 'category_name', 'name', 'label']);
+    let pct = pickNumber(row, ['pct', 'percentage', 'ratio', 'utilization', 'usage']);
+    if (!category || pct <= 0) continue;
+    if (pct <= 1) {
+      pct *= 100;
+    }
+    if (pct >= 100) {
+      overBudget.push({ category, pct });
+    } else if (pct >= 80) {
+      nearBudget.push({ category, pct });
+    }
+  }
+
+  overBudget.sort((a, b) => b.pct - a.pct);
+  nearBudget.sort((a, b) => b.pct - a.pct);
+
+  return { nearBudget, overBudget };
+}
+
+function pickString(row: Record<string, any>, keys: string[]): string {
+  for (const key of keys) {
+    const value = row?.[key];
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+  return '';
+}
+
+function pickNumber(row: Record<string, any>, keys: string[]): number {
+  for (const key of keys) {
+    const value = row?.[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === 'string' && value.trim()) {
+      const parsed = Number(value);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+  }
+  return 0;
+}
+
+function getMonthLabel(row: Record<string, any>): string | null {
+  const directLabel = pickString(row, ['month_label', 'label']);
+  if (directLabel) return directLabel;
+
+  const candidates = [row?.month, row?.period, row?.month_start, row?.date];
+  for (const value of candidates) {
+    const date = coerceDate(value);
+    if (date) {
+      return MONTH_FORMAT.format(date);
+    }
+  }
+  return null;
+}
+
+function getMonthTimestamp(row: Record<string, any>): number | null {
+  const candidates = [row?.month, row?.period, row?.month_start, row?.date];
+  for (const value of candidates) {
+    const date = coerceDate(value);
+    if (date) {
+      return date.getTime();
+    }
+  }
+  return null;
+}
+
+function coerceDate(value: unknown): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) return value;
+  if (typeof value === 'number') {
+    const fromNumber = new Date(value);
+    return Number.isNaN(fromNumber.getTime()) ? null : fromNumber;
+  }
+  if (typeof value === 'string') {
+    if (!value.trim()) return null;
+    const normalized = value.length === 7 ? `${value}-01` : value;
+    const fromString = new Date(normalized);
+    return Number.isNaN(fromString.getTime()) ? null : fromString;
+  }
+  return null;
+}
+
+export function formatCount(value: number): string {
+  return NUMBER_FORMAT.format(Math.max(0, Math.round(value)));
+}
+
+export function formatAmount(value: number): string {
+  return NUMBER_FORMAT.format(Math.max(0, Math.round(value)));
+}

--- a/src/lib/quoteEngine.ts
+++ b/src/lib/quoteEngine.ts
@@ -1,587 +1,172 @@
-const IDR = new Intl.NumberFormat('id-ID');
-const MONTH_FORMAT = new Intl.DateTimeFormat('id-ID', { month: 'long' });
-const SHORT_DATE_FORMAT = new Intl.DateTimeFormat('id-ID', {
-  day: '2-digit',
-  month: 'short',
-});
+import { EMPTY_SIGNALS, getDashboardSignals, type DashboardSignals } from './dashboardSignals';
 
-const LARGE_TX_THRESHOLD = 500_000;
-const LOW_BALANCE_THRESHOLD = 50_000;
-const UPCOMING_SUB_WINDOW_DAYS = 7;
+const NUMBER_FORMAT = new Intl.NumberFormat('id-ID', { maximumFractionDigits: 0 });
+
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
-const HIGHLIGHT_KEYS = new Set([
-  'total',
-  'amount',
-  'pct',
-  'left',
-  'streak',
-  'count',
-  'goal',
-]);
-
-interface TransactionLike {
-  id?: string;
-  date?: string;
-  type?: string;
-  amount?: number;
-  merchant?: string | null;
-  title?: string | null;
-  notes?: string | null;
-  category?: string | null;
-  category_id?: string | null;
-  account?: string | null;
-}
-
-interface BudgetLike {
-  id?: string;
-  name?: string | null;
-  planned?: number;
-  rollover_in?: number;
-  activity?: {
-    actual?: number;
-  } | null;
-  category_id?: string | null;
-  category_name?: string | null;
-  label?: string | null;
-  actual?: number;
-  spent?: number;
-}
-
-interface GoalLike {
-  id?: string;
-  title?: string;
-  name?: string;
-  status?: string;
-  target_amount?: number;
-  saved_amount?: number;
-}
-
-interface SubscriptionLike {
-  id?: string;
-  name?: string;
-  vendor?: string | null;
-  amount?: number;
-  next_due_date?: string | null;
-  due_date?: string | null;
-  anchor_date?: string | null;
-}
-
-interface AccountLike {
-  id?: string;
-  name?: string;
-  balance?: number;
-}
-
-export interface DashboardSignals {
-  weeklyRepeats: Array<{
-    merchant: string;
-    count: number;
-    total: number;
-  }>;
-  nearBudget: Array<{
-    category: string;
-    pct: number;
-  }>;
-  overBudget: Array<{
-    category: string;
-    pct: number;
-  }>;
-  largeTx?: {
-    merchant: string;
-    amount: number;
-  } | null;
-  streak: number;
-  noSpendToday: boolean;
-  goalTop?: {
-    goal: string;
-    pct: number;
-    amountLeft: number;
-  } | null;
-  upcomingSub?: {
-    merchant: string;
-    amount: number;
-    date: Date;
-  } | null;
-  roundUp?: {
-    amount: number;
-    goal?: string;
-  } | null;
-  weeklyTop?: {
-    category: string;
-    total: number;
-  } | null;
-  quietCats: Array<{
-    category: string;
-    pct: number;
-  }>;
-  netMonth?: {
-    amount: number;
-    monthLabel: string;
-  } | null;
-  lowBalance?: {
-    account: string;
-    left: number;
-  } | null;
-  lastExpense?: {
-    merchant?: string;
-    amount?: number;
-  } | null;
-}
+export type QuoteGroup =
+  | 'over-budget'
+  | 'near-budget'
+  | 'weekly-repeats'
+  | 'large-transaction'
+  | 'net-cashflow'
+  | 'weekly-top'
+  | 'fallback';
 
 export interface QuoteResult {
-  group: string;
+  group: QuoteGroup;
   text: string;
   template: string;
   vars: Record<string, string>;
 }
 
-const FALLBACK_SIGNALS: DashboardSignals = {
-  weeklyRepeats: [],
-  nearBudget: [],
-  overBudget: [],
-  largeTx: null,
-  streak: 0,
-  noSpendToday: false,
-  goalTop: null,
-  upcomingSub: null,
-  roundUp: null,
-  weeklyTop: null,
-  quietCats: [],
-  netMonth: null,
-  lowBalance: null,
-  lastExpense: null,
-};
-
-function startOfWeek(date: Date): Date {
-  const clone = new Date(date);
-  const day = clone.getDay();
-  const diff = (day === 0 ? -6 : 1) - day;
-  clone.setDate(clone.getDate() + diff);
-  clone.setHours(0, 0, 0, 0);
-  return clone;
+interface QuoteCandidate {
+  group: QuoteGroup;
+  uniqueKey: string;
+  vars: Record<string, string>;
 }
 
-function startOfMonth(date: Date): Date {
-  const clone = new Date(date);
-  clone.setDate(1);
-  clone.setHours(0, 0, 0, 0);
-  return clone;
-}
-
-function endOfMonth(date: Date): Date {
-  const start = startOfMonth(date);
-  return new Date(start.getFullYear(), start.getMonth() + 1, 1);
-}
-
-function parseDate(value?: string | null): Date | null {
-  if (!value) return null;
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  return date;
-}
-
-function formatNumber(value: number | undefined | null): string {
-  if (!value) return '0';
-  return IDR.format(Math.round(value));
-}
-
-function normalizeName(...candidates: Array<string | null | undefined>): string {
-  for (const candidate of candidates) {
-    if (candidate && String(candidate).trim()) {
-      return String(candidate).trim();
-    }
-  }
-  return 'Item ini';
-}
-
-function sanitizeBudgetName(budget: BudgetLike): string {
-  return normalizeName(
-    budget.name,
-    budget.label,
-    budget.category_name,
-    budget.category_id ? `Kategori ${budget.category_id.slice(0, 4)}` : null,
-  );
-}
-
-function calculateBudgetActual(budget: BudgetLike): number {
-  if (typeof budget.activity?.actual === 'number') return budget.activity.actual;
-  if (typeof budget.actual === 'number') return budget.actual;
-  if (typeof budget.spent === 'number') return budget.spent;
-  return 0;
-}
-
-function calculateBudgetPlanned(budget: BudgetLike): number {
-  const planned = typeof budget.planned === 'number' ? budget.planned : 0;
-  const rollover = typeof budget.rollover_in === 'number' ? budget.rollover_in : 0;
-  return planned + rollover;
-}
-
-function uniqueKey(value: string): string {
-  return value.toLowerCase();
-}
-
-function computeRoundUp(amount: number): number {
-  if (!Number.isFinite(amount) || amount <= 0) return 0;
-  const rounded = Math.ceil(amount / 1000) * 1000;
-  const diff = rounded - amount;
-  if (diff <= 0 || diff >= 1000) return 0;
-  return diff;
-}
-
-export function fillTemplate(template: string, vars: Record<string, string | number>): string {
-  if (!template) return '';
-  return template.replace(/\{(\w+)\}/g, (_, key: string) => {
-    const value = vars[key];
-    if (value == null) return `{${key}}`;
-    return String(value);
-  });
-}
-
-export function getDashboardSignals({
-  fromTx = [],
-  budgets = [],
-  goals = [],
-  subs = [],
-  accounts = [],
-}: {
-  fromTx?: TransactionLike[];
-  budgets?: BudgetLike[];
-  goals?: GoalLike[];
-  subs?: SubscriptionLike[];
-  accounts?: AccountLike[];
-}): DashboardSignals {
-  if (!Array.isArray(fromTx)) {
-    return { ...FALLBACK_SIGNALS };
-  }
-
-  const now = new Date();
-  const weekStart = startOfWeek(now);
-  const weekEnd = new Date(weekStart);
-  weekEnd.setDate(weekStart.getDate() + 7);
-  const monthStart = startOfMonth(now);
-  const nextMonthStart = endOfMonth(now);
-
-  const txs = fromTx
-    .map((tx) => {
-      const dateObj = parseDate(tx.date);
-      return dateObj
-        ? {
-            ...tx,
-            dateObj,
-          }
-        : null;
-    })
-    .filter((tx): tx is TransactionLike & { dateObj: Date } => Boolean(tx));
-
-  const monthTxs = txs.filter(
-    (tx) => tx.dateObj >= monthStart && tx.dateObj < nextMonthStart,
-  );
-  const weekTxs = txs.filter((tx) => tx.dateObj >= weekStart && tx.dateObj < weekEnd);
-  const weekExpenses = weekTxs.filter((tx) => tx.type === 'expense');
-  const monthExpenses = monthTxs.filter((tx) => tx.type === 'expense');
-  const monthIncomes = monthTxs.filter((tx) => tx.type === 'income');
-
-  const weeklyRepeatMap = new Map<string, { merchant: string; count: number; total: number }>();
-  for (const tx of weekExpenses) {
-    const merchant = normalizeName(tx.merchant, tx.title, tx.notes);
-    const key = uniqueKey(merchant);
-    if (!weeklyRepeatMap.has(key)) {
-      weeklyRepeatMap.set(key, { merchant, count: 0, total: 0 });
-    }
-    const entry = weeklyRepeatMap.get(key)!;
-    entry.count += 1;
-    entry.total += Math.abs(Number(tx.amount ?? 0));
-  }
-  const weeklyRepeats = Array.from(weeklyRepeatMap.values())
-    .filter((entry) => entry.count >= 2)
-    .sort((a, b) => b.total - a.total);
-
-  const budgetSignals = Array.isArray(budgets)
-    ? budgets.map((budget) => {
-        const planned = calculateBudgetPlanned(budget);
-        const actual = calculateBudgetActual(budget);
-        const pct = planned > 0 ? (actual / planned) * 100 : 0;
-        return {
-          category: sanitizeBudgetName(budget),
-          pct: Number.isFinite(pct) ? pct : 0,
-        };
-      })
-    : [];
-
-  const overBudget = budgetSignals
-    .filter((budget) => budget.pct >= 100)
-    .sort((a, b) => b.pct - a.pct);
-  const nearBudget = budgetSignals
-    .filter((budget) => budget.pct >= 80 && budget.pct < 100)
-    .sort((a, b) => b.pct - a.pct);
-  const quietCats = budgetSignals
-    .filter((budget) => budget.pct > 0 && budget.pct < 20)
-    .sort((a, b) => a.pct - b.pct);
-
-  const largeTx = monthExpenses
-    .filter((tx) => Math.abs(Number(tx.amount ?? 0)) >= LARGE_TX_THRESHOLD)
-    .sort((a, b) => Math.abs(Number(b.amount ?? 0)) - Math.abs(Number(a.amount ?? 0)))[0];
-
-  const dateKeys = new Set<string>();
-  for (const tx of txs) {
-    const key = tx.dateObj.toDateString();
-    dateKeys.add(key);
-  }
-  let streak = 0;
-  while (true) {
-    const probe = new Date(now);
-    probe.setDate(now.getDate() - streak);
-    if (!dateKeys.has(probe.toDateString())) break;
-    streak += 1;
-  }
-
-  const todayKey = now.toDateString();
-  const noSpendToday = !monthExpenses.some((tx) => tx.dateObj.toDateString() === todayKey);
-
-  const goalCandidates = Array.isArray(goals)
-    ? goals
-        .map((goal) => {
-          const title = normalizeName(goal.title, goal.name, 'Goal');
-          const target = Number(goal.target_amount ?? 0);
-          const saved = Number(goal.saved_amount ?? 0);
-          const pct = target > 0 ? (saved / target) * 100 : 0;
-          const amountLeft = Math.max(target - saved, 0);
-          const status = goal.status ?? 'active';
-          return {
-            goal: title,
-            pct: Number.isFinite(pct) ? pct : 0,
-            amountLeft,
-            status,
-          };
-        })
-        .filter((goal) => goal.status !== 'archived')
-    : [];
-  const goalTop = goalCandidates
-    .filter((goal) => goal.pct > 0 || goal.amountLeft > 0)
-    .sort((a, b) => b.pct - a.pct)[0];
-
-  const upcomingCandidates = Array.isArray(subs)
-    ? subs
-        .map((sub) => {
-          const due = parseDate(sub.next_due_date ?? sub.due_date ?? sub.anchor_date);
-          if (!due) return null;
-          const merchant = normalizeName(sub.name, sub.vendor);
-          const amount = Math.abs(Number(sub.amount ?? 0));
-          return { merchant, amount, date: due };
-        })
-        .filter((item): item is { merchant: string; amount: number; date: Date } => Boolean(item))
-    : [];
-  const upcomingWindowEnd = new Date(now);
-  upcomingWindowEnd.setDate(now.getDate() + UPCOMING_SUB_WINDOW_DAYS);
-  const upcomingSub = upcomingCandidates
-    .filter((item) => item.date >= now && item.date <= upcomingWindowEnd)
-    .sort((a, b) => a.date.getTime() - b.date.getTime())[0];
-
-  const latestExpense = monthExpenses
-    .slice()
-    .sort((a, b) => b.dateObj.getTime() - a.dateObj.getTime())[0];
-  const roundUp = latestExpense
-    ? (() => {
-        const remainder = computeRoundUp(Math.abs(Number(latestExpense.amount ?? 0)));
-        if (remainder >= 100) {
-          return {
-            amount: remainder,
-            goal: goalTop?.goal,
-          };
-        }
-        return null;
-      })()
-    : null;
-
-  const weeklyCategoryMap = new Map<string, { label: string; total: number }>();
-  for (const tx of weekExpenses) {
-    const category = normalizeName(tx.category, tx.notes, 'Pengeluaran');
-    const key = uniqueKey(category);
-    const prev = weeklyCategoryMap.get(key);
-    if (prev) {
-      prev.total += Math.abs(Number(tx.amount ?? 0));
-    } else {
-      weeklyCategoryMap.set(key, {
-        label: category,
-        total: Math.abs(Number(tx.amount ?? 0)),
-      });
-    }
-  }
-  let weeklyTop: DashboardSignals['weeklyTop'] = null;
-  for (const entry of weeklyCategoryMap.values()) {
-    if (!weeklyTop || entry.total > weeklyTop.total) {
-      weeklyTop = {
-        category: entry.label,
-        total: entry.total,
-      };
-    }
-  }
-
-  const incomeTotal = monthIncomes.reduce((sum, tx) => sum + Math.abs(Number(tx.amount ?? 0)), 0);
-  const expenseTotal = monthExpenses.reduce(
-    (sum, tx) => sum + Math.abs(Number(tx.amount ?? 0)),
-    0,
-  );
-  const netMonth = {
-    amount: incomeTotal - expenseTotal,
-    monthLabel: MONTH_FORMAT.format(now),
-  };
-
-  const lowBalanceCandidate = Array.isArray(accounts)
-    ? accounts
-        .map((account) => ({
-          account: normalizeName(account.name, 'Akun'),
-          left: Number(account.balance ?? 0),
-        }))
-        .filter((account) => account.left > 0 && account.left < LOW_BALANCE_THRESHOLD)
-        .sort((a, b) => a.left - b.left)[0]
-    : null;
-
-  const lastExpense = latestExpense
-    ? {
-        merchant: normalizeName(
-          latestExpense.merchant,
-          latestExpense.title,
-          latestExpense.notes,
-        ),
-        amount: Math.abs(Number(latestExpense.amount ?? 0)),
-      }
-    : null;
-
-  return {
-    weeklyRepeats,
-    nearBudget,
-    overBudget,
-    largeTx: largeTx
-      ? {
-          merchant: normalizeName(largeTx.merchant, largeTx.title, largeTx.notes),
-          amount: Math.abs(Number(largeTx.amount ?? 0)),
-        }
-      : null,
-    streak,
-    noSpendToday,
-    goalTop: goalTop
-      ? {
-          goal: goalTop.goal,
-          pct: goalTop.pct,
-          amountLeft: goalTop.amountLeft,
-        }
-      : null,
-    upcomingSub: upcomingSub ?? null,
-    roundUp,
-    weeklyTop,
-    quietCats,
-    netMonth,
-    lowBalance: lowBalanceCandidate ?? null,
-    lastExpense,
-  };
-}
-
-const TEMPLATE_GROUPS = {
-  'weekly-repeats': [
-    'Minggu ini ketemu {merchant} {count}×. Dompet: tolong… (total Rp {total}).',
-    '{merchant} lagi {count}×? Kamu fans garis keras ya 😆 (total Rp {total}).',
-    'Radar cemilan bunyi! {merchant} muncul {count}×, total Rp {total}.',
-    'Boba itu manis, cicilan nggak. {merchant} {count}×, Rp {total} 👀.',
-    'Kita dukung—asal nabung juga. {merchant} {count}× (Rp {total}).',
+const TEMPLATE_GROUPS: Record<QuoteGroup, string[]> = {
+  'over-budget': [
+    'Waduh, {category} tembus {pct}%. Saatnya tekan remnya dulu 🚨',
+    '{category} sudah {pct}%. Yuk cek mana yang bisa dihemat?',
+    'Alert! {category} sudah over budget ({pct}%). Mau ku bantu cari solusi?',
   ],
   'near-budget': [
-    'Kategori {category} sudah {pct}%. Remnya dicoba dulu, ya 🛑',
-    '{category} tinggal dikit lagi. Aku pasang mode hemat? 😉',
-    "Dompet bisik: 'pelan-pelan di {category}' ({pct}%).",
-    'Check engine: {category} {pct}%. Pit stop dulu?',
+    '{category} sudah menyentuh {pct}%. Rem tipis dulu ya 😉',
+    'Kategori {category} di {pct}%. Mau alihin sebagian pos?',
+    'Hati-hati, {category} tinggal sedikit lagi ({pct}%).',
   ],
-  'over-budget': [
-    'Waduh, {category} tembus {pct}%. Kita susun misi penyelamatan? 🚑',
-    '{category} sudah lewat garis finish ({pct}%). Gas tabungannya pelan2 dulu.',
-    'Alarm dompet: {category} over budget. Mau aku bantu cari pos pengganti?',
-    'Overtime di {category} nih. Kita evaluasi bareng?',
+  'weekly-repeats': [
+    'Minggu ini ketemu {merchant} {count}×. Totalnya Rp {total}!',
+    '{merchant} muncul {count}× minggu ini (Rp {total}). Fans garis keras nih 😄',
+    'Radar belanja bunyi: {merchant} {count}×, total Rp {total}.',
   ],
   'large-transaction': [
-    'Transaksi jumbo Rp {amount}. Perlu dipecah (split) biar rapi?',
-    'Wuih, Rp {amount} sekali gesek. Ini belanja bahagia atau upgrade hidup? 😄',
-    'Rp {amount} terdeteksi. Simpen nota ya—biar histori kinclong.',
-    'Belanja besar masuk. Mau tandai sebagai one-off?',
-  ],
-  streak: [
-    'Kamu catat {streak} hari berturut-turut. Konsisten parah! 💪',
-    'Mantap! {streak} hari non-stop. Dompet auto sayang.',
-    'Nyaris jadi atlet pencatat: {streak} hari. Keep it rolling!',
-    'Streak {streak} hari! Aku kasih confetti virtual 🎉',
-  ],
-  'no-spend': [
-    'Hari ini nggak belanja. Dompet tepuk tangan 👏',
-    'No-spend day! Mari rayakan dengan… tidak belanja lagi 😁',
-    'Kosong belanja, penuh bahagia. Nice!',
-    'Dompet istirahat. Kamu hebat.',
-  ],
-  goal: [
-    'Goal {goal} sudah {pct}%. Dikit lagi, ayo sprint! 🏁',
-    'Kabar baik! {goal} tembus {pct}%. Mau auto-transfer Rp {amount}?',
-    '{goal} tercapai! 🎉 Bikin goal baru atau upgrade target?',
-    'Progres {goal} sehat ({pct}%). Aku jaga ritmenya ya.',
-  ],
-  subscription: [
-    'Inget ya, {merchant} bakal tagih Rp {amount} {date}. Masih kepake?',
-    'Langganan {merchant} datang {date}. Pause dulu atau lanjut?',
-    'Reminder: {merchant} (Rp {amount}). Mau auto-siapkan dana?',
-    'Tagihan {merchant} sebentar lagi. Biar aman, parkir duitnya?',
-  ],
-  'round-up': [
-    'Receh Rp {amount} nganggur. Aku sweep ke tabungan?',
-    'Biar estetik, bulatkan transaksi—lebihkan Rp {amount} ke {goal}?',
-    'Ada sisa Rp {amount}. Auto-nabungkan?',
-  ],
-  'weekly-summary': [
-    'Minggu ini top spend: {category} (Rp {total}). Mau batasin minggu depan?',
-    'Saldo mingguan aman. Aku siapin challenge mini hemat?',
-    'Highlights minggu ini siap! Spoiler: {merchant} sering lewat 😜',
-    'Rekap beres. Kita bikin rencana pekanan bareng?',
-  ],
-  'quiet-category': [
-    '{category} sepi bulan ini. Mau kecilkan anggarannya?',
-    'Budget {category} nganggur. Pindahin ke {goal}?',
-    '{category} adem ayem. Geser dikit ke tabungan?',
+    'Transaksi jumbo Rp {amount}. Mau tandai sebagai one-off?',
+    'Rp {amount} sekali gesek di {merchant}. Worth it?',
+    'Belanja besar Rp {amount}. Simpan nota biar histori rapi!',
   ],
   'net-cashflow': [
-    'Net {month}: Rp {amount}. Dompet senyum simpul 😌',
-    'Arus kas {month} aman. Mau lock in ke {goal}?',
-    'Bulan ini cuan Rp {amount}. Saatnya celebrate murah meriah?',
+    'Cashflow {month}: Rp {amount}. Mau review bareng?',
+    'Bulan {month} net Rp {amount}. Sudah sesuai harapan?',
+    '{month} mencatat cashflow Rp {amount}. Next step apa nih?',
   ],
-  'low-balance': [
-    'Saldo akun {account} tinggal Rp {left}. Isi bensin dikit?',
-    '{account} menipis (Rp {left}). Transfer dari akun lain?',
+  'weekly-top': [
+    'Kategori teratas minggu ini: {category} (Rp {total}).',
+    '{category} jadi juara minggu ini dengan Rp {total}.',
+    'Paling boros minggu ini: {category} senilai Rp {total}.',
   ],
   fallback: [
-    '{merchant} memanggil… dompet menangis—tapi bahagia.',
-    'Minum boba: +10 joy, -Rp {amount} balance. Worth it?',
-    'Kopi itu perlu, over-budget tidak. Santuy ya ☕',
+    'Dompet lagi santai, jadi aku kasih jokes aja: nabung itu kayak diet, niatnya besar godaannya lebih besar. 😄',
+    'Belum ada insight panas. Santuy dulu sambil bikin kopi favorit ☕️',
+    'Data sepi. Saatnya tarik napas, nikmati hari tanpa laporan berat 🙌',
   ],
 };
 
-interface QuoteCandidate {
-  group: keyof typeof TEMPLATE_GROUPS;
-  templateVars: Record<string, string>;
-  uniqueKey?: string;
-}
-
-const PRIORITY_ORDER: Array<keyof typeof TEMPLATE_GROUPS> = [
+const PRIORITY_ORDER: QuoteGroup[] = [
   'over-budget',
   'near-budget',
   'weekly-repeats',
   'large-transaction',
-  'low-balance',
-  'subscription',
   'net-cashflow',
-  'weekly-summary',
-  'streak',
-  'no-spend',
-  'quiet-category',
-  'round-up',
-  'goal',
+  'weekly-top',
   'fallback',
 ];
+
+export const highlightKeys = new Set(['category', 'pct', 'merchant', 'count', 'total', 'amount', 'month']);
+
+function normalizeKey(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/gi, '-');
+}
+
+function formatNumber(value: number): string {
+  return NUMBER_FORMAT.format(Math.max(0, Math.round(value)));
+}
+
+function formatSignedNumber(value: number): string {
+  const formatted = formatNumber(Math.abs(value));
+  return value < 0 ? `-${formatted}` : formatted;
+}
+
+function fillTemplate(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{(\w+)\}/g, (_, key) => vars[key] ?? '');
+}
+
+function buildCandidates(signals: DashboardSignals): Record<QuoteGroup, QuoteCandidate[]> {
+  const candidates: Record<QuoteGroup, QuoteCandidate[]> = {
+    'over-budget': signals.overBudget.map((item) => ({
+      group: 'over-budget',
+      uniqueKey: `over-${normalizeKey(item.category)}`,
+      vars: {
+        category: item.category,
+        pct: formatNumber(item.pct),
+      },
+    })),
+    'near-budget': signals.nearBudget.map((item) => ({
+      group: 'near-budget',
+      uniqueKey: `near-${normalizeKey(item.category)}`,
+      vars: {
+        category: item.category,
+        pct: formatNumber(item.pct),
+      },
+    })),
+    'weekly-repeats': signals.weeklyRepeats.map((item) => ({
+      group: 'weekly-repeats',
+      uniqueKey: `repeat-${normalizeKey(item.merchant)}`,
+      vars: {
+        merchant: item.merchant,
+        count: formatNumber(item.count),
+        total: formatNumber(item.total),
+      },
+    })),
+    'large-transaction': signals.largeTransaction
+      ? [
+          {
+            group: 'large-transaction',
+            uniqueKey: `large-${normalizeKey(signals.largeTransaction.merchant)}`,
+            vars: {
+              merchant: signals.largeTransaction.merchant,
+              amount: formatNumber(signals.largeTransaction.amount),
+            },
+          },
+        ]
+      : [],
+    'net-cashflow': signals.netCashflow
+      ? [
+          {
+            group: 'net-cashflow',
+            uniqueKey: `net-${normalizeKey(signals.netCashflow.month)}`,
+            vars: {
+              month: signals.netCashflow.month,
+              amount: formatSignedNumber(signals.netCashflow.amount),
+            },
+          },
+        ]
+      : [],
+    'weekly-top': signals.weeklyTop
+      ? [
+          {
+            group: 'weekly-top',
+            uniqueKey: `top-${normalizeKey(signals.weeklyTop.category)}`,
+            vars: {
+              category: signals.weeklyTop.category,
+              total: formatNumber(signals.weeklyTop.total),
+            },
+          },
+        ]
+      : [],
+    fallback: [
+      {
+        group: 'fallback',
+        uniqueKey: 'fallback',
+        vars: {},
+      },
+    ],
+  };
+
+  return candidates;
+}
 
 function pickRandom<T>(items: T[], rng: () => number): T {
   if (!items.length) {
@@ -591,179 +176,16 @@ function pickRandom<T>(items: T[], rng: () => number): T {
   return items[Math.max(0, Math.min(items.length - 1, index))];
 }
 
-function buildCandidates(signals: DashboardSignals): Record<string, QuoteCandidate[]> {
-  const monthName = MONTH_FORMAT.format(new Date());
-  const candidates: Record<string, QuoteCandidate[]> = {
-    'over-budget': signals.overBudget.map((item) => ({
-      group: 'over-budget',
-      uniqueKey: uniqueKey(item.category),
-      templateVars: {
-        category: item.category,
-        pct: formatNumber(Math.round(item.pct)),
-      },
-    })),
-    'near-budget': signals.nearBudget.map((item) => ({
-      group: 'near-budget',
-      uniqueKey: uniqueKey(item.category),
-      templateVars: {
-        category: item.category,
-        pct: formatNumber(Math.round(item.pct)),
-      },
-    })),
-    'weekly-repeats': signals.weeklyRepeats.map((item) => ({
-      group: 'weekly-repeats',
-      uniqueKey: uniqueKey(item.merchant),
-      templateVars: {
-        merchant: item.merchant,
-        count: formatNumber(item.count),
-        total: formatNumber(item.total),
-      },
-    })),
-    'large-transaction': signals.largeTx
-      ? [
-          {
-            group: 'large-transaction',
-            uniqueKey: uniqueKey(signals.largeTx.merchant),
-            templateVars: {
-              merchant: signals.largeTx.merchant,
-              amount: formatNumber(signals.largeTx.amount),
-            },
-          },
-        ]
-      : [],
-    streak:
-      signals.streak >= 2
-        ? [
-            {
-              group: 'streak',
-              uniqueKey: 'streak',
-              templateVars: { streak: formatNumber(signals.streak) },
-            },
-          ]
-        : [],
-    'no-spend': signals.noSpendToday
-      ? [
-          {
-            group: 'no-spend',
-            uniqueKey: 'no-spend',
-            templateVars: {},
-          },
-        ]
-      : [],
-    goal:
-      signals.goalTop && (signals.goalTop.pct >= 10 || signals.goalTop.amountLeft > 0)
-        ? [
-            {
-              group: 'goal',
-              uniqueKey: uniqueKey(signals.goalTop.goal),
-              templateVars: {
-                goal: signals.goalTop.goal,
-                pct: formatNumber(Math.round(signals.goalTop.pct)),
-                amount: formatNumber(Math.max(0, Math.round(signals.goalTop.amountLeft))),
-              },
-            },
-          ]
-        : [],
-    subscription: signals.upcomingSub
-      ? [
-          {
-            group: 'subscription',
-            uniqueKey: uniqueKey(signals.upcomingSub.merchant),
-            templateVars: {
-              merchant: signals.upcomingSub.merchant,
-              amount: formatNumber(signals.upcomingSub.amount),
-              date: SHORT_DATE_FORMAT.format(signals.upcomingSub.date),
-            },
-          },
-        ]
-      : [],
-    'round-up': signals.roundUp
-      ? [
-          {
-            group: 'round-up',
-            uniqueKey: 'round-up',
-            templateVars: {
-              amount: formatNumber(signals.roundUp.amount),
-              goal: signals.roundUp.goal ?? 'tabungan',
-            },
-          },
-        ]
-      : [],
-    'weekly-summary': signals.weeklyTop
-      ? [
-          {
-            group: 'weekly-summary',
-            uniqueKey: uniqueKey(signals.weeklyTop.category),
-            templateVars: {
-              category: signals.weeklyTop.category,
-              total: formatNumber(signals.weeklyTop.total),
-              merchant: signals.weeklyRepeats[0]?.merchant ?? signals.weeklyTop.category,
-            },
-          },
-        ]
-      : [],
-    'quiet-category': signals.quietCats.map((item) => ({
-      group: 'quiet-category',
-      uniqueKey: uniqueKey(item.category),
-      templateVars: {
-        category: item.category,
-        goal: signals.goalTop?.goal ?? 'tabungan',
-        pct: formatNumber(Math.round(item.pct)),
-      },
-    })),
-    'net-cashflow': signals.netMonth && Math.abs(signals.netMonth.amount) >= 1000
-      ? [
-          {
-            group: 'net-cashflow',
-            uniqueKey: 'net-cashflow',
-            templateVars: {
-              month: signals.netMonth.monthLabel ?? monthName,
-              amount: formatNumber(Math.round(signals.netMonth.amount)),
-              goal: signals.goalTop?.goal ?? 'tabungan',
-            },
-          },
-        ]
-      : [],
-    'low-balance': signals.lowBalance
-      ? [
-          {
-            group: 'low-balance',
-            uniqueKey: uniqueKey(signals.lowBalance.account),
-            templateVars: {
-              account: signals.lowBalance.account,
-              left: formatNumber(Math.round(signals.lowBalance.left)),
-            },
-          },
-        ]
-      : [],
-    fallback: [
-      {
-        group: 'fallback',
-        uniqueKey: 'fallback',
-        templateVars: {
-          merchant: signals.lastExpense?.merchant ?? 'boba',
-          amount: formatNumber(Math.max(0, Math.round(signals.lastExpense?.amount ?? 0))),
-        },
-      },
-    ],
-  };
-
-  return candidates;
-}
-
 export function generateQuotes(
-  signals: DashboardSignals,
+  signals: DashboardSignals | null,
   options: { max?: number; random?: () => number } = {},
 ): QuoteResult[] {
   const rng = options.random ?? Math.random;
   const maxQuotes = options.max ?? 3;
-  if (!signals) {
-    return generateQuotes({ ...FALLBACK_SIGNALS }, options);
-  }
-
-  const candidates = buildCandidates(signals);
-  const usedKeys = new Set<string>();
+  const source = signals ?? { ...EMPTY_SIGNALS };
+  const candidates = buildCandidates(source);
   const results: QuoteResult[] = [];
+  const usedKeys = new Set<string>();
 
   for (const group of PRIORITY_ORDER) {
     if (results.length >= maxQuotes) break;
@@ -774,178 +196,58 @@ export function generateQuotes(
         continue;
       }
       const templates = TEMPLATE_GROUPS[group];
-      if (!templates || !templates.length) continue;
+      if (!templates?.length) continue;
       const template = pickRandom(templates, rng);
-      const text = fillTemplate(template, candidate.templateVars);
-      results.push({
-        group,
-        text,
-        template,
-        vars: candidate.templateVars,
-      });
+      const text = fillTemplate(template, candidate.vars);
+      results.push({ group, text, template, vars: candidate.vars });
       if (candidate.uniqueKey) usedKeys.add(candidate.uniqueKey);
     }
   }
 
   if (!results.length) {
-    const template = TEMPLATE_GROUPS.fallback[0];
-    const vars = {
-      merchant: signals.lastExpense?.merchant ?? 'boba',
-      amount: formatNumber(Math.max(0, Math.round(signals.lastExpense?.amount ?? 0))),
-    };
-    results.push({
-      group: 'fallback',
-      text: fillTemplate(template, vars),
-      template,
-      vars,
-    });
+    const template = pickRandom(TEMPLATE_GROUPS.fallback, rng);
+    results.push({ group: 'fallback', text: template, template, vars: {} });
   }
 
   return results.slice(0, maxQuotes);
 }
 
-interface QuoteEngineSources {
-  transactions: TransactionLike[];
-  budgets: BudgetLike[];
-  goals: GoalLike[];
-  subscriptions: SubscriptionLike[];
-  accounts: AccountLike[];
-}
-
-interface QuoteEngineCacheEntry {
-  expiresAt: number;
-  value: QuoteEnginePayload;
-}
-
 export interface QuoteEnginePayload {
   fetchedAt: number;
-  sources: QuoteEngineSources;
   signals: DashboardSignals;
 }
 
-let quoteEngineCache: QuoteEngineCacheEntry | null = null;
-let inflightPromise: Promise<QuoteEnginePayload> | null = null;
-
-function formatDateInput(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
-
-async function loadSources(): Promise<QuoteEngineSources> {
-  const now = new Date();
-  const monthPreset = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
-  const weekStart = startOfWeek(now);
-  const weekEnd = new Date(weekStart);
-  weekEnd.setDate(weekStart.getDate() + UPCOMING_SUB_WINDOW_DAYS);
-
-  const dateFrom = formatDateInput(weekStart);
-  const dateTo = formatDateInput(weekEnd);
-
-  const [transactionsRes, budgetsRes, goalsRes, subsRes, accountsRes] = await Promise.allSettled([
-    import('./api').then(({ listTransactions }) =>
-      listTransactions({ period: { preset: 'month', month: monthPreset }, pageSize: 500, sort: 'date-desc' }),
-    ),
-    import('./api-budgets').then(({ listBudgets }) =>
-      listBudgets({ period: monthPreset, withActivity: true }).catch(() => []),
-    ),
-    import('./api-goals').then(({ listGoals }) =>
-      listGoals({ status: 'active' }).catch(() => ({ items: [] })),
-    ),
-    import('./api-subscriptions').then(({ listSubscriptions }) =>
-      listSubscriptions({ status: 'active', dueFrom: dateFrom, dueTo: dateTo }).catch(() => []),
-    ),
-    import('./api').then(({ listAccounts }) => listAccounts().catch(() => [])),
-  ]);
-
-  const transactions =
-    transactionsRes.status === 'fulfilled'
-      ? Array.isArray((transactionsRes.value as any)?.rows)
-        ? ((transactionsRes.value as any).rows as TransactionLike[])
-        : ((transactionsRes.value as unknown as TransactionLike[]) ?? [])
-      : [];
-
-  const budgets =
-    budgetsRes.status === 'fulfilled'
-      ? (budgetsRes.value as BudgetLike[])
-      : [];
-
-  const goals =
-    goalsRes.status === 'fulfilled'
-      ? ((goalsRes.value as { items?: GoalLike[] }).items ?? [])
-      : [];
-
-  const subscriptions =
-    subsRes.status === 'fulfilled'
-      ? (subsRes.value as SubscriptionLike[])
-      : [];
-
-  const accounts =
-    accountsRes.status === 'fulfilled'
-      ? (accountsRes.value as AccountLike[])
-      : [];
-
-  return { transactions, budgets, goals, subscriptions, accounts };
-}
+let cache: { expiresAt: number; payload: QuoteEnginePayload } | null = null;
+let inflight: Promise<QuoteEnginePayload> | null = null;
 
 export async function loadQuoteEngine({ force = false } = {}): Promise<QuoteEnginePayload> {
   const now = Date.now();
-  if (!force && quoteEngineCache && quoteEngineCache.expiresAt > now) {
-    return quoteEngineCache.value;
+  if (!force && cache && cache.expiresAt > now) {
+    return cache.payload;
   }
-  if (!force && inflightPromise) {
-    return inflightPromise;
+  if (!force && inflight) {
+    return inflight;
   }
 
-  inflightPromise = (async () => {
+  inflight = (async () => {
     try {
-      const sources = await loadSources();
-      const signals = getDashboardSignals({
-        fromTx: sources.transactions,
-        budgets: sources.budgets,
-        goals: sources.goals,
-        subs: sources.subscriptions,
-        accounts: sources.accounts,
-      });
+      const signals = await getDashboardSignals();
       const payload: QuoteEnginePayload = {
         fetchedAt: Date.now(),
-        sources,
         signals,
       };
-      quoteEngineCache = {
-        expiresAt: Date.now() + CACHE_TTL_MS,
-        value: payload,
-      };
+      cache = { expiresAt: Date.now() + CACHE_TTL_MS, payload };
       return payload;
     } catch (error) {
-      if (typeof console !== 'undefined') {
-        console.error('[HW][quotes] gagal memuat data quote', error);
-      }
-      const signals = getDashboardSignals({
-        fromTx: [],
-        budgets: [],
-        goals: [],
-        subs: [],
-        accounts: [],
-      });
+      cache = null;
       return {
         fetchedAt: Date.now(),
-        sources: {
-          transactions: [],
-          budgets: [],
-          goals: [],
-          subscriptions: [],
-          accounts: [],
-        },
-        signals,
+        signals: { ...EMPTY_SIGNALS },
       };
     } finally {
-      inflightPromise = null;
+      inflight = null;
     }
   })();
 
-  return inflightPromise;
+  return inflight;
 }
-
-export const highlightKeys = HIGHLIGHT_KEYS;


### PR DESCRIPTION
## Summary
- add a dashboard signal helper that queries the new Supabase views and normalizes the payloads
- rebuild the quote engine around the fetched signals with the requested priority order and refreshed templates
- update the QuoteBoard layout/labels so the refreshed quotes render cleanly and the refresh button simply reshuffles

## Testing
- pnpm lint *(fails with existing warnings in src/pages/AddWizard.jsx)*
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d235e0b1008332a20297902166ad45