### PR TITLE
Implement resume last page routing

### DIFF
--- a/src/guards/BootGate.tsx
+++ b/src/guards/BootGate.tsx
@@ -1,15 +1,81 @@
-import type { ReactNode } from 'react';
-import { useMode } from '../hooks/useMode';
+import { ReactNode, useEffect, useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useMode } from "../hooks/useMode";
+import { supabase } from "../lib/supabase";
+import { isPrivateRoute, normalizeRoute, readLastRoute } from "../lib/lastRoute";
 
 interface BootGateProps {
-  ready: boolean;
   children: ReactNode;
 }
 
-export default function BootGate({ ready, children }: BootGateProps) {
+export default function BootGate({ children }: BootGateProps) {
   const { mode } = useMode();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const initialLocationRef = useRef(location);
+  const [bootReady, setBootReady] = useState(false);
 
-  if (!ready || !mode) {
+  useEffect(() => {
+    let active = true;
+
+    async function restoreLastRoute() {
+      try {
+        const { data } = await supabase.auth.getSession();
+        if (!active) return;
+
+        const session = data.session ?? null;
+        if (session?.user) {
+          const stored = readLastRoute(session.user.id);
+          if (stored) {
+            const initialLocation = initialLocationRef.current;
+            const initialFull = normalizeRoute(
+              `${initialLocation.pathname}${initialLocation.search}${initialLocation.hash}`
+            );
+            const target = normalizeRoute(stored);
+            const isDefaultDestination =
+              !initialFull ||
+              initialFull === normalizeRoute("/") ||
+              initialFull === normalizeRoute("/auth");
+
+            if (target && isDefaultDestination && target !== initialFull) {
+              navigate(stored, { replace: true });
+            }
+          }
+        } else {
+          const globalLast = readLastRoute();
+          if (globalLast && !isPrivateRoute(globalLast)) {
+            const initialLocation = initialLocationRef.current;
+            const initialFull = normalizeRoute(
+              `${initialLocation.pathname}${initialLocation.search}${initialLocation.hash}`
+            );
+            const target = normalizeRoute(globalLast);
+            const isDefaultDestination =
+              !initialFull ||
+              initialFull === normalizeRoute("/") ||
+              initialFull === normalizeRoute("/auth");
+
+            if (target && isDefaultDestination && target !== initialFull) {
+              navigate(globalLast, { replace: true });
+            }
+          }
+        }
+      } catch {
+        // keep splash without logging to console
+      } finally {
+        if (active) {
+          setBootReady(true);
+        }
+      }
+    }
+
+    restoreLastRoute();
+
+    return () => {
+      active = false;
+    };
+  }, [navigate]);
+
+  if (!bootReady || !mode) {
     return (
       <div className="grid min-h-screen place-items-center bg-bg text-text">
         <div className="space-y-2 text-center">

--- a/src/hooks/useLastRouteTracker.js
+++ b/src/hooks/useLastRouteTracker.js
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from "react";
+import { useLocation } from "react-router-dom";
+import { isBlacklisted, writeLastRoute } from "../lib/lastRoute";
+
+const DEBOUNCE_MS = 150;
+
+export default function useLastRouteTracker(userId) {
+  const location = useLocation();
+  const timerRef = useRef();
+
+  useEffect(() => {
+    const fullPath = `${location.pathname}${location.search}${location.hash}`;
+
+    if (isBlacklisted(fullPath)) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = undefined;
+      return () => {
+        window.clearTimeout(timerRef.current);
+      };
+    }
+
+    window.clearTimeout(timerRef.current);
+    timerRef.current = window.setTimeout(() => {
+      writeLastRoute(userId, fullPath);
+    }, DEBOUNCE_MS);
+
+    return () => {
+      window.clearTimeout(timerRef.current);
+    };
+  }, [location.pathname, location.search, location.hash, userId]);
+}

--- a/src/lib/lastRoute.js
+++ b/src/lib/lastRoute.js
@@ -1,0 +1,118 @@
+const GLOBAL_KEY = "hw:lastRoute:global";
+const UID_PREFIX = "hw:lastRoute:uid:";
+const BLACKLIST_PATHS = ["/auth", "/logout", "/404"];
+const NOT_FOUND_PATTERNS = ["/404", "not-found"];
+const PUBLIC_PREFIXES = ["/auth", "/logout"];
+
+function parseRoute(path) {
+  if (typeof path !== "string") return null;
+  const trimmed = path.trim();
+  if (!trimmed) return null;
+
+  let rest = trimmed;
+  let hash = "";
+  let search = "";
+
+  const hashIndex = rest.indexOf("#");
+  if (hashIndex >= 0) {
+    hash = rest.slice(hashIndex);
+    rest = rest.slice(0, hashIndex);
+  }
+
+  const searchIndex = rest.indexOf("?");
+  if (searchIndex >= 0) {
+    search = rest.slice(searchIndex);
+    rest = rest.slice(0, searchIndex);
+  }
+
+  let pathname = rest || "/";
+  if (!pathname.startsWith("/")) pathname = `/${pathname}`;
+  if (pathname.length > 1) pathname = pathname.replace(/\/+$/, "");
+  if (!pathname) pathname = "/";
+
+  return { pathname, search, hash };
+}
+
+export function normalizeRoute(path) {
+  const parsed = parseRoute(path);
+  if (!parsed) return null;
+  return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+}
+
+export function isBlacklisted(path) {
+  const parsed = parseRoute(path);
+  if (!parsed) return true;
+  const { pathname } = parsed;
+  if (
+    BLACKLIST_PATHS.some(
+      (blocked) => pathname === blocked || pathname.startsWith(`${blocked}/`)
+    )
+  ) {
+    return true;
+  }
+  return NOT_FOUND_PATTERNS.some((pattern) => pathname.includes(pattern));
+}
+
+export function isPrivateRoute(path) {
+  const parsed = parseRoute(path);
+  if (!parsed) return false;
+  const { pathname } = parsed;
+  if (pathname === "/") return true;
+  return !PUBLIC_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
+  );
+}
+
+function sanitizeStoredRoute(path) {
+  const normalized = normalizeRoute(path);
+  if (!normalized) return null;
+  if (isBlacklisted(normalized)) return null;
+  return normalized;
+}
+
+function getUserKey(uid) {
+  return `${UID_PREFIX}${uid}`;
+}
+
+export function readLastRoute(uid) {
+  if (typeof window === "undefined" || !window.localStorage) return null;
+  try {
+    if (uid) {
+      const userValue = window.localStorage.getItem(getUserKey(uid));
+      const sanitized = sanitizeStoredRoute(userValue);
+      if (sanitized) return sanitized;
+    }
+    const globalValue = window.localStorage.getItem(GLOBAL_KEY);
+    const sanitizedGlobal = sanitizeStoredRoute(globalValue);
+    if (sanitizedGlobal) return sanitizedGlobal;
+  } catch {
+    // ignore storage errors
+  }
+  return null;
+}
+
+export function writeLastRoute(uid, path) {
+  if (typeof window === "undefined" || !window.localStorage) return;
+  const sanitized = sanitizeStoredRoute(path);
+  if (!sanitized) return;
+  try {
+    window.localStorage.setItem(GLOBAL_KEY, sanitized);
+    if (uid) {
+      window.localStorage.setItem(getUserKey(uid), sanitized);
+    }
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export function clearGlobalLastRoute() {
+  if (typeof window === "undefined" || !window.localStorage) return;
+  try {
+    window.localStorage.removeItem(GLOBAL_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+export const LAST_ROUTE_GLOBAL_KEY = GLOBAL_KEY;
+export const LAST_ROUTE_USER_PREFIX = UID_PREFIX;


### PR DESCRIPTION
## Summary
- add localStorage helpers and a debounced hook to persist the latest route globally and per user
- restore the last non-blacklisted route during boot and sign-in while avoiding the default redirect to "/"
- integrate the route tracker and updated auth handling in the app shell to keep the connection mode in sync

## Testing
- pnpm lint
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68d287fd1e408332917876617bf2a9cb