### PR TITLE
Implement last route persistence and restore

### DIFF
--- a/src/guards/BootGate.tsx
+++ b/src/guards/BootGate.tsx
@@ -1,15 +1,86 @@
 import type { ReactNode } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
 import { useMode } from '../hooks/useMode';
+import { supabase } from '../lib/supabase';
+import { isBlacklisted, isPrivateRoute, readLastRoute } from '../lib/lastRoute';
 
 interface BootGateProps {
   ready: boolean;
   children: ReactNode;
 }
 
+function getBasePath(path: string): string {
+  if (!path) return '/';
+  const hashIndex = path.indexOf('#');
+  const withoutHash = hashIndex >= 0 ? path.slice(0, hashIndex) : path;
+  const queryIndex = withoutHash.indexOf('?');
+  const base = queryIndex >= 0 ? withoutHash.slice(0, queryIndex) : withoutHash;
+  return base || '/';
+}
+
 export default function BootGate({ ready, children }: BootGateProps) {
   const { mode } = useMode();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [sessionReady, setSessionReady] = useState(false);
+  const initialPathRef = useRef('');
 
-  if (!ready || !mode) {
+  if (!initialPathRef.current) {
+    initialPathRef.current = `${location.pathname}${location.search}${location.hash}`;
+  }
+
+  const initialPath = initialPathRef.current || '/';
+  const initialBasePath = getBasePath(initialPath);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function restoreLastRoute() {
+      try {
+        const { data } = await supabase.auth.getSession();
+        if (cancelled) return;
+
+        const uid = data.session?.user?.id ?? null;
+
+        if (uid) {
+          const target = readLastRoute(uid);
+          if (target && initialPath !== target) {
+            if (initialBasePath === '/' || initialBasePath === '/auth') {
+              navigate(target, { replace: true });
+            }
+          } else if (!target && initialBasePath === '/auth') {
+            navigate('/', { replace: true });
+          }
+        } else {
+          const globalTarget = readLastRoute(null);
+          if (
+            globalTarget &&
+            !isPrivateRoute(globalTarget) &&
+            initialPath !== globalTarget &&
+            !isBlacklisted(globalTarget)
+          ) {
+            navigate(globalTarget, { replace: true });
+          }
+        }
+      } catch {
+        // keep console clean
+      } finally {
+        if (!cancelled) {
+          setSessionReady(true);
+        }
+      }
+    }
+
+    restoreLastRoute();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [initialBasePath, initialPath, navigate]);
+
+  if (!ready || !sessionReady || !mode) {
     return (
       <div className="grid min-h-screen place-items-center bg-bg text-text">
         <div className="space-y-2 text-center">

--- a/src/lib/lastRoute.ts
+++ b/src/lib/lastRoute.ts
@@ -1,0 +1,121 @@
+const GLOBAL_KEY = 'hw:lastRoute:global';
+const USER_KEY_PREFIX = 'hw:lastRoute:uid:';
+const BLACKLIST = ['/auth', '/logout', '/404'];
+
+const ABSOLUTE_URL_PATTERN = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//;
+
+function getStorage(): Storage | null {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return null;
+    }
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function toRelativePath(path: string): string | null {
+  if (typeof path !== 'string') return null;
+  const trimmed = path.trim();
+  if (!trimmed) return null;
+
+  if (ABSOLUTE_URL_PATTERN.test(trimmed)) {
+    try {
+      const url = new URL(trimmed);
+      return `${url.pathname}${url.search}${url.hash}` || '/';
+    } catch {
+      return null;
+    }
+  }
+
+  if (trimmed.startsWith('/')) {
+    return trimmed;
+  }
+
+  return `/${trimmed}`;
+}
+
+function extractBasePath(path: string | null | undefined): string {
+  const relative = typeof path === 'string' ? toRelativePath(path) : null;
+  if (!relative) return '/';
+  const hashIndex = relative.indexOf('#');
+  const queryIndex = relative.indexOf('?');
+  const endIndex = Math.min(
+    hashIndex === -1 ? relative.length : hashIndex,
+    queryIndex === -1 ? relative.length : queryIndex
+  );
+  const base = relative.slice(0, endIndex);
+  return base || '/';
+}
+
+function sanitizeStoredRoute(path: string | null | undefined): string | null {
+  if (typeof path !== 'string') return null;
+  const relative = toRelativePath(path);
+  if (!relative) return null;
+  if (isBlacklisted(relative)) return null;
+  return relative;
+}
+
+export function isBlacklisted(path: string | null | undefined): boolean {
+  if (!path) return true;
+  const base = extractBasePath(path);
+  return BLACKLIST.some((blocked) =>
+    base === blocked || base.startsWith(`${blocked}/`)
+  );
+}
+
+export function isPrivateRoute(path: string | null | undefined): boolean {
+  if (!path) return false;
+  if (isBlacklisted(path)) return false;
+  return true;
+}
+
+export function lastRouteKeyForUser(uid: string): string {
+  return `${USER_KEY_PREFIX}${uid}`;
+}
+
+export function readLastRoute(uid?: string | null): string | null {
+  const storage = getStorage();
+  if (!storage) return null;
+
+  const keys: string[] = [];
+  if (uid) keys.push(lastRouteKeyForUser(uid));
+  keys.push(GLOBAL_KEY);
+
+  for (const key of keys) {
+    try {
+      const candidate = sanitizeStoredRoute(storage.getItem(key));
+      if (candidate) return candidate;
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return null;
+}
+
+export function writeLastRoute(uid: string | null | undefined, path: string): void {
+  const storage = getStorage();
+  if (!storage) return;
+  const sanitized = sanitizeStoredRoute(path);
+  if (!sanitized) return;
+
+  try {
+    storage.setItem(GLOBAL_KEY, sanitized);
+  } catch {
+    /* ignore */
+  }
+
+  if (uid) {
+    try {
+      storage.setItem(lastRouteKeyForUser(uid), sanitized);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+export function getGlobalLastRouteKey(): string {
+  return GLOBAL_KEY;
+}


### PR DESCRIPTION
## Summary
- add a reusable last-route helper to persist global and per-user locations with blacklist handling
- record route changes with a debounced effect and restore the saved path during auth transitions
- update BootGate to resolve the correct initial route after validating the Supabase session before rendering the app

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d287fd1e408332917876617bf2a9cb