### PR TITLE
Add daily digest summary experience

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import {
 import AppSidebar from "./layout/AppSidebar";
 import MainLayout from "./layout/MainLayout";
 import SettingsPanel from "./components/SettingsPanel";
+import DailyDigest from "./components/DailyDigest";
 import SyncBanner from "./components/SyncBanner";
 import BootGate from "./guards/BootGate";
 
@@ -52,6 +53,7 @@ import MoneyTalkProvider, {
   useMoneyTalk,
 } from "./context/MoneyTalkContext.jsx";
 import { ModeProvider, useMode } from "./hooks/useMode";
+import useDailyDigest from "./hooks/useDailyDigest";
 import useLastRouteTracker from "./hooks/useLastRouteTracker";
 import { normalizeRoute, readLastRoute } from "./lib/lastRoute";
 
@@ -233,6 +235,11 @@ function AppShell({ prefs, setPrefs }) {
   const [sessionUser, setSessionUser] = useState(null);
   const [sessionChecked, setSessionChecked] = useState(false);
   const [profileSyncEnabled, setProfileSyncEnabled] = useState(true);
+  const dailyDigest = useDailyDigest({
+    transactions: data.txs,
+    userId: sessionUser?.id ?? null,
+    authReady: sessionChecked,
+  });
   const useCloud = mode === "online";
   const [catMeta, setCatMeta] = useState(() => {
     try {
@@ -958,6 +965,12 @@ function AppShell({ prefs, setPrefs }) {
 
   return (
     <CategoryProvider catMeta={catMeta}>
+      <DailyDigest
+        open={dailyDigest.open}
+        data={dailyDigest.data}
+        variant={dailyDigest.variant}
+        onClose={dailyDigest.close}
+      />
       <BootGate>
         <Routes>
           <Route path="/auth" element={<AuthLogin />} />

--- a/src/components/DailyDigest.tsx
+++ b/src/components/DailyDigest.tsx
@@ -1,0 +1,240 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import clsx from "clsx";
+import type { DailyDigestData } from "../hooks/useDailyDigest";
+import { useLockBodyScroll } from "../hooks/useLockBodyScroll";
+
+interface DailyDigestProps {
+  open: boolean;
+  data: DailyDigestData | null;
+  variant?: "modal" | "banner";
+  onClose: () => void;
+}
+
+const focusableSelectors = [
+  "a[href]",
+  "button",
+  "textarea",
+  "input[type=\"text\"]",
+  "input[type=\"email\"]",
+  "input[type=\"number\"]",
+  "input[type=\"search\"]",
+  "input[type=\"tel\"]",
+  "input[type=\"url\"]",
+  "input[type=\"date\"]",
+  "select",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("id-ID", {
+    style: "currency",
+    currency: "IDR",
+    minimumFractionDigits: 0,
+  }).format(Math.round(value));
+}
+
+function formatPercentage(direction: DailyDigestData["diffDirection"], value: number): string {
+  const rounded = Math.round(Math.abs(value));
+  if (direction === "flat") return "0%";
+  return `${direction === "down" ? "-" : "+"}${rounded}%`;
+}
+
+export default function DailyDigest({ open, data, variant = "modal", onClose }: DailyDigestProps) {
+  const [displayMode, setDisplayMode] = useState<"modal" | "banner">(variant);
+  const modalRef = useRef<HTMLDivElement | null>(null);
+  const okButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setDisplayMode(variant);
+    }
+  }, [open, variant]);
+
+  useLockBodyScroll(open && displayMode === "modal");
+
+  useEffect(() => {
+    if (!open || displayMode !== "modal") return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const container = modalRef.current;
+      if (!container) return;
+      const focusables = Array.from(
+        container.querySelectorAll<HTMLElement>(focusableSelectors),
+      ).filter((el) => !el.hasAttribute("disabled"));
+      if (!focusables.length) {
+        event.preventDefault();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (event.shiftKey) {
+        if (active === first || !container.contains(active)) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    const timer = window.setTimeout(() => {
+      if (okButtonRef.current) {
+        okButtonRef.current.focus();
+        return;
+      }
+      const container = modalRef.current;
+      if (!container) return;
+      const focusables = container.querySelectorAll<HTMLElement>(focusableSelectors);
+      focusables[0]?.focus();
+    }, 30);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      window.clearTimeout(timer);
+    };
+  }, [displayMode, onClose, open]);
+
+  const highlights = useMemo<DailyDigestData["topCategories"]>(() => {
+    if (!data) return [];
+    if (data.topCategories.length) return data.topCategories;
+    return data.topMerchants;
+  }, [data]);
+
+  if (!open || !data) return null;
+
+  const content = (
+    <div className="text-sm text-muted">
+      <div className="text-xs uppercase tracking-wide text-muted">{data.yesterdayLabel}</div>
+      <h2 id="daily-digest-title" className="mt-2 text-2xl font-semibold text-text">
+        Daily Digest
+      </h2>
+      <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{data.summary}</p>
+
+      <div className="mt-6 grid gap-3 sm:grid-cols-2">
+        <div className="rounded-2xl border border-border/60 bg-surface-1/95 p-4">
+          <div className="text-xs font-medium uppercase text-muted">Total Pengeluaran</div>
+          <div className="mt-2 text-xl font-semibold text-brand">{formatCurrency(data.totalSpent)}</div>
+        </div>
+        <div className="rounded-2xl border border-border/60 bg-surface-1/95 p-4">
+          <div className="text-xs font-medium uppercase text-muted">Jumlah Transaksi</div>
+          <div className="mt-2 text-xl font-semibold text-text">{data.transactionCount}</div>
+        </div>
+        <div className="rounded-2xl border border-border/60 bg-surface-1/95 p-4">
+          <div className="text-xs font-medium uppercase text-muted">Rata-rata 7 Hari</div>
+          <div className="mt-2 text-xl font-semibold text-text">{formatCurrency(data.average7Day)}</div>
+        </div>
+        <div className="rounded-2xl border border-border/60 bg-surface-1/95 p-4">
+          <div className="text-xs font-medium uppercase text-muted">Perbandingan</div>
+          <div
+            className={clsx("mt-2 text-xl font-semibold", {
+              "text-danger": data.diffDirection === "up",
+              "text-success": data.diffDirection === "down",
+              "text-text": data.diffDirection === "flat",
+            })}
+          >
+            {formatPercentage(data.diffDirection, data.diffPercent)}
+          </div>
+          <div className="text-xs text-muted">{data.comparisonSentence}</div>
+        </div>
+      </div>
+
+      {highlights.length ? (
+        <div className="mt-6 rounded-2xl border border-border/60 bg-surface-1/95 p-4">
+          <div className="text-xs font-medium uppercase text-muted">
+            {data.topCategories.length ? "Top Kategori" : "Top Merchant"}
+          </div>
+          <ul className="mt-3 space-y-2 text-sm text-text">
+            {highlights.map((item) => (
+              <li key={item.name} className="flex items-center justify-between gap-2">
+                <span>{item.name}</span>
+                <span className="font-medium text-brand">{formatCurrency(item.amount)}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <div className="mt-6 flex flex-wrap items-center justify-between gap-2">
+        <button
+          ref={okButtonRef}
+          type="button"
+          onClick={onClose}
+          className="inline-flex h-[44px] items-center justify-center rounded-xl bg-brand px-6 text-sm font-semibold text-brand-foreground shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+        >
+          Oke, mengerti
+        </button>
+        <button
+          type="button"
+          onClick={() => setDisplayMode("banner")}
+          className="inline-flex h-[44px] items-center justify-center rounded-xl border border-border bg-surface-1 px-4 text-sm font-medium text-text transition hover:bg-border/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+        >
+          Tampilkan ringkasan mini
+        </button>
+      </div>
+    </div>
+  );
+
+  if (displayMode === "banner") {
+    return createPortal(
+      <div className="fixed bottom-4 left-1/2 z-[95] w-[calc(100%-2rem)] max-w-md -translate-x-1/2 rounded-2xl border border-border/60 bg-surface-1/95 p-4 shadow-xl backdrop-blur">
+        <div className="text-xs uppercase text-muted">{data.yesterdayLabel}</div>
+        <div className="mt-1 text-base font-semibold text-text">Daily Digest</div>
+        <p className="mt-2 text-sm text-muted-foreground">{data.summary}</p>
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-[38px] items-center justify-center rounded-lg bg-brand px-4 text-sm font-semibold text-brand-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+          >
+            Oke, mengerti
+          </button>
+          <button
+            type="button"
+            onClick={() => setDisplayMode("modal")}
+            className="inline-flex h-[38px] items-center justify-center rounded-lg border border-border bg-surface-1 px-3 text-xs font-medium text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+          >
+            Lihat detail
+          </button>
+        </div>
+      </div>,
+      document.body,
+    );
+  }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[95] flex flex-col bg-black/50 px-4 py-6 md:items-center md:justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="daily-digest-title"
+    >
+      <div
+        ref={modalRef}
+        className="mx-auto flex h-full w-full max-w-2xl flex-col overflow-hidden rounded-3xl border border-border bg-surface-1/95 p-6 text-text shadow-2xl backdrop-blur md:h-auto md:max-h-[85vh] md:p-8"
+      >
+        <button
+          type="button"
+          aria-label="Tutup"
+          onClick={onClose}
+          className="ml-auto flex h-9 w-9 items-center justify-center rounded-full border border-border text-muted transition hover:bg-border/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+        >
+          ×
+        </button>
+        <div className="mt-2 flex-1 overflow-y-auto pr-1">
+          {content}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/hooks/useDailyDigest.ts
+++ b/src/hooks/useDailyDigest.ts
@@ -1,0 +1,325 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+const TIMEZONE = "Asia/Jakarta";
+const STORAGE_PREFIX = "hw:digest:last:";
+const DATE_FORMATTER = new Intl.DateTimeFormat("en-CA", {
+  timeZone: TIMEZONE,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+const HUMAN_DATE_FORMATTER = new Intl.DateTimeFormat("id-ID", {
+  timeZone: TIMEZONE,
+  weekday: "long",
+  day: "numeric",
+  month: "long",
+});
+const CURRENCY_FORMATTER = new Intl.NumberFormat("id-ID", {
+  style: "currency",
+  currency: "IDR",
+  minimumFractionDigits: 0,
+});
+
+export interface DigestTransaction {
+  amount?: number | string | null;
+  type?: string | null;
+  date?: string | null;
+  category?: string | null;
+  category_name?: string | null;
+  merchant?: string | null | { name?: string | null };
+  merchant_name?: string | null;
+  deleted_at?: string | null;
+}
+
+interface HighlightItem {
+  name: string;
+  amount: number;
+}
+
+export interface DailyDigestData {
+  totalSpent: number;
+  transactionCount: number;
+  average7Day: number;
+  diffPercent: number;
+  diffDirection: "up" | "down" | "flat";
+  topCategories: HighlightItem[];
+  topMerchants: HighlightItem[];
+  highlightLabel: string | null;
+  suggestion: string;
+  summary: string;
+  comparisonSentence: string;
+  yesterdayLabel: string;
+  yesterdayDate: string;
+}
+
+export interface UseDailyDigestOptions {
+  transactions?: DigestTransaction[] | null;
+  userId?: string | null;
+  authReady: boolean;
+}
+
+export interface UseDailyDigestResult {
+  open: boolean;
+  data: DailyDigestData | null;
+  close: () => void;
+  markSeen: () => void;
+  variant: "modal" | "banner";
+}
+
+function formatDateInZone(date: Date): string {
+  return DATE_FORMATTER.format(date);
+}
+
+function shiftLocalDateString(base: string, offset: number): string {
+  const [year, month, day] = base.split("-").map((part) => Number.parseInt(part, 10));
+  if (!year || !month || !day) return base;
+  const ref = new Date(Date.UTC(year, month - 1, day));
+  ref.setUTCDate(ref.getUTCDate() + offset);
+  const y = ref.getUTCFullYear();
+  const m = String(ref.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(ref.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+function getTransactionDate(tx: DigestTransaction): string | null {
+  if (!tx?.date) return null;
+  const parsed = new Date(tx.date);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return formatDateInZone(parsed);
+}
+
+function toNumber(value: number | string | null | undefined): number {
+  const numeric = typeof value === "string" ? Number.parseFloat(value) : Number(value ?? 0);
+  return Number.isFinite(numeric) ? numeric : 0;
+}
+
+function getMerchantName(tx: DigestTransaction): string | null {
+  const candidates: Array<string | null | undefined> = [
+    tx.merchant_name,
+    typeof tx.merchant === "string" ? tx.merchant : null,
+    tx.merchant && typeof tx.merchant === "object" ? tx.merchant.name : null,
+  ];
+  for (const candidate of candidates) {
+    const trimmed = typeof candidate === "string" ? candidate.trim() : "";
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+function getCategoryName(tx: DigestTransaction): string | null {
+  const candidates: Array<string | null | undefined> = [
+    tx.category,
+    tx.category_name,
+  ];
+  for (const candidate of candidates) {
+    const trimmed = typeof candidate === "string" ? candidate.trim() : "";
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+function summarizeHighlights(entries: HighlightItem[]): string | null {
+  if (!entries.length) return null;
+  if (entries.length === 1) return entries[0].name;
+  return `${entries[0].name} & ${entries[1].name}`;
+}
+
+function formatCurrency(value: number): string {
+  return CURRENCY_FORMATTER.format(Math.round(value));
+}
+
+function buildSummary(
+  totalSpent: number,
+  transactionCount: number,
+  diffDirection: "up" | "down" | "flat",
+  diffPercent: number,
+  average7Day: number,
+  suggestion: string,
+): { comparison: string; summary: string } {
+  const spendSentence = `Kemarin kamu belanja ${formatCurrency(totalSpent)} di ${transactionCount} transaksi.`;
+  let comparisonSentence: string;
+  if (average7Day > 0) {
+    if (diffDirection === "flat") {
+      comparisonSentence = "Itu setara dengan rata-rata 7 hari.";
+    } else if (diffDirection === "up") {
+      comparisonSentence = `Itu lebih tinggi ${Math.abs(Math.round(diffPercent))}% dari rata-rata 7 hari.`;
+    } else {
+      comparisonSentence = `Itu lebih rendah ${Math.abs(Math.round(diffPercent))}% dari rata-rata 7 hari.`;
+    }
+  } else {
+    comparisonSentence = "Belum ada cukup data untuk rata-rata 7 hari.";
+  }
+  const summary = `${spendSentence} ${comparisonSentence} ${suggestion}`.trim();
+  return { comparison: comparisonSentence, summary };
+}
+
+function computeHighlights(map: Map<string, number>): HighlightItem[] {
+  return Array.from(map.entries())
+    .filter(([, amount]) => amount > 0)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 2)
+    .map(([name, amount]) => ({ name, amount }));
+}
+
+function computeDigest(
+  transactions: DigestTransaction[] | null | undefined,
+  todayLocal: string,
+): DailyDigestData {
+  const yesterdayLocal = shiftLocalDateString(todayLocal, -1);
+  const weekStart = shiftLocalDateString(yesterdayLocal, -6);
+
+  const expenses = Array.isArray(transactions)
+    ? transactions.filter((tx) => tx && tx.type === "expense" && !tx.deleted_at)
+    : [];
+
+  let totalSpent = 0;
+  let transactionCount = 0;
+  const categoryTotals = new Map<string, number>();
+  const merchantTotals = new Map<string, number>();
+  let weekTotal = 0;
+
+  for (const tx of expenses) {
+    const date = getTransactionDate(tx);
+    if (!date) continue;
+
+    const amount = toNumber(tx.amount);
+    if (amount <= 0) continue;
+
+    if (date === yesterdayLocal) {
+      totalSpent += amount;
+      transactionCount += 1;
+      const category = getCategoryName(tx);
+      if (category) {
+        categoryTotals.set(category, (categoryTotals.get(category) || 0) + amount);
+      }
+      const merchant = getMerchantName(tx);
+      if (merchant) {
+        merchantTotals.set(merchant, (merchantTotals.get(merchant) || 0) + amount);
+      }
+    }
+
+    if (date >= weekStart && date <= yesterdayLocal) {
+      weekTotal += amount;
+    }
+  }
+
+  const average7Day = weekTotal / 7;
+  const diffPercent = average7Day > 0 ? ((totalSpent - average7Day) / average7Day) * 100 : 0;
+  const diffDirection: "up" | "down" | "flat" =
+    average7Day === 0 || Math.abs(diffPercent) < 0.5
+      ? "flat"
+      : diffPercent > 0
+      ? "up"
+      : "down";
+
+  const topCategories = computeHighlights(categoryTotals);
+  const topMerchants = computeHighlights(merchantTotals);
+
+  let suggestion = "Tetap pantau pengeluaran kecil ya 😉";
+  const highlightChoices = topCategories.length ? topCategories : topMerchants;
+  const highlightLabel = summarizeHighlights(highlightChoices);
+  if (highlightLabel) {
+    suggestion = diffDirection === "down"
+      ? `Mantap! Pertahankan kontrol di ${highlightLabel} ya 😉`
+      : `Coba hemat di ${highlightLabel} ya 😉`;
+  }
+
+  const { comparison, summary } = buildSummary(
+    totalSpent,
+    transactionCount,
+    diffDirection,
+    diffPercent,
+    average7Day,
+    suggestion,
+  );
+
+  const yesterdayDate = yesterdayLocal;
+  const yesterdayLabel = HUMAN_DATE_FORMATTER.format(
+    new Date(`${yesterdayLocal}T00:00:00+07:00`),
+  );
+
+  return {
+    totalSpent,
+    transactionCount,
+    average7Day,
+    diffPercent,
+    diffDirection,
+    topCategories,
+    topMerchants,
+    highlightLabel,
+    suggestion,
+    summary,
+    comparisonSentence: comparison,
+    yesterdayLabel,
+    yesterdayDate,
+  };
+}
+
+interface DigestState {
+  open: boolean;
+  data: DailyDigestData | null;
+  today: string;
+}
+
+const DEFAULT_STATE: DigestState = {
+  open: false,
+  data: null,
+  today: "",
+};
+
+export default function useDailyDigest({
+  transactions,
+  userId,
+  authReady,
+}: UseDailyDigestOptions): UseDailyDigestResult {
+  const [{ open, data, today }, setState] = useState<DigestState>(DEFAULT_STATE);
+
+  const storageKey = useMemo(
+    () => `${STORAGE_PREFIX}${userId ? userId : "anon"}`,
+    [userId],
+  );
+
+  useEffect(() => {
+    if (!authReady) return;
+    if (typeof window === "undefined") return;
+
+    const todayLocal = formatDateInZone(new Date());
+    let lastShown = "";
+    try {
+      lastShown = window.localStorage.getItem(storageKey) || "";
+    } catch {
+      lastShown = "";
+    }
+
+    if (lastShown === todayLocal) {
+      setState({ open: false, data: null, today: todayLocal });
+      return;
+    }
+
+    const digest = computeDigest(transactions ?? [], todayLocal);
+    setState({ open: true, data: digest, today: todayLocal });
+  }, [authReady, storageKey, transactions]);
+
+  const markSeen = useCallback(() => {
+    if (typeof window === "undefined") return;
+    const targetDate = today || formatDateInZone(new Date());
+    try {
+      window.localStorage.setItem(storageKey, targetDate);
+    } catch {
+      /* ignore */
+    }
+    setState((prev) => ({ ...prev, open: false }));
+  }, [storageKey, today]);
+
+  const close = useCallback(() => {
+    markSeen();
+  }, [markSeen]);
+
+  return {
+    open,
+    data,
+    close,
+    markSeen,
+    variant: "modal",
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable daily digest hook that aggregates yesterday’s spend, top categories, and 7-day comparisons in Asia/Jakarta time
- introduce a DailyDigest modal/banner component with focus trap, banner fallback, and storage tracking per user
- wire the digest into AppShell so it shows once per local day after auth resolution

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d291d9f6908332b4da7d96bfddbe72