### PR TITLE
Add daily digest modal for spending summary

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import AppSidebar from "./layout/AppSidebar";
 import MainLayout from "./layout/MainLayout";
 import SettingsPanel from "./components/SettingsPanel";
 import SyncBanner from "./components/SyncBanner";
+import DailyDigest from "./components/DailyDigest";
 import BootGate from "./guards/BootGate";
 
 import Dashboard from "./pages/Dashboard";
@@ -52,6 +53,7 @@ import MoneyTalkProvider, {
   useMoneyTalk,
 } from "./context/MoneyTalkContext.jsx";
 import { ModeProvider, useMode } from "./hooks/useMode";
+import useDailyDigest from "./hooks/useDailyDigest";
 import useLastRouteTracker from "./hooks/useLastRouteTracker";
 import { normalizeRoute, readLastRoute } from "./lib/lastRoute";
 
@@ -233,6 +235,11 @@ function AppShell({ prefs, setPrefs }) {
   const [sessionUser, setSessionUser] = useState(null);
   const [sessionChecked, setSessionChecked] = useState(false);
   const [profileSyncEnabled, setProfileSyncEnabled] = useState(true);
+  const dailyDigest = useDailyDigest({
+    transactions: data.txs,
+    userId: sessionUser?.id ?? null,
+    ready: sessionChecked,
+  });
   const useCloud = mode === "online";
   const [catMeta, setCatMeta] = useState(() => {
     try {
@@ -958,6 +965,14 @@ function AppShell({ prefs, setPrefs }) {
 
   return (
     <CategoryProvider catMeta={catMeta}>
+      <DailyDigest
+        open={dailyDigest.open}
+        mode={dailyDigest.mode}
+        data={dailyDigest.data}
+        onAcknowledge={dailyDigest.acknowledge}
+        onDismiss={dailyDigest.dismiss}
+        onReopen={dailyDigest.reopen}
+      />
       <BootGate>
         <Routes>
           <Route path="/auth" element={<AuthLogin />} />

--- a/src/components/DailyDigest.tsx
+++ b/src/components/DailyDigest.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useMemo, useRef } from "react";
+import { createPortal } from "react-dom";
+import { DailyDigestData, DailyDigestMode } from "../hooks/useDailyDigest";
+import { formatCurrency } from "../lib/format";
+import { useLockBodyScroll } from "../hooks/useLockBodyScroll";
+
+type DailyDigestProps = {
+  open: boolean;
+  mode: DailyDigestMode;
+  data: DailyDigestData | null;
+  onAcknowledge: () => void;
+  onDismiss: () => void;
+  onReopen: () => void;
+};
+
+const numberFormatter = new Intl.NumberFormat("id-ID");
+
+function classNames(...values: Array<string | false | null | undefined>) {
+  return values.filter(Boolean).join(" ");
+}
+
+export default function DailyDigest({
+  open,
+  mode,
+  data,
+  onAcknowledge,
+  onDismiss,
+  onReopen,
+}: DailyDigestProps) {
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  useLockBodyScroll(open && mode === "modal");
+
+  useEffect(() => {
+    if (!open || mode !== "modal") return undefined;
+    const dialog = dialogRef.current;
+    if (!dialog) return undefined;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    const getFocusable = () =>
+      dialog.querySelectorAll<HTMLElement>(
+        "a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex='-1'])"
+      );
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onDismiss();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const focusable = getFocusable();
+      if (focusable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey) {
+        if (document.activeElement === first || !dialog.contains(document.activeElement)) {
+          event.preventDefault();
+          last.focus();
+        }
+        return;
+      }
+      if (document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    const focusTimer = window.setTimeout(() => {
+      const autofocus = dialog.querySelector<HTMLElement>("[data-autofocus='true']");
+      if (autofocus) {
+        autofocus.focus();
+        return;
+      }
+      const focusable = getFocusable();
+      focusable[0]?.focus();
+    }, 30);
+
+    return () => {
+      window.clearTimeout(focusTimer);
+      window.removeEventListener("keydown", handleKeyDown);
+      previouslyFocused?.focus?.();
+    };
+  }, [open, mode, onDismiss]);
+
+  const diffColor = useMemo(() => {
+    if (!data) return "text-muted";
+    if (data.differenceDirection === "up") return "text-danger";
+    if (data.differenceDirection === "down") return "text-success";
+    return "text-muted";
+  }, [data]);
+
+  if (!open || !data) return null;
+
+  const modalContent = (
+    <div className="fixed inset-0 z-[110] flex flex-col bg-black/40 px-4 py-6 sm:py-10">
+      <div
+        role="presentation"
+        className="absolute inset-0"
+        onClick={onDismiss}
+      />
+      <div className="relative z-[111] mx-auto flex w-full max-w-xl flex-1 items-end justify-center sm:items-center">
+        <div
+          ref={dialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="daily-digest-title"
+          className="relative flex h-full w-full flex-col overflow-y-auto rounded-3xl border border-border/60 bg-surface-1/95 p-6 text-text shadow-xl backdrop-blur sm:h-auto sm:max-h-[90vh]"
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted">Daily Digest</p>
+              <h2 id="daily-digest-title" className="mt-1 text-2xl font-semibold leading-snug">
+                Ringkasan kemarin
+              </h2>
+              <p className="text-sm text-muted">{data.dateLabel}</p>
+            </div>
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-border text-sm text-muted transition hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+              aria-label="Tampilkan sebagai banner"
+            >
+              ×
+            </button>
+          </div>
+
+          <div className="mt-6 space-y-4">
+            <div className="rounded-3xl border border-border bg-surface-1/80 p-5 shadow-sm">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted">Total pengeluaran</p>
+              <p className="mt-2 text-3xl font-semibold tracking-tight">{formatCurrency(data.totalSpent)}</p>
+              <p className="text-sm text-muted">{numberFormatter.format(data.transactionCount)} transaksi</p>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="rounded-3xl border border-border bg-surface-1/80 p-4 shadow-sm">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted">Rata-rata 7 hari</p>
+                <p className="mt-2 text-lg font-semibold">{formatCurrency(data.average7Day)}</p>
+                <p className={classNames("text-xs font-semibold", diffColor)}>
+                  {data.differenceLabel} vs rata-rata
+                </p>
+              </div>
+              <div className="rounded-3xl border border-border bg-surface-1/80 p-4 shadow-sm">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted">Jumlah transaksi</p>
+                <p className="mt-2 text-lg font-semibold">{numberFormatter.format(data.transactionCount)}</p>
+                <p className="text-xs text-muted">di hari kemarin</p>
+              </div>
+            </div>
+
+            {data.topCategories.length ? (
+              <div className="rounded-3xl border border-border bg-surface-1/80 p-4 shadow-sm">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted">Kategori teratas</p>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {data.topCategories.map((item) => (
+                    <span
+                      key={`cat-${item.name}`}
+                      className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-surface-1 px-3 py-1 text-xs font-medium text-text"
+                    >
+                      <span>{item.name}</span>
+                      <span className="text-[11px] font-semibold text-muted">
+                        {formatCurrency(item.amount)}
+                      </span>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            {data.topMerchants.length ? (
+              <div className="rounded-3xl border border-border bg-surface-1/80 p-4 shadow-sm">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted">Merchant teratas</p>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {data.topMerchants.map((item) => (
+                    <span
+                      key={`merchant-${item.name}`}
+                      className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-surface-1 px-3 py-1 text-xs font-medium text-text"
+                    >
+                      <span>{item.name}</span>
+                      <span className="text-[11px] font-semibold text-muted">
+                        {formatCurrency(item.amount)}
+                      </span>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            <p className="text-sm leading-relaxed text-muted">{data.message}</p>
+          </div>
+
+          <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-2xl border border-border bg-transparent px-4 text-sm font-medium text-text transition hover:bg-border/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)] sm:w-auto"
+            >
+              Lihat nanti
+            </button>
+            <button
+              type="button"
+              data-autofocus="true"
+              onClick={onAcknowledge}
+              className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-2xl bg-brand px-4 text-sm font-semibold text-brand-foreground shadow-sm transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)] sm:w-auto"
+            >
+              Oke, mengerti
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  const bannerContent = (
+    <div className="fixed inset-x-4 bottom-6 z-[90] sm:left-auto sm:right-8 sm:w-[360px]">
+      <div className="flex items-start gap-3 rounded-3xl border border-border bg-surface-1/95 px-4 py-3 text-sm text-text shadow-xl backdrop-blur">
+        <div className="flex-1">
+          <p className="text-sm font-semibold">Daily Digest</p>
+          <p className="mt-1 text-xs leading-relaxed text-muted">{data.message}</p>
+        </div>
+        <div className="flex flex-col items-end gap-1">
+          <button
+            type="button"
+            onClick={onReopen}
+            className="text-xs font-semibold text-primary transition hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/45"
+          >
+            Lihat
+          </button>
+          <button
+            type="button"
+            onClick={onAcknowledge}
+            className="text-xs font-medium text-muted transition hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/45"
+          >
+            Selesai
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  if (mode === "banner") {
+    return createPortal(bannerContent, document.body);
+  }
+
+  return createPortal(modalContent, document.body);
+}

--- a/src/hooks/useDailyDigest.ts
+++ b/src/hooks/useDailyDigest.ts
@@ -1,0 +1,359 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { formatCurrency } from "../lib/format";
+
+type TransactionLike = {
+  id?: string | number;
+  date?: string | null;
+  created_at?: string | null;
+  amount?: number | string | null;
+  type?: string | null;
+  transaction_type?: string | null;
+  deleted_at?: string | null;
+  category?: string | null;
+  category_name?: string | null;
+  categories?: { name?: string | null } | null;
+  merchant?: string | null;
+  merchant_name?: string | null;
+  merchants?: { name?: string | null } | null;
+};
+
+export type DailyDigestMode = "modal" | "banner";
+
+export interface DailyDigestTopItem {
+  name: string;
+  amount: number;
+}
+
+export interface DailyDigestData {
+  date: string;
+  dateLabel: string;
+  totalSpent: number;
+  transactionCount: number;
+  average7Day: number;
+  differencePercent: number;
+  differenceLabel: string;
+  differenceDirection: "up" | "down" | "flat";
+  message: string;
+  topCategories: DailyDigestTopItem[];
+  topMerchants: DailyDigestTopItem[];
+}
+
+interface UseDailyDigestOptions {
+  transactions?: TransactionLike[] | null;
+  userId?: string | null;
+  ready: boolean;
+}
+
+interface UseDailyDigestResult {
+  open: boolean;
+  mode: DailyDigestMode;
+  data: DailyDigestData | null;
+  acknowledge: () => void;
+  dismiss: () => void;
+  reopen: () => void;
+}
+
+const TIMEZONE = "Asia/Jakarta";
+const DAY_IN_MS = 86400000;
+
+const isoFormatterCache = new Map<string, Intl.DateTimeFormat>();
+const labelFormatterCache = new Map<string, Intl.DateTimeFormat>();
+const numberFormatter = new Intl.NumberFormat("id-ID");
+
+function getIsoFormatter(timeZone: string) {
+  if (!isoFormatterCache.has(timeZone)) {
+    isoFormatterCache.set(
+      timeZone,
+      new Intl.DateTimeFormat("en-CA", {
+        timeZone,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      })
+    );
+  }
+  return isoFormatterCache.get(timeZone)!;
+}
+
+function getLabelFormatter(timeZone: string) {
+  if (!labelFormatterCache.has(timeZone)) {
+    labelFormatterCache.set(
+      timeZone,
+      new Intl.DateTimeFormat("id-ID", {
+        timeZone,
+        weekday: "long",
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+      })
+    );
+  }
+  return labelFormatterCache.get(timeZone)!;
+}
+
+function resolveLocalDate(
+  input: TransactionLike,
+  formatter: Intl.DateTimeFormat
+): string | null {
+  const raw = input?.date ?? input?.created_at;
+  if (!raw) return null;
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return formatter.format(parsed);
+}
+
+function resolveCategory(tx: TransactionLike): string | null {
+  return (
+    tx?.category ??
+    tx?.category_name ??
+    tx?.categories?.name ??
+    null
+  );
+}
+
+function resolveMerchant(tx: TransactionLike): string | null {
+  return tx?.merchant ?? tx?.merchant_name ?? tx?.merchants?.name ?? null;
+}
+
+function toAmount(value: TransactionLike["amount"]): number {
+  const parsed = Number(value ?? 0);
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.abs(parsed);
+}
+
+function buildMessage(
+  totalSpent: number,
+  transactionCount: number,
+  average7Day: number,
+  differencePercent: number,
+  focusName: string | null
+) {
+  const parts: string[] = [];
+  const formattedTotal = formatCurrency(totalSpent);
+  const countText = numberFormatter.format(transactionCount);
+
+  if (transactionCount > 0) {
+    parts.push(`Kemarin kamu belanja ${formattedTotal} di ${countText} transaksi.`);
+  } else {
+    parts.push("Kemarin kamu tidak ada pengeluaran.");
+  }
+
+  if (average7Day > 0 && transactionCount > 0) {
+    const rounded = Math.round(differencePercent);
+    const sign = rounded > 0 ? "+" : rounded < 0 ? "" : "";
+    if (rounded === 0) {
+      parts.push("Itu setara dengan rata-rata 7 hari.");
+    } else {
+      parts.push(`Itu ${sign}${rounded}% dari rata-rata 7 hari.`);
+    }
+  } else if (average7Day > 0) {
+    parts.push("Rata-rata 7 harimu tetap aman.");
+  } else if (transactionCount > 0) {
+    parts.push("Belum ada rata-rata 7 hari untuk dibandingkan.");
+  }
+
+  if (transactionCount > 0) {
+    const focus = focusName?.trim();
+    const label = focus && focus !== "Tanpa kategori" && focus !== "Tanpa merchant"
+      ? focus
+      : "pengeluaran harianmu";
+    parts.push(`Coba hemat di ${label} ya 😉`);
+  } else {
+    parts.push("Tetap pertahankan kebiasaan baik ini ya 😉");
+  }
+
+  return parts.join(" ");
+}
+
+function computeTop(
+  expenses: TransactionLike[],
+  resolver: (tx: TransactionLike) => string | null,
+  limit: number,
+  fallbackLabel: string
+): DailyDigestTopItem[] {
+  const map = new Map<string, number>();
+  expenses.forEach((tx) => {
+    const name = resolver(tx)?.trim();
+    const label = name && name.length ? name : fallbackLabel;
+    const prev = map.get(label) ?? 0;
+    map.set(label, prev + toAmount(tx.amount));
+  });
+  return Array.from(map.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([name, amount]) => ({ name, amount }));
+}
+
+function computeDigest(
+  transactions: TransactionLike[] | null | undefined,
+  timeZone: string
+): DailyDigestData {
+  const isoFormatter = getIsoFormatter(timeZone);
+  const labelFormatter = getLabelFormatter(timeZone);
+  const now = new Date();
+  const yesterdayDate = new Date(now.getTime() - DAY_IN_MS);
+  const yesterday = isoFormatter.format(yesterdayDate);
+  const dateLabel = labelFormatter.format(yesterdayDate);
+
+  const lastSevenDates = Array.from({ length: 7 }, (_, idx) =>
+    isoFormatter.format(new Date(now.getTime() - DAY_IN_MS * (idx + 1)))
+  );
+
+  const list = Array.isArray(transactions) ? transactions : [];
+  const totalsByDate = new Map<string, { total: number; count: number }>();
+  const yesterdayExpenses: TransactionLike[] = [];
+
+  list.forEach((tx) => {
+    if (!tx || tx.deleted_at) return;
+    const type = String(tx.type ?? tx.transaction_type ?? "").toLowerCase();
+    if (type !== "expense") return;
+    const localDate = resolveLocalDate(tx, isoFormatter);
+    if (!localDate) return;
+    const amount = toAmount(tx.amount);
+    if (localDate === yesterday) {
+      yesterdayExpenses.push(tx);
+    }
+    const stats = totalsByDate.get(localDate);
+    if (stats) {
+      stats.total += amount;
+      stats.count += 1;
+    } else {
+      totalsByDate.set(localDate, { total: amount, count: 1 });
+    }
+  });
+
+  const yesterdayStats = totalsByDate.get(yesterday) ?? { total: 0, count: 0 };
+  const totalSpent = yesterdayStats.total ?? 0;
+  const transactionCount = yesterdayExpenses.length;
+
+  const sevenDayTotal = lastSevenDates.reduce(
+    (sum, date) => sum + (totalsByDate.get(date)?.total ?? 0),
+    0
+  );
+  const average7Day = sevenDayTotal / lastSevenDates.length;
+
+  const differencePercent = average7Day > 0
+    ? ((totalSpent - average7Day) / average7Day) * 100
+    : 0;
+  const roundedDiff = Number.isFinite(differencePercent)
+    ? Math.round(differencePercent)
+    : 0;
+  const differenceLabel =
+    roundedDiff > 0
+      ? `+${roundedDiff}%`
+      : roundedDiff < 0
+      ? `${roundedDiff}%`
+      : "0%";
+  const differenceDirection =
+    roundedDiff > 0 ? "up" : roundedDiff < 0 ? "down" : "flat";
+
+  const topCategories = computeTop(
+    yesterdayExpenses,
+    resolveCategory,
+    2,
+    "Tanpa kategori"
+  );
+  const topMerchants = computeTop(
+    yesterdayExpenses,
+    resolveMerchant,
+    2,
+    "Tanpa merchant"
+  );
+
+  const focusCandidate =
+    topCategories.find((item) => item.name && item.name !== "Tanpa kategori")?.name ??
+    topMerchants.find((item) => item.name && item.name !== "Tanpa merchant")?.name ??
+    null;
+
+  const message = buildMessage(
+    totalSpent,
+    transactionCount,
+    average7Day,
+    differencePercent,
+    focusCandidate
+  );
+
+  return {
+    date: yesterday,
+    dateLabel,
+    totalSpent,
+    transactionCount,
+    average7Day,
+    differencePercent,
+    differenceLabel,
+    differenceDirection,
+    message,
+    topCategories,
+    topMerchants,
+  };
+}
+
+export default function useDailyDigest({
+  transactions,
+  userId,
+  ready,
+}: UseDailyDigestOptions): UseDailyDigestResult {
+  const timeZone = TIMEZONE;
+  const today = getIsoFormatter(timeZone).format(new Date());
+  const digestData = useMemo(
+    () => computeDigest(transactions, timeZone),
+    [transactions, timeZone]
+  );
+
+  const storageKey = `hw:digest:last:${userId ?? "anon"}`;
+  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<DailyDigestMode>("modal");
+
+  useEffect(() => {
+    if (!ready) return;
+    let lastShown: string | null = null;
+    try {
+      lastShown = localStorage.getItem(storageKey);
+    } catch {
+      lastShown = null;
+    }
+    if (lastShown === today) {
+      setOpen(false);
+      setMode("modal");
+      return;
+    }
+    if (!digestData) return;
+    setOpen((prev) => {
+      if (!prev) {
+        setMode("modal");
+      }
+      return true;
+    });
+  }, [ready, storageKey, today, digestData]);
+
+  const acknowledge = useCallback(() => {
+    try {
+      localStorage.setItem(storageKey, today);
+    } catch {
+      /* ignore */
+    }
+    setOpen(false);
+    setMode("modal");
+  }, [storageKey, today]);
+
+  const dismiss = useCallback(() => {
+    setMode("banner");
+    setOpen(true);
+  }, []);
+
+  const reopen = useCallback(() => {
+    if (!open) {
+      setOpen(true);
+    }
+    setMode("modal");
+  }, [open]);
+
+  return {
+    open,
+    mode,
+    data: digestData,
+    acknowledge,
+    dismiss,
+    reopen,
+  };
+}


### PR DESCRIPTION
## Summary
- add a `useDailyDigest` hook that aggregates yesterday's spending, seven day averages, and enforces the once-per-day display per user
- build a `DailyDigest` modal/banner component with focus trap and Asia/Jakarta-localised copy, then integrate it into `AppShell`

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d291d9f6908332b4da7d96bfddbe72