### PR TITLE
Fix persistent route restore behaviour

### DIFF
--- a/src/pages/AuthLogin.tsx
+++ b/src/pages/AuthLogin.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import LoginCard from '../components/auth/LoginCard';
 import ErrorBoundary from '../components/system/ErrorBoundary';
 import { getSession, onAuthStateChange } from '../lib/auth';
@@ -11,7 +11,6 @@ const heroTips = [
 ];
 
 export default function AuthLogin() {
-  const navigate = useNavigate();
   const location = useLocation();
   const [checking, setChecking] = useState(true);
   const [sessionError, setSessionError] = useState<string | null>(null);
@@ -30,7 +29,6 @@ export default function AuthLogin() {
         const session = await getSession();
         if (!isMounted) return;
         if (session) {
-          navigate('/', { replace: true });
           return;
         }
         setChecking(false);
@@ -52,7 +50,7 @@ export default function AuthLogin() {
           /* ignore */
         }
         if (location.pathname === '/auth') {
-          navigate('/', { replace: true });
+          return;
         }
       }
     });
@@ -61,7 +59,7 @@ export default function AuthLogin() {
       isMounted = false;
       listener?.subscription?.unsubscribe();
     };
-  }, [location.pathname, navigate]);
+    }, [location.pathname]);
 
   const skeleton = useMemo(
     () => (
@@ -87,7 +85,7 @@ export default function AuthLogin() {
     } catch {
       /* ignore */
     }
-    navigate('/', { replace: true });
+    // Navigasi ditangani oleh BootGate
   };
 
   return (


### PR DESCRIPTION
## Summary
- normalize stored routes, reuse blacklist checks, and centralize read/write helpers for last-route storage
- refactor the route persistence hook and BootGate so restores only happen once per session and writes are debounced with a skip-after-restore guard
- defer post-login navigation to BootGate to prevent flashes to the dashboard while still honoring invalid-route fallbacks

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d2bbcedf388332a1b6a483ee922e42