### PR TITLE
Prevent BootGate from overriding manual navigation

### DIFF
--- a/src/components/BootGate.tsx
+++ b/src/components/BootGate.tsx
@@ -126,6 +126,7 @@ export default function BootGate({ children }: BootGateProps) {
 
   useEffect(() => {
     let active = true;
+    const startPath = getCurrentPath();
     (async () => {
       try {
         const { data } = await supabase.auth.getSession();
@@ -134,9 +135,12 @@ export default function BootGate({ children }: BootGateProps) {
         const uid = session?.user?.id ?? null;
         currentUserIdRef.current = uid;
         const { target, invalid } = resolveStoredRoute(uid);
-        const restored = attemptRestore(target);
-        if (!restored && invalid) {
-          attemptFallbackToRoot();
+        const hasUserNavigated = !samePath(getCurrentPath(), startPath);
+        if (!hasUserNavigated) {
+          const restored = attemptRestore(target);
+          if (!restored && invalid) {
+            attemptFallbackToRoot();
+          }
         }
         restoredOnceRef.current = Boolean(session?.user);
       } catch {


### PR DESCRIPTION
## Summary
- avoid BootGate triggering a stored-route restore if the user has already navigated during boot

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d348ce48188332ad97f2a995e30aa8