### PR TITLE
Fix subscriptions page data fetching and add Vercel rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
## Summary
- add a Vercel SPA rewrite so `/subscriptions` refreshes no longer 404s
- expose Supabase helpers for listing and mutating subscription data via the JS SDK
- refactor the subscriptions page to load data with the new helpers, filter client-side, and surface friendly loading/error states

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d389336b348332923040b21cd608bf