### PR TITLE
Fix budgets routing and Supabase queries

### DIFF
--- a/src/components/budgets/AutoAllocateDialog.tsx
+++ b/src/components/budgets/AutoAllocateDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import Modal from '../Modal.jsx';
-import { bulkUpsertBudgets, listRules } from '../../lib/api-budgets';
+import { bulkUpsertBudgets, listRules, BudgetRulesUnavailableError } from '../../lib/api-budgets';
 import type { BudgetRuleRecord } from '../../lib/api-budgets';
 import type { BudgetViewModel } from './types';
 import { supabase } from '../../lib/supabase';
@@ -82,7 +82,11 @@ export default function AutoAllocateDialog({ open, onClose, period, budgets, onA
         const rows = await listRules();
         if (!cancelled) setRules(rows.filter((row) => row.active));
       } catch (error) {
-        addToast(`Gagal memuat aturan: ${error instanceof Error ? error.message : 'tidak diketahui'}`, 'error');
+        if (error instanceof BudgetRulesUnavailableError) {
+          if (!cancelled) setRules([]);
+        } else {
+          addToast(`Gagal memuat aturan: ${error instanceof Error ? error.message : 'tidak diketahui'}`, 'error');
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }

--- a/src/components/budgets/BudgetCard.tsx
+++ b/src/components/budgets/BudgetCard.tsx
@@ -5,7 +5,7 @@ interface BudgetCardProps {
   budget: BudgetViewModel;
   onOpenDetail: () => void;
   onEdit: (field: 'planned' | 'rollover_in', value: number) => void;
-  onRule: () => void;
+  onRule?: () => void;
   onDelete: () => void;
 }
 
@@ -97,13 +97,19 @@ export default function BudgetCard({ budget, onOpenDetail, onEdit, onRule, onDel
         />
       </div>
       <div className="grid grid-cols-3 gap-2 text-xs">
-        <button
-          type="button"
-          className="rounded-2xl border border-border px-3 py-2"
-          onClick={onRule}
-        >
-          Aturan
-        </button>
+        {onRule ? (
+          <button
+            type="button"
+            className="rounded-2xl border border-border px-3 py-2"
+            onClick={onRule}
+          >
+            Aturan
+          </button>
+        ) : (
+          <span className="rounded-2xl border border-dashed border-border px-3 py-2 text-muted">
+            Aturan tidak tersedia
+          </span>
+        )}
         <button
           type="button"
           className="rounded-2xl border border-border px-3 py-2"

--- a/src/components/budgets/BudgetRuleForm.tsx
+++ b/src/components/budgets/BudgetRuleForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useToast } from '../../context/ToastContext';
-import { deleteRule, upsertRule } from '../../lib/api-budgets';
+import { BudgetRulesUnavailableError, deleteRule, upsertRule } from '../../lib/api-budgets';
 import type { BudgetRuleRecord } from '../../lib/api-budgets';
 import type { BudgetViewModel } from './types';
 
@@ -40,7 +40,12 @@ export default function BudgetRuleForm({ budget, rule, onSaved }: BudgetRuleForm
       addToast('Aturan anggaran tersimpan', 'success');
       onSaved();
     } catch (error) {
-      addToast(`Gagal menyimpan aturan: ${error instanceof Error ? error.message : 'tidak diketahui'}`, 'error');
+      if (error instanceof BudgetRulesUnavailableError) {
+        addToast('Aturan anggaran belum tersedia di akun Anda', 'warning');
+        onSaved();
+      } else {
+        addToast(`Gagal menyimpan aturan: ${error instanceof Error ? error.message : 'tidak diketahui'}`, 'error');
+      }
     } finally {
       setLoading(false);
     }
@@ -54,7 +59,12 @@ export default function BudgetRuleForm({ budget, rule, onSaved }: BudgetRuleForm
       addToast('Aturan dihapus', 'success');
       onSaved();
     } catch (error) {
-      addToast(`Gagal menghapus aturan: ${error instanceof Error ? error.message : 'tidak diketahui'}`, 'error');
+      if (error instanceof BudgetRulesUnavailableError) {
+        addToast('Aturan anggaran belum tersedia di akun Anda', 'warning');
+        onSaved();
+      } else {
+        addToast(`Gagal menghapus aturan: ${error instanceof Error ? error.message : 'tidak diketahui'}`, 'error');
+      }
     } finally {
       setLoading(false);
     }

--- a/src/components/budgets/BudgetsTable.tsx
+++ b/src/components/budgets/BudgetsTable.tsx
@@ -11,7 +11,7 @@ interface BudgetsTableProps {
   ) => void;
   onOpenDetail: (budget: BudgetViewModel) => void;
   onDelete: (id: string) => void;
-  onManageRule: (budget: BudgetViewModel) => void;
+  onManageRule?: (budget: BudgetViewModel) => void;
   onComputeRollover: () => void;
   onApplyRollover: () => void;
 }
@@ -203,13 +203,19 @@ export default function BudgetsTable({
                   </td>
                   <td className="px-4 py-3">
                     <div className="flex flex-wrap gap-2 text-xs">
-                      <button
-                        type="button"
-                        className="rounded-xl border border-border px-3 py-1"
-                        onClick={() => onManageRule(budget)}
-                      >
-                        Atur Aturan
-                      </button>
+                      {onManageRule ? (
+                        <button
+                          type="button"
+                          className="rounded-xl border border-border px-3 py-1"
+                          onClick={() => onManageRule(budget)}
+                        >
+                          Atur Aturan
+                        </button>
+                      ) : (
+                        <span className="rounded-xl border border-dashed border-border px-3 py-1 text-muted">
+                          Aturan tidak tersedia
+                        </span>
+                      )}
                       <button
                         type="button"
                         className="rounded-xl border border-border px-3 py-1"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,42 @@
+import { supabase } from './supabase';
+
+export interface BudgetMonthRow {
+  id: string;
+  category_id: string | null;
+  amount_planned: number | null;
+  period_month: string;
+  current_spent: number | null;
+  name?: string | null;
+  notes?: string | null;
+  carryover_enabled?: boolean | null;
+}
+
+function normalizeMonthISO(input: string): string {
+  if (!input) {
+    throw new Error('Format bulan tidak valid');
+  }
+  const base = input.length === 7 ? `${input}-01` : input;
+  const parsed = new Date(`${base}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error('Format bulan tidak valid');
+  }
+  const year = parsed.getUTCFullYear();
+  const month = String(parsed.getUTCMonth() + 1).padStart(2, '0');
+  return `${year}-${month}-01`;
+}
+
+export async function listBudgetsByMonth(userId: string, monthISO: string) {
+  const periodMonth = normalizeMonthISO(monthISO);
+  const { data, error } = await supabase
+    .from('budgets')
+    .select('id, category_id, amount_planned, period_month, current_spent, name, notes, carryover_enabled')
+    .eq('user_id', userId)
+    .eq('period_month', periodMonth)
+    .order('category_id', { ascending: true });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []) as BudgetMonthRow[];
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
## Summary
- add a Vercel rewrite so SPA routes like /budgets resolve without a 404 on refresh
- replace manual REST budget calls with a Supabase SDK helper that uses the correct period_month schema
- disable rule-related UI when the budget_rules table is unavailable and surface friendly messaging

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d387741e308332803a16266ee60d6a