### PR TITLE
feat: add guest data driver scaffolding

### DIFF
--- a/src/hooks/useDataProvider.ts
+++ b/src/hooks/useDataProvider.ts
@@ -1,0 +1,111 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { Session } from '@supabase/supabase-js';
+import { supabase } from '../lib/supabase';
+import { CloudDriver, DataDriver, LocalDriver } from '../lib/data-driver';
+import { getGuestSyncTimestamp, syncGuestToCloud } from '../lib/sync';
+
+type ProviderMode = 'guest' | 'online';
+
+interface ProviderState {
+  driver: DataDriver;
+  mode: ProviderMode;
+  syncing: boolean;
+  error: Error | null;
+  session: Session | null;
+}
+
+const defaultState: ProviderState = {
+  driver: new LocalDriver(),
+  mode: 'guest',
+  syncing: false,
+  error: null,
+  session: null,
+};
+
+export function useDataProvider(): ProviderState {
+  const [state, setState] = useState<ProviderState>(defaultState);
+  const [session, setSession] = useState<Session | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    supabase.auth.getSession().then(({ data, error }) => {
+      if (cancelled) return;
+      if (error) {
+        console.error('[useDataProvider] Failed to fetch session', error);
+      }
+      setSession(data.session ?? null);
+    });
+
+    const { data: subscription } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+      setSession(nextSession);
+    });
+    return () => {
+      cancelled = true;
+      subscription.subscription.unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!session?.user) {
+      setState((prev) => ({
+        ...prev,
+        driver: new LocalDriver(),
+        mode: 'guest',
+        syncing: false,
+        error: null,
+        session: null,
+      }));
+      return;
+    }
+
+    const uid = session.user.id;
+    let cancelled = false;
+
+    setState((prev) => ({
+      ...prev,
+      syncing: true,
+      error: null,
+      session,
+    }));
+
+    const run = async () => {
+      let syncError: Error | null = null;
+      const syncedAt = getGuestSyncTimestamp(uid);
+      if (!syncedAt) {
+        try {
+          await syncGuestToCloud(supabase, uid);
+        } catch (err) {
+          console.error('[useDataProvider] Sync failed', err);
+          syncError = err instanceof Error ? err : new Error('Sync failed');
+        }
+      }
+      if (!cancelled) {
+        setState({
+          driver: new CloudDriver(supabase, uid),
+          mode: 'online',
+          syncing: false,
+          error: syncError,
+          session,
+        });
+      }
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [session]);
+
+  return useMemo(
+    () => ({
+      driver: state.driver,
+      mode: state.mode,
+      syncing: state.syncing,
+      error: state.error,
+      session: state.session,
+    }),
+    [state],
+  );
+}
+

--- a/src/lib/data-driver.ts
+++ b/src/lib/data-driver.ts
@@ -1,0 +1,223 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { idbGet, idbGetAll, idbPut, idbStores } from './idb';
+
+export type EntityName =
+  | 'transactions'
+  | 'categories'
+  | 'accounts'
+  | 'budgets'
+  | 'goals'
+  | 'debts'
+  | 'subscriptions'
+  | 'tags';
+
+export interface DataDriver<T = any> {
+  readonly mode: 'guest' | 'online';
+  list(entity: EntityName): Promise<T[]>;
+  get(entity: EntityName, clientId: string): Promise<T | null>;
+  insert(entity: EntityName, payload: Partial<T> & Record<string, any>): Promise<T>;
+  update(
+    entity: EntityName,
+    clientId: string,
+    payload: Partial<T> & Record<string, any>,
+  ): Promise<T>;
+  softDelete(entity: EntityName, clientId: string): Promise<void>;
+}
+
+const SOFT_DELETE_TABLES = new Set<EntityName>([
+  'transactions',
+  'categories',
+  'accounts',
+  'budgets',
+  'goals',
+  'debts',
+  'subscriptions',
+]);
+
+function nowISO() {
+  return new Date().toISOString();
+}
+
+function ensureClientRecord(payload: Record<string, any>) {
+  const clientId = payload.client_id ?? globalThis.crypto?.randomUUID?.();
+  const result = {
+    ...payload,
+    client_id: clientId ?? Math.random().toString(36).slice(2),
+  };
+  if (!result.id) {
+    result.id = result.client_id;
+  }
+  result.updated_at = payload.updated_at ?? nowISO();
+  return result;
+}
+
+export class LocalDriver implements DataDriver {
+  readonly mode = 'guest' as const;
+
+  async list<T = any>(entity: EntityName): Promise<T[]> {
+    if (!idbStores().includes(entity)) {
+      return [];
+    }
+    const rows = await idbGetAll(entity);
+    return rows.filter((row) => !row.deleted_at).map((row) => ({ ...row })) as T[];
+  }
+
+  async get<T = any>(entity: EntityName, clientId: string): Promise<T | null> {
+    const value = await idbGet(entity, clientId);
+    if (!value || value.deleted_at) return null;
+    return { ...value } as T;
+  }
+
+  async insert<T = any>(
+    entity: EntityName,
+    payload: Partial<T> & Record<string, any>,
+  ): Promise<T> {
+    const value = ensureClientRecord({ ...payload });
+    await idbPut(entity, value);
+    return { ...value } as T;
+  }
+
+  async update<T = any>(
+    entity: EntityName,
+    clientId: string,
+    payload: Partial<T> & Record<string, any>,
+  ): Promise<T> {
+    const existing = (await idbGet(entity, clientId)) ?? { client_id: clientId };
+    const value = ensureClientRecord({ ...existing, ...payload, client_id: clientId });
+    await idbPut(entity, value);
+    return { ...value } as T;
+  }
+
+  async softDelete(entity: EntityName, clientId: string): Promise<void> {
+    const existing = await idbGet(entity, clientId);
+    if (!existing) {
+      return;
+    }
+    const value = {
+      ...existing,
+      deleted_at: nowISO(),
+      updated_at: nowISO(),
+    };
+    await idbPut(entity, value);
+  }
+}
+
+export class CloudDriver implements DataDriver {
+  readonly mode = 'online' as const;
+  private client: SupabaseClient;
+  private userId: string;
+
+  constructor(client: SupabaseClient, userId: string) {
+    this.client = client;
+    this.userId = userId;
+  }
+
+  private ensureClientPayload(payload: Record<string, any>) {
+    const result = ensureClientRecord(payload);
+    result.user_id = this.userId;
+    if (!result.updated_at) {
+      result.updated_at = nowISO();
+    }
+    return result;
+  }
+
+  async list<T = any>(entity: EntityName): Promise<T[]> {
+    let query = this.client
+      .from(entity)
+      .select('*')
+      .eq('user_id', this.userId)
+      .order('updated_at', { ascending: false });
+    if (SOFT_DELETE_TABLES.has(entity)) {
+      query = query.is('deleted_at', null);
+    }
+    const { data, error } = await query;
+    if (error) {
+      console.error(`[CloudDriver] Failed to list ${entity}`, error);
+      throw error;
+    }
+    return (data ?? []) as T[];
+  }
+
+  async get<T = any>(entity: EntityName, clientId: string): Promise<T | null> {
+    const { data, error } = await this.client
+      .from(entity)
+      .select('*')
+      .eq('user_id', this.userId)
+      .eq('client_id', clientId)
+      .maybeSingle();
+    if (error) {
+      console.error(`[CloudDriver] Failed to get ${entity}`, error);
+      throw error;
+    }
+    if (!data || (SOFT_DELETE_TABLES.has(entity) && data.deleted_at)) {
+      return null;
+    }
+    return data as T;
+  }
+
+  async insert<T = any>(
+    entity: EntityName,
+    payload: Partial<T> & Record<string, any>,
+  ): Promise<T> {
+    const record = this.ensureClientPayload(payload);
+    const { data, error } = await this.client
+      .from(entity)
+      .upsert(record, { onConflict: 'user_id,client_id' })
+      .select()
+      .maybeSingle();
+    if (error) {
+      console.error(`[CloudDriver] Failed to upsert ${entity}`, error);
+      throw error;
+    }
+    return (data ?? record) as T;
+  }
+
+  async update<T = any>(
+    entity: EntityName,
+    clientId: string,
+    payload: Partial<T> & Record<string, any>,
+  ): Promise<T> {
+    const record = this.ensureClientPayload({ ...payload, client_id: clientId });
+    const { data, error } = await this.client
+      .from(entity)
+      .upsert(record, { onConflict: 'user_id,client_id' })
+      .select()
+      .maybeSingle();
+    if (error) {
+      console.error(`[CloudDriver] Failed to update ${entity}`, error);
+      throw error;
+    }
+    return (data ?? record) as T;
+  }
+
+  async softDelete(entity: EntityName, clientId: string): Promise<void> {
+    if (!SOFT_DELETE_TABLES.has(entity)) {
+      const { error: deleteError } = await this.client
+        .from(entity)
+        .delete()
+        .eq('user_id', this.userId)
+        .eq('client_id', clientId);
+      if (deleteError) {
+        console.error(`[CloudDriver] Failed to delete ${entity}`, deleteError);
+        throw deleteError;
+      }
+      return;
+    }
+    const { error } = await this.client
+      .from(entity)
+      .upsert(
+        {
+          user_id: this.userId,
+          client_id: clientId,
+          deleted_at: nowISO(),
+          updated_at: nowISO(),
+        },
+        { onConflict: 'user_id,client_id' },
+      );
+    if (error) {
+      console.error(`[CloudDriver] Failed to soft delete ${entity}`, error);
+      throw error;
+    }
+  }
+}
+

--- a/src/lib/idb.ts
+++ b/src/lib/idb.ts
@@ -1,0 +1,221 @@
+const DB_NAME = 'hematwoi';
+const DB_VERSION = 1;
+const STORES = [
+  'transactions',
+  'categories',
+  'accounts',
+  'budgets',
+  'goals',
+  'debts',
+  'subscriptions',
+  'tags',
+];
+
+type StoreName = (typeof STORES)[number];
+
+type StoreValue = Record<string, any> & { client_id: string };
+
+let dbPromise: Promise<IDBDatabase | null> | null = null;
+let fallback = false;
+
+function openDatabase(): Promise<IDBDatabase | null> {
+  if (fallback) return Promise.resolve(null);
+  if (!('indexedDB' in globalThis)) {
+    fallback = true;
+    return Promise.resolve(null);
+  }
+  if (!dbPromise) {
+    dbPromise = new Promise((resolve) => {
+      try {
+        const request = globalThis.indexedDB.open(DB_NAME, DB_VERSION);
+        request.onupgradeneeded = () => {
+          const db = request.result;
+          STORES.forEach((name) => {
+            if (!db.objectStoreNames.contains(name)) {
+              db.createObjectStore(name, { keyPath: 'client_id' });
+            }
+          });
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => {
+          console.warn('[idb] Falling back to localStorage', request.error);
+          fallback = true;
+          resolve(null);
+        };
+      } catch (err) {
+        console.warn('[idb] Failed to open IndexedDB, using fallback', err);
+        fallback = true;
+        resolve(null);
+      }
+    });
+  }
+  return dbPromise;
+}
+
+function withStore<T>(
+  name: StoreName,
+  mode: IDBTransactionMode,
+  handler: (store: IDBObjectStore) => Promise<T> | T,
+): Promise<T> {
+  return openDatabase().then((db) => {
+    if (!db) throw new Error('IndexedDB not available');
+    return new Promise<T>((resolve, reject) => {
+      try {
+        const tx = db.transaction(name, mode);
+        const store = tx.objectStore(name);
+        const result = handler(store);
+        const maybePromise = Promise.resolve(result);
+        maybePromise.then(resolve).catch(reject);
+        tx.onerror = () => reject(tx.error);
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+function lsKey(name: StoreName) {
+  return `hw:idb:${name}`;
+}
+
+function loadFromLocalStorage(name: StoreName): StoreValue[] {
+  if (!globalThis.localStorage) return [];
+  try {
+    const raw = globalThis.localStorage.getItem(lsKey(name));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((item) => item && typeof item === 'object');
+  } catch (err) {
+    console.warn('[idb] Failed to parse localStorage cache', err);
+    return [];
+  }
+}
+
+function saveToLocalStorage(name: StoreName, values: StoreValue[]) {
+  if (!globalThis.localStorage) return;
+  try {
+    globalThis.localStorage.setItem(lsKey(name), JSON.stringify(values));
+  } catch (err) {
+    console.warn('[idb] Failed to persist localStorage cache', err);
+  }
+}
+
+async function ensureArray(name: StoreName): Promise<StoreValue[]> {
+  if (!fallback) {
+    try {
+      const rows = await withStore(name, 'readonly', (store) => {
+        return new Promise<StoreValue[]>((resolve, reject) => {
+          const request = store.getAll();
+          request.onsuccess = () => resolve(request.result as StoreValue[]);
+          request.onerror = () => reject(request.error);
+        });
+      });
+      return rows || [];
+    } catch (err) {
+      console.warn('[idb] Failed to read store, switching to fallback', err);
+      fallback = true;
+    }
+  }
+  const cache = loadFromLocalStorage(name);
+  return cache;
+}
+
+export async function idbGetAll(name: StoreName): Promise<StoreValue[]> {
+  return ensureArray(name);
+}
+
+export async function idbGet(
+  name: StoreName,
+  clientId: string,
+): Promise<StoreValue | null> {
+  if (!fallback) {
+    try {
+      return await withStore(name, 'readonly', (store) => {
+        return new Promise<StoreValue | null>((resolve, reject) => {
+          const request = store.get(clientId);
+          request.onsuccess = () => resolve((request.result as StoreValue) ?? null);
+          request.onerror = () => reject(request.error);
+        });
+      });
+    } catch (err) {
+      console.warn('[idb] Failed to get record, switching to fallback', err);
+      fallback = true;
+    }
+  }
+  const rows = loadFromLocalStorage(name);
+  return rows.find((item) => item?.client_id === clientId) ?? null;
+}
+
+export async function idbPut(name: StoreName, value: StoreValue): Promise<void> {
+  if (!value?.client_id) {
+    throw new Error('idbPut requires client_id');
+  }
+  if (!fallback) {
+    try {
+      await withStore(name, 'readwrite', (store) => {
+        return new Promise<void>((resolve, reject) => {
+          const request = store.put(value);
+          request.onsuccess = () => resolve();
+          request.onerror = () => reject(request.error);
+        });
+      });
+      return;
+    } catch (err) {
+      console.warn('[idb] Failed to write record, switching to fallback', err);
+      fallback = true;
+    }
+  }
+  const rows = loadFromLocalStorage(name);
+  const next = rows.filter((item) => item?.client_id !== value.client_id);
+  next.push(value);
+  saveToLocalStorage(name, next);
+}
+
+export async function idbDelete(name: StoreName, clientId: string): Promise<void> {
+  if (!fallback) {
+    try {
+      await withStore(name, 'readwrite', (store) => {
+        return new Promise<void>((resolve, reject) => {
+          const request = store.delete(clientId);
+          request.onsuccess = () => resolve();
+          request.onerror = () => reject(request.error);
+        });
+      });
+      return;
+    } catch (err) {
+      console.warn('[idb] Failed to delete record, switching to fallback', err);
+      fallback = true;
+    }
+  }
+  const rows = loadFromLocalStorage(name);
+  const next = rows.filter((item) => item?.client_id !== clientId);
+  saveToLocalStorage(name, next);
+}
+
+export function idbClear(name: StoreName): Promise<void> {
+  if (!fallback) {
+    return withStore(name, 'readwrite', (store) => {
+      return new Promise<void>((resolve, reject) => {
+        const request = store.clear();
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(request.error);
+      });
+    }).catch((err) => {
+      console.warn('[idb] Failed to clear store, switching to fallback', err);
+      fallback = true;
+      saveToLocalStorage(name, []);
+    });
+  }
+  saveToLocalStorage(name, []);
+  return Promise.resolve();
+}
+
+export function idbUseFallback() {
+  return fallback;
+}
+
+export function idbStores() {
+  return [...STORES];
+}
+

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -1,0 +1,89 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { idbGetAll, idbPut, idbStores } from './idb';
+
+const SYNC_FLAG_PREFIX = 'hw:guestSynced:';
+const CHUNK_SIZE = 500;
+
+function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+function ensureClientId(value: Record<string, any>) {
+  if (value.client_id) return value.client_id;
+  const id = globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+  value.client_id = id;
+  if (!value.id) value.id = id;
+  return id;
+}
+
+function normalizePayload(value: Record<string, any>, uid: string) {
+  const clientId = ensureClientId(value);
+  const updatedAt = value.updated_at ?? new Date().toISOString();
+  return {
+    ...value,
+    user_id: uid,
+    client_id: clientId,
+    updated_at: updatedAt,
+  };
+}
+
+async function upsertChunk(
+  supabase: SupabaseClient,
+  table: string,
+  rows: Record<string, any>[],
+): Promise<void> {
+  if (!rows.length) return;
+  const { error } = await supabase
+    .from(table)
+    .upsert(rows, { onConflict: 'user_id,client_id' })
+    .select('client_id');
+  if (error) throw error;
+}
+
+export async function syncGuestToCloud(supabase: SupabaseClient, uid: string) {
+  const stores = idbStores();
+  for (const store of stores) {
+    const records = await idbGetAll(store as any);
+    if (!records.length) continue;
+    const payloads = await Promise.all(
+      records.map(async (row) => {
+        const normalized = normalizePayload({ ...row }, uid);
+        // ensure local copy has identifiers for future syncs
+        await idbPut(store as any, normalized);
+        return normalized;
+      }),
+    );
+
+    const batches = chunkArray(payloads, CHUNK_SIZE);
+    for (const batch of batches) {
+      try {
+        await upsertChunk(supabase, store, batch);
+      } catch (err) {
+        console.error(`[sync] Failed to sync ${store}`, err);
+        throw err;
+      }
+    }
+  }
+
+  try {
+    globalThis.localStorage?.setItem(
+      `${SYNC_FLAG_PREFIX}${uid}`,
+      new Date().toISOString(),
+    );
+  } catch (err) {
+    console.warn('[sync] Failed to persist sync flag', err);
+  }
+}
+
+export function getGuestSyncTimestamp(uid: string): string | null {
+  try {
+    return globalThis.localStorage?.getItem(`${SYNC_FLAG_PREFIX}${uid}`) ?? null;
+  } catch {
+    return null;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add IndexedDB helper with localStorage fallback for core entities
- create data drivers for guest and cloud modes that enforce client_id metadata
- introduce guest-to-cloud sync orchestration and hook for choosing drivers

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d3ce4d5ba88332904314dea68cb821