### PR TITLE
Handle unauthenticated access for cloud pages

### DIFF
--- a/src/hooks/useSupabaseUser.ts
+++ b/src/hooks/useSupabaseUser.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import type { User } from '@supabase/supabase-js';
+import { supabase } from '../lib/supabase';
+
+interface SupabaseUserState {
+  user: User | null;
+  loading: boolean;
+}
+
+export default function useSupabaseUser(): SupabaseUserState {
+  const [state, setState] = useState<SupabaseUserState>({ user: null, loading: true });
+
+  useEffect(() => {
+    let active = true;
+
+    supabase.auth
+      .getUser()
+      .then(({ data }) => {
+        if (!active) return;
+        setState({ user: data.user ?? null, loading: false });
+      })
+      .catch(() => {
+        if (!active) return;
+        setState({ user: null, loading: false });
+      });
+
+    const { data: subscription } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!active) return;
+      setState({ user: session?.user ?? null, loading: false });
+    });
+
+    return () => {
+      active = false;
+      subscription.subscription?.unsubscribe();
+    };
+  }, []);
+
+  return state;
+}


### PR DESCRIPTION
## Summary
- add a reusable hook for observing Supabase auth state
- guard accounts, subscriptions, and debts pages against unauthenticated sessions with user-facing notices
- disable cloud-only actions while offline to avoid repeated "auth missing" errors

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d3e06f823c83329842c9fdb8ab7274