### PR TITLE
Allow guest access to protected routes

### DIFF
--- a/src/guards/AuthGuard.tsx
+++ b/src/guards/AuthGuard.tsx
@@ -1,10 +1,24 @@
-import { ReactNode } from 'react';
-import { Navigate } from 'react-router-dom';
+import { ReactNode, useEffect } from 'react';
+
+function ensureLocalMode() {
+  if (typeof window === 'undefined') return;
+
+  try {
+    const storage = window.localStorage;
+    const hasSession = !!storage.getItem('session');
+    if (!hasSession) {
+      storage.setItem('hw:connectionMode', 'local');
+      storage.setItem('hw:mode', 'local');
+    }
+  } catch {
+    // ignore storage errors silently
+  }
+}
 
 export default function AuthGuard({ children }: { children: ReactNode }) {
-  const hasSession = typeof window !== 'undefined' && !!localStorage.getItem('session');
-  if (!hasSession) {
-    return <Navigate to="/auth" replace />;
-  }
+  useEffect(() => {
+    ensureLocalMode();
+  }, []);
+
   return <>{children}</>;
 }


### PR DESCRIPTION
## Summary
- update the AuthGuard so guests are not redirected to the auth page
- force the connection mode to local when no session is present to keep offline features working

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d3e91d3e248332a2a9d2bf7fc7cc9d