### PR TITLE
Fix category color form resetting on rerenders

### DIFF
--- a/src/components/categories/CategoryForm.tsx
+++ b/src/components/categories/CategoryForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useMemo, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import type { CategoryType } from "../../lib/api-categories";
 import ColorSwatch from "./ColorSwatch";
 
@@ -34,18 +34,13 @@ export default function CategoryForm({
   isSubmitting = false,
   allowTypeChange = mode === "create",
 }: CategoryFormProps) {
-  const defaults = useMemo(
-    () => ({
-      name: initialValues?.name ?? "",
-      color: initialValues?.color ?? "#64748B",
-      type: normalizeType(initialValues?.type),
-    }),
-    [initialValues]
-  );
+  const defaultName = initialValues?.name ?? "";
+  const defaultColor = initialValues?.color ?? "#64748B";
+  const defaultType = normalizeType(initialValues?.type);
 
-  const [name, setName] = useState(defaults.name);
-  const [color, setColor] = useState(defaults.color);
-  const [type, setType] = useState<CategoryType>(defaults.type);
+  const [name, setName] = useState(defaultName);
+  const [color, setColor] = useState(defaultColor);
+  const [type, setType] = useState<CategoryType>(defaultType);
   const [nameError, setNameError] = useState<string | null>(null);
   const [colorError, setColorError] = useState<string | null>(null);
 
@@ -53,12 +48,12 @@ export default function CategoryForm({
   const typeId = useId();
 
   useEffect(() => {
-    setName(defaults.name);
-    setColor(defaults.color);
-    setType(defaults.type);
+    setName(defaultName);
+    setColor(defaultColor);
+    setType(defaultType);
     setNameError(null);
     setColorError(null);
-  }, [defaults]);
+  }, [defaultName, defaultColor, defaultType]);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();


### PR DESCRIPTION
## Summary
- derive CategoryForm defaults from primitive values so parent rerenders no longer reset the form
- ensure the color picker remains editable after signing in by preventing unnecessary resets

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d3eb7a65f083328ae7a33f39a243af