### PR TITLE
feat: add admin panel with guard and settings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,9 +29,11 @@ import SettingsPage from "./pages/SettingsPage";
 import ProfilePage from "./pages/Profile";
 import AccountsPage from "./pages/AccountsPage";
 import AuthLogin from "./pages/AuthLogin";
+import AdminPage from "./pages/AdminPage";
 import ChallengesPage from "./pages/Challenges.jsx";
 import useChallenges from "./hooks/useChallenges.js";
 import AuthGuard from "./components/AuthGuard";
+import AdminGuard from "./components/AdminGuard";
 import { DataProvider } from "./context/DataContext";
 
 import { supabase } from "./lib/supabase";
@@ -1068,6 +1070,14 @@ function AppShell({ prefs, setPrefs }) {
                   element={<Navigate to="/transaction/add" replace />}
                 />
                 <Route path="settings" element={<SettingsPage />} />
+                <Route
+                  path="admin"
+                  element={
+                    <AdminGuard>
+                      <AdminPage />
+                    </AdminGuard>
+                  }
+                />
                 <Route
                   path="profile"
                   element={<ProfilePage transactions={data.txs} challenges={challenges} />}

--- a/src/components/AdminGuard.tsx
+++ b/src/components/AdminGuard.tsx
@@ -1,0 +1,50 @@
+import { ReactNode, useEffect, useRef } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import useIsAdmin from '../hooks/useIsAdmin';
+import { useToast } from '../context/ToastContext.jsx';
+
+type AdminGuardProps = {
+  children: ReactNode;
+};
+
+export default function AdminGuard({ children }: AdminGuardProps) {
+  const { addToast } = useToast();
+  const { user, loading, isAdmin, error } = useIsAdmin();
+  const location = useLocation();
+  const toastShownRef = useRef(false);
+
+  useEffect(() => {
+    if (loading) return;
+    if (error && !toastShownRef.current) {
+      addToast('Gagal memeriksa hak akses admin', 'error');
+      toastShownRef.current = true;
+      return;
+    }
+    if (user && !isAdmin && !toastShownRef.current) {
+      addToast('Akses admin diperlukan', 'error');
+      toastShownRef.current = true;
+    }
+  }, [addToast, loading, user, isAdmin, error]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center">
+        <div className="animate-pulse text-sm text-muted-foreground">Memeriksa akses admin…</div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/auth" state={{ from: location }} replace />;
+  }
+
+  if (error) {
+    return <Navigate to="/" replace />;
+  }
+
+  if (!isAdmin) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/hooks/useIsAdmin.ts
+++ b/src/hooks/useIsAdmin.ts
@@ -1,0 +1,121 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { User } from '@supabase/supabase-js';
+import { supabase } from '../lib/supabase';
+
+type AdminProfile = {
+  id: string;
+  role: 'user' | 'admin';
+  is_active: boolean | null;
+  updated_at?: string | null;
+};
+
+type AdminState = {
+  user: User | null;
+  profile: AdminProfile | null;
+  loading: boolean;
+  error: string | null;
+};
+
+type UseIsAdminResult = AdminState & {
+  isAdmin: boolean;
+  refresh: () => Promise<void>;
+};
+
+const INITIAL_STATE: AdminState = {
+  user: null,
+  profile: null,
+  loading: true,
+  error: null,
+};
+
+function normalizeProfile(row: any): AdminProfile | null {
+  if (!row) return null;
+  const role = row.role === 'admin' ? 'admin' : 'user';
+  let isActive: boolean | null = null;
+  if (typeof row.is_active === 'boolean') {
+    isActive = row.is_active;
+  } else if (row.is_active == null) {
+    isActive = null;
+  } else if (typeof row.is_active === 'number') {
+    isActive = row.is_active !== 0;
+  } else if (typeof row.is_active === 'string') {
+    isActive = row.is_active === 'true' || row.is_active === '1';
+  }
+
+  return {
+    id: String(row.id ?? ''),
+    role,
+    is_active: isActive,
+    updated_at: row.updated_at ?? null,
+  };
+}
+
+export default function useIsAdmin(): UseIsAdminResult {
+  const [state, setState] = useState<AdminState>(INITIAL_STATE);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const loadProfile = useCallback(async () => {
+    if (!mountedRef.current) return;
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+
+    try {
+      const { data: userData, error: userError } = await supabase.auth.getUser();
+      if (userError) throw userError;
+
+      const currentUser = userData.user ?? null;
+
+      if (!mountedRef.current) return;
+
+      if (!currentUser) {
+        setState({ user: null, profile: null, loading: false, error: null });
+        return;
+      }
+
+      const { data: profileData, error: profileError } = await supabase
+        .from('user_profiles')
+        .select('id, role, is_active, updated_at')
+        .eq('id', currentUser.id)
+        .maybeSingle();
+
+      if (profileError) throw profileError;
+
+      if (!mountedRef.current) return;
+
+      setState({
+        user: currentUser,
+        profile: normalizeProfile(profileData),
+        loading: false,
+        error: null,
+      });
+    } catch (err) {
+      if (!mountedRef.current) return;
+      const message = err instanceof Error ? err.message : 'Terjadi kesalahan saat memuat profil admin';
+      setState({ user: null, profile: null, loading: false, error: message });
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadProfile();
+    const { data: subscription } = supabase.auth.onAuthStateChange(() => {
+      void loadProfile();
+    });
+
+    return () => {
+      subscription.subscription?.unsubscribe();
+    };
+  }, [loadProfile]);
+
+  const refresh = useCallback(async () => {
+    await loadProfile();
+  }, [loadProfile]);
+
+  const isAdmin = state.profile?.role === 'admin';
+
+  return { ...state, isAdmin, refresh };
+}

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -1,0 +1,271 @@
+import type { PostgrestSingleResponse } from '@supabase/supabase-js';
+import { supabase } from './supabase';
+
+type AccessLevel = 'public' | 'user' | 'admin';
+
+export type RouteAccessRecord = {
+  id: string;
+  route: string;
+  access_level: AccessLevel;
+  is_enabled: boolean;
+  updated_at: string | null;
+  created_at?: string | null;
+};
+
+export type UpsertRouteInput = {
+  id?: string;
+  route: string;
+  access_level: AccessLevel;
+  is_enabled: boolean;
+};
+
+type UserRole = 'user' | 'admin';
+
+export type UserProfileRecord = {
+  id: string;
+  email?: string | null;
+  username?: string | null;
+  role: UserRole;
+  is_active: boolean;
+  created_at: string | null;
+  updated_at?: string | null;
+};
+
+export type CreateUserProfileInput = {
+  id?: string;
+  username?: string;
+  email?: string;
+  role: UserRole;
+  is_active: boolean;
+};
+
+export type UpdateUserProfileInput = Partial<Pick<UserProfileRecord, 'role' | 'is_active'>>;
+
+type Nullable<T> = T | null;
+
+function ensureResponse<T>(response: PostgrestSingleResponse<T>): T {
+  if (response.error) {
+    throw response.error;
+  }
+  return response.data as T;
+}
+
+function isUnknownColumnError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const code = 'code' in error ? String((error as { code?: string }).code) : '';
+  if (code === '42703') return true;
+  const message = 'message' in error ? String((error as { message?: string }).message).toLowerCase() : '';
+  return message.includes('column') && message.includes('email');
+}
+
+function sanitizeBoolean(value: unknown, fallback = false): boolean {
+  if (typeof value === 'boolean') return value;
+  if (value == null) return fallback;
+  if (typeof value === 'number') return value !== 0;
+  if (typeof value === 'string') return value === 'true' || value === '1';
+  return fallback;
+}
+
+function mapUserProfileRow(row: any): UserProfileRecord {
+  return {
+    id: String(row?.id ?? ''),
+    email: 'email' in (row ?? {}) ? row.email ?? null : null,
+    username: row?.username ?? null,
+    role: (row?.role as UserRole) === 'admin' ? 'admin' : 'user',
+    is_active: sanitizeBoolean(row?.is_active, true),
+    created_at: row?.created_at ?? null,
+    updated_at: row?.updated_at ?? null,
+  };
+}
+
+export async function listRoutes(): Promise<RouteAccessRecord[]> {
+  const { data, error } = await supabase
+    .from('app_routes_access')
+    .select('id, route, access_level, is_enabled, updated_at, created_at')
+    .order('route', { ascending: true });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((item) => ({
+    id: String(
+      item.id ??
+        item.route ??
+        globalThis.crypto?.randomUUID?.() ??
+        Math.random().toString(36).slice(2)
+    ),
+    route: String(item.route ?? ''),
+    access_level: (item.access_level as AccessLevel) ?? 'public',
+    is_enabled: sanitizeBoolean(item.is_enabled, true),
+    updated_at: item.updated_at ?? null,
+    created_at: item.created_at ?? null,
+  }));
+}
+
+export async function upsertRoute(input: UpsertRouteInput): Promise<RouteAccessRecord> {
+  const payload: Record<string, unknown> = {
+    route: input.route,
+    access_level: input.access_level,
+    is_enabled: input.is_enabled,
+  };
+
+  if (input.id) {
+    payload.id = input.id;
+  }
+
+  const response = await supabase
+    .from('app_routes_access')
+    .upsert(payload, { onConflict: 'route' })
+    .select('id, route, access_level, is_enabled, updated_at, created_at')
+    .single();
+
+  const data = ensureResponse(response);
+
+  return {
+    id: String(
+      data.id ??
+        input.id ??
+        data.route ??
+        globalThis.crypto?.randomUUID?.() ??
+        Math.random().toString(36).slice(2)
+    ),
+    route: String(data.route ?? input.route),
+    access_level: (data.access_level as AccessLevel) ?? input.access_level,
+    is_enabled: sanitizeBoolean(data.is_enabled, input.is_enabled),
+    updated_at: data.updated_at ?? null,
+    created_at: data.created_at ?? null,
+  };
+}
+
+export async function deleteRoute(id: string): Promise<void> {
+  const { error } = await supabase.from('app_routes_access').delete().eq('id', id);
+  if (error) {
+    throw error;
+  }
+}
+
+export async function listUsers(): Promise<UserProfileRecord[]> {
+  const columnsWithEmail = 'id, email, username, role, is_active, created_at, updated_at';
+  const columnsFallback = 'id, username, role, is_active, created_at, updated_at';
+
+  let { data, error } = await supabase
+    .from('user_profiles')
+    .select(columnsWithEmail)
+    .order('created_at', { ascending: true });
+
+  if (error && isUnknownColumnError(error)) {
+    ({ data, error } = await supabase
+      .from('user_profiles')
+      .select(columnsFallback)
+      .order('created_at', { ascending: true }));
+  }
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((item) => mapUserProfileRow(item));
+}
+
+export async function updateUserProfile(
+  id: string,
+  updates: UpdateUserProfileInput
+): Promise<UserProfileRecord> {
+  const payload: Record<string, unknown> = {};
+  if (updates.role) {
+    payload.role = updates.role;
+  }
+  if (typeof updates.is_active === 'boolean') {
+    payload.is_active = updates.is_active;
+  }
+
+  let response = await supabase
+    .from('user_profiles')
+    .update(payload)
+    .eq('id', id)
+    .select('id, email, username, role, is_active, created_at, updated_at')
+    .single();
+
+  if (response.error && isUnknownColumnError(response.error)) {
+    response = await supabase
+      .from('user_profiles')
+      .update(payload)
+      .eq('id', id)
+      .select('id, username, role, is_active, created_at, updated_at')
+      .single();
+  }
+
+  const data = ensureResponse(response);
+
+  return mapUserProfileRow(data);
+}
+
+export async function createUserProfile(
+  input: CreateUserProfileInput
+): Promise<UserProfileRecord> {
+  const payload: Record<string, unknown> = {
+    role: input.role,
+    is_active: input.is_active,
+  };
+
+  if (input.id) payload.id = input.id;
+  if (input.username) payload.username = input.username;
+  if (input.email) payload.email = input.email;
+
+  let response = await supabase
+    .from('user_profiles')
+    .insert(payload)
+    .select('id, email, username, role, is_active, created_at, updated_at')
+    .single();
+
+  if (response.error && isUnknownColumnError(response.error)) {
+    delete payload.email;
+    response = await supabase
+      .from('user_profiles')
+      .insert(payload)
+      .select('id, username, role, is_active, created_at, updated_at')
+      .single();
+  }
+
+  const data = ensureResponse(response);
+
+  return mapUserProfileRow(data);
+}
+
+export async function getAppDescription(): Promise<string> {
+  const { data, error } = await supabase
+    .from('app_settings')
+    .select('value')
+    .eq('key', 'app_description')
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  const text =
+    typeof data?.value === 'object' && data?.value !== null && 'text' in data.value
+      ? (data.value.text as Nullable<string>)
+      : null;
+
+  return text ?? '';
+}
+
+export async function setAppDescription(text: string): Promise<string> {
+  const { error } = await supabase
+    .from('app_settings')
+    .upsert(
+      {
+        key: 'app_description',
+        value: { text },
+      },
+      { onConflict: 'key' }
+    );
+
+  if (error) {
+    throw error;
+  }
+
+  return text;
+}

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,0 +1,812 @@
+import type { ReactNode } from 'react';
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import clsx from 'clsx';
+import {
+  createUserProfile,
+  deleteRoute,
+  getAppDescription,
+  listRoutes,
+  listUsers,
+  setAppDescription,
+  updateUserProfile,
+  upsertRoute,
+  type RouteAccessRecord,
+  type UserProfileRecord,
+} from '../lib/adminApi';
+import { useToast } from '../context/ToastContext.jsx';
+
+type TabKey = 'access' | 'users' | 'settings' | 'audit';
+
+type RouteDraft = RouteAccessRecord;
+
+type UserDraft = UserProfileRecord;
+
+const TABS: { key: TabKey; label: string }[] = [
+  { key: 'access', label: 'Access Control' },
+  { key: 'users', label: 'Users' },
+  { key: 'settings', label: 'App Settings' },
+  { key: 'audit', label: 'Audit Log' },
+];
+
+const ACCESS_OPTIONS = [
+  { value: 'public', label: 'Public' },
+  { value: 'user', label: 'User' },
+  { value: 'admin', label: 'Admin' },
+] as const;
+
+function Switch({
+  checked,
+  onChange,
+  id,
+  label,
+}: {
+  checked: boolean;
+  onChange: (value: boolean) => void;
+  id?: string;
+  label?: string;
+}) {
+  return (
+    <button
+      type="button"
+      id={id}
+      onClick={() => onChange(!checked)}
+      className={clsx(
+        'relative inline-flex h-6 w-11 items-center rounded-full transition',
+        checked ? 'bg-brand' : 'bg-border'
+      )}
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+    >
+      <span
+        className={clsx(
+          'inline-block h-5 w-5 transform rounded-full bg-white transition',
+          checked ? 'translate-x-5' : 'translate-x-1'
+        )}
+      />
+    </button>
+  );
+}
+
+function SectionCard({ children }: { children: ReactNode }) {
+  return (
+    <div className="rounded-2xl bg-surface-1/70 p-6 ring-2 ring-border/40 shadow-sm">{children}</div>
+  );
+}
+
+function SkeletonTable({ rows = 4, columns = 4 }: { rows?: number; columns?: number }) {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: rows }).map((_, rowIndex) => (
+        <div key={rowIndex} className="grid gap-3 md:grid-cols-4">
+          {Array.from({ length: columns }).map((__, colIndex) => (
+            <div key={colIndex} className="h-11 animate-pulse rounded-xl bg-border/50" />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function AdminPage() {
+  const { addToast } = useToast();
+  const [activeTab, setActiveTab] = useState<TabKey>('access');
+
+  const [routes, setRoutes] = useState<RouteAccessRecord[]>([]);
+  const [routeDrafts, setRouteDrafts] = useState<RouteDraft[]>([]);
+  const [routesLoading, setRoutesLoading] = useState(true);
+  const [routeSavingId, setRouteSavingId] = useState<string | null>(null);
+
+  const [users, setUsers] = useState<UserProfileRecord[]>([]);
+  const [userDrafts, setUserDrafts] = useState<UserDraft[]>([]);
+  const [usersLoading, setUsersLoading] = useState(true);
+  const [userSavingId, setUserSavingId] = useState<string | null>(null);
+
+  const [newRoute, setNewRoute] = useState({
+    route: '',
+    access_level: 'public' as RouteAccessRecord['access_level'],
+    is_enabled: true,
+  });
+
+  const [newUser, setNewUser] = useState({
+    id: '',
+    username: '',
+    role: 'user' as UserProfileRecord['role'],
+    is_active: true,
+  });
+
+  const [description, setDescription] = useState('');
+  const [descriptionDraft, setDescriptionDraft] = useState('');
+  const [descriptionLoading, setDescriptionLoading] = useState(true);
+  const [savingDescription, setSavingDescription] = useState(false);
+
+  const loadRoutes = useCallback(async () => {
+    setRoutesLoading(true);
+    try {
+      const data = await listRoutes();
+      setRoutes(data);
+      setRouteDrafts(data.map((item) => ({ ...item })));
+    } catch (error) {
+      addToast('Gagal memuat daftar route', 'error');
+    } finally {
+      setRoutesLoading(false);
+    }
+  }, [addToast]);
+
+  const loadUsers = useCallback(async () => {
+    setUsersLoading(true);
+    try {
+      const data = await listUsers();
+      setUsers(data);
+      setUserDrafts(data.map((item) => ({ ...item })));
+    } catch (error) {
+      addToast('Gagal memuat daftar pengguna', 'error');
+    } finally {
+      setUsersLoading(false);
+    }
+  }, [addToast]);
+
+  const loadDescription = useCallback(async () => {
+    setDescriptionLoading(true);
+    try {
+      const text = await getAppDescription();
+      setDescription(text);
+      setDescriptionDraft(text);
+    } catch (error) {
+      addToast('Gagal memuat deskripsi aplikasi', 'error');
+    } finally {
+      setDescriptionLoading(false);
+    }
+  }, [addToast]);
+
+  useEffect(() => {
+    void loadRoutes();
+    void loadUsers();
+    void loadDescription();
+  }, [loadRoutes, loadUsers, loadDescription]);
+
+  const handleRouteChange = (
+    id: string,
+    field: 'route' | 'access_level' | 'is_enabled',
+    value: string | boolean
+  ) => {
+    setRouteDrafts((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, [field]: value } : item))
+    );
+  };
+
+  const handleUserChange = (
+    id: string,
+    field: 'role' | 'is_active',
+    value: string | boolean
+  ) => {
+    setUserDrafts((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, [field]: value } : item))
+    );
+  };
+
+  const handleSaveRoute = async (draft: RouteDraft) => {
+    const trimmedRoute = draft.route.trim();
+    if (!trimmedRoute) {
+      addToast('Route tidak boleh kosong', 'error');
+      return;
+    }
+
+    if (!ACCESS_OPTIONS.some((option) => option.value === draft.access_level)) {
+      addToast('Level akses tidak valid', 'error');
+      return;
+    }
+
+    setRouteSavingId(draft.id);
+    try {
+      const saved = await upsertRoute({
+        id: draft.id,
+        route: trimmedRoute,
+        access_level: draft.access_level,
+        is_enabled: draft.is_enabled,
+      });
+      setRoutes((prev) => {
+        const exists = prev.some((item) => item.id === saved.id);
+        const updated = exists
+          ? prev.map((item) => (item.id === saved.id ? saved : item))
+          : [...prev, saved];
+        return [...updated].sort((a, b) => a.route.localeCompare(b.route));
+      });
+      setRouteDrafts((prev) => {
+        const exists = prev.some((item) => item.id === saved.id);
+        const updated = exists
+          ? prev.map((item) => (item.id === saved.id ? saved : item))
+          : [...prev, saved];
+        return [...updated].sort((a, b) => a.route.localeCompare(b.route));
+      });
+      addToast('Route berhasil disimpan', 'success');
+    } catch (error) {
+      addToast('Gagal menyimpan route', 'error');
+    } finally {
+      setRouteSavingId(null);
+    }
+  };
+
+  const handleDeleteRoute = async (draft: RouteDraft) => {
+    if (!draft.id) return;
+    const confirmDelete = window.confirm(`Hapus route ${draft.route}?`);
+    if (!confirmDelete) return;
+    setRouteSavingId(draft.id);
+    try {
+      await deleteRoute(draft.id);
+      setRoutes((prev) => prev.filter((item) => item.id !== draft.id));
+      setRouteDrafts((prev) => prev.filter((item) => item.id !== draft.id));
+      addToast('Route berhasil dihapus', 'success');
+    } catch (error) {
+      addToast('Gagal menghapus route', 'error');
+    } finally {
+      setRouteSavingId(null);
+    }
+  };
+
+  const handleAddRoute = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedRoute = newRoute.route.trim();
+    if (!trimmedRoute) {
+      addToast('Route baru wajib diisi', 'error');
+      return;
+    }
+
+    if (!ACCESS_OPTIONS.some((option) => option.value === newRoute.access_level)) {
+      addToast('Level akses tidak valid', 'error');
+      return;
+    }
+
+    if (routes.some((item) => item.route === trimmedRoute)) {
+      addToast('Route sudah terdaftar', 'error');
+      return;
+    }
+
+    if (routeDrafts.some((item) => item.route === trimmedRoute)) {
+      addToast('Route sudah ada dalam daftar', 'error');
+      return;
+    }
+
+    setRouteSavingId('new');
+    try {
+      const saved = await upsertRoute({
+        route: trimmedRoute,
+        access_level: newRoute.access_level,
+        is_enabled: newRoute.is_enabled,
+      });
+      setRoutes((prev) => [...prev, saved].sort((a, b) => a.route.localeCompare(b.route)));
+      setRouteDrafts((prev) => [...prev, saved].sort((a, b) => a.route.localeCompare(b.route)));
+      setNewRoute({ route: '', access_level: 'public', is_enabled: true });
+      addToast('Route baru berhasil ditambahkan', 'success');
+    } catch (error) {
+      addToast('Gagal menambahkan route baru', 'error');
+    } finally {
+      setRouteSavingId(null);
+    }
+  };
+
+  const handleSaveUser = async (draft: UserDraft) => {
+    if (!draft.id) {
+      addToast('ID pengguna tidak ditemukan', 'error');
+      return;
+    }
+
+    if (draft.role !== 'user' && draft.role !== 'admin') {
+      addToast('Role pengguna harus user atau admin', 'error');
+      return;
+    }
+
+    setUserSavingId(draft.id);
+    try {
+      const saved = await updateUserProfile(draft.id, {
+        role: draft.role,
+        is_active: draft.is_active,
+      });
+      setUsers((prev) => prev.map((item) => (item.id === saved.id ? saved : item)));
+      setUserDrafts((prev) => prev.map((item) => (item.id === saved.id ? saved : item)));
+      addToast('Profil pengguna diperbarui', 'success');
+    } catch (error) {
+      addToast('Gagal memperbarui profil pengguna', 'error');
+    } finally {
+      setUserSavingId(null);
+    }
+  };
+
+  const handleCreateUser = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const id = newUser.id.trim();
+    const username = newUser.username.trim() || undefined;
+    const role = newUser.role;
+
+    if (role !== 'user' && role !== 'admin') {
+      addToast('Role pengguna harus user atau admin', 'error');
+      return;
+    }
+
+    if (!id) {
+      addToast('ID pengguna wajib diisi', 'error');
+      return;
+    }
+
+    setUserSavingId('new');
+    try {
+      const created = await createUserProfile({
+        id,
+        username,
+        role,
+        is_active: newUser.is_active,
+      });
+      setUsers((prev) => [...prev, created]);
+      setUserDrafts((prev) => [...prev, created]);
+      setNewUser({ id: '', username: '', role: 'user', is_active: true });
+      addToast('Profil pengguna berhasil dibuat', 'success');
+    } catch (error) {
+      addToast('Gagal membuat profil pengguna', 'error');
+    } finally {
+      setUserSavingId(null);
+    }
+  };
+
+  const handleSaveDescription = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSavingDescription(true);
+    try {
+      const text = descriptionDraft.trim();
+      await setAppDescription(text);
+      setDescription(text);
+      addToast('Deskripsi aplikasi tersimpan', 'success');
+    } catch (error) {
+      addToast('Gagal menyimpan deskripsi aplikasi', 'error');
+    } finally {
+      setSavingDescription(false);
+    }
+  };
+
+  const auditEntries = useMemo(() => {
+    const resolveTime = (value: string | null) => {
+      if (!value) return 0;
+      const parsed = Date.parse(String(value));
+      return Number.isFinite(parsed) ? parsed : 0;
+    };
+    const routeEntries = routes.map((item) => ({
+      id: `route-${item.id}`,
+      type: 'Access Control',
+      name: item.route,
+      timestamp: item.updated_at ?? item.created_at ?? null,
+      detail: `${item.access_level.toUpperCase()} • ${item.is_enabled ? 'Aktif' : 'Nonaktif'}`,
+    }));
+    const userEntries = users.map((item) => ({
+      id: `user-${item.id}`,
+      type: 'User',
+      name: item.username || item.email || item.id,
+      timestamp: item.updated_at ?? item.created_at ?? null,
+      detail: `${item.role === 'admin' ? 'Admin' : 'User'} • ${item.is_active ? 'Aktif' : 'Nonaktif'}`,
+    }));
+    const all = [...routeEntries, ...userEntries];
+    all.sort((a, b) => {
+      const aTime = resolveTime(a.timestamp);
+      const bTime = resolveTime(b.timestamp);
+      return bTime - aTime;
+    });
+    return all.slice(0, 10);
+  }, [routes, users]);
+
+  const hasAuditTimestamp = auditEntries.some((entry) => entry.timestamp);
+
+  const renderAccessControl = () => (
+    <SectionCard>
+      <div className="space-y-6">
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">Daftar Route</h2>
+          <p className="text-sm text-muted-foreground">
+            Kelola hak akses setiap route aplikasi.
+          </p>
+        </div>
+        {routesLoading ? (
+          <SkeletonTable rows={4} columns={4} />
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full table-fixed text-left text-sm">
+              <thead className="text-xs uppercase text-muted-foreground">
+                <tr>
+                  <th className="w-[35%] pb-3 font-medium">Route</th>
+                  <th className="w-[20%] pb-3 font-medium">Level Akses</th>
+                  <th className="w-[15%] pb-3 font-medium">Aktif</th>
+                  <th className="pb-3 text-right font-medium">Aksi</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/60">
+                {routeDrafts.map((item) => {
+                  const original = routes.find((route) => route.id === item.id);
+                  const isDirty =
+                    !original ||
+                    original.route !== item.route ||
+                    original.access_level !== item.access_level ||
+                    original.is_enabled !== item.is_enabled;
+                  const isSaving = routeSavingId === item.id;
+                  return (
+                    <tr key={item.id} className="align-middle">
+                      <td className="py-3 pr-4">
+                        <input
+                          value={item.route}
+                          onChange={(event) =>
+                            handleRouteChange(item.id, 'route', event.target.value)
+                          }
+                          className="h-11 w-full rounded-xl border border-border bg-surface-1 px-3 text-sm shadow-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/60"
+                          placeholder="/dashboard"
+                        />
+                      </td>
+                      <td className="py-3 pr-4">
+                        <select
+                          value={item.access_level}
+                          onChange={(event) =>
+                            handleRouteChange(item.id, 'access_level', event.target.value)
+                          }
+                          className="h-11 w-full rounded-xl border border-border bg-surface-1 px-3 text-sm shadow-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/60"
+                        >
+                          {ACCESS_OPTIONS.map((option) => (
+                            <option key={option.value} value={option.value}>
+                              {option.label}
+                            </option>
+                          ))}
+                        </select>
+                      </td>
+                      <td className="py-3 pr-4">
+                        <div className="flex items-center gap-3">
+                          <Switch
+                            checked={item.is_enabled}
+                            onChange={(value) => handleRouteChange(item.id, 'is_enabled', value)}
+                            label={`Status route ${item.route || 'tanpa nama'}`}
+                          />
+                          <span className="text-xs text-muted-foreground">
+                            {item.is_enabled ? 'Aktif' : 'Nonaktif'}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="py-3 text-right">
+                        <div className="flex justify-end gap-2">
+                          <button
+                            type="button"
+                            onClick={() => handleSaveRoute(item)}
+                            disabled={!isDirty || isSaving}
+                            className={clsx(
+                              'inline-flex h-11 items-center justify-center rounded-xl px-4 text-sm font-medium transition',
+                              isDirty && !isSaving
+                                ? 'bg-brand text-white hover:bg-brand/90'
+                                : 'cursor-not-allowed bg-border text-muted-foreground'
+                            )}
+                          >
+                            {isSaving ? 'Menyimpan…' : 'Simpan'}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleDeleteRoute(item)}
+                            disabled={isSaving}
+                            className="inline-flex h-11 items-center justify-center rounded-xl border border-danger/50 px-4 text-sm font-medium text-danger transition hover:bg-danger/10 disabled:cursor-not-allowed disabled:opacity-70"
+                          >
+                            Hapus
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+                {routeDrafts.length === 0 && (
+                  <tr>
+                    <td colSpan={4} className="py-6 text-center text-sm text-muted-foreground">
+                      Belum ada data route.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+        <form onSubmit={handleAddRoute} className="space-y-4 rounded-xl border border-dashed border-border/60 bg-surface-1/60 p-4">
+          <h3 className="text-sm font-semibold text-foreground">Tambah Route Baru</h3>
+          <div className="grid gap-3 md:grid-cols-4">
+            <input
+              value={newRoute.route}
+              onChange={(event) => setNewRoute((prev) => ({ ...prev, route: event.target.value }))}
+              className="h-11 w-full rounded-xl border border-border bg-surface-1 px-3 text-sm shadow-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/60"
+              placeholder="/admin/fitur-baru"
+            />
+            <select
+              value={newRoute.access_level}
+              onChange={(event) =>
+                setNewRoute((prev) => ({ ...prev, access_level: event.target.value as RouteAccessRecord['access_level'] }))
+              }
+              className="h-11 w-full rounded-xl border border-border bg-surface-1 px-3 text-sm shadow-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/60"
+            >
+              {ACCESS_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            <div className="flex items-center gap-3">
+              <Switch
+                checked={newRoute.is_enabled}
+                onChange={(value) => setNewRoute((prev) => ({ ...prev, is_enabled: value }))}
+                label="Status route baru"
+              />
+              <span className="text-xs text-muted-foreground">
+                {newRoute.is_enabled ? 'Aktif' : 'Nonaktif'}
+              </span>
+            </div>
+            <div className="flex items-center justify-end">
+              <button
+                type="submit"
+                disabled={routeSavingId === 'new'}
+                className="inline-flex h-11 w-full items-center justify-center rounded-xl bg-brand px-4 text-sm font-medium text-white transition hover:bg-brand/90 disabled:cursor-not-allowed disabled:opacity-70"
+              >
+                {routeSavingId === 'new' ? 'Menyimpan…' : 'Tambah Route'}
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </SectionCard>
+  );
+
+  const renderUsers = () => (
+    <SectionCard>
+      <div className="space-y-6">
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">Daftar Pengguna</h2>
+          <p className="text-sm text-muted-foreground">
+            Ubah role dan status aktif pengguna aplikasi.
+          </p>
+        </div>
+        {usersLoading ? (
+          <SkeletonTable rows={4} columns={4} />
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full table-fixed text-left text-sm">
+              <thead className="text-xs uppercase text-muted-foreground">
+                <tr>
+                  <th className="w-[30%] pb-3 font-medium">Pengguna</th>
+                  <th className="w-[20%] pb-3 font-medium">Role</th>
+                  <th className="w-[20%] pb-3 font-medium">Aktif</th>
+                  <th className="pb-3 text-right font-medium">Aksi</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/60">
+                {userDrafts.map((item) => {
+                  const original = users.find((user) => user.id === item.id);
+                  const isDirty =
+                    !original ||
+                    original.role !== item.role ||
+                    original.is_active !== item.is_active;
+                  const isSaving = userSavingId === item.id;
+                  return (
+                    <tr key={item.id} className="align-middle">
+                      <td className="py-3 pr-4">
+                        <div className="flex flex-col">
+                          <span className="font-medium text-foreground">{item.username || item.email || item.id}</span>
+                          <span className="text-xs text-muted-foreground">ID: {item.id}</span>
+                        </div>
+                      </td>
+                      <td className="py-3 pr-4">
+                        <select
+                          value={item.role}
+                          onChange={(event) => handleUserChange(item.id, 'role', event.target.value)}
+                          className="h-11 w-full rounded-xl border border-border bg-surface-1 px-3 text-sm shadow-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/60"
+                        >
+                          <option value="user">User</option>
+                          <option value="admin">Admin</option>
+                        </select>
+                      </td>
+                      <td className="py-3 pr-4">
+                        <div className="flex items-center gap-3">
+                          <Switch
+                            checked={item.is_active}
+                            onChange={(value) => handleUserChange(item.id, 'is_active', value)}
+                            label={`Status aktif ${item.username || item.email || item.id}`}
+                          />
+                          <span className="text-xs text-muted-foreground">
+                            {item.is_active ? 'Aktif' : 'Nonaktif'}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="py-3 text-right">
+                        <button
+                          type="button"
+                          onClick={() => handleSaveUser(item)}
+                          disabled={!isDirty || isSaving}
+                          className={clsx(
+                            'inline-flex h-11 items-center justify-center rounded-xl px-4 text-sm font-medium transition',
+                            isDirty && !isSaving
+                              ? 'bg-brand text-white hover:bg-brand/90'
+                              : 'cursor-not-allowed bg-border text-muted-foreground'
+                          )}
+                        >
+                          {isSaving ? 'Menyimpan…' : 'Simpan'}
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
+                {userDrafts.length === 0 && (
+                  <tr>
+                    <td colSpan={4} className="py-6 text-center text-sm text-muted-foreground">
+                      Belum ada data pengguna.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+        <form onSubmit={handleCreateUser} className="space-y-4 rounded-xl border border-dashed border-border/60 bg-surface-1/60 p-4">
+          <h3 className="text-sm font-semibold text-foreground">Tambah Profil Pengguna</h3>
+          <div className="grid gap-3 md:grid-cols-4">
+            <input
+              value={newUser.id}
+              onChange={(event) => setNewUser((prev) => ({ ...prev, id: event.target.value }))}
+              className="h-11 w-full rounded-xl border border-border bg-surface-1 px-3 text-sm shadow-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/60"
+              placeholder="UUID auth user"
+              required
+            />
+            <input
+              value={newUser.username}
+              onChange={(event) => setNewUser((prev) => ({ ...prev, username: event.target.value }))}
+              className="h-11 w-full rounded-xl border border-border bg-surface-1 px-3 text-sm shadow-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/60"
+              placeholder="Username opsional"
+            />
+            <select
+              value={newUser.role}
+              onChange={(event) =>
+                setNewUser((prev) => ({ ...prev, role: event.target.value as UserProfileRecord['role'] }))
+              }
+              className="h-11 w-full rounded-xl border border-border bg-surface-1 px-3 text-sm shadow-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/60"
+            >
+              <option value="user">User</option>
+              <option value="admin">Admin</option>
+            </select>
+            <div className="flex items-center gap-3">
+              <Switch
+                checked={newUser.is_active}
+                onChange={(value) => setNewUser((prev) => ({ ...prev, is_active: value }))}
+                label="Status aktif profil baru"
+              />
+              <span className="text-xs text-muted-foreground">
+                {newUser.is_active ? 'Aktif' : 'Nonaktif'}
+              </span>
+            </div>
+          </div>
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              disabled={userSavingId === 'new'}
+              className="inline-flex h-11 items-center justify-center rounded-xl bg-brand px-4 text-sm font-medium text-white transition hover:bg-brand/90 disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {userSavingId === 'new' ? 'Menyimpan…' : 'Tambah Profil'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </SectionCard>
+  );
+
+  const renderSettings = () => (
+    <SectionCard>
+      <div className="space-y-6">
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">Deskripsi Aplikasi</h2>
+          <p className="text-sm text-muted-foreground">
+            Ubah deskripsi aplikasi yang tampil pada halaman publik.
+          </p>
+        </div>
+        {descriptionLoading ? (
+          <div className="space-y-3">
+            <div className="h-6 w-40 animate-pulse rounded bg-border/60" />
+            <div className="h-32 animate-pulse rounded-xl bg-border/40" />
+          </div>
+        ) : (
+          <form onSubmit={handleSaveDescription} className="space-y-4">
+            <textarea
+              value={descriptionDraft}
+              onChange={(event) => setDescriptionDraft(event.target.value)}
+              className="min-h-[160px] w-full rounded-2xl border border-border bg-surface-1 px-4 py-3 text-sm shadow-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/60"
+              placeholder="Tuliskan deskripsi aplikasi di sini"
+            />
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                disabled={savingDescription || descriptionDraft === description}
+                className={clsx(
+                  'inline-flex h-11 items-center justify-center rounded-xl px-4 text-sm font-medium transition',
+                  descriptionDraft !== description && !savingDescription
+                    ? 'bg-brand text-white hover:bg-brand/90'
+                    : 'cursor-not-allowed bg-border text-muted-foreground'
+                )}
+              >
+                {savingDescription ? 'Menyimpan…' : 'Simpan Deskripsi'}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </SectionCard>
+  );
+
+  const renderAuditLog = () => (
+    <SectionCard>
+      <div className="space-y-6">
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">Audit Log</h2>
+          <p className="text-sm text-muted-foreground">
+            {hasAuditTimestamp
+              ? 'Riwayat perubahan terbaru pada konfigurasi aplikasi.'
+              : 'Snapshot terkini dari konfigurasi aplikasi.'}
+          </p>
+        </div>
+        {auditEntries.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-border/50 bg-surface-1/60 p-6 text-center text-sm text-muted-foreground">
+            Belum ada aktivitas yang terekam.
+          </div>
+        ) : (
+          <ul className="space-y-4">
+            {auditEntries.map((entry) => {
+              const hasTimestamp = entry.timestamp && Number.isFinite(Date.parse(String(entry.timestamp)));
+              const timestampLabel = hasTimestamp
+                ? new Date(String(entry.timestamp)).toLocaleString('id-ID', {
+                    dateStyle: 'medium',
+                    timeStyle: 'short',
+                  })
+                : 'Snapshot';
+              return (
+                <li
+                  key={entry.id}
+                  className="flex flex-col gap-1 rounded-xl border border-border/60 bg-surface-1/60 p-4 shadow-sm"
+                >
+                  <div className="flex items-center justify-between text-sm font-semibold text-foreground">
+                    <span>{entry.name}</span>
+                    <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      {entry.type}
+                    </span>
+                  </div>
+                  <div className="text-sm text-muted-foreground">{entry.detail}</div>
+                  <div className="text-xs text-muted-foreground/80">{timestampLabel}</div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </SectionCard>
+  );
+
+  return (
+    <div className="space-y-6 pb-16">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold text-foreground">Admin Panel</h1>
+        <p className="text-sm text-muted-foreground">
+          Kelola akses aplikasi, pengguna, dan pengaturan global dalam satu tempat.
+        </p>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {TABS.map((tab) => (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => setActiveTab(tab.key)}
+            className={clsx(
+              'inline-flex h-11 items-center justify-center rounded-full px-5 text-sm font-medium transition',
+              activeTab === tab.key
+                ? 'bg-brand text-white shadow-lg'
+                : 'bg-surface-1/70 text-muted-foreground ring-1 ring-border hover:text-foreground'
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      {activeTab === 'access' && renderAccessControl()}
+      {activeTab === 'users' && renderUsers()}
+      {activeTab === 'settings' && renderSettings()}
+      {activeTab === 'audit' && renderAuditLog()}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add an admin guard with useIsAdmin hook to restrict the `/admin` route to admins only
- provide Supabase helpers for managing routes, users, and app settings from the admin panel
- build the tabbed admin page UI covering access control, users, app description, and a lightweight audit log
- register the new `/admin` route inside the authenticated app shell

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d3f00302c88332827cafb765c7fb71