### PR TITLE
Add admin columns to user_profiles table

### DIFF
--- a/supabase/migrations/20250420000000_add_admin_columns_to_user_profiles.sql
+++ b/supabase/migrations/20250420000000_add_admin_columns_to_user_profiles.sql
@@ -1,0 +1,7 @@
+alter table public.user_profiles
+  add column if not exists email text,
+  add column if not exists role text not null default 'user' check (role in ('user','admin')),
+  add column if not exists is_active boolean not null default true;
+
+create index if not exists user_profiles_role_idx on public.user_profiles (role);
+create index if not exists user_profiles_is_active_idx on public.user_profiles (is_active);


### PR DESCRIPTION
## Summary
- add missing admin columns to the user_profiles table expected by the Supabase client
- index the new columns for efficient role and active-state lookups

## Testing
- not run (SQL migration only)


------
https://chatgpt.com/codex/tasks/task_e_68d40309397c83328865c6d3bc689ff3