### PR TITLE
Use lucide icons for sidebar menus

### DIFF
--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,0 +1,136 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  Bell,
+  Calendar,
+  ChartLine,
+  Circle,
+  FolderKanban,
+  Home,
+  List,
+  PieChart,
+  PiggyBank,
+  Receipt,
+  Repeat,
+  Settings,
+  Shield,
+  Tag,
+  Target,
+  TrendingUp,
+  User,
+  Wallet,
+} from "lucide-react";
+
+export const ICONS: Record<string, LucideIcon> = {
+  home: Home,
+  dashboard: Home,
+  wallet: Wallet,
+  wallets: Wallet,
+  saving: PiggyBank,
+  savings: PiggyBank,
+  piggybank: PiggyBank,
+  "piggy-bank": PiggyBank,
+  piggy_bank: PiggyBank,
+  budget: PiggyBank,
+  budgets: PiggyBank,
+  target: Target,
+  goal: Target,
+  goals: Target,
+  tag: Tag,
+  tags: Tag,
+  label: Tag,
+  labels: Tag,
+  repeat: Repeat,
+  recurring: Repeat,
+  list: List,
+  lists: List,
+  tasks: List,
+  checklist: List,
+  chartline: ChartLine,
+  chart: ChartLine,
+  charts: ChartLine,
+  analytics: ChartLine,
+  analysis: ChartLine,
+  graph: ChartLine,
+  graphs: ChartLine,
+  data: ChartLine,
+  debt: ChartLine,
+  debts: ChartLine,
+  shield: Shield,
+  security: Shield,
+  protect: Shield,
+  protection: Shield,
+  settings: Settings,
+  preference: Settings,
+  preferences: Settings,
+  config: Settings,
+  configuration: Settings,
+  user: User,
+  users: User,
+  profile: User,
+  account: User,
+  person: User,
+  people: User,
+  bell: Bell,
+  notification: Bell,
+  notifications: Bell,
+  alert: Bell,
+  alerts: Bell,
+  reminder: Bell,
+  reminders: Bell,
+  subscription: Bell,
+  subscriptions: Bell,
+  piechart: PieChart,
+  "pie-chart": PieChart,
+  pie_chart: PieChart,
+  calendar: Calendar,
+  schedule: Calendar,
+  date: Calendar,
+  dates: Calendar,
+  folderkanban: FolderKanban,
+  "folder-kanban": FolderKanban,
+  folder: FolderKanban,
+  folders: FolderKanban,
+  kanban: FolderKanban,
+  board: FolderKanban,
+  category: FolderKanban,
+  categories: FolderKanban,
+  project: FolderKanban,
+  projects: FolderKanban,
+  trendingup: TrendingUp,
+  trending: TrendingUp,
+  trend: TrendingUp,
+  growth: TrendingUp,
+  progress: TrendingUp,
+  performance: TrendingUp,
+  insight: TrendingUp,
+  insights: TrendingUp,
+  receipt: Receipt,
+  receipts: Receipt,
+  transaction: Receipt,
+  transactions: Receipt,
+  report: Receipt,
+  reports: Receipt,
+  invoice: Receipt,
+  invoices: Receipt,
+  statement: Receipt,
+};
+
+export const ICON_NAMES = Object.keys(ICONS).sort((a, b) => a.localeCompare(b));
+
+interface IconProps {
+  name?: string | null;
+  className?: string;
+  label?: string;
+}
+
+export function Icon({ name, className, label }: IconProps) {
+  const normalized = typeof name === "string" ? name.trim().toLowerCase() : "";
+  const IconComponent = normalized ? ICONS[normalized] ?? Circle : Circle;
+
+  return (
+    <IconComponent
+      aria-label={label ?? (normalized || "icon")}
+      className={className ?? "w-5 h-5"}
+    />
+  );
+}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -19,6 +19,7 @@ import Logo from "../Logo";
 import { supabase } from "../../lib/supabase";
 import { useMode } from "../../hooks/useMode";
 import type { User } from "@supabase/supabase-js";
+import { Icon } from "../icons";
 
 const BRAND_SWATCHES = [
   { name: "Blue", h: 211, s: 92, l: 60 },
@@ -56,36 +57,6 @@ function formatEmail(email?: string | null) {
   return email.length > 24 ? `${email.slice(0, 21)}…` : email;
 }
 
-const MENU_ICON_EMOJI: Record<string, string> = {
-  home: "🏠",
-  dashboard: "📊",
-  wallets: "👛",
-  wallet: "👛",
-  savings: "💰",
-  saving: "💰",
-  budget: "💰",
-  budgets: "💰",
-  goals: "🎯",
-  goal: "🎯",
-  subscriptions: "🔔",
-  subscription: "🔔",
-  transactions: "💵",
-  transaction: "💵",
-  debts: "📉",
-  debt: "📉",
-  categories: "🗂️",
-  category: "🗂️",
-  report: "📄",
-  reports: "📑",
-  analytics: "📈",
-  graph: "📈",
-  data: "🧾",
-  profile: "👤",
-  account: "👤",
-  settings: "⚙️",
-  insight: "💡",
-  insights: "💡",
-};
 
 type SidebarMenuEntry = {
   id: string;
@@ -118,21 +89,6 @@ function normalizeSidebarRoute(path: string): string {
   }
 
   return collapsed;
-}
-
-function renderMenuIcon(iconName?: string | null) {
-  const key = iconName?.trim().toLowerCase();
-  if (key && MENU_ICON_EMOJI[key]) {
-    return <span className="text-lg leading-none">{MENU_ICON_EMOJI[key]}</span>;
-  }
-  if (key && key.length) {
-    return (
-      <span className="text-[11px] font-semibold uppercase leading-none tracking-wide">
-        {key.slice(0, 2)}
-      </span>
-    );
-  }
-  return <span className="text-lg leading-none">•</span>;
 }
 
 export default function Sidebar({
@@ -353,7 +309,13 @@ export default function Sidebar({
                       <li key={item.id}>
                         <SidebarItem
                           to={item.route}
-                          icon={renderMenuIcon(item.icon_name)}
+                          icon={
+                            <Icon
+                              name={item.icon_name}
+                              label={item.title || item.route}
+                              className="w-5 h-5 shrink-0"
+                            />
+                          }
                           label={item.title || item.route}
                           collapsed={collapsed}
                           onNavigate={onNavigate}

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
+import { Icon, ICON_NAMES } from '../components/icons';
 import {
   createUserProfile,
   deleteRoute,
@@ -372,7 +373,7 @@ export default function AdminPage() {
 
   const handleStartSidebarEdit = (item: SidebarItemRecord) => {
     setEditingSidebarId(item.id);
-    setSidebarDraft({ ...item, icon_name: item.icon_name ?? '' });
+    setSidebarDraft({ ...item, icon_name: (item.icon_name ?? '').toLowerCase() });
   };
 
   const handleCancelSidebarEdit = () => {
@@ -418,7 +419,7 @@ export default function AdminPage() {
       return;
     }
 
-    const iconValue = sidebarDraft.icon_name.trim();
+    const iconValue = sidebarDraft.icon_name.trim().toLowerCase();
 
     setSidebarSavingId(editingSidebarId);
     try {
@@ -517,7 +518,7 @@ export default function AdminPage() {
 
     const nextPosition =
       sidebarItems.reduce((max, item) => Math.max(max, item.position ?? 0), 0) + 1;
-    const iconValue = newSidebarItem.icon_name.trim();
+    const iconValue = newSidebarItem.icon_name.trim().toLowerCase();
 
     setSidebarSavingId('new');
     try {
@@ -818,6 +819,9 @@ export default function AdminPage() {
     const baseInputClass =
       'h-11 w-full rounded-2xl border border-border/70 bg-surface-1 px-4 text-sm shadow-sm ring-2 ring-transparent transition focus:border-brand focus:outline-none focus:ring-brand/60';
 
+    const newIconValue = newSidebarItem.icon_name.trim().toLowerCase();
+    const newIconSelectValue = ICON_NAMES.includes(newIconValue) ? newIconValue : '';
+
     return (
       <SectionCard>
         <div className="space-y-6">
@@ -853,7 +857,10 @@ export default function AdminPage() {
                     const routeValue = draft?.route ?? item.route;
                     const accessValue = draft?.access_level ?? item.access_level;
                     const enabledValue = draft?.is_enabled ?? item.is_enabled;
-                    const iconValue = draft?.icon_name ?? item.icon_name ?? '';
+                    const iconRawValue = draft?.icon_name ?? item.icon_name ?? '';
+                    const iconValue = iconRawValue.trim().toLowerCase();
+                    const iconStoredValue = (item.icon_name ?? '').trim().toLowerCase();
+                    const iconSelectValue = ICON_NAMES.includes(iconValue) ? iconValue : '';
                     const isProcessing = sidebarSavingId === item.id;
                     const isAnotherEditing =
                       editingSidebarId !== null && editingSidebarId !== item.id;
@@ -865,7 +872,7 @@ export default function AdminPage() {
                         draft.route.trim() !== item.route ||
                         draft.access_level !== item.access_level ||
                         draft.is_enabled !== item.is_enabled ||
-                        draft.icon_name.trim() !== (item.icon_name ?? ''));
+                        draft.icon_name.trim().toLowerCase() !== iconStoredValue);
 
                     return (
                       <tr key={item.id} className="align-middle">
@@ -944,20 +951,38 @@ export default function AdminPage() {
                           </div>
                         </td>
                         <td className="py-3 pr-4">
-                          {isEditing ? (
-                            <input
-                              value={iconValue}
-                              onChange={(event) =>
-                                handleSidebarDraftChange('icon_name', event.target.value)
-                              }
-                              className={baseInputClass}
-                              placeholder="contoh: home"
-                            />
-                          ) : (
-                            <span className="inline-flex min-h-[32px] items-center rounded-full bg-surface-2/60 px-3 text-xs text-muted-foreground">
-                              {item.icon_name || '—'}
+                          <div className="flex items-center gap-3">
+                            <span className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/60 bg-surface-2/60 text-muted-foreground">
+                              <Icon
+                                name={iconRawValue}
+                                label={titleValue || item.route}
+                                className="h-5 w-5 shrink-0"
+                              />
                             </span>
-                          )}
+                            {isEditing ? (
+                              <select
+                                value={iconSelectValue}
+                                onChange={(event) =>
+                                  handleSidebarDraftChange(
+                                    'icon_name',
+                                    event.target.value.toLowerCase()
+                                  )
+                                }
+                                className={clsx(baseInputClass, 'flex-1')}
+                              >
+                                <option value="">Tanpa ikon</option>
+                                {ICON_NAMES.map((option) => (
+                                  <option key={option} value={option}>
+                                    {option}
+                                  </option>
+                                ))}
+                              </select>
+                            ) : (
+                              <span className="inline-flex min-h-[32px] items-center rounded-full bg-surface-2/60 px-3 text-xs text-muted-foreground">
+                                {iconValue || '—'}
+                              </span>
+                            )}
+                          </div>
                         </td>
                         <td className="py-3 text-right">
                           <div className="flex flex-wrap justify-end gap-2">
@@ -1095,14 +1120,32 @@ export default function AdminPage() {
                 <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted">
                   Ikon (opsional)
                 </label>
-                <input
-                  value={newSidebarItem.icon_name}
-                  onChange={(event) =>
-                    setNewSidebarItem((prev) => ({ ...prev, icon_name: event.target.value }))
-                  }
-                  className={baseInputClass}
-                  placeholder="home"
-                />
+                <div className="flex items-center gap-3">
+                  <span className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/60 bg-surface-2/60 text-muted-foreground">
+                    <Icon
+                      name={newSidebarItem.icon_name}
+                      label={newSidebarItem.title || newSidebarItem.route || 'Ikon menu baru'}
+                      className="h-5 w-5 shrink-0"
+                    />
+                  </span>
+                  <select
+                    value={newIconSelectValue}
+                    onChange={(event) =>
+                      setNewSidebarItem((prev) => ({
+                        ...prev,
+                        icon_name: event.target.value.toLowerCase(),
+                      }))
+                    }
+                    className={clsx(baseInputClass, 'flex-1')}
+                  >
+                    <option value="">Tanpa ikon</option>
+                    {ICON_NAMES.map((option) => (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    ))}
+                  </select>
+                </div>
               </div>
               <div className="md:col-span-2">
                 <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted">


### PR DESCRIPTION
## Summary
- add a lucide icon mapper and lightweight Icon component with Circle fallback
- render sidebar navigation icons with lucide-react instead of emoji placeholders
- update admin sidebar management to select icons from predefined options with live previews

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d40f03f4dc8332bc5726657bb3b8b0