### PR TITLE
feat(sidebar): add category support for menu items

### DIFF
--- a/supabase/migrations/20250412000000_add_category_to_app_sidebar_items.sql
+++ b/supabase/migrations/20250412000000_add_category_to_app_sidebar_items.sql
@@ -1,0 +1,2 @@
+alter table public.app_sidebar_items
+  add column if not exists category text;


### PR DESCRIPTION
## Summary
- add optional category management to the admin sidebar form and table
- persist sidebar item categories in Supabase APIs and schema
- group visible sidebar navigation items by their configured categories

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4137355a883328f00dda3f402941f