### PR TITLE
feat: sync debt payments with automatic transactions

### DIFF
--- a/src/components/debts/PaymentsList.tsx
+++ b/src/components/debts/PaymentsList.tsx
@@ -26,8 +26,16 @@ export default function PaymentsList({ payments, onDelete, deletingId }: Payment
     <ul className="flex flex-col gap-3">
       {payments.map((payment) => {
         const amountLabel = currencyFormatter.format(payment.amount ?? 0);
-        const dateLabel = payment.date ? dateFormatter.format(new Date(payment.date)) : '-';
+        const dateLabel = payment.paid_at
+          ? dateFormatter.format(new Date(`${payment.paid_at}T00:00:00`))
+          : '-';
         const isDeleting = deletingId === payment.id;
+        const disableDelete = isDeleting || payment.queued;
+        const accountLabel = payment.account?.name ?? 'Akun tidak tersedia';
+        const transaction = payment.transaction;
+        const transactionTitle = transaction?.title ?? 'Transaksi otomatis';
+        const transactionDeleted = Boolean(transaction?.deleted_at);
+        const awaitingSync = payment.queued || !transaction;
         return (
           <li
             key={payment.id}
@@ -35,17 +43,40 @@ export default function PaymentsList({ payments, onDelete, deletingId }: Payment
           >
             <div className="min-w-0">
               <p className="text-sm font-semibold text-text">{amountLabel}</p>
-              <p className="text-xs text-muted">{dateLabel}</p>
-              {payment.notes ? (
-                <p className="mt-2 break-words text-sm text-text/80" title={payment.notes}>
-                  {payment.notes}
+              <p className="text-xs text-muted">{dateLabel} • {accountLabel}</p>
+              {payment.note ? (
+                <p className="mt-2 break-words text-sm text-text/80" title={payment.note}>
+                  {payment.note}
                 </p>
+              ) : null}
+              <p className="mt-2 text-xs text-muted">
+                {awaitingSync ? (
+                  <span className="inline-flex items-center gap-2 text-amber-700">
+                    <span className="inline-flex h-2 w-2 flex-shrink-0 rounded-full bg-amber-500" aria-hidden="true" />
+                    Transaksi otomatis akan dibuat setelah sinkronisasi.
+                  </span>
+                ) : (
+                  <span className="inline-flex flex-wrap items-center gap-2">
+                    <span>Transaksi otomatis:</span>
+                    <span className="font-medium text-text" title={transactionTitle}>
+                      {transactionTitle}
+                    </span>
+                    {transactionDeleted ? (
+                      <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-800">
+                        Dinonaktifkan
+                      </span>
+                    ) : null}
+                  </span>
+                )}
+              </p>
+              {payment.queued ? (
+                <p className="mt-2 text-xs font-medium text-amber-700">Menunggu koneksi. Pembayaran belum tersinkron.</p>
               ) : null}
             </div>
             <button
               type="button"
               onClick={() => onDelete(payment)}
-              disabled={isDeleting}
+              disabled={disableDelete}
               className="inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-border bg-surface-1 text-muted transition hover:text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)] disabled:cursor-not-allowed disabled:opacity-60"
               aria-label="Hapus pembayaran"
             >

--- a/supabase/migrations/20250412000000_update_debt_payments_transactions.sql
+++ b/supabase/migrations/20250412000000_update_debt_payments_transactions.sql
@@ -1,0 +1,212 @@
+-- Update debt_payments structure and automate related transactions
+
+alter table public.debt_payments
+  rename column date to paid_at;
+
+alter table public.debt_payments
+  alter column paid_at type date using paid_at::date;
+
+alter table public.debt_payments
+  alter column paid_at set default current_date;
+
+alter table public.debt_payments
+  rename column notes to note;
+
+alter table public.debt_payments
+  add column if not exists account_id uuid;
+
+alter table public.debt_payments
+  add column if not exists related_tx_id uuid;
+
+alter table public.debt_payments
+  add column if not exists updated_at timestamptz not null default timezone('utc', now());
+
+update public.debt_payments
+set updated_at = coalesce(updated_at, created_at)
+where updated_at is null;
+
+alter table public.debt_payments
+  add constraint debt_payments_related_tx_unique unique (related_tx_id);
+
+alter table public.debt_payments
+  add constraint debt_payments_account_fk foreign key (account_id) references public.accounts (id) on delete set null;
+
+alter table public.debt_payments
+  add constraint debt_payments_transaction_fk foreign key (related_tx_id) references public.transactions (id) on delete set null;
+
+create or replace function public.debt_payment_set_meta()
+returns trigger
+language plpgsql
+as $$
+declare
+  trimmed_note text;
+begin
+  if new.paid_at is null then
+    new.paid_at := current_date;
+  end if;
+
+  trimmed_note := nullif(btrim(coalesce(new.note, '')), '');
+  new.note := trimmed_note;
+  new.updated_at := timezone('utc', now());
+  return new;
+end;
+$$;
+
+drop trigger if exists debt_payments_set_meta on public.debt_payments;
+create trigger debt_payments_set_meta
+before insert or update on public.debt_payments
+for each row
+execute function public.debt_payment_set_meta();
+
+create or replace function public.debt_payment_create_transaction()
+returns trigger
+language plpgsql
+as $$
+declare
+  debt_title text;
+  transaction_title text;
+  tx_id uuid;
+  payment_note text;
+  payment_date timestamptz;
+begin
+  if new.related_tx_id is not null then
+    return new;
+  end if;
+
+  if new.paid_at is null then
+    new.paid_at := current_date;
+  end if;
+
+  if new.account_id is null then
+    raise exception 'Akun sumber wajib diisi untuk pembayaran hutang.';
+  end if;
+
+  select title into debt_title
+  from public.debts
+  where id = new.debt_id;
+
+  if debt_title is null then
+    raise exception 'Hutang tidak ditemukan untuk pembayaran.';
+  end if;
+
+  payment_note := nullif(btrim(coalesce(new.note, '')), '');
+  new.note := payment_note;
+  if payment_note is not null then
+    transaction_title := format('Bayar utang: %s - %s', debt_title, payment_note);
+  else
+    transaction_title := format('Bayar utang: %s', debt_title);
+  end if;
+
+  payment_date := new.paid_at::timestamptz;
+
+  insert into public.transactions (
+    user_id,
+    date,
+    type,
+    amount,
+    account_id,
+    title,
+    notes,
+    created_at,
+    updated_at,
+    deleted_at
+  )
+  values (
+    new.user_id,
+    payment_date,
+    'expense',
+    new.amount,
+    new.account_id,
+    transaction_title,
+    payment_note,
+    timezone('utc', now()),
+    timezone('utc', now()),
+    null
+  )
+  returning id into tx_id;
+
+  new.related_tx_id := tx_id;
+  return new;
+end;
+$$;
+
+drop trigger if exists debt_payments_before_insert on public.debt_payments;
+create trigger debt_payments_before_insert
+before insert on public.debt_payments
+for each row
+execute function public.debt_payment_create_transaction();
+
+create or replace function public.debt_payment_sync_transaction()
+returns trigger
+language plpgsql
+as $$
+declare
+  debt_title text;
+  payment_note text;
+  transaction_title text;
+begin
+  if new.related_tx_id is null then
+    return new;
+  end if;
+
+  if (new.amount is distinct from old.amount)
+     or (new.account_id is distinct from old.account_id)
+     or (new.paid_at is distinct from old.paid_at)
+     or (coalesce(new.note, '') is distinct from coalesce(old.note, '')) then
+    select title into debt_title
+    from public.debts
+    where id = new.debt_id;
+
+    payment_note := new.note;
+    if payment_note is not null then
+      transaction_title := format('Bayar utang: %s - %s', coalesce(debt_title, '-'), payment_note);
+    else
+      transaction_title := format('Bayar utang: %s', coalesce(debt_title, '-'));
+    end if;
+
+    update public.transactions
+    set
+      amount = new.amount,
+      account_id = new.account_id,
+      date = new.paid_at::timestamptz,
+      title = transaction_title,
+      notes = payment_note,
+      deleted_at = null,
+      updated_at = timezone('utc', now())
+    where id = new.related_tx_id and user_id = new.user_id;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists debt_payments_after_update on public.debt_payments;
+create trigger debt_payments_after_update
+after update on public.debt_payments
+for each row
+execute function public.debt_payment_sync_transaction();
+
+create or replace function public.debt_payment_soft_delete_transaction()
+returns trigger
+language plpgsql
+as $$
+begin
+  if old.related_tx_id is null then
+    return old;
+  end if;
+
+  update public.transactions
+  set
+    deleted_at = timezone('utc', now()),
+    updated_at = timezone('utc', now())
+  where id = old.related_tx_id and user_id = old.user_id;
+
+  return old;
+end;
+$$;
+
+drop trigger if exists debt_payments_after_delete on public.debt_payments;
+create trigger debt_payments_after_delete
+after delete on public.debt_payments
+for each row
+execute function public.debt_payment_soft_delete_transaction();


### PR DESCRIPTION
## Summary
- add a migration that renames debt payment columns, links payments to transactions and accounts, and adds triggers to create/update/soft-delete matching expense rows
- extend the debts API to work with the new schema, join account and transaction details, and queue inserts via SyncEngine when offline
- refresh the payment drawer UX to require an account, validate Jakarta dates, surface offline behaviour, and show linked transaction information in the payments list

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d411a56e38833286d128a35eb4b009