### PR TITLE
Add automated debt payment transactions and offline drafts

### DIFF
--- a/src/components/debts/PaymentsList.tsx
+++ b/src/components/debts/PaymentsList.tsx
@@ -26,8 +26,12 @@ export default function PaymentsList({ payments, onDelete, deletingId }: Payment
     <ul className="flex flex-col gap-3">
       {payments.map((payment) => {
         const amountLabel = currencyFormatter.format(payment.amount ?? 0);
-        const dateLabel = payment.date ? dateFormatter.format(new Date(payment.date)) : '-';
+        const dateLabel = payment.paid_at ? dateFormatter.format(new Date(payment.paid_at)) : '-';
         const isDeleting = deletingId === payment.id;
+        const accountLabel = payment.account_name ?? 'Akun tidak diketahui';
+        const isDraft = payment.sync_status === 'queued';
+        const transactionNote = payment.transaction?.note ?? null;
+        const transactionDeleted = Boolean(payment.transaction?.deleted_at);
         return (
           <li
             key={payment.id}
@@ -35,11 +39,27 @@ export default function PaymentsList({ payments, onDelete, deletingId }: Payment
           >
             <div className="min-w-0">
               <p className="text-sm font-semibold text-text">{amountLabel}</p>
-              <p className="text-xs text-muted">{dateLabel}</p>
-              {payment.notes ? (
-                <p className="mt-2 break-words text-sm text-text/80" title={payment.notes}>
-                  {payment.notes}
+              <p className="text-xs text-muted">
+                {dateLabel}
+                {accountLabel ? ` • ${accountLabel}` : ''}
+              </p>
+              {isDraft ? (
+                <span className="mt-2 inline-flex items-center rounded-full bg-yellow-50 px-3 py-1 text-xs font-medium text-yellow-800">
+                  Draft offline
+                </span>
+              ) : null}
+              {payment.note ? (
+                <p className="mt-2 break-words text-sm text-text/80" title={payment.note}>
+                  {payment.note}
                 </p>
+              ) : null}
+              {transactionNote ? (
+                <p className="mt-2 break-words text-xs text-muted" title={transactionNote}>
+                  Transaksi: {transactionNote}
+                </p>
+              ) : null}
+              {transactionDeleted ? (
+                <p className="mt-2 text-xs font-medium text-red-600">Transaksi terkait ditandai terhapus.</p>
               ) : null}
             </div>
             <button

--- a/src/lib/debt-payment-drafts.ts
+++ b/src/lib/debt-payment-drafts.ts
@@ -1,0 +1,93 @@
+export interface DebtPaymentDraft {
+  id: string;
+  debt_id: string;
+  user_id?: string | null;
+  amount: number;
+  paid_at: string;
+  account_id: string;
+  note: string | null;
+  created_at: string;
+}
+
+const STORAGE_KEY = 'hw:debtPaymentDrafts';
+
+type StoredDraft = DebtPaymentDraft & { version?: number };
+
+function isLocalStorageAvailable(): boolean {
+  try {
+    if (typeof globalThis.localStorage === 'undefined') return false;
+    const key = `${STORAGE_KEY}:check`;
+    globalThis.localStorage.setItem(key, '1');
+    globalThis.localStorage.removeItem(key);
+    return true;
+  } catch (error) {
+    console.warn('[HW] debt-payment-drafts storage unavailable', error);
+    return false;
+  }
+}
+
+function readDrafts(): StoredDraft[] {
+  if (!isLocalStorageAvailable()) return [];
+  try {
+    const raw = globalThis.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((item) => ({
+        id: String(item.id ?? ''),
+        debt_id: String(item.debt_id ?? ''),
+        user_id: item.user_id ?? null,
+        amount: Number(item.amount ?? 0),
+        paid_at: typeof item.paid_at === 'string' ? item.paid_at : new Date().toISOString().slice(0, 10),
+        account_id: String(item.account_id ?? ''),
+        note: item.note ?? null,
+        created_at: typeof item.created_at === 'string' ? item.created_at : new Date().toISOString(),
+        version: typeof item.version === 'number' ? item.version : undefined,
+      }))
+      .filter((item) => item.id && item.debt_id && item.account_id);
+  } catch (error) {
+    console.warn('[HW] debt-payment-drafts read failed', error);
+    return [];
+  }
+}
+
+function writeDrafts(drafts: StoredDraft[]): void {
+  if (!isLocalStorageAvailable()) return;
+  try {
+    globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify(drafts));
+  } catch (error) {
+    console.warn('[HW] debt-payment-drafts write failed', error);
+  }
+}
+
+export function listDrafts(): DebtPaymentDraft[] {
+  return readDrafts();
+}
+
+export function listDraftsByDebt(debtId: string): DebtPaymentDraft[] {
+  if (!debtId) return [];
+  return readDrafts().filter((draft) => draft.debt_id === debtId);
+}
+
+export function saveDraft(draft: DebtPaymentDraft): void {
+  if (!draft.id) {
+    throw new Error('Draft harus memiliki id.');
+  }
+  const existing = readDrafts();
+  const filtered = existing.filter((item) => item.id !== draft.id);
+  filtered.unshift({ ...draft, version: Date.now() });
+  writeDrafts(filtered);
+}
+
+export function removeDraft(id: string): void {
+  if (!id) return;
+  const existing = readDrafts();
+  const filtered = existing.filter((item) => item.id !== id);
+  if (filtered.length === existing.length) return;
+  writeDrafts(filtered);
+}
+
+export function replaceDrafts(next: DebtPaymentDraft[]): void {
+  writeDrafts(next.map((item) => ({ ...item, version: Date.now() })));
+}

--- a/supabase/migrations/20250420090000_update_debt_payments_transactions.sql
+++ b/supabase/migrations/20250420090000_update_debt_payments_transactions.sql
@@ -1,0 +1,234 @@
+-- Update debt_payments to link automatic transactions
+alter table public.debt_payments
+  add column if not exists account_id uuid,
+  add column if not exists paid_at date not null default (timezone('Asia/Jakarta', now()))::date,
+  add column if not exists related_tx_id uuid,
+  add column if not exists note text;
+
+-- migrate legacy notes column if present
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'debt_payments'
+      AND column_name = 'notes'
+  ) THEN
+    UPDATE public.debt_payments
+       SET note = COALESCE(note, notes)
+     WHERE note IS NULL;
+    ALTER TABLE public.debt_payments
+      DROP COLUMN notes;
+  END IF;
+END;
+$$;
+
+-- backfill paid_at from previous date column when available
+UPDATE public.debt_payments
+   SET paid_at = COALESCE(paid_at, date::date)
+ WHERE paid_at IS NULL;
+
+-- ensure account foreign key
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.constraint_column_usage ccu
+      ON ccu.constraint_name = tc.constraint_name
+     AND ccu.constraint_schema = tc.constraint_schema
+    WHERE tc.table_schema = 'public'
+      AND tc.table_name = 'debt_payments'
+      AND tc.constraint_type = 'FOREIGN KEY'
+      AND ccu.column_name = 'account_id'
+  ) THEN
+    ALTER TABLE public.debt_payments
+      ADD CONSTRAINT debt_payments_account_id_fkey
+        FOREIGN KEY (account_id)
+        REFERENCES public.accounts (id)
+        ON DELETE RESTRICT;
+  END IF;
+END;
+$$;
+
+-- ensure related transaction reference
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.constraint_column_usage ccu
+      ON ccu.constraint_name = tc.constraint_name
+     AND ccu.constraint_schema = tc.constraint_schema
+    WHERE tc.table_schema = 'public'
+      AND tc.table_name = 'debt_payments'
+      AND tc.constraint_type = 'FOREIGN KEY'
+      AND ccu.column_name = 'related_tx_id'
+  ) THEN
+    ALTER TABLE public.debt_payments
+      ADD CONSTRAINT debt_payments_related_tx_id_fkey
+        FOREIGN KEY (related_tx_id)
+        REFERENCES public.transactions (id)
+        ON DELETE SET NULL;
+  END IF;
+END;
+$$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS debt_payments_related_tx_id_key
+  ON public.debt_payments (related_tx_id);
+
+-- helper to build transaction description
+CREATE OR REPLACE FUNCTION public.build_debt_payment_description(p_debt_id uuid, p_note text)
+RETURNS text
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  debt_title text;
+  trimmed_note text;
+  description text;
+BEGIN
+  SELECT title INTO debt_title
+    FROM public.debts
+   WHERE id = p_debt_id;
+
+  IF debt_title IS NULL THEN
+    debt_title := 'Hutang';
+  END IF;
+
+  trimmed_note := NULLIF(BTRIM(p_note), '');
+  description := 'Bayar utang: ' || debt_title;
+  IF trimmed_note IS NOT NULL THEN
+    description := description || ' - ' || trimmed_note;
+  END IF;
+
+  RETURN description;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.debt_payments_before_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  description text;
+  inserted_tx_id uuid;
+  now_utc timestamptz := timezone('utc', now());
+BEGIN
+  IF NEW.user_id IS NULL THEN
+    NEW.user_id := auth.uid();
+  END IF;
+
+  IF NEW.account_id IS NULL THEN
+    RAISE EXCEPTION 'Account wajib diisi untuk pembayaran utang.';
+  END IF;
+
+  IF NEW.paid_at IS NULL THEN
+    NEW.paid_at := (timezone('Asia/Jakarta', now()))::date;
+  END IF;
+
+  NEW.date := COALESCE(NEW.date, NEW.paid_at::timestamp AT TIME ZONE 'Asia/Jakarta');
+
+  description := public.build_debt_payment_description(NEW.debt_id, NEW.note);
+
+  INSERT INTO public.transactions (
+    user_id,
+    date,
+    type,
+    amount,
+    account_id,
+    note,
+    notes,
+    title,
+    created_at,
+    updated_at,
+    rev
+  )
+  VALUES (
+    NEW.user_id,
+    NEW.paid_at,
+    'expense',
+    NEW.amount,
+    NEW.account_id,
+    description,
+    description,
+    description,
+    now_utc,
+    now_utc,
+    1
+  )
+  RETURNING id INTO inserted_tx_id;
+
+  NEW.related_tx_id := inserted_tx_id;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.debt_payments_after_change()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  description text;
+  now_utc timestamptz := timezone('utc', now());
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.related_tx_id IS NOT NULL THEN
+      UPDATE public.transactions
+         SET deleted_at = now_utc,
+             updated_at = now_utc,
+             rev = COALESCE(rev, 0) + 1
+       WHERE id = OLD.related_tx_id;
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  IF NEW.related_tx_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.account_id IS NULL THEN
+    RAISE EXCEPTION 'Account wajib diisi untuk pembayaran utang.';
+  END IF;
+
+  IF NEW.paid_at IS NULL THEN
+    NEW.paid_at := (timezone('Asia/Jakarta', now()))::date;
+  END IF;
+
+  IF (NEW.amount IS DISTINCT FROM OLD.amount)
+     OR (NEW.account_id IS DISTINCT FROM OLD.account_id)
+     OR (NEW.paid_at IS DISTINCT FROM OLD.paid_at)
+     OR (COALESCE(NEW.note, '') IS DISTINCT FROM COALESCE(OLD.note, '')) THEN
+    description := public.build_debt_payment_description(NEW.debt_id, NEW.note);
+
+    UPDATE public.transactions
+       SET amount = NEW.amount,
+           account_id = NEW.account_id,
+           date = NEW.paid_at,
+           note = description,
+           notes = description,
+           title = description,
+           updated_at = now_utc,
+           deleted_at = NULL,
+           rev = COALESCE(rev, 0) + 1
+     WHERE id = NEW.related_tx_id;
+  END IF;
+
+  NEW.date := NEW.paid_at::timestamp AT TIME ZONE 'Asia/Jakarta';
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS debt_payments_before_insert ON public.debt_payments;
+CREATE TRIGGER debt_payments_before_insert
+BEFORE INSERT ON public.debt_payments
+FOR EACH ROW
+EXECUTE FUNCTION public.debt_payments_before_insert();
+
+DROP TRIGGER IF EXISTS debt_payments_after_change ON public.debt_payments;
+CREATE TRIGGER debt_payments_after_change
+AFTER UPDATE OR DELETE ON public.debt_payments
+FOR EACH ROW
+EXECUTE FUNCTION public.debt_payments_after_change();


### PR DESCRIPTION
## Summary
- add Supabase migration to enrich debt payments and create expense transactions via triggers
- implement client-side debt payment drafts with automatic sync and transaction refresh
- update payment UI to require accounts, capture notes, and show linked transactions

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d411a56e38833286d128a35eb4b009