### PR TITLE
Support guest mode category management

### DIFF
--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -279,6 +279,7 @@ export default function BudgetsPage({ currentMonth }: BudgetsPageProps) {
     (async () => {
       try {
         await upsertBudget({
+          id: target.previous.id,
           period: target.previous.period_month.slice(0, 7),
           category_id: target.previous.category_id ?? undefined,
           name: target.previous.name ?? undefined,
@@ -333,6 +334,7 @@ export default function BudgetsPage({ currentMonth }: BudgetsPageProps) {
     pushUndo(previous);
     try {
       await upsertBudget({
+        id: next.id,
         period: next.period_month.slice(0, 7),
         category_id: next.category_id ?? undefined,
         name: next.name ?? undefined,


### PR DESCRIPTION
## Summary
- add LocalDriver-backed helpers so category listing, creation, updates, deletion, and reordering work while signed out in guest mode
- extend category mapping to carry client identifiers and normalize data consistently across Supabase and guest storage
- reuse the new guest helpers in the existing API flows to eliminate the remaining errors on the categories page

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d41c86fd68833297982f64a9945083