### PR TITLE
Enable guest category management

### DIFF
--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -279,6 +279,7 @@ export default function BudgetsPage({ currentMonth }: BudgetsPageProps) {
     (async () => {
       try {
         await upsertBudget({
+          id: target.previous.id,
           period: target.previous.period_month.slice(0, 7),
           category_id: target.previous.category_id ?? undefined,
           name: target.previous.name ?? undefined,
@@ -333,6 +334,7 @@ export default function BudgetsPage({ currentMonth }: BudgetsPageProps) {
     pushUndo(previous);
     try {
       await upsertBudget({
+        id: next.id,
         period: next.period_month.slice(0, 7),
         category_id: next.category_id ?? undefined,
         name: next.name ?? undefined,


### PR DESCRIPTION
## Summary
- align the Supabase budget API to the available columns by mapping `amount_planned`/`current_spent`, joining category names, and guarding against missing helper tables
- update budget persistence helpers to support client-driven IDs and degrade unsupported rollover/rule features gracefully
- ensure inline undo/redo paths pass record IDs so edits continue to update the right rows
- allow the categories page to create, edit, reorder, and delete entries while offline/guest by falling back to the local data driver and shared validation logic

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d41c86fd68833297982f64a9945083