### PR TITLE
Fix Supabase category creation timestamps

### DIFF
--- a/src/lib/api-categories.ts
+++ b/src/lib/api-categories.ts
@@ -446,6 +446,15 @@ export async function createCategory(input: {
       [sortColumn]: nextOrder,
     };
 
+    const timestamp = nowISO();
+    insertPayload.updated_at = timestamp;
+    const createdColumn = getCategoryCreatedColumn();
+    if (createdColumn === "created_at") {
+      insertPayload.created_at = timestamp;
+    } else {
+      insertPayload.inserted_at = timestamp;
+    }
+
     if (shouldUseCategoryColor()) {
       insertPayload.color = color;
     }


### PR DESCRIPTION
## Summary
- ensure new Supabase categories include created/updated timestamps during insert so online mode can persist records

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d4830860e88332b1b5139932ad567a