### PR TITLE
Fix category uniqueness check for logged in users

### DIFF
--- a/src/lib/api-categories.ts
+++ b/src/lib/api-categories.ts
@@ -392,13 +392,13 @@ async function assertUniqueName(
     .select("id, name")
     .eq("user_id", userId)
     .eq("type", type)
-    .ilike("name", name)
-    .limit(5);
+    .limit(200);
   const { data, error } = await query;
   if (error) throw error;
+  const normalized = name.toLowerCase();
   const conflict = (data ?? []).find((row) => {
     if (excludeId && row.id === excludeId) return false;
-    return normalizeName(row.name).toLowerCase() === name.toLowerCase();
+    return normalizeName(row.name).toLowerCase() === normalized;
   });
   if (conflict) {
     throw new Error("Nama kategori sudah digunakan pada tipe ini.");


### PR DESCRIPTION
## Summary
- adjust the authenticated category uniqueness guard to fetch existing names without relying on Supabase's `ilike`
- ensure duplicate detection matches the client-side normalization so logged-in users can add new categories successfully

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4830860e88332b1b5139932ad567a