### PR TITLE
fix: allow users to create categories online

### DIFF
--- a/supabase/migrations/20250420000000_fix_categories_rls.sql
+++ b/supabase/migrations/20250420000000_fix_categories_rls.sql
@@ -1,0 +1,55 @@
+-- Ensure categories table grants access to the owning user
+alter table if exists public.categories enable row level security;
+
+-- Basic CRUD policies so authenticated users can manage their own categories
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'categories'
+      AND policyname = 'categories_select_own'
+  ) THEN
+    CREATE POLICY categories_select_own ON public.categories
+      FOR SELECT USING (auth.uid() = user_id);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'categories'
+      AND policyname = 'categories_insert_own'
+  ) THEN
+    CREATE POLICY categories_insert_own ON public.categories
+      FOR INSERT WITH CHECK (auth.uid() = user_id);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'categories'
+      AND policyname = 'categories_update_own'
+  ) THEN
+    CREATE POLICY categories_update_own ON public.categories
+      FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'categories'
+      AND policyname = 'categories_delete_own'
+  ) THEN
+    CREATE POLICY categories_delete_own ON public.categories
+      FOR DELETE USING (auth.uid() = user_id);
+  END IF;
+END
+$$;
+
+-- Keep category names unique per user & type without blocking different types
+CREATE UNIQUE INDEX IF NOT EXISTS categories_user_type_name_idx
+  ON public.categories (user_id, type, lower(name));
+
+-- Help ordering queries continue to work even if only one of the ordering columns exists
+CREATE INDEX IF NOT EXISTS categories_order_idx
+  ON public.categories (user_id, type, coalesce(sort_order, order_index), coalesce(created_at, inserted_at));


### PR DESCRIPTION
## Summary
- enable row level security policies on `public.categories` so authenticated users can insert, update, select, and delete their own categories
- add safety indexes to preserve per-user uniqueness and ordering queries for categories

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4830860e88332b1b5139932ad567a