### PR TITLE
Automate debt payment expenses and enforce account selection

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,4 @@
 # Changelog
 
 - Remove Resume Last Page to resolve navigation lock bug.
+- Otomatiskan transaksi keluar saat pembayaran hutang (Supabase trigger + UI akun sumber dana).

--- a/docs/debt-payments.md
+++ b/docs/debt-payments.md
@@ -1,0 +1,7 @@
+# Pembayaran Hutang & Transaksi Otomatis
+
+- Setiap baris baru di `debt_payments` secara otomatis membuat transaksi keluar (`transactions.type = 'expense'`) via trigger `handle_debt_payment_before_insert`. Deskripsi transaksi menggunakan pola `Bayar utang: <judul utang> - <catatan pembayaran?>` dan ID transaksi disimpan pada kolom `debt_payments.related_tx_id`.
+- Perubahan nominal, tanggal (`paid_at`), akun (`account_id`), atau catatan pada pembayaran akan menjaga transaksi terkait tetap sinkron lewat trigger `handle_debt_payment_after_update`.
+- Menghapus pembayaran tidak menghapus transaksi secara permanen. Trigger `handle_debt_payment_after_delete` hanya mengisi `transactions.deleted_at` (soft delete) sehingga arus kas bisa dipulihkan bila diperlukan.
+- Form "Bayar Utang" di aplikasi meminta nominal, tanggal bayar, dan akun sumber dana. Catatan bersifat opsional. Setelah submit berhasil pengguna menerima notifikasi bahwa transaksi keluar dibuat otomatis dan daftar transaksi bulan berjalan ikut disegarkan.
+- Rollback: hapus pembayaran dari panel pembayaran hutang untuk menandai transaksi keluar terkait sebagai terhapus (soft delete). Jika perlu membatalkan soft delete, pulihkan transaksi langsung dari modul transaksi.

--- a/src/components/debts/PaymentsList.tsx
+++ b/src/components/debts/PaymentsList.tsx
@@ -26,8 +26,9 @@ export default function PaymentsList({ payments, onDelete, deletingId }: Payment
     <ul className="flex flex-col gap-3">
       {payments.map((payment) => {
         const amountLabel = currencyFormatter.format(payment.amount ?? 0);
-        const dateLabel = payment.date ? dateFormatter.format(new Date(payment.date)) : '-';
+        const dateLabel = payment.paid_at ? dateFormatter.format(new Date(payment.paid_at)) : '-';
         const isDeleting = deletingId === payment.id;
+        const accountLabel = payment.account?.name;
         return (
           <li
             key={payment.id}
@@ -36,9 +37,14 @@ export default function PaymentsList({ payments, onDelete, deletingId }: Payment
             <div className="min-w-0">
               <p className="text-sm font-semibold text-text">{amountLabel}</p>
               <p className="text-xs text-muted">{dateLabel}</p>
-              {payment.notes ? (
-                <p className="mt-2 break-words text-sm text-text/80" title={payment.notes}>
-                  {payment.notes}
+              {accountLabel ? (
+                <p className="mt-1 text-xs text-muted" title={accountLabel}>
+                  {accountLabel}
+                </p>
+              ) : null}
+              {payment.note ? (
+                <p className="mt-2 break-words text-sm text-text/80" title={payment.note}>
+                  {payment.note}
                 </p>
               ) : null}
             </div>

--- a/supabase/migrations/20250420000000_add_debt_payment_transaction_triggers.sql
+++ b/supabase/migrations/20250420000000_add_debt_payment_transaction_triggers.sql
@@ -1,0 +1,132 @@
+create or replace function public.handle_debt_payment_before_insert()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  debt_owner uuid;
+  debt_title text;
+  tx_id uuid;
+  description text;
+  trimmed_note text;
+  payment_date date;
+begin
+  if new.related_tx_id is not null then
+    return new;
+  end if;
+
+  select d.user_id, d.title
+    into debt_owner, debt_title
+  from public.debts d
+  where d.id = new.debt_id
+  limit 1;
+
+  if debt_owner is null then
+    raise exception 'Debt % not found or inaccessible', new.debt_id;
+  end if;
+
+  trimmed_note := nullif(trim(coalesce(new.note, '')), '');
+  new.user_id := debt_owner;
+
+  payment_date := coalesce(new.paid_at::date, now()::date);
+
+  description := 'Bayar utang: ' || coalesce(nullif(trim(debt_title), ''), 'Tanpa judul');
+  if trimmed_note is not null then
+    description := description || ' - ' || trimmed_note;
+  end if;
+
+  insert into public.transactions (user_id, date, type, amount, account_id, title, notes)
+  values (debt_owner, payment_date, 'expense', new.amount, new.account_id, description, null)
+  returning id into tx_id;
+
+  new.related_tx_id := tx_id;
+  new.paid_at := payment_date;
+
+  return new;
+end;
+$$;
+
+create or replace function public.handle_debt_payment_after_update()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  debt_title text;
+  debt_owner uuid;
+  description text;
+  trimmed_note text;
+  payment_date date;
+begin
+  if new.related_tx_id is null then
+    return new;
+  end if;
+
+  select d.title, d.user_id
+    into debt_title, debt_owner
+  from public.debts d
+  where d.id = new.debt_id
+  limit 1;
+
+  trimmed_note := nullif(trim(coalesce(new.note, '')), '');
+
+  payment_date := coalesce(new.paid_at::date, now()::date);
+
+  description := 'Bayar utang: ' || coalesce(nullif(trim(debt_title), ''), 'Tanpa judul');
+  if trimmed_note is not null then
+    description := description || ' - ' || trimmed_note;
+  end if;
+
+  update public.transactions
+     set user_id = coalesce(debt_owner, new.user_id),
+         amount = new.amount,
+         date = payment_date,
+         account_id = new.account_id,
+         title = description,
+         notes = null,
+         deleted_at = null
+   where id = new.related_tx_id;
+
+  return new;
+end;
+$$;
+
+create or replace function public.handle_debt_payment_after_delete()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if old.related_tx_id is null then
+    return old;
+  end if;
+
+  update public.transactions
+     set deleted_at = now()
+   where id = old.related_tx_id
+     and deleted_at is null;
+
+  return old;
+end;
+$$;
+
+drop trigger if exists trg_debt_payments_before_insert on public.debt_payments;
+create trigger trg_debt_payments_before_insert
+before insert on public.debt_payments
+for each row
+execute function public.handle_debt_payment_before_insert();
+
+drop trigger if exists trg_debt_payments_after_update on public.debt_payments;
+create trigger trg_debt_payments_after_update
+after update on public.debt_payments
+for each row
+execute function public.handle_debt_payment_after_update();
+
+drop trigger if exists trg_debt_payments_after_delete on public.debt_payments;
+create trigger trg_debt_payments_after_delete
+after delete on public.debt_payments
+for each row
+execute function public.handle_debt_payment_after_delete();


### PR DESCRIPTION
## Summary
- add trigger functions so debt_payments inserts/updates/deletes mirror a related expense transaction via related_tx_id
- require source account when recording debt payments, sync new schema fields, and refresh transactions list in the UI
- document the automatic transaction behaviour and soft-delete rollback flow

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4921b6d888332a03d1119ff9bde7c