### PR TITLE
Add automatic expense sync for debt payments

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,4 @@
 # Changelog
 
 - Remove Resume Last Page to resolve navigation lock bug.
+- Catat pembayaran hutang kini otomatis membuat transaksi keluar dengan tautan `related_tx_id`. Hapus pembayaran jika perlu rollback—transaksi terkait akan di-soft delete.

--- a/src/components/debts/PaymentsList.tsx
+++ b/src/components/debts/PaymentsList.tsx
@@ -26,7 +26,7 @@ export default function PaymentsList({ payments, onDelete, deletingId }: Payment
     <ul className="flex flex-col gap-3">
       {payments.map((payment) => {
         const amountLabel = currencyFormatter.format(payment.amount ?? 0);
-        const dateLabel = payment.date ? dateFormatter.format(new Date(payment.date)) : '-';
+        const dateLabel = payment.paid_at ? dateFormatter.format(new Date(payment.paid_at)) : '-';
         const isDeleting = deletingId === payment.id;
         return (
           <li
@@ -36,9 +36,12 @@ export default function PaymentsList({ payments, onDelete, deletingId }: Payment
             <div className="min-w-0">
               <p className="text-sm font-semibold text-text">{amountLabel}</p>
               <p className="text-xs text-muted">{dateLabel}</p>
-              {payment.notes ? (
-                <p className="mt-2 break-words text-sm text-text/80" title={payment.notes}>
-                  {payment.notes}
+              {payment.account_name ? (
+                <p className="mt-1 text-xs text-muted">{payment.account_name}</p>
+              ) : null}
+              {payment.note ? (
+                <p className="mt-2 break-words text-sm text-text/80" title={payment.note}>
+                  {payment.note}
                 </p>
               ) : null}
             </div>

--- a/src/hooks/useTransactionsQuery.js
+++ b/src/hooks/useTransactionsQuery.js
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { getTransactionsSummary, listCategories } from "../lib/api";
 import { listTransactions } from "../lib/api-transactions";
+import { TRANSACTIONS_REFRESH_EVENT } from "../lib/events";
 
 const PAGE_SIZE = 50;
 
@@ -219,6 +220,19 @@ export default function useTransactionsQuery() {
     },
     [page, updateParams],
   );
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.addEventListener !== "function") {
+      return undefined;
+    }
+    const handler = () => {
+      refresh({ keepPage: true });
+    };
+    window.addEventListener(TRANSACTIONS_REFRESH_EVENT, handler);
+    return () => {
+      window.removeEventListener(TRANSACTIONS_REFRESH_EVENT, handler);
+    };
+  }, [refresh]);
 
   const hasMore = items.length < total;
 

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,0 +1,8 @@
+export const TRANSACTIONS_REFRESH_EVENT = 'hematwoi:transactions-refresh';
+
+export function dispatchTransactionsRefresh(detail?: unknown) {
+  if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') {
+    return;
+  }
+  window.dispatchEvent(new CustomEvent(TRANSACTIONS_REFRESH_EVENT, { detail }));
+}

--- a/supabase/migrations/20250420000000_manage_debt_payment_transactions.sql
+++ b/supabase/migrations/20250420000000_manage_debt_payment_transactions.sql
@@ -1,0 +1,221 @@
+-- Ensure debt payment columns align with latest app expectations
+do $$
+begin
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'debt_payments'
+      and column_name = 'date'
+  )
+  and not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'debt_payments'
+      and column_name = 'paid_at'
+  ) then
+    alter table public.debt_payments rename column "date" to paid_at;
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'debt_payments'
+      and column_name = 'notes'
+  )
+  and not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'debt_payments'
+      and column_name = 'note'
+  ) then
+    alter table public.debt_payments rename column notes to note;
+  end if;
+end;
+$$;
+
+alter table public.debt_payments
+  add column if not exists paid_at date default timezone('Asia/Jakarta', now())::date;
+
+alter table public.debt_payments
+  add column if not exists account_id uuid references public.accounts (id) on delete set null;
+
+alter table public.debt_payments
+  add column if not exists note text;
+
+alter table public.debt_payments
+  add column if not exists related_tx_id uuid;
+
+do $$
+begin
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'debt_payments'
+      and column_name = 'paid_at'
+  ) then
+    execute $$alter table public.debt_payments alter column paid_at type date using paid_at::date$$;
+    execute $$alter table public.debt_payments alter column paid_at set default timezone('Asia/Jakarta', now())::date$$;
+    execute $$alter table public.debt_payments alter column paid_at set not null$$;
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.debt_payments'::regclass
+      and conname = 'debt_payments_related_tx_id_fkey'
+  ) then
+    alter table public.debt_payments
+      add constraint debt_payments_related_tx_id_fkey
+      foreign key (related_tx_id) references public.transactions (id) on delete set null;
+  end if;
+end;
+$$;
+
+create unique index if not exists debt_payments_related_tx_id_key
+  on public.debt_payments (related_tx_id)
+  where related_tx_id is not null;
+
+create index if not exists debt_payments_paid_at_idx
+  on public.debt_payments (paid_at desc);
+
+create or replace function public.debt_payments_before_insert()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  debt_owner uuid;
+  debt_title text;
+  description text;
+begin
+  if new.related_tx_id is not null then
+    return new;
+  end if;
+
+  select d.user_id, d.title
+    into debt_owner, debt_title
+  from public.debts d
+  where d.id = new.debt_id;
+
+  if debt_owner is null then
+    raise exception 'Debt % not found', new.debt_id;
+  end if;
+
+  new.user_id := debt_owner;
+  if new.paid_at is null then
+    new.paid_at := timezone('Asia/Jakarta', now())::date;
+  end if;
+
+  description := coalesce('Bayar utang: ' || debt_title, 'Bayar utang');
+  if new.note is not null and length(trim(new.note)) > 0 then
+    description := description || ' - ' || trim(new.note);
+  end if;
+
+  insert into public.transactions (user_id, date, type, amount, account_id, title)
+    values (
+      debt_owner,
+      coalesce(new.paid_at, timezone('Asia/Jakarta', now())::date),
+      'expense',
+      new.amount,
+      new.account_id,
+      description
+    )
+    returning id into new.related_tx_id;
+
+  return new;
+end;
+$$;
+
+create or replace function public.debt_payments_after_update()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  debt_owner uuid;
+  debt_title text;
+  description text;
+begin
+  if new.related_tx_id is null then
+    return new;
+  end if;
+
+  select d.user_id, d.title
+    into debt_owner, debt_title
+  from public.debts d
+  where d.id = new.debt_id;
+
+  if debt_owner is null then
+    return new;
+  end if;
+
+  description := coalesce('Bayar utang: ' || debt_title, 'Bayar utang');
+  if new.note is not null and length(trim(new.note)) > 0 then
+    description := description || ' - ' || trim(new.note);
+  end if;
+
+  update public.transactions
+     set user_id = debt_owner,
+         type = 'expense',
+         amount = new.amount,
+         account_id = new.account_id,
+         date = coalesce(new.paid_at, timezone('Asia/Jakarta', now())::date),
+         title = description,
+         updated_at = timezone('utc', now())
+   where id = new.related_tx_id;
+
+  return new;
+end;
+$$;
+
+create or replace function public.debt_payments_after_delete()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if old.related_tx_id is null then
+    return old;
+  end if;
+
+  update public.transactions
+     set deleted_at = coalesce(deleted_at, timezone('utc', now())),
+         updated_at = timezone('utc', now())
+   where id = old.related_tx_id
+     and deleted_at is null;
+
+  return old;
+end;
+$$;
+
+drop trigger if exists debt_payments_before_insert on public.debt_payments;
+create trigger debt_payments_before_insert
+before insert on public.debt_payments
+for each row
+execute function public.debt_payments_before_insert();
+
+drop trigger if exists debt_payments_after_update on public.debt_payments;
+create trigger debt_payments_after_update
+after update on public.debt_payments
+for each row
+execute function public.debt_payments_after_update();
+
+drop trigger if exists debt_payments_after_delete on public.debt_payments;
+create trigger debt_payments_after_delete
+after delete on public.debt_payments
+for each row
+execute function public.debt_payments_after_delete();


### PR DESCRIPTION
## Summary
- add Supabase trigger functions to create, update, and soft delete related expense transactions when debt payments change
- require account selection in the debt payment form and wire Supabase API updates to persist paid_at, account, and note fields while preventing duplicate transactions
- refresh the transactions listing after payments/deletions and document the automatic rollback behavior

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d4921b6d888332a03d1119ff9bde7c