### PR TITLE
Add automatic transaction sync for debt payments

### DIFF
--- a/docs/debt-payments-transactions.md
+++ b/docs/debt-payments-transactions.md
@@ -1,0 +1,16 @@
+# Pembayaran Hutang & Transaksi Otomatis
+
+Pemicu basis data baru memastikan pencatatan pembayaran hutang selalu sinkron dengan transaksi keuangan pengguna:
+
+- **Insert** ke `public.debt_payments` otomatis membuat satu baris `public.transactions` bertipe `expense` dengan tanggal `paid_at`, jumlah sesuai `amount`, akun sumber dari `account_id`, dan judul "Bayar utang: <judul hutang>" (ditambah catatan jika ada). Kolom `related_tx_id` pada pembayaran diisi dengan ID transaksi tersebut sehingga pencatatan idempoten.
+- **Update** pada pembayaran akan memperbarui transaksi terkait (nominal, tanggal, akun, serta judul/catatan) selama `related_tx_id` terisi.
+- **Delete** pembayaran hanya melakukan soft delete pada transaksi terkait (`deleted_at = now()`), sehingga histori arus kas tetap dapat dipulihkan.
+
+## Cara rollback
+
+Jika terjadi kekeliruan pada pembayaran:
+
+1. Edit kembali baris `debt_payments` untuk mengoreksi nominal/tanggal/akun — transaksi yang terhubung ikut berubah otomatis.
+2. Hapus pembayaran apabila transaksi perlu dibatalkan. Transaksi terkait tidak hilang, namun ditandai `deleted_at` sehingga dapat dipulihkan jika dibutuhkan.
+
+> Catatan: Seluruh logika dijalankan di PostgreSQL (security definer + `search_path=public`) sehingga tetap mematuhi RLS. Tidak perlu (dan tidak boleh) membuat transaksi manual dari sisi klien.

--- a/src/components/debts/PaymentsList.tsx
+++ b/src/components/debts/PaymentsList.tsx
@@ -26,7 +26,14 @@ export default function PaymentsList({ payments, onDelete, deletingId }: Payment
     <ul className="flex flex-col gap-3">
       {payments.map((payment) => {
         const amountLabel = currencyFormatter.format(payment.amount ?? 0);
-        const dateLabel = payment.date ? dateFormatter.format(new Date(payment.date)) : '-';
+        const dateValue = payment.paid_at
+          ? new Date(`${payment.paid_at}T00:00:00+07:00`)
+          : new Date(payment.created_at ?? Date.now());
+        const dateLabel = dateFormatter.format(dateValue);
+        const metaParts: string[] = [dateLabel];
+        if (payment.account_name) {
+          metaParts.push(payment.account_name);
+        }
         const isDeleting = deletingId === payment.id;
         return (
           <li
@@ -35,10 +42,10 @@ export default function PaymentsList({ payments, onDelete, deletingId }: Payment
           >
             <div className="min-w-0">
               <p className="text-sm font-semibold text-text">{amountLabel}</p>
-              <p className="text-xs text-muted">{dateLabel}</p>
-              {payment.notes ? (
-                <p className="mt-2 break-words text-sm text-text/80" title={payment.notes}>
-                  {payment.notes}
+              <p className="text-xs text-muted">{metaParts.join(' • ')}</p>
+              {payment.note ? (
+                <p className="mt-2 break-words text-sm text-text/80" title={payment.note}>
+                  {payment.note}
                 </p>
               ) : null}
             </div>

--- a/src/hooks/useTransactionsQuery.js
+++ b/src/hooks/useTransactionsQuery.js
@@ -139,6 +139,17 @@ export default function useTransactionsQuery() {
   }, []);
 
   useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+    const handler = () => {
+      setRefreshToken((token) => token + 1);
+    };
+    window.addEventListener("hematwoi:transactions:refresh", handler);
+    return () => {
+      window.removeEventListener("hematwoi:transactions:refresh", handler);
+    };
+  }, []);
+
+  useEffect(() => {
     let cancelled = false;
     const request = toRequestFilter(filter, page);
     setLoading(true);

--- a/supabase/migrations/20250418000000_debt_payments_transactions_triggers.sql
+++ b/supabase/migrations/20250418000000_debt_payments_transactions_triggers.sql
@@ -1,0 +1,189 @@
+-- Ensure debt_payments has the columns required for automatic transaction sync
+alter table public.debt_payments
+  add column if not exists account_id uuid references public.accounts (id) on delete set null,
+  add column if not exists paid_at date not null default (timezone('Asia/Jakarta', now())::date),
+  add column if not exists note text,
+  add column if not exists related_tx_id uuid;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'debt_payments'
+      AND column_name = 'date'
+  ) THEN
+    EXECUTE $$
+      update public.debt_payments
+         set paid_at = coalesce(public.debt_payments.paid_at, (timezone('Asia/Jakarta', public.debt_payments.date)::date))
+       where public.debt_payments.paid_at is null
+         and public.debt_payments.date is not null
+    $$;
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'debt_payments'
+      AND column_name = 'notes'
+  ) THEN
+    EXECUTE $$
+      update public.debt_payments
+         set note = coalesce(public.debt_payments.note, public.debt_payments.notes)
+       where public.debt_payments.note is null
+         and public.debt_payments.notes is not null
+    $$;
+  END IF;
+END
+$$;
+
+-- Ensure related_tx_id has a unique constraint and foreign key to transactions
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'debt_payments_related_tx_id_key'
+      AND table_schema = 'public'
+      AND table_name = 'debt_payments'
+  ) THEN
+    ALTER TABLE public.debt_payments
+      ADD CONSTRAINT debt_payments_related_tx_id_key UNIQUE (related_tx_id);
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'debt_payments_related_tx_id_fkey'
+      AND table_schema = 'public'
+      AND table_name = 'debt_payments'
+  ) THEN
+    ALTER TABLE public.debt_payments
+      ADD CONSTRAINT debt_payments_related_tx_id_fkey FOREIGN KEY (related_tx_id)
+        REFERENCES public.transactions (id) ON DELETE SET NULL;
+  END IF;
+END
+$$;
+
+create or replace function public.debt_payment_before_insert()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  debt_owner uuid;
+  debt_title text;
+  tx_title text;
+begin
+  -- Prevent duplicate transaction creation when retrying inserts
+  if new.related_tx_id is not null then
+    return new;
+  end if;
+
+  select d.user_id, d.title
+    into debt_owner, debt_title
+  from public.debts d
+  where d.id = new.debt_id;
+
+  if debt_owner is null then
+    raise exception 'Debt % not found for payment', new.debt_id;
+  end if;
+
+  new.user_id := debt_owner;
+  new.paid_at := coalesce(new.paid_at, timezone('Asia/Jakarta', now())::date);
+  new.note := case when new.note is null then null else nullif(trim(new.note), '') end;
+
+  tx_title := 'Bayar utang: ' || coalesce(debt_title, 'Tanpa judul');
+  if new.note is not null then
+    tx_title := tx_title || ' - ' || new.note;
+  end if;
+
+  insert into public.transactions (user_id, date, type, amount, account_id, title, notes)
+  values (debt_owner, new.paid_at, 'expense', new.amount, new.account_id, tx_title, new.note)
+  returning id into new.related_tx_id;
+
+  return new;
+end;
+$$;
+
+create or replace function public.debt_payment_after_update()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  debt_title text;
+  tx_title text;
+begin
+  if new.related_tx_id is null then
+    return new;
+  end if;
+
+  select d.title
+    into debt_title
+  from public.debts d
+  where d.id = new.debt_id;
+
+  tx_title := 'Bayar utang: ' || coalesce(debt_title, 'Tanpa judul');
+  if new.note is not null and trim(new.note) <> '' then
+    tx_title := tx_title || ' - ' || trim(new.note);
+  end if;
+
+  update public.transactions
+     set amount = new.amount,
+         date = coalesce(new.paid_at, timezone('Asia/Jakarta', now())::date),
+         account_id = new.account_id,
+         title = tx_title,
+         notes = case when new.note is null or trim(new.note) = '' then null else trim(new.note) end,
+         deleted_at = null
+   where id = new.related_tx_id;
+
+  return new;
+end;
+$$;
+
+create or replace function public.debt_payment_after_delete()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if old.related_tx_id is null then
+    return old;
+  end if;
+
+  update public.transactions
+     set deleted_at = coalesce(deleted_at, timezone('utc', now()))
+   where id = old.related_tx_id
+     and deleted_at is null;
+
+  return old;
+end;
+$$;
+
+drop trigger if exists debt_payment_before_insert_trigger on public.debt_payments;
+create trigger debt_payment_before_insert_trigger
+before insert on public.debt_payments
+for each row
+execute function public.debt_payment_before_insert();
+
+drop trigger if exists debt_payment_after_update_trigger on public.debt_payments;
+create trigger debt_payment_after_update_trigger
+after update on public.debt_payments
+for each row
+execute function public.debt_payment_after_update();
+
+drop trigger if exists debt_payment_after_delete_trigger on public.debt_payments;
+create trigger debt_payment_after_delete_trigger
+after delete on public.debt_payments
+for each row
+execute function public.debt_payment_after_delete();


### PR DESCRIPTION
## Summary
- create Supabase trigger functions to mirror debt payments into expense transactions and keep them in sync on update/delete
- refresh the “Bayar Utang” flow to require account selection, send paid_at/note fields, and show the linked account in the list
- dispatch a global transactions refresh event, run it on payment changes, and document the automatic behaviour and rollback notes

## Testing
- pnpm lint
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68d4921b6d888332a03d1119ff9bde7c