### PR TITLE
Add dashboard balances summary cards

### DIFF
--- a/src/components/dashboard/DashboardBalances.tsx
+++ b/src/components/dashboard/DashboardBalances.tsx
@@ -1,0 +1,83 @@
+import { Banknote, CreditCard, Wallet } from 'lucide-react';
+
+import Skeleton from '../Skeleton';
+import { formatCurrency } from '../../lib/format';
+import useBalances from '../../hooks/useBalances';
+
+const cards = [
+  {
+    key: 'cashTotal' as const,
+    label: 'Uang Cash',
+    Icon: Wallet,
+  },
+  {
+    key: 'allTotal' as const,
+    label: 'Total Saldo',
+    Icon: Banknote,
+  },
+  {
+    key: 'nonCashTotal' as const,
+    label: 'Saldo Non-Cash',
+    Icon: CreditCard,
+  },
+];
+
+export default function DashboardBalances() {
+  const { cashTotal, allTotal, nonCashTotal, loading, error, refetch } = useBalances();
+
+  if (loading) {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {cards.map((card) => (
+          <div key={card.key} className="rounded-2xl border border-border bg-card p-5 ring-2 ring-border/50">
+            <Skeleton className="h-7 w-24" />
+            <Skeleton className="mt-4 h-10 w-3/4" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-red-200 bg-red-50 p-5 text-sm text-red-700">
+        <p className="font-semibold">Gagal memuat saldo</p>
+        <p className="mt-1 text-xs opacity-80">{error.message || 'Silakan coba lagi.'}</p>
+        <button
+          type="button"
+          onClick={refetch}
+          className="mt-4 inline-flex items-center gap-1 rounded-full bg-red-600 px-3 py-1 text-xs font-medium text-white transition hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
+        >
+          Coba lagi
+        </button>
+      </div>
+    );
+  }
+
+  const values = {
+    cashTotal,
+    allTotal,
+    nonCashTotal,
+  } satisfies Record<(typeof cards)[number]['key'], number>;
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+      {cards.map(({ key, label, Icon }) => (
+        <div
+          key={key}
+          className="flex items-start justify-between gap-4 rounded-2xl border border-border bg-card p-5 ring-2 ring-border/50"
+        >
+          <div>
+            <p className="text-sm font-medium text-muted-foreground">{label}</p>
+            <p className="mt-2 text-2xl font-bold tracking-tight">
+              {formatCurrency(values[key] ?? 0, 'IDR')}
+            </p>
+          </div>
+          <span className="rounded-full bg-primary/10 p-2 text-primary">
+            <Icon aria-hidden className="h-6 w-6" />
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useBalances.ts
+++ b/src/hooks/useBalances.ts
@@ -1,0 +1,164 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { PostgrestError } from '@supabase/supabase-js';
+
+import { supabase } from '../lib/supabase';
+import useSupabaseUser from './useSupabaseUser';
+import {
+  aggregateAccountBalances,
+  type AccountSummary,
+  type TransactionSummary,
+} from '../lib/balances';
+
+interface BalanceState {
+  cashTotal: number;
+  nonCashTotal: number;
+  allTotal: number;
+  loading: boolean;
+  error: Error | null;
+}
+
+const INITIAL_TOTALS = {
+  cashTotal: 0,
+  nonCashTotal: 0,
+  allTotal: 0,
+};
+
+function normalizeError(error: unknown): Error {
+  if (error instanceof Error) return error;
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = String((error as { message: unknown }).message);
+    return new Error(message);
+  }
+  return new Error('Terjadi kesalahan tak terduga.');
+}
+
+function isMissingView(error: PostgrestError | null): boolean {
+  if (!error) return false;
+  if (error.code === '42P01' || error.code === 'PGRST202') return true;
+  const message = (error.message ?? '').toLowerCase();
+  return message.includes('relation') && message.includes('does not exist');
+}
+
+export default function useBalances() {
+  const { user, loading: userLoading } = useSupabaseUser();
+  const [state, setState] = useState<BalanceState>({
+    ...INITIAL_TOTALS,
+    loading: true,
+    error: null,
+  });
+  const isMounted = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  const setSafeState = useCallback((updater: BalanceState | ((prev: BalanceState) => BalanceState)) => {
+    if (!isMounted.current) return;
+    setState(updater);
+  }, []);
+
+  const fetchBalances = useCallback(async () => {
+    if (!isMounted.current) return;
+
+    const userId = user?.id;
+    if (!userId) {
+      setSafeState({ ...INITIAL_TOTALS, loading: false, error: null });
+      return;
+    }
+
+    setSafeState((prev) => ({ ...prev, loading: true, error: null }));
+
+    const { data: viewData, error: viewError } = await supabase
+      .from('v_balance_by_type')
+      .select('type,total_balance')
+      .eq('user_id', userId);
+
+    if (!isMounted.current) return;
+
+    if (!viewError && Array.isArray(viewData)) {
+      let cashTotal = 0;
+      let allTotal = 0;
+
+      for (const row of viewData) {
+        const amount = Number(row?.total_balance ?? 0) || 0;
+        allTotal += amount;
+        if (row?.type === 'cash') {
+          cashTotal += amount;
+        }
+      }
+
+      setSafeState({
+        cashTotal,
+        allTotal,
+        nonCashTotal: allTotal - cashTotal,
+        loading: false,
+        error: null,
+      });
+      return;
+    }
+
+    if (viewError && !isMissingView(viewError)) {
+      setSafeState({ ...INITIAL_TOTALS, loading: false, error: normalizeError(viewError) });
+      return;
+    }
+
+    const { data: accounts, error: accountError } = await supabase
+      .from('accounts')
+      .select('id,type')
+      .eq('user_id', userId);
+
+    if (!isMounted.current) return;
+
+    if (accountError) {
+      setSafeState({ ...INITIAL_TOTALS, loading: false, error: normalizeError(accountError) });
+      return;
+    }
+
+    const { data: transactions, error: txError } = await supabase
+      .from('transactions')
+      .select('account_id,to_account_id,type,amount')
+      .eq('user_id', userId)
+      .is('deleted_at', null);
+
+    if (!isMounted.current) return;
+
+    if (txError) {
+      setSafeState({ ...INITIAL_TOTALS, loading: false, error: normalizeError(txError) });
+      return;
+    }
+
+    const aggregation = aggregateAccountBalances(
+      (accounts ?? []) as AccountSummary[],
+      (transactions ?? []) as TransactionSummary[]
+    );
+
+    setSafeState({
+      cashTotal: aggregation.cashTotal,
+      nonCashTotal: aggregation.nonCashTotal,
+      allTotal: aggregation.allTotal,
+      loading: false,
+      error: null,
+    });
+  }, [setSafeState, user?.id]);
+
+  useEffect(() => {
+    if (userLoading) return;
+    fetchBalances();
+  }, [userLoading, fetchBalances]);
+
+  const refetch = useCallback(() => {
+    if (userLoading) return;
+    fetchBalances();
+  }, [fetchBalances, userLoading]);
+
+  return {
+    cashTotal: state.cashTotal,
+    nonCashTotal: state.nonCashTotal,
+    allTotal: state.allTotal,
+    loading: state.loading,
+    error: state.error,
+    refetch,
+  } as const;
+}

--- a/src/lib/balances.test.ts
+++ b/src/lib/balances.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { aggregateAccountBalances } from './balances';
+
+describe('aggregateAccountBalances', () => {
+  it('sums balances per account with incomes, expenses, and transfers', () => {
+    const accounts = [
+      { id: 'a1', type: 'cash' },
+      { id: 'a2', type: 'bank' },
+      { id: 'a3', type: 'ewallet' },
+    ];
+
+    const transactions = [
+      { account_id: 'a1', to_account_id: null, type: 'income', amount: 500_000 },
+      { account_id: 'a1', to_account_id: null, type: 'expense', amount: 200_000 },
+      { account_id: 'a2', to_account_id: 'a3', type: 'transfer', amount: 150_000 },
+      { account_id: 'a3', to_account_id: null, type: 'income', amount: 50_000 },
+      { account_id: 'a2', to_account_id: null, type: 'expense', amount: 20_000 },
+    ];
+
+    const result = aggregateAccountBalances(accounts, transactions);
+
+    expect(result.perAccount).toEqual({
+      a1: 300_000,
+      a2: -170_000,
+      a3: 200_000,
+    });
+    expect(result.cashTotal).toBe(300_000);
+    expect(result.allTotal).toBe(330_000);
+    expect(result.nonCashTotal).toBe(30_000);
+  });
+
+  it('ignores unknown accounts and empty datasets', () => {
+    const accounts = [{ id: 'cash-1', type: 'cash' }];
+    const transactions = [
+      { account_id: 'unknown', to_account_id: 'cash-1', type: 'transfer', amount: 80_000 },
+      { account_id: 'cash-1', to_account_id: null, type: 'income', amount: '100000' },
+      { account_id: null, to_account_id: 'cash-1', type: 'income', amount: 20_000 },
+      { account_id: 'cash-1', to_account_id: null, type: 'unknown', amount: 5_000 },
+    ];
+
+    const result = aggregateAccountBalances(accounts, transactions);
+
+    expect(result.perAccount).toEqual({ 'cash-1': 180_000 });
+    expect(result.cashTotal).toBe(180_000);
+    expect(result.allTotal).toBe(180_000);
+    expect(result.nonCashTotal).toBe(0);
+
+    const emptyResult = aggregateAccountBalances([], []);
+    expect(emptyResult.perAccount).toEqual({});
+    expect(emptyResult.cashTotal).toBe(0);
+    expect(emptyResult.allTotal).toBe(0);
+    expect(emptyResult.nonCashTotal).toBe(0);
+  });
+});

--- a/src/lib/balances.ts
+++ b/src/lib/balances.ts
@@ -1,0 +1,112 @@
+export type AccountType = 'cash' | 'bank' | 'ewallet' | 'other' | string;
+
+export interface AccountSummary {
+  id: string;
+  type: AccountType;
+}
+
+export type TransactionType = 'income' | 'expense' | 'transfer' | string;
+
+export interface TransactionSummary {
+  account_id: string | null;
+  to_account_id: string | null;
+  type: TransactionType;
+  amount: number | string | null;
+}
+
+export interface BalanceAggregation {
+  perAccount: Record<string, number>;
+  cashTotal: number;
+  nonCashTotal: number;
+  allTotal: number;
+}
+
+const ZERO_TOTALS = {
+  perAccount: {},
+  cashTotal: 0,
+  nonCashTotal: 0,
+  allTotal: 0,
+} satisfies BalanceAggregation;
+
+function normalizeAmount(value: number | string | null | undefined): number {
+  const amount = typeof value === 'string' ? Number.parseFloat(value) : value;
+  if (Number.isNaN(amount) || amount == null) return 0;
+  return amount;
+}
+
+/**
+ * Aggregates balances per account based on income, expense, and transfer transactions.
+ *
+ * Transfers are treated as a debit on the source account (account_id) and a credit on
+ * the destination account (to_account_id) to avoid double counting.
+ */
+export function aggregateAccountBalances(
+  accounts: AccountSummary[] = [],
+  transactions: TransactionSummary[] = []
+): BalanceAggregation {
+  if (!accounts.length) return ZERO_TOTALS;
+
+  const balances = new Map<string, number>();
+
+  for (const account of accounts) {
+    if (account?.id) {
+      balances.set(account.id, 0);
+    }
+  }
+
+  for (const tx of transactions) {
+    if (!tx) continue;
+
+    const amount = normalizeAmount(tx.amount);
+    if (amount === 0) continue;
+
+    const accountId = tx.account_id ?? undefined;
+    const destinationId = tx.to_account_id ?? undefined;
+
+    switch (tx.type) {
+      case 'income': {
+        if (accountId && balances.has(accountId)) {
+          balances.set(accountId, balances.get(accountId)! + amount);
+        }
+        break;
+      }
+      case 'expense': {
+        if (accountId && balances.has(accountId)) {
+          balances.set(accountId, balances.get(accountId)! - amount);
+        }
+        break;
+      }
+      case 'transfer': {
+        if (destinationId && balances.has(destinationId)) {
+          balances.set(destinationId, balances.get(destinationId)! + amount);
+        }
+        if (accountId && destinationId && balances.has(accountId)) {
+          balances.set(accountId, balances.get(accountId)! - amount);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  let cashTotal = 0;
+  let allTotal = 0;
+
+  for (const account of accounts) {
+    const balance = balances.get(account.id) ?? 0;
+    if (account.type === 'cash') {
+      cashTotal += balance;
+    }
+    allTotal += balance;
+  }
+
+  const nonCashTotal = allTotal - cashTotal;
+
+  return {
+    perAccount: Object.fromEntries(balances.entries()),
+    cashTotal,
+    nonCashTotal,
+    allTotal,
+  };
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -12,6 +12,7 @@ import TopSpendsTable from "../components/TopSpendsTable";
 import RecentTransactions from "../components/RecentTransactions";
 import useInsights from "../hooks/useInsights";
 import EventBus from "../lib/eventBus";
+import DashboardBalances from "../components/dashboard/DashboardBalances";
 
 // Each content block uses <Section> to maintain a single vertical rhythm.
 export default function Dashboard({ stats, txs, budgetStatus = [] }) {
@@ -46,6 +47,8 @@ export default function Dashboard({ stats, txs, budgetStatus = [] }) {
           Ringkasan keuanganmu
         </p>
       </header>
+
+      <DashboardBalances />
 
       <KpiCards
         income={stats?.income || 0}


### PR DESCRIPTION
## Summary
- add a reusable balance aggregation helper and hook to load account totals from Supabase
- render new DashboardBalances cards on the dashboard with loading and error states
- cover the aggregation logic with unit tests for transfers, income, and expenses

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d529b1ccc08332b3fa5d2bb7a4b3d4