### PR TITLE
Add dashboard balance summaries

### DIFF
--- a/src/components/DashboardBalances.tsx
+++ b/src/components/DashboardBalances.tsx
@@ -1,0 +1,104 @@
+import { Banknote, PieChart, Wallet } from 'lucide-react';
+import useBalances from '../hooks/useBalances';
+import { fmtIDR } from '../lib/balances';
+
+type Totals = {
+  cashTotal: number;
+  nonCashTotal: number;
+  allTotal: number;
+};
+
+const cards = [
+  {
+    key: 'cash',
+    label: 'Uang Cash',
+    icon: Wallet,
+    valueSelector: (totals: Totals) => totals.cashTotal,
+  },
+  {
+    key: 'all',
+    label: 'Total Saldo',
+    icon: Banknote,
+    valueSelector: (totals: Totals) => totals.allTotal,
+  },
+  {
+    key: 'non-cash',
+    label: 'Saldo Non-Cash',
+    icon: PieChart,
+    valueSelector: (totals: Totals) => totals.nonCashTotal,
+  },
+] as const;
+
+function SkeletonCard() {
+  return (
+    <div className="rounded-2xl border border-border/60 bg-card p-5 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <div className="h-4 w-24 animate-pulse rounded-full bg-muted" />
+          <div className="h-7 w-32 animate-pulse rounded-full bg-muted" />
+        </div>
+        <div className="h-10 w-10 animate-pulse rounded-full bg-muted" />
+      </div>
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  icon: Icon,
+}: {
+  label: string;
+  value: number;
+  icon: typeof Wallet;
+}) {
+  return (
+    <div className="rounded-2xl border border-border/60 bg-card p-5 shadow-sm ring-1 ring-border/60">
+      <div className="flex items-center justify-between gap-4">
+        <div className="space-y-1.5">
+          <p className="text-sm font-medium text-muted-foreground">{label}</p>
+          <p className="text-2xl font-bold tracking-tight">{fmtIDR(value)}</p>
+        </div>
+        <span className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <Icon className="h-6 w-6" aria-hidden="true" />
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default function DashboardBalances() {
+  const { cashTotal, nonCashTotal, allTotal, loading, error, refetch } = useBalances();
+
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-red-200 bg-red-50/70 p-5 text-red-700 ring-1 ring-red-300">
+        <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="font-semibold">Gagal memuat saldo akun</p>
+            <p className="text-sm text-red-600/80">{error.message || 'Terjadi kesalahan tak terduga.'}</p>
+          </div>
+          <button
+            type="button"
+            onClick={refetch}
+            className="inline-flex items-center gap-1 rounded-lg bg-red-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-red-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500"
+          >
+            Coba lagi
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const totals = { cashTotal, nonCashTotal, allTotal };
+
+  return (
+    <section aria-label="Ringkasan saldo" className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {loading
+        ? cards.map((card) => <SkeletonCard key={card.key} />)
+        : cards.map((card) => (
+            <StatCard key={card.key} label={card.label} value={card.valueSelector(totals)} icon={card.icon} />
+          ))}
+    </section>
+  );
+}

--- a/src/hooks/useBalances.ts
+++ b/src/hooks/useBalances.ts
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { supabase } from '../lib/supabase';
+import useSupabaseUser from './useSupabaseUser';
+import {
+  type AccountRow,
+  type AggregateResult,
+  type TransactionRow,
+  aggregateAccountBalances,
+} from '../lib/balances';
+
+interface BalanceState {
+  cashTotal: number;
+  nonCashTotal: number;
+  allTotal: number;
+}
+
+const ZERO_STATE: BalanceState = Object.freeze({
+  cashTotal: 0,
+  nonCashTotal: 0,
+  allTotal: 0,
+});
+
+export interface UseBalancesResult extends BalanceState {
+  loading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+export default function useBalances(): UseBalancesResult {
+  const { user, loading: userLoading } = useSupabaseUser();
+  const [state, setState] = useState<BalanceState>(ZERO_STATE);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  const fetchBalances = useCallback(
+    async (isActive: () => boolean) => {
+      if (!user) {
+        if (!isActive()) return;
+        setState(ZERO_STATE);
+        setError(null);
+        setLoading(false);
+        return;
+      }
+
+      if (!isActive()) return;
+      setLoading(true);
+      setError(null);
+
+      try {
+        const { data: accounts, error: accountError } = await supabase
+          .from('accounts')
+          .select('id, type')
+          .eq('user_id', user.id);
+
+        if (accountError) {
+          throw accountError;
+        }
+
+        const { data: transactions, error: transactionsError } = await supabase
+          .from('transactions')
+          .select('account_id, to_account_id, type, amount, deleted_at')
+          .eq('user_id', user.id)
+          .is('deleted_at', null);
+
+        if (transactionsError) {
+          throw transactionsError;
+        }
+
+        if (!isActive()) return;
+
+        const result: AggregateResult = aggregateAccountBalances(
+          (accounts as AccountRow[]) ?? [],
+          (transactions as TransactionRow[]) ?? []
+        );
+
+        setState({
+          cashTotal: result.cashTotal,
+          nonCashTotal: result.nonCashTotal,
+          allTotal: result.allTotal,
+        });
+        setLoading(false);
+      } catch (err) {
+        if (!isActive()) return;
+        const handledError = err instanceof Error ? err : new Error('Gagal memuat saldo');
+        setError(handledError);
+        setState(ZERO_STATE);
+        setLoading(false);
+      }
+    },
+    [user]
+  );
+
+  useEffect(() => {
+    if (userLoading) {
+      setLoading(true);
+      return;
+    }
+
+    let active = true;
+
+    fetchBalances(() => active);
+
+    return () => {
+      active = false;
+    };
+  }, [userLoading, fetchBalances, reloadToken]);
+
+  const refetch = useCallback(() => {
+    setReloadToken((token) => token + 1);
+  }, []);
+
+  const memoizedState = useMemo(
+    () => ({
+      cashTotal: state.cashTotal,
+      nonCashTotal: state.nonCashTotal,
+      allTotal: state.allTotal,
+    }),
+    [state]
+  );
+
+  return {
+    ...memoizedState,
+    loading: userLoading || loading,
+    error,
+    refetch,
+  };
+}

--- a/src/lib/balances.test.ts
+++ b/src/lib/balances.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { aggregateAccountBalances, fmtIDR } from './balances';
+
+describe('aggregateAccountBalances', () => {
+  const accounts = [
+    { id: 'cash-1', type: 'cash' as const },
+    { id: 'bank-1', type: 'bank' as const },
+  ];
+
+  it('calculates income and expense balances correctly', () => {
+    const { perAccount, cashTotal, nonCashTotal, allTotal } = aggregateAccountBalances(accounts, [
+      { account_id: 'cash-1', to_account_id: null, type: 'income', amount: 100_000 },
+      { account_id: 'cash-1', to_account_id: null, type: 'expense', amount: 25_000 },
+      { account_id: 'bank-1', to_account_id: null, type: 'income', amount: '50000' },
+    ]);
+
+    expect(perAccount['cash-1']).toBe(75_000);
+    expect(perAccount['bank-1']).toBe(50_000);
+    expect(cashTotal).toBe(75_000);
+    expect(nonCashTotal).toBe(50_000);
+    expect(allTotal).toBe(125_000);
+  });
+
+  it('ignores deleted transactions', () => {
+    const { allTotal } = aggregateAccountBalances(accounts, [
+      { account_id: 'cash-1', to_account_id: null, type: 'income', amount: 100_000, deleted_at: '2024-01-01' },
+    ]);
+
+    expect(allTotal).toBe(0);
+  });
+
+  it('handles transfers between accounts without duplication', () => {
+    const { perAccount, cashTotal, nonCashTotal, allTotal } = aggregateAccountBalances(accounts, [
+      { account_id: 'cash-1', to_account_id: null, type: 'income', amount: 200_000 },
+      { account_id: 'cash-1', to_account_id: 'bank-1', type: 'transfer', amount: 50_000 },
+    ]);
+
+    expect(perAccount['cash-1']).toBe(150_000);
+    expect(perAccount['bank-1']).toBe(50_000);
+    expect(cashTotal).toBe(150_000);
+    expect(nonCashTotal).toBe(50_000);
+    expect(allTotal).toBe(200_000);
+  });
+});
+
+describe('fmtIDR', () => {
+  it('formats numbers as Indonesian Rupiah', () => {
+    expect(fmtIDR(123456)).toBe('Rp123.456');
+    expect(fmtIDR(0)).toBe('Rp0');
+  });
+});

--- a/src/lib/balances.ts
+++ b/src/lib/balances.ts
@@ -1,0 +1,101 @@
+export type AccountType = 'cash' | 'bank' | 'ewallet' | 'other';
+
+export interface AccountRow {
+  id: string;
+  type: AccountType;
+}
+
+export type TransactionType = 'income' | 'expense' | 'transfer';
+
+export interface TransactionRow {
+  account_id: string | null;
+  to_account_id: string | null;
+  type: TransactionType;
+  amount: number | string | null;
+  deleted_at?: string | null;
+}
+
+export interface AggregateResult {
+  perAccount: Record<string, number>;
+  cashTotal: number;
+  nonCashTotal: number;
+  allTotal: number;
+}
+
+export const fmtIDR = (n: number): string =>
+  new Intl.NumberFormat('id-ID', {
+    style: 'currency',
+    currency: 'IDR',
+    maximumFractionDigits: 0,
+  })
+    .format(n || 0)
+    .replace(/ /g, '');
+
+const NORMALIZED_ZERO = 0;
+
+const toNumber = (value: number | string | null | undefined): number => {
+  if (value == null) return NORMALIZED_ZERO;
+  const parsed = typeof value === 'string' ? Number.parseFloat(value) : Number(value);
+  return Number.isFinite(parsed) ? parsed : NORMALIZED_ZERO;
+};
+
+export function aggregateAccountBalances(
+  accounts: AccountRow[] = [],
+  transactions: TransactionRow[] = []
+): AggregateResult {
+  const perAccount = new Map<string, { balance: number; type: AccountType }>();
+
+  for (const account of accounts) {
+    if (!account?.id) continue;
+    perAccount.set(account.id, { balance: 0, type: account.type });
+  }
+
+  for (const tx of transactions) {
+    if (!tx || tx.deleted_at) continue;
+
+    const amount = toNumber(tx.amount);
+    if (!amount) {
+      continue;
+    }
+
+    const sourceId = tx.account_id ?? null;
+    const targetId = tx.to_account_id ?? null;
+
+    if (tx.type === 'income' && sourceId && perAccount.has(sourceId)) {
+      perAccount.get(sourceId)!.balance += amount;
+    } else if (tx.type === 'expense' && sourceId && perAccount.has(sourceId)) {
+      perAccount.get(sourceId)!.balance -= amount;
+    } else if (tx.type === 'transfer') {
+      if (sourceId && perAccount.has(sourceId)) {
+        perAccount.get(sourceId)!.balance -= amount;
+      }
+      if (targetId && perAccount.has(targetId)) {
+        perAccount.get(targetId)!.balance += amount;
+      }
+    }
+  }
+
+  let cashTotal = 0;
+  let allTotal = 0;
+
+  for (const { balance, type } of perAccount.values()) {
+    allTotal += balance;
+    if (type === 'cash') {
+      cashTotal += balance;
+    }
+  }
+
+  const perAccountRecord: Record<string, number> = {};
+  for (const [id, { balance }] of perAccount) {
+    perAccountRecord[id] = balance;
+  }
+
+  const nonCashTotal = allTotal - cashTotal;
+
+  return {
+    perAccount: perAccountRecord,
+    cashTotal,
+    nonCashTotal,
+    allTotal,
+  };
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import DashboardBalances from "../components/DashboardBalances";
 import KpiCards from "../components/KpiCards";
 import QuoteBoard from "../components/QuoteBoard";
 import SavingsProgress from "../components/SavingsProgress";
@@ -46,6 +47,8 @@ export default function Dashboard({ stats, txs, budgetStatus = [] }) {
           Ringkasan keuanganmu
         </p>
       </header>
+
+      <DashboardBalances />
 
       <KpiCards
         income={stats?.income || 0}


### PR DESCRIPTION
## Summary
- add balance aggregation helpers with IDR formatter for dashboard totals
- implement `useBalances` hook and dashboard cards for cash, total, and non-cash balances
- cover balance aggregation with vitest unit tests

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d529b1ccc08332b3fa5d2bb7a4b3d4