### PR TITLE
feat: show dashboard balances summary

### DIFF
--- a/src/components/DashboardBalances.tsx
+++ b/src/components/DashboardBalances.tsx
@@ -1,0 +1,86 @@
+import { Banknote, PieChart, Wallet } from 'lucide-react';
+import useBalances from '../hooks/useBalances';
+import Skeleton from './Skeleton';
+import { fmtIDR } from '../lib/format';
+
+const CARDS = [
+  {
+    key: 'cash',
+    title: 'Uang Cash',
+    icon: Wallet,
+    getValue: (cash: number, _nonCash: number, _all: number) => cash,
+  },
+  {
+    key: 'total',
+    title: 'Total Saldo',
+    icon: Banknote,
+    getValue: (_cash: number, _nonCash: number, all: number) => all,
+  },
+  {
+    key: 'noncash',
+    title: 'Saldo Non-Cash',
+    icon: PieChart,
+    getValue: (_cash: number, nonCash: number) => nonCash,
+  },
+] as const;
+
+export default function DashboardBalances() {
+  const { cashTotal, nonCashTotal, allTotal, loading, error, refetch } = useBalances();
+
+  if (loading) {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {CARDS.map((card) => (
+          <div
+            key={card.key}
+            className="rounded-2xl border border-border bg-surface-1 p-5 ring-1 ring-border/60"
+          >
+            <Skeleton className="h-7 w-24" />
+            <Skeleton className="mt-4 h-7 w-32" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-danger/30 bg-danger/10 p-5 text-danger">
+        <p className="text-sm font-medium">Gagal memuat saldo akun.</p>
+        <p className="mt-1 text-sm text-danger/80">{error}</p>
+        <button
+          type="button"
+          onClick={refetch}
+          className="mt-4 inline-flex items-center justify-center rounded-lg border border-danger/40 px-4 py-2 text-sm font-semibold text-danger transition hover:bg-danger/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger/40"
+        >
+          Coba lagi
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+      {CARDS.map(({ key, title, icon: Icon, getValue }) => (
+        <article
+          key={key}
+          className="rounded-2xl border border-border bg-surface-1 p-5 ring-1 ring-border/60"
+        >
+          <div className="flex items-center gap-3">
+            <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-brand/10 text-brand">
+              <Icon className="h-5 w-5" />
+            </span>
+            <div className="space-y-1">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                {title}
+              </p>
+              <p className="text-2xl font-bold text-text">
+                {fmtIDR(getValue(cashTotal, nonCashTotal, allTotal))}
+              </p>
+            </div>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useBalances.ts
+++ b/src/hooks/useBalances.ts
@@ -1,0 +1,156 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { PostgrestError } from '@supabase/supabase-js';
+import { supabase } from '../lib/supabase';
+import useSupabaseUser from './useSupabaseUser';
+import { calculateAccountBalances, type AccountRow, type TransactionRow } from '../lib/balance-utils';
+
+interface BalanceState {
+  cashTotal: number;
+  nonCashTotal: number;
+  allTotal: number;
+}
+
+const EMPTY_STATE: BalanceState = {
+  cashTotal: 0,
+  nonCashTotal: 0,
+  allTotal: 0,
+};
+
+function isMissingViewError(error: PostgrestError | null): boolean {
+  if (!error) return false;
+  if (error.code === '42P01') return true;
+  const message = error.message?.toLowerCase() ?? '';
+  return (
+    message.includes('relation') && message.includes('does not exist')
+  ) || message.includes('v_balance_by_type');
+}
+
+async function fetchBalancesFromView(userId: string): Promise<BalanceState | null> {
+  const { data, error } = await supabase
+    .from('v_balance_by_type')
+    .select('type,total_balance')
+    .eq('user_id', userId);
+
+  if (error) {
+    if (isMissingViewError(error)) {
+      return null;
+    }
+    throw error;
+  }
+
+  const rows = data ?? [];
+  let cashTotal = 0;
+  let allTotal = 0;
+
+  for (const row of rows) {
+    const balance = Number(row?.total_balance ?? 0) || 0;
+    allTotal += balance;
+    if ((row?.type ?? '').toLowerCase() === 'cash') {
+      cashTotal += balance;
+    }
+  }
+
+  return {
+    cashTotal,
+    allTotal,
+    nonCashTotal: allTotal - cashTotal,
+  };
+}
+
+async function fetchBalancesManually(userId: string): Promise<BalanceState> {
+  const { data: accounts, error: accountError } = await supabase
+    .from('accounts')
+    .select('id,type')
+    .eq('user_id', userId);
+
+  if (accountError) {
+    throw accountError;
+  }
+
+  const { data: transactions, error: txError } = await supabase
+    .from('transactions')
+    .select('account_id,to_account_id,type,amount')
+    .eq('user_id', userId)
+    .is('deleted_at', null);
+
+  if (txError) {
+    throw txError;
+  }
+
+  const result = calculateAccountBalances(
+    (accounts ?? []) as AccountRow[],
+    (transactions ?? []) as TransactionRow[],
+  );
+
+  return {
+    cashTotal: result.cashTotal,
+    allTotal: result.allTotal,
+    nonCashTotal: result.nonCashTotal,
+  };
+}
+
+export default function useBalances() {
+  const { user, loading: userLoading } = useSupabaseUser();
+  const [state, setState] = useState<BalanceState>(EMPTY_STATE);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshToken, setRefreshToken] = useState(0);
+
+  const userId = user?.id ?? null;
+
+  const refetch = useCallback(() => {
+    setRefreshToken((prev) => prev + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!userId) {
+      if (!userLoading) {
+        setState(EMPTY_STATE);
+        setLoading(false);
+      }
+      return;
+    }
+
+    let active = true;
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        const viaView = await fetchBalancesFromView(userId);
+        if (!active) return;
+        if (viaView) {
+          setState(viaView);
+          setLoading(false);
+          return;
+        }
+
+        const manual = await fetchBalancesManually(userId);
+        if (!active) return;
+        setState(manual);
+        setLoading(false);
+      } catch (_err) {
+        if (!active) return;
+        setError('Terjadi kesalahan saat memuat saldo.');
+        setState(EMPTY_STATE);
+        setLoading(false);
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [userId, refreshToken, userLoading]);
+
+  return useMemo(
+    () => ({
+      cashTotal: state.cashTotal,
+      nonCashTotal: state.nonCashTotal,
+      allTotal: state.allTotal,
+      loading: loading || userLoading,
+      error,
+      refetch,
+    }),
+    [state, loading, userLoading, error, refetch],
+  );
+}

--- a/src/lib/balance-utils.test.ts
+++ b/src/lib/balance-utils.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { calculateAccountBalances, type AccountRow, type TransactionRow } from './balance-utils';
+
+describe('calculateAccountBalances', () => {
+  const accounts: AccountRow[] = [
+    { id: 'cash-1', type: 'cash' },
+    { id: 'bank-1', type: 'bank' },
+    { id: 'ewallet-1', type: 'ewallet' },
+  ];
+
+  it('computes balances for income and expense transactions', () => {
+    const transactions: TransactionRow[] = [
+      { account_id: 'cash-1', to_account_id: null, type: 'income', amount: 100_000 },
+      { account_id: 'cash-1', to_account_id: null, type: 'expense', amount: 25_000 },
+      { account_id: 'bank-1', to_account_id: null, type: 'income', amount: 50_000 },
+    ];
+
+    const result = calculateAccountBalances(accounts, transactions);
+
+    expect(result.accountBalances).toMatchObject({
+      'cash-1': 75_000,
+      'bank-1': 50_000,
+      'ewallet-1': 0,
+    });
+    expect(result.cashTotal).toBe(75_000);
+    expect(result.allTotal).toBe(125_000);
+    expect(result.nonCashTotal).toBe(50_000);
+  });
+
+  it('keeps transfers net neutral across accounts', () => {
+    const transactions: TransactionRow[] = [
+      { account_id: 'cash-1', to_account_id: 'bank-1', type: 'transfer', amount: 40_000 },
+      { account_id: 'bank-1', to_account_id: 'ewallet-1', type: 'transfer', amount: 10_000 },
+    ];
+
+    const result = calculateAccountBalances(accounts, transactions);
+
+    expect(result.accountBalances).toMatchObject({
+      'cash-1': -40_000,
+      'bank-1': 30_000,
+      'ewallet-1': 10_000,
+    });
+    expect(result.cashTotal).toBe(-40_000);
+    expect(result.allTotal).toBe(0);
+    expect(result.nonCashTotal).toBe(40_000);
+  });
+
+  it('ignores invalid transaction types gracefully', () => {
+    const transactions: TransactionRow[] = [
+      { account_id: 'cash-1', to_account_id: null, type: 'bonus', amount: 12_500 },
+      { account_id: 'missing', to_account_id: null, type: 'income', amount: 5_000 },
+    ];
+
+    const result = calculateAccountBalances(accounts, transactions);
+
+    expect(result.accountBalances['cash-1']).toBe(12_500);
+    expect(result.accountBalances['missing']).toBe(5_000);
+    expect(result.allTotal).toBe(12_500);
+    expect(result.cashTotal).toBe(12_500);
+  });
+});

--- a/src/lib/balance-utils.ts
+++ b/src/lib/balance-utils.ts
@@ -1,0 +1,101 @@
+export type AccountType = 'cash' | 'bank' | 'ewallet' | 'other' | string;
+
+export interface AccountRow {
+  id: string;
+  type: AccountType | null;
+}
+
+export interface TransactionRow {
+  account_id: string | null;
+  to_account_id: string | null;
+  type: string | null;
+  amount: number | null;
+}
+
+export interface AccountBalancesResult {
+  accountBalances: Record<string, number>;
+  cashTotal: number;
+  nonCashTotal: number;
+  allTotal: number;
+}
+
+function normalizeAmount(value: number | null | undefined): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function applyDelta(balances: Record<string, number>, accountId: string | null | undefined, delta: number) {
+  if (!accountId) return;
+  if (!Object.prototype.hasOwnProperty.call(balances, accountId)) {
+    balances[accountId] = 0;
+  }
+  balances[accountId] += delta;
+}
+
+export function calculateAccountBalances(
+  accounts: readonly AccountRow[] = [],
+  transactions: readonly TransactionRow[] = [],
+): AccountBalancesResult {
+  const balances: Record<string, number> = {};
+
+  for (const account of accounts) {
+    if (!account?.id) continue;
+    if (!Object.prototype.hasOwnProperty.call(balances, account.id)) {
+      balances[account.id] = 0;
+    }
+  }
+
+  for (const tx of transactions) {
+    if (!tx) continue;
+    const type = (tx.type ?? '').toLowerCase();
+    const amount = normalizeAmount(tx.amount);
+
+    switch (type) {
+      case 'income': {
+        applyDelta(balances, tx.account_id, amount);
+        break;
+      }
+      case 'expense': {
+        applyDelta(balances, tx.account_id, -amount);
+        break;
+      }
+      case 'transfer': {
+        if (tx.account_id && tx.to_account_id && tx.account_id === tx.to_account_id) {
+          break;
+        }
+        applyDelta(balances, tx.account_id, -amount);
+        applyDelta(balances, tx.to_account_id, amount);
+        break;
+      }
+      default: {
+        if (tx.account_id) {
+          applyDelta(balances, tx.account_id, amount);
+        }
+      }
+    }
+  }
+
+  let cashTotal = 0;
+  let allTotal = 0;
+
+  for (const account of accounts) {
+    if (!account?.id) continue;
+    const balance = balances[account.id] ?? 0;
+    allTotal += balance;
+    if ((account.type ?? '').toLowerCase() === 'cash') {
+      cashTotal += balance;
+    }
+  }
+
+  const nonCashTotal = allTotal - cashTotal;
+
+  return {
+    accountBalances: balances,
+    cashTotal,
+    nonCashTotal,
+    allTotal,
+  };
+}

--- a/src/lib/format.js
+++ b/src/lib/format.js
@@ -6,6 +6,13 @@ export function formatCurrency(n = 0, currency = 'IDR') {
   }).format(n ?? 0);
 }
 
+export const fmtIDR = (n = 0) =>
+  new Intl.NumberFormat('id-ID', {
+    style: 'currency',
+    currency: 'IDR',
+    maximumFractionDigits: 0,
+  }).format(n || 0);
+
 export function humanDate(date) {
   const d = new Date(date);
   return d.toLocaleDateString('id-ID');

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import DashboardBalances from "../components/DashboardBalances";
 import KpiCards from "../components/KpiCards";
 import QuoteBoard from "../components/QuoteBoard";
 import SavingsProgress from "../components/SavingsProgress";
@@ -46,6 +47,8 @@ export default function Dashboard({ stats, txs, budgetStatus = [] }) {
           Ringkasan keuanganmu
         </p>
       </header>
+
+      <DashboardBalances />
 
       <KpiCards
         income={stats?.income || 0}


### PR DESCRIPTION
## Summary
- add a reusable IDR formatter and balance aggregation helper with unit tests
- introduce a `useBalances` hook that fetches account totals via view or manual aggregation
- render new `DashboardBalances` cards at the top of the dashboard

## Testing
- pnpm test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d529b1ccc08332b3fa5d2bb7a4b3d4