### PR TITLE
Add dashboard balances hook and component

### DIFF
--- a/src/components/dashboard/DashboardBalances.tsx
+++ b/src/components/dashboard/DashboardBalances.tsx
@@ -1,0 +1,82 @@
+import { Banknote, PieChart, Wallet } from 'lucide-react';
+import Skeleton from '../Skeleton';
+import { formatCurrency } from '../../lib/format';
+import useBalances from '../../hooks/useBalances';
+
+const CARD_STYLES =
+  'rounded-2xl border border-surface-3 bg-surface-1 p-5 ring-2 ring-transparent shadow-sm';
+const RETRY_BUTTON_CLASSES =
+  'mt-4 inline-flex items-center rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-red-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-600';
+
+const SkeletonCard = () => (
+  <div className={CARD_STYLES}>
+    <Skeleton className="h-7 w-24" />
+    <Skeleton className="mt-4 h-7 w-32" />
+  </div>
+);
+
+export default function DashboardBalances() {
+  const { cashTotal, nonCashTotal, allTotal, loading, error, refetch } = useBalances();
+
+  if (loading) {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        <SkeletonCard />
+        <SkeletonCard />
+        <SkeletonCard />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-red-300 bg-red-50 p-5 text-red-700 ring-2 ring-red-200">
+        <p className="font-semibold">Gagal memuat saldo</p>
+        <p className="mt-1 text-sm text-red-600/80">{error}</p>
+        <button type="button" onClick={refetch} className={RETRY_BUTTON_CLASSES}>
+          Coba lagi
+        </button>
+      </div>
+    );
+  }
+
+  const cards = [
+    {
+      key: 'cash',
+      label: 'Uang Cash',
+      value: cashTotal,
+      icon: Wallet,
+      iconClass: 'text-emerald-500',
+    },
+    {
+      key: 'total',
+      label: 'Total Saldo',
+      value: allTotal,
+      icon: Banknote,
+      iconClass: 'text-primary',
+    },
+    {
+      key: 'non-cash',
+      label: 'Saldo Non-Cash',
+      value: nonCashTotal,
+      icon: PieChart,
+      iconClass: 'text-indigo-500',
+    },
+  ];
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+      {cards.map(({ key, label, value, icon: Icon, iconClass }) => (
+        <div key={key} className={`${CARD_STYLES} flex items-center justify-between`}>
+          <div>
+            <p className="text-sm text-muted-foreground">{label}</p>
+            <p className="mt-2 text-2xl font-bold text-foreground">{formatCurrency(value ?? 0)}</p>
+          </div>
+          <div className={`flex h-12 w-12 items-center justify-center rounded-xl bg-surface-2 ${iconClass}`}>
+            <Icon className="h-6 w-6" aria-hidden="true" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useBalances.ts
+++ b/src/hooks/useBalances.ts
@@ -1,0 +1,153 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { PostgrestError } from '@supabase/supabase-js';
+import { supabase } from '../lib/supabase';
+import { aggregateAccountBalances, type BalanceSummary } from '../lib/balance';
+import useSupabaseUser from './useSupabaseUser';
+
+type BalanceState = Pick<BalanceSummary, 'cashTotal' | 'nonCashTotal' | 'allTotal'>;
+
+const INITIAL_STATE: BalanceState = {
+  cashTotal: 0,
+  nonCashTotal: 0,
+  allTotal: 0,
+};
+
+interface UseBalancesResult extends BalanceState {
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+const isViewNotAvailable = (error: PostgrestError | null): boolean => {
+  if (!error) return false;
+  return error.code === '42P01' || error.code === '42501' || /does not exist/i.test(error.message);
+};
+
+const parseViewAmount = (value: unknown): number => {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+};
+
+export default function useBalances(): UseBalancesResult {
+  const { user, loading: userLoading } = useSupabaseUser();
+  const [state, setState] = useState<BalanceState>(INITIAL_STATE);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshToken, setRefreshToken] = useState(0);
+
+  const uid = user?.id ?? null;
+
+  useEffect(() => {
+    if (userLoading) return undefined;
+
+    let cancelled = false;
+
+    const load = async () => {
+      if (!uid) {
+        if (!cancelled) {
+          setState(INITIAL_STATE);
+          setError(null);
+          setLoading(false);
+        }
+        return;
+      }
+
+      if (!cancelled) {
+        setLoading(true);
+        setError(null);
+      }
+
+      try {
+        const { data: viewData, error: viewError } = await supabase
+          .from('v_balance_by_type')
+          .select('type,total_balance')
+          .eq('user_id', uid);
+
+        if (!cancelled && !viewError && viewData) {
+          let cashTotal = 0;
+          let allTotal = 0;
+
+          for (const row of viewData) {
+            const amount = parseViewAmount((row as { total_balance?: unknown }).total_balance);
+            const type = String((row as { type?: unknown }).type ?? '').toLowerCase();
+            allTotal += amount;
+            if (type === 'cash') {
+              cashTotal += amount;
+            }
+          }
+
+          setState({
+            cashTotal,
+            nonCashTotal: allTotal - cashTotal,
+            allTotal,
+          });
+          setLoading(false);
+          return;
+        }
+
+        if (viewError && !isViewNotAvailable(viewError)) {
+          throw viewError;
+        }
+
+        const { data: accounts, error: accountsError } = await supabase
+          .from('accounts')
+          .select('id,type')
+          .eq('user_id', uid);
+
+        if (accountsError) {
+          throw accountsError;
+        }
+
+        const { data: transactions, error: txError } = await supabase
+          .from('transactions')
+          .select('account_id,to_account_id,type,amount,deleted_at')
+          .eq('user_id', uid)
+          .is('deleted_at', null);
+
+        if (txError) {
+          throw txError;
+        }
+
+        if (cancelled) return;
+
+        const summary = aggregateAccountBalances(accounts ?? [], transactions ?? []);
+        setState({
+          cashTotal: summary.cashTotal,
+          nonCashTotal: summary.nonCashTotal,
+          allTotal: summary.allTotal,
+        });
+        setLoading(false);
+      } catch (err) {
+        console.error('Failed to fetch balances', err);
+        if (!cancelled) {
+          setState(INITIAL_STATE);
+          setError(err instanceof Error ? err.message : 'Gagal memuat saldo.');
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [uid, userLoading, refreshToken]);
+
+  const refetch = useCallback(() => {
+    setRefreshToken((value) => value + 1);
+  }, []);
+
+  const result = useMemo<UseBalancesResult>(() => ({
+    ...state,
+    loading,
+    error,
+    refetch,
+  }), [state, loading, error, refetch]);
+
+  return result;
+}

--- a/src/lib/balance.test.ts
+++ b/src/lib/balance.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { aggregateAccountBalances } from './balance';
+
+describe('aggregateAccountBalances', () => {
+  it('returns zero balances when there are no accounts', () => {
+    const summary = aggregateAccountBalances([], []);
+    expect(summary).toEqual({
+      perAccount: {},
+      cashTotal: 0,
+      nonCashTotal: 0,
+      allTotal: 0,
+    });
+  });
+
+  it('calculates balances across income, expense, and transfers', () => {
+    const accounts = [
+      { id: 'cash-1', type: 'cash' },
+      { id: 'bank-1', type: 'bank' },
+      { id: 'wallet-1', type: 'ewallet' },
+    ];
+
+    const transactions = [
+      { account_id: 'cash-1', to_account_id: null, type: 'income', amount: 200_000 },
+      { account_id: 'cash-1', to_account_id: null, type: 'expense', amount: 25_000 },
+      { account_id: 'cash-1', to_account_id: 'bank-1', type: 'transfer', amount: 50_000 },
+      { account_id: 'bank-1', to_account_id: 'wallet-1', type: 'transfer', amount: '30000' },
+      { account_id: 'wallet-1', to_account_id: 'cash-1', type: 'transfer', amount: 10_000 },
+      { account_id: 'cash-1', to_account_id: null, type: 'income', amount: '15500' },
+      { account_id: 'wallet-1', to_account_id: null, type: 'expense', amount: 5_500, deleted_at: '2024-01-01' },
+    ];
+
+    const summary = aggregateAccountBalances(accounts, transactions);
+
+    expect(summary.perAccount).toEqual({
+      'cash-1': 150_500,
+      'bank-1': 20_000,
+      'wallet-1': 20_000,
+    });
+    expect(summary.cashTotal).toBe(150_500);
+    expect(summary.nonCashTotal).toBe(40_000);
+    expect(summary.allTotal).toBe(190_500);
+  });
+
+  it('ignores transactions that reference unknown accounts', () => {
+    const accounts = [{ id: 'cash-1', type: 'cash' }];
+
+    const transactions = [
+      { account_id: 'cash-1', to_account_id: null, type: 'income', amount: 100_000 },
+      { account_id: 'missing', to_account_id: 'missing', type: 'transfer', amount: 20_000 },
+    ];
+
+    const summary = aggregateAccountBalances(accounts, transactions);
+
+    expect(summary.perAccount['cash-1']).toBe(100_000);
+    expect(summary.cashTotal).toBe(100_000);
+    expect(summary.nonCashTotal).toBe(0);
+    expect(summary.allTotal).toBe(100_000);
+  });
+});

--- a/src/lib/balance.ts
+++ b/src/lib/balance.ts
@@ -1,0 +1,116 @@
+export type AccountType = 'cash' | 'bank' | 'ewallet' | 'other' | (string & {});
+
+export interface BalanceAccount {
+  id: string;
+  type: AccountType | null | undefined;
+}
+
+export interface BalanceTransaction {
+  account_id: string | null;
+  to_account_id: string | null;
+  type: string | null;
+  amount: number | string | null;
+  deleted_at?: string | null;
+}
+
+export interface BalanceSummary {
+  perAccount: Record<string, number>;
+  cashTotal: number;
+  nonCashTotal: number;
+  allTotal: number;
+}
+
+const EMPTY_SUMMARY: BalanceSummary = {
+  perAccount: {},
+  cashTotal: 0,
+  nonCashTotal: 0,
+  allTotal: 0,
+};
+
+const normalizeAmount = (value: number | string | null | undefined): number => {
+  if (value === null || value === undefined) return 0;
+  const parsed = typeof value === 'string' ? Number.parseFloat(value) : value;
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const isCashAccount = (type: AccountType | null | undefined): boolean =>
+  (type ?? '').toLowerCase() === 'cash';
+
+export function aggregateAccountBalances(
+  accounts: BalanceAccount[] | null | undefined,
+  transactions: BalanceTransaction[] | null | undefined
+): BalanceSummary {
+  if (!accounts?.length) {
+    return { ...EMPTY_SUMMARY };
+  }
+
+  const balances = new Map<string, number>();
+
+  for (const account of accounts) {
+    if (!account?.id) continue;
+    balances.set(account.id, 0);
+  }
+
+  if (!balances.size) {
+    return { ...EMPTY_SUMMARY };
+  }
+
+  for (const tx of transactions ?? []) {
+    if (!tx || tx.deleted_at) continue;
+
+    const amount = normalizeAmount(tx.amount);
+    if (!amount) continue;
+
+    const txType = (tx.type ?? '').toLowerCase();
+
+    if (txType === 'income') {
+      if (tx.account_id && balances.has(tx.account_id)) {
+        balances.set(tx.account_id, balances.get(tx.account_id)! + amount);
+      }
+      continue;
+    }
+
+    if (txType === 'expense') {
+      if (tx.account_id && balances.has(tx.account_id)) {
+        balances.set(tx.account_id, balances.get(tx.account_id)! - amount);
+      }
+      continue;
+    }
+
+    if (txType === 'transfer') {
+      if (tx.account_id && balances.has(tx.account_id)) {
+        balances.set(tx.account_id, balances.get(tx.account_id)! - amount);
+      }
+      if (tx.to_account_id && balances.has(tx.to_account_id)) {
+        balances.set(tx.to_account_id, balances.get(tx.to_account_id)! + amount);
+      }
+      continue;
+    }
+
+    // Fallback for any other type - treat as income on account_id
+    if (tx.account_id && balances.has(tx.account_id)) {
+      balances.set(tx.account_id, balances.get(tx.account_id)! + amount);
+    }
+  }
+
+  const perAccount: Record<string, number> = {};
+  let cashTotal = 0;
+  let allTotal = 0;
+
+  for (const account of accounts) {
+    if (!account?.id) continue;
+    const balance = balances.get(account.id) ?? 0;
+    perAccount[account.id] = balance;
+    allTotal += balance;
+    if (isCashAccount(account.type)) {
+      cashTotal += balance;
+    }
+  }
+
+  return {
+    perAccount,
+    cashTotal,
+    nonCashTotal: allTotal - cashTotal,
+    allTotal,
+  };
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -12,6 +12,7 @@ import TopSpendsTable from "../components/TopSpendsTable";
 import RecentTransactions from "../components/RecentTransactions";
 import useInsights from "../hooks/useInsights";
 import EventBus from "../lib/eventBus";
+import DashboardBalances from "../components/dashboard/DashboardBalances";
 
 // Each content block uses <Section> to maintain a single vertical rhythm.
 export default function Dashboard({ stats, txs, budgetStatus = [] }) {
@@ -52,6 +53,8 @@ export default function Dashboard({ stats, txs, budgetStatus = [] }) {
         expense={stats?.expense || 0}
         net={stats?.balance || 0}
       />
+
+      <DashboardBalances />
 
       <QuoteBoard />
 


### PR DESCRIPTION
## Summary
- add a shared balance aggregation utility with unit tests covering income, expenses, transfers, and edge cases
- implement a `useBalances` hook that loads cash and total balances using Supabase views when available and falls back to client aggregation
- render new dashboard balance cards with loading skeletons and retryable error state to surface cash and total funds

## Testing
- pnpm test
- pnpm test -- --run --filter balance

------
https://chatgpt.com/codex/tasks/task_e_68d529b1ccc08332b3fa5d2bb7a4b3d4