### PR TITLE
feat: add dashboard balances summary and filters

### DIFF
--- a/src/components/dashboard/DashboardSummary.tsx
+++ b/src/components/dashboard/DashboardSummary.tsx
@@ -1,0 +1,233 @@
+import {
+  ArrowDownRight,
+  ArrowUpRight,
+  Banknote,
+  CreditCard,
+  TrendingDown,
+  TrendingUp,
+  Wallet,
+} from 'lucide-react';
+import type { ReactNode } from 'react';
+
+const fmtIDR = (value: number) =>
+  new Intl.NumberFormat('id-ID', {
+    style: 'currency',
+    currency: 'IDR',
+    maximumFractionDigits: 0,
+  }).format(Math.trunc(value ?? 0));
+
+function cx(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(' ');
+}
+
+type DashboardSummaryProps = {
+  income: number;
+  expense: number;
+  cashBalance: number;
+  nonCashBalance: number;
+  totalBalance: number;
+  netTrend?: number[];
+  periodLabel: string;
+  loading: boolean;
+  error?: string | null;
+  onRetry?: () => void;
+};
+
+type SummaryCardProps = {
+  label: string;
+  icon: ReactNode;
+  value: ReactNode;
+  accentClassName?: string;
+  loading?: boolean;
+  helperText?: string;
+  footer?: ReactNode;
+};
+
+function SkeletonValue() {
+  return <span className="inline-block h-7 w-32 animate-pulse rounded-full bg-muted/60" />;
+}
+
+function SummaryCard({
+  label,
+  icon,
+  value,
+  accentClassName,
+  loading,
+  helperText,
+  footer,
+}: SummaryCardProps) {
+  return (
+    <article className="group relative overflow-hidden rounded-2xl border bg-gradient-to-b from-white/80 to-white/40 p-5 shadow-sm backdrop-blur transition hover:border-primary/20 hover:shadow-md dark:from-zinc-900/60 dark:to-zinc-900/30">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-3">
+          <p className="text-sm font-medium text-muted-foreground">{label}</p>
+          <div className={cx('text-2xl font-bold tracking-tight md:text-3xl', accentClassName)}>
+            {loading ? <SkeletonValue /> : value}
+          </div>
+          {helperText ? (
+            loading ? (
+              <span className="inline-block h-5 w-24 animate-pulse rounded-full bg-muted/40" />
+            ) : (
+              <p className="text-xs text-muted-foreground">{helperText}</p>
+            )
+          ) : null}
+        </div>
+        <div className="h-9 w-9 shrink-0 rounded-xl bg-primary/10 text-primary">
+          <div className="grid h-full w-full place-items-center" title={label}>
+            {icon}
+          </div>
+        </div>
+      </div>
+      {footer && <div className="text-sm text-muted-foreground">{footer}</div>}
+    </article>
+  );
+}
+
+type SparklineProps = {
+  data: number[];
+  loading?: boolean;
+};
+
+function Sparkline({ data, loading }: SparklineProps) {
+  if (loading) {
+    return (
+      <div className="h-12 w-full animate-pulse rounded-xl bg-muted/40" aria-hidden="true" />
+    );
+  }
+
+  if (!data.length) {
+    return (
+      <div className="flex h-12 w-full items-center justify-center rounded-xl bg-muted/40 text-xs text-muted-foreground">
+        Tidak ada data tren
+      </div>
+    );
+  }
+
+  const maxAbs = Math.max(...data.map((value) => Math.abs(value)), 1);
+
+  return (
+    <div className="flex h-12 w-full items-end gap-1 rounded-xl bg-muted/30 p-2">
+      {data.map((value, index) => {
+        const height = Math.max(4, Math.round((Math.abs(value) / maxAbs) * 100));
+        const positive = value >= 0;
+        return (
+          <span
+            key={`${index}-${value}`}
+            className={cx(
+              'w-2 rounded-full transition-colors',
+              positive
+                ? 'bg-emerald-400/70 group-hover:bg-emerald-400'
+                : 'bg-rose-400/70 group-hover:bg-rose-400'
+            )}
+            style={{ height: `${height}%` }}
+            aria-hidden="true"
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+export default function DashboardSummary({
+  income,
+  expense,
+  cashBalance,
+  nonCashBalance,
+  totalBalance,
+  netTrend = [],
+  periodLabel,
+  loading,
+  error,
+  onRetry,
+}: DashboardSummaryProps) {
+  const net = income - expense;
+  const netPositive = net >= 0;
+
+  return (
+    <section className="space-y-4">
+      {error ? (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-rose-200/60 bg-rose-100/50 p-4 text-rose-600 dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-300">
+          <div className="text-sm">{error}</div>
+          {onRetry && (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="rounded-full border border-rose-500/40 bg-transparent px-4 py-2 text-sm font-semibold text-rose-600 transition hover:bg-rose-500/10 dark:text-rose-200"
+            >
+              Coba lagi
+            </button>
+          )}
+        </div>
+      ) : null}
+
+      <div className="text-sm text-muted-foreground">Periode {periodLabel}</div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <SummaryCard
+          label="Pemasukan"
+          icon={<TrendingUp className="h-5 w-5" />}
+          value={<span className="text-emerald-600 dark:text-emerald-400">{fmtIDR(income)}</span>}
+          accentClassName="text-emerald-600 dark:text-emerald-400"
+          loading={loading}
+          helperText={`Periode ${periodLabel}`}
+        />
+        <SummaryCard
+          label="Pengeluaran"
+          icon={<TrendingDown className="h-5 w-5" />}
+          value={<span className="text-rose-600 dark:text-rose-400">{fmtIDR(expense)}</span>}
+          accentClassName="text-rose-600 dark:text-rose-400"
+          loading={loading}
+          helperText={`Periode ${periodLabel}`}
+        />
+        <SummaryCard
+          label="Saldo Cash"
+          icon={<Wallet className="h-5 w-5" />}
+          value={<span className="text-amber-600 dark:text-amber-400">{fmtIDR(cashBalance)}</span>}
+          accentClassName="text-amber-600 dark:text-amber-400"
+          loading={loading}
+          footer={
+            <div className="mt-3 border-t border-muted-foreground/20 pt-3">
+              <div className="flex items-center justify-between text-xs font-medium uppercase tracking-wide">
+                <span className="flex items-center gap-2 text-[0.8rem] text-sky-600 dark:text-sky-400">
+                  <CreditCard className="h-4 w-4" /> Non-Cash
+                </span>
+                <span className="text-base font-semibold text-sky-600 dark:text-sky-400">
+                  {loading ? <SkeletonValue /> : fmtIDR(nonCashBalance)}
+                </span>
+              </div>
+            </div>
+          }
+        />
+        <SummaryCard
+          label="Total Saldo"
+          icon={<Banknote className="h-5 w-5" />}
+          value={<span className="text-primary">{fmtIDR(totalBalance)}</span>}
+          loading={loading}
+          footer={
+            <div className="mt-3 space-y-3">
+              <div className="flex items-center justify-between text-sm font-medium">
+                <span
+                  className={cx(
+                    'inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold',
+                    netPositive
+                      ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
+                      : 'bg-rose-500/10 text-rose-600 dark:text-rose-400'
+                  )}
+                >
+                  {netPositive ? (
+                    <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+                  ) : (
+                    <ArrowDownRight className="h-4 w-4" aria-hidden="true" />
+                  )}
+                  Net {fmtIDR(Math.abs(net))}
+                </span>
+                <span className="text-xs text-muted-foreground">vs periode</span>
+              </div>
+              <Sparkline data={netTrend} loading={loading} />
+            </div>
+          }
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/components/dashboard/PeriodPicker.tsx
+++ b/src/components/dashboard/PeriodPicker.tsx
@@ -1,0 +1,205 @@
+import { useMemo } from 'react';
+import { CalendarRange, RotateCcw } from 'lucide-react';
+
+const PRESETS = ['today', 'thisWeek', 'thisMonth', 'custom'] as const;
+
+export type PeriodPreset = (typeof PRESETS)[number];
+
+export type PeriodSelection = {
+  preset: PeriodPreset;
+  start: Date;
+  end: Date;
+};
+
+type PeriodPickerProps = {
+  value: PeriodSelection;
+  onChange: (value: PeriodSelection) => void;
+  onRefresh?: () => void;
+  loading?: boolean;
+};
+
+function formatInputDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function clampRange(start: Date, end: Date): { start: Date; end: Date } {
+  if (start > end) {
+    return { start: end, end: start };
+  }
+  return { start, end };
+}
+
+function withStartOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function getTodayRange(): { start: Date; end: Date } {
+  const now = new Date();
+  const start = withStartOfDay(now);
+  const end = withStartOfDay(now);
+  return { start, end };
+}
+
+function getThisWeekRange(): { start: Date; end: Date } {
+  const now = new Date();
+  const end = withStartOfDay(now);
+  const currentDay = end.getDay();
+  const mondayIndex = (currentDay + 6) % 7; // Monday as first day
+  const start = new Date(end);
+  start.setDate(end.getDate() - mondayIndex);
+  return { start, end };
+}
+
+function getThisMonthRange(): { start: Date; end: Date } {
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth(), 1);
+  const end = withStartOfDay(now);
+  return { start, end };
+}
+
+function parseDateInput(value: string): Date {
+  const [year, month, day] = value.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
+function labelForPreset(preset: PeriodPreset): string {
+  switch (preset) {
+    case 'today':
+      return 'Today';
+    case 'thisWeek':
+      return 'This Week';
+    case 'thisMonth':
+      return 'This Month';
+    case 'custom':
+    default:
+      return 'Custom';
+  }
+}
+
+export function getInitialSelection(): PeriodSelection {
+  const { start, end } = getThisMonthRange();
+  return { preset: 'thisMonth', start, end };
+}
+
+export function labelRange(start: Date, end: Date): string {
+  const intl = new Intl.DateTimeFormat('id-ID', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'Asia/Jakarta',
+  });
+
+  if (start.getFullYear() === end.getFullYear() && start.getMonth() === end.getMonth()) {
+    const startDay = start.getDate();
+    const endDay = end.getDate();
+    const month = intl.formatToParts(start).find((part) => part.type === 'month')?.value ?? '';
+    const year = start.getFullYear();
+    return `${startDay}\u2013${endDay} ${month} ${year}`;
+  }
+
+  return `${intl.format(start)} – ${intl.format(end)}`;
+}
+
+export default function PeriodPicker({ value, onChange, onRefresh, loading }: PeriodPickerProps) {
+  const { preset, start, end } = value;
+
+  const presets = useMemo(
+    () => ({
+      today: getTodayRange,
+      thisWeek: getThisWeekRange,
+      thisMonth: getThisMonthRange,
+      custom: () => ({ start, end }),
+    }),
+    [start, end]
+  );
+
+  const handlePresetClick = (nextPreset: PeriodPreset) => {
+    const rangeFactory = presets[nextPreset];
+    const range = rangeFactory();
+    const selection: PeriodSelection = {
+      preset: nextPreset,
+      start: range.start,
+      end: range.end,
+    };
+    onChange(selection);
+  };
+
+  const handleDateChange = (key: 'start' | 'end', dateString: string) => {
+    if (!dateString) return;
+    const parsed = parseDateInput(dateString);
+    const { start: nextStart, end: nextEnd } = clampRange(
+      key === 'start' ? parsed : start,
+      key === 'end' ? parsed : end
+    );
+
+    const selection: PeriodSelection = {
+      preset: 'custom',
+      start: withStartOfDay(nextStart),
+      end: withStartOfDay(nextEnd),
+    };
+    onChange(selection);
+  };
+
+  const isLoading = Boolean(loading);
+
+  return (
+    <section className="flex flex-col gap-4 rounded-2xl border bg-card/60 p-4 shadow-sm backdrop-blur">
+      <div className="flex flex-wrap items-center gap-2">
+        {PRESETS.map((option) => {
+          const active = preset === option;
+          return (
+            <button
+              key={option}
+              type="button"
+              onClick={() => handlePresetClick(option)}
+              className={`flex items-center gap-2 rounded-2xl border px-4 py-2 text-sm font-medium transition ${
+                active
+                  ? 'border-primary/30 bg-primary/10 text-primary'
+                  : 'border-transparent bg-muted/40 text-muted-foreground hover:border-primary/20 hover:bg-muted/60'
+              }`}
+            >
+              <CalendarRange className="h-4 w-4" aria-hidden="true" />
+              {labelForPreset(option)}
+            </button>
+          );
+        })}
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={isLoading}
+          className="flex items-center gap-2 rounded-2xl border border-transparent bg-muted/40 px-4 py-2 text-sm font-medium text-muted-foreground transition hover:border-primary/20 hover:bg-muted/60 disabled:cursor-not-allowed disabled:opacity-60"
+          title="Muat ulang"
+        >
+          <RotateCcw className="h-4 w-4" aria-hidden="true" />
+          Refresh
+        </button>
+      </div>
+
+      {preset === 'custom' && (
+        <div className="flex flex-wrap items-center gap-3 rounded-2xl border border-dashed border-muted-foreground/40 bg-muted/20 p-3">
+          <label className="flex items-center gap-2 text-sm text-muted-foreground">
+            <span>Dari</span>
+            <input
+              type="date"
+              value={formatInputDate(start)}
+              onChange={(event) => handleDateChange('start', event.target.value)}
+              className="h-11 rounded-2xl border border-transparent bg-background px-3 text-base shadow-sm ring-2 ring-muted-foreground/10 focus:outline-none focus:ring-primary/40"
+            />
+          </label>
+          <label className="flex items-center gap-2 text-sm text-muted-foreground">
+            <span>Sampai</span>
+            <input
+              type="date"
+              value={formatInputDate(end)}
+              onChange={(event) => handleDateChange('end', event.target.value)}
+              className="h-11 rounded-2xl border border-transparent bg-background px-3 text-base shadow-sm ring-2 ring-muted-foreground/10 focus:outline-none focus:ring-primary/40"
+            />
+          </label>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/hooks/useDashboardBalances.ts
+++ b/src/hooks/useDashboardBalances.ts
@@ -1,0 +1,272 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { PostgrestSingleResponse } from '@supabase/supabase-js';
+import { supabase } from '../lib/supabase';
+
+const JAKARTA_OFFSET_HOURS = 7;
+const JAKARTA_DATE_FORMAT = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'Asia/Jakarta',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+type AccountRecord = {
+  id: string;
+  type: 'cash' | 'bank' | 'ewallet' | 'other';
+};
+
+type TransactionRecord = {
+  id?: string;
+  account_id: string | null;
+  to_account_id: string | null;
+  type: 'income' | 'expense';
+  amount: number;
+  date?: string;
+};
+
+type DashboardBalancesOptions = {
+  start: Date;
+  end: Date;
+};
+
+type DashboardBalancesData = {
+  income: number;
+  expense: number;
+  cashBalance: number;
+  nonCashBalance: number;
+  totalBalance: number;
+  netTrend: number[];
+};
+
+export type DashboardBalancesResult = DashboardBalancesData & {
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+};
+
+const initialData: DashboardBalancesData = {
+  income: 0,
+  expense: 0,
+  cashBalance: 0,
+  nonCashBalance: 0,
+  totalBalance: 0,
+  netTrend: [],
+};
+
+function toJakartaISOString(date: Date, endOfDay = false): string {
+  const year = date.getFullYear();
+  const month = date.getMonth();
+  const day = date.getDate();
+  const hours = endOfDay ? 23 : 0;
+  const minutes = endOfDay ? 59 : 0;
+  const seconds = endOfDay ? 59 : 0;
+  const milliseconds = endOfDay ? 999 : 0;
+
+  const utcTimestamp = Date.UTC(
+    year,
+    month,
+    day,
+    hours - JAKARTA_OFFSET_HOURS,
+    minutes,
+    seconds,
+    milliseconds
+  );
+
+  return new Date(utcTimestamp).toISOString();
+}
+
+function jakartaDateKey(value: string | Date): string {
+  const date = typeof value === 'string' ? new Date(value) : value;
+  return JAKARTA_DATE_FORMAT.format(date);
+}
+
+function sum(values: Iterable<number>): number {
+  let total = 0;
+  for (const value of values) {
+    total += value;
+  }
+  return total;
+}
+
+function extractErrorMessage<T>(response: PostgrestSingleResponse<T>): string {
+  return response.error?.message ?? 'Terjadi kesalahan saat memuat data.';
+}
+
+function toNumber(value: number | string | null | undefined): number {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+export default function useDashboardBalances(
+  options: DashboardBalancesOptions
+): DashboardBalancesResult {
+  const { start, end } = options;
+  const [data, setData] = useState<DashboardBalancesData>(initialData);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState<number>(0);
+
+  const refresh = useCallback(() => {
+    setRefreshKey((value) => value + 1);
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const {
+          data: userData,
+          error: userError,
+        } = await supabase.auth.getUser();
+
+        if (userError) throw userError;
+
+        const uid = userData.user?.id;
+        if (!uid) {
+          throw new Error('Pengguna tidak ditemukan.');
+        }
+
+        const [accountsRes, periodTxRes, balanceTxRes] = await Promise.all([
+          supabase
+            .from('accounts')
+            .select('id, type')
+            .eq('user_id', uid),
+          supabase
+            .from('transactions')
+            .select(
+              'id, account_id, to_account_id, type, amount, date, deleted_at'
+            )
+            .eq('user_id', uid)
+            .is('deleted_at', null)
+            .gte('date', toJakartaISOString(start, false))
+            .lte('date', toJakartaISOString(end, true)),
+          supabase
+            .from('transactions')
+            .select('account_id, to_account_id, type, amount, deleted_at')
+            .eq('user_id', uid)
+            .is('deleted_at', null),
+        ]);
+
+        if (accountsRes.error) throw new Error(extractErrorMessage(accountsRes));
+        if (periodTxRes.error) throw new Error(extractErrorMessage(periodTxRes));
+        if (balanceTxRes.error) throw new Error(extractErrorMessage(balanceTxRes));
+
+        const accounts = (accountsRes.data ?? []) as AccountRecord[];
+        const periodTxs = (periodTxRes.data ?? []) as TransactionRecord[];
+        const balanceTxs = (balanceTxRes.data ?? []) as TransactionRecord[];
+
+        const income = sum(
+          periodTxs
+            .filter((tx) => tx.type === 'income' && !tx.to_account_id)
+            .map((tx) => toNumber(tx.amount))
+        );
+
+        const expense = sum(
+          periodTxs
+            .filter((tx) => tx.type === 'expense' && !tx.to_account_id)
+            .map((tx) => toNumber(tx.amount))
+        );
+
+        const balances = new Map<string, number>();
+        const increment = (accountId: string | null, amount: number) => {
+          if (!accountId) return;
+          balances.set(accountId, (balances.get(accountId) ?? 0) + amount);
+        };
+
+        for (const tx of balanceTxs) {
+          const amount = toNumber(tx.amount);
+
+          if (!tx.to_account_id) {
+            if (tx.type === 'income') {
+              increment(tx.account_id, amount);
+            } else if (tx.type === 'expense') {
+              increment(tx.account_id, -amount);
+            }
+          }
+
+          if (tx.to_account_id) {
+            increment(tx.account_id, -amount);
+            increment(tx.to_account_id, amount);
+          }
+        }
+
+        const cashBalance = sum(
+          accounts
+            .filter((account) => account.type === 'cash')
+            .map((account) => balances.get(account.id) ?? 0)
+        );
+
+        const nonCashBalance = sum(
+          accounts
+            .filter((account) => account.type !== 'cash')
+            .map((account) => balances.get(account.id) ?? 0)
+        );
+
+        const totalBalance = cashBalance + nonCashBalance;
+
+        const netByDate = new Map<string, number>();
+        for (const tx of periodTxs) {
+          if (tx.to_account_id) continue;
+          const amount = toNumber(tx.amount);
+          const dateKey = tx.date ? jakartaDateKey(tx.date) : null;
+          if (!dateKey) continue;
+          const current = netByDate.get(dateKey) ?? 0;
+          if (tx.type === 'income') {
+            netByDate.set(dateKey, current + amount);
+          } else if (tx.type === 'expense') {
+            netByDate.set(dateKey, current - amount);
+          }
+        }
+
+        const sortedNet = Array.from(netByDate.entries())
+          .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+          .map(([, value]) => value);
+
+        if (active) {
+          setData({
+            income,
+            expense,
+            cashBalance,
+            nonCashBalance,
+            totalBalance,
+            netTrend: sortedNet,
+          });
+          setLoading(false);
+        }
+      } catch (err) {
+        if (!active) return;
+        setLoading(false);
+        setData(initialData);
+        setError(
+          err instanceof Error
+            ? err.message
+            : 'Terjadi kesalahan saat memuat data.'
+        );
+      }
+    }
+
+    load();
+
+    return () => {
+      active = false;
+    };
+  }, [start, end, refreshKey]);
+
+  return useMemo(
+    () => ({
+      ...data,
+      loading,
+      error,
+      refresh,
+    }),
+    [data, loading, error, refresh]
+  );
+}


### PR DESCRIPTION
## Summary
- add a Supabase-powered `useDashboardBalances` hook to aggregate income, expense, and real-time account balances
- build modern `DashboardSummary` and `PeriodPicker` components to display metrics and control the reporting range
- wire the new metrics and filters into the dashboard page

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d52cc387288332a40c875e7a4c5201