### PR TITLE
feat: add dashboard period metrics

### DIFF
--- a/src/components/dashboard/DashboardSummary.tsx
+++ b/src/components/dashboard/DashboardSummary.tsx
@@ -1,0 +1,281 @@
+import {
+  Banknote,
+  CreditCard,
+  TrendingDown,
+  TrendingUp,
+  Wallet,
+} from "lucide-react";
+import clsx from "clsx";
+import { ReactNode, useMemo } from "react";
+import { formatRangeLabel, DateRangeValue } from "../../lib/date-range";
+
+const currencyFormatter = new Intl.NumberFormat("id-ID", {
+  style: "currency",
+  currency: "IDR",
+  maximumFractionDigits: 0,
+});
+
+const formatCurrency = (value: number) =>
+  currencyFormatter.format(Math.max(0, Math.trunc(value ?? 0)));
+
+const formatSignedCurrency = (value: number, withPlus = false) => {
+  const absolute = currencyFormatter.format(
+    Math.max(0, Math.trunc(Math.abs(value ?? 0)))
+  );
+  if (value < 0) return `-${absolute}`;
+  return withPlus ? `+${absolute}` : absolute;
+};
+
+interface SummaryCardProps {
+  icon: ReactNode;
+  label: string;
+  children: ReactNode;
+  className?: string;
+  footer?: ReactNode;
+}
+
+const SummaryCard = ({ icon, label, children, footer, className }: SummaryCardProps) => (
+  <article
+    className={clsx(
+      "rounded-2xl border border-border/60 bg-gradient-to-b from-white/80 to-white/40 p-5 shadow-sm backdrop-blur transition hover:border-primary/20 hover:shadow-md dark:from-zinc-900/60 dark:to-zinc-900/30",
+      className
+    )}
+  >
+    <div className="flex items-start justify-between gap-3">
+      <div className="grid h-9 w-9 place-items-center rounded-xl bg-primary/10 text-primary" title={label}>
+        {icon}
+      </div>
+      {footer}
+    </div>
+    <div className="mt-6 space-y-3">
+      <p className="text-sm font-medium text-muted-foreground">{label}</p>
+      {children}
+    </div>
+  </article>
+);
+
+const SkeletonValue = () => (
+  <div className="h-7 w-24 animate-pulse rounded-xl bg-muted/50" />
+);
+
+const Sparkline = ({ values }: { values: number[] }) => {
+  const points = useMemo(() => {
+    if (!values.length) {
+      return "";
+    }
+    const localMin = Math.min(...values);
+    const localMax = Math.max(...values);
+    const safeMin = Number.isFinite(localMin) ? localMin : 0;
+    const safeMax = Number.isFinite(localMax) ? localMax : 0;
+    const span = safeMax - safeMin || 1;
+    return values
+      .map((value, index) => {
+        const x = (index / Math.max(values.length - 1, 1)) * 100;
+        const y = 100 - ((value - safeMin) / span) * 100;
+        return `${x},${y}`;
+      })
+      .join(" ");
+  }, [values]);
+
+  if (!points) {
+    return (
+      <div className="h-12 w-full rounded-xl bg-muted/40" aria-hidden />
+    );
+  }
+
+  return (
+    <svg
+      viewBox="0 0 100 40"
+      role="presentation"
+      className="h-12 w-full text-primary"
+    >
+      <defs>
+        <linearGradient id="sparklineGradient" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="currentColor" stopOpacity="0.45" />
+          <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <polyline
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2.5}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+        points={points}
+      />
+      <polygon
+        fill="url(#sparklineGradient)"
+        points={`${points} 100,100 0,100`}
+        opacity={0.35}
+      />
+    </svg>
+  );
+};
+
+interface DashboardSummaryProps {
+  range: DateRangeValue;
+  income: number;
+  expense: number;
+  cashBalance: number;
+  nonCashBalance: number;
+  totalBalance: number;
+  loading?: boolean;
+  error?: string | null;
+  onRetry?: () => void;
+}
+
+const DashboardSummary = ({
+  range,
+  income,
+  expense,
+  cashBalance,
+  nonCashBalance,
+  totalBalance,
+  loading,
+  error,
+  onRetry,
+}: DashboardSummaryProps) => {
+  const net = income - expense;
+  const sparklineValues = useMemo(() => {
+    const steps = 8;
+    if (steps <= 1) return [net];
+    return Array.from({ length: steps }, (_, index) => {
+      const progress = index / (steps - 1);
+      const gross = income * progress;
+      const spend = expense * Math.pow(progress, 1.15);
+      return gross - spend;
+    });
+  }, [income, expense, net]);
+
+  const rangeLabel = useMemo(() => formatRangeLabel(range), [range]);
+
+  return (
+    <section className="space-y-4">
+      <header className="flex flex-col gap-1">
+        <h2 className="text-base font-semibold tracking-tight text-foreground">
+          Ringkasan keuangan
+        </h2>
+        <p className="text-sm text-muted-foreground">Periode {rangeLabel}</p>
+      </header>
+
+      {error ? (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-rose-200/70 bg-rose-50/70 p-4 text-sm text-rose-700 dark:border-rose-900/60 dark:bg-rose-900/30 dark:text-rose-200">
+          <span>{error}</span>
+          {onRetry ? (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="rounded-full bg-rose-600/90 px-3 py-1 text-xs font-semibold text-white shadow-sm transition hover:bg-rose-600"
+            >
+              Coba lagi
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <SummaryCard
+          label="Pemasukan"
+          icon={<TrendingUp className="h-5 w-5" />}
+          footer={
+            <span className="rounded-full bg-emerald-100/70 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:bg-emerald-400/10 dark:text-emerald-300">
+              Masuk
+            </span>
+          }
+        >
+          {loading ? (
+            <SkeletonValue />
+          ) : (
+            <div className="text-2xl font-bold tracking-tight text-emerald-600 dark:text-emerald-400 md:text-3xl">
+              {formatCurrency(income)}
+            </div>
+          )}
+        </SummaryCard>
+
+        <SummaryCard
+          label="Pengeluaran"
+          icon={<TrendingDown className="h-5 w-5" />}
+          footer={
+            <span className="rounded-full bg-rose-100/70 px-2 py-0.5 text-xs font-semibold text-rose-700 dark:bg-rose-400/10 dark:text-rose-300">
+              Keluar
+            </span>
+          }
+        >
+          {loading ? (
+            <SkeletonValue />
+          ) : (
+            <div className="text-2xl font-bold tracking-tight text-rose-600 dark:text-rose-400 md:text-3xl">
+              {formatCurrency(expense)}
+            </div>
+          )}
+        </SummaryCard>
+
+        <SummaryCard
+          label="Saldo Cash & Non-Cash"
+          icon={<Wallet className="h-5 w-5" title="Saldo cash" />}
+        >
+          {loading ? (
+            <SkeletonValue />
+          ) : (
+            <div className="space-y-3">
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+                  <Wallet className="h-4 w-4 text-amber-600 dark:text-amber-400" title="Saldo cash" />
+                  Cash
+                </div>
+                <span className="text-base font-semibold text-amber-600 dark:text-amber-400">
+                  {formatCurrency(cashBalance)}
+                </span>
+              </div>
+              <div className="h-px w-full bg-border/60" />
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+                  <CreditCard className="h-4 w-4 text-sky-600 dark:text-sky-400" title="Saldo non-cash" />
+                  Non-Cash
+                </div>
+                <span className="text-base font-semibold text-sky-600 dark:text-sky-400">
+                  {formatCurrency(nonCashBalance)}
+                </span>
+              </div>
+            </div>
+          )}
+        </SummaryCard>
+
+        <SummaryCard
+          label="Total Saldo"
+          icon={<Banknote className="h-5 w-5" title="Total saldo" />}
+          footer={
+            loading ? null : (
+              <div className="flex items-center gap-2">
+                <span
+                  className={clsx(
+                    "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold",
+                    net >= 0
+                      ? "bg-emerald-100/70 text-emerald-700 dark:bg-emerald-400/10 dark:text-emerald-300"
+                      : "bg-rose-100/70 text-rose-700 dark:bg-rose-400/10 dark:text-rose-300"
+                  )}
+                >
+                  Net {formatSignedCurrency(net, true)} {net >= 0 ? "↑" : "↓"}
+                </span>
+              </div>
+            )
+          }
+        >
+          {loading ? (
+            <SkeletonValue />
+          ) : (
+            <div className="space-y-4">
+              <div className="text-2xl font-bold tracking-tight md:text-3xl">
+                {formatCurrency(totalBalance)}
+              </div>
+              <Sparkline values={sparklineValues} />
+            </div>
+          )}
+        </SummaryCard>
+      </div>
+    </section>
+  );
+};
+
+export default DashboardSummary;
+

--- a/src/components/dashboard/PeriodPicker.tsx
+++ b/src/components/dashboard/PeriodPicker.tsx
@@ -1,0 +1,194 @@
+import { RefreshCcw } from "lucide-react";
+import clsx from "clsx";
+import {
+  DateRangeValue,
+  ensureRangeOrder,
+  formatRangeLabel,
+  getThisMonthRange,
+  getThisWeekRange,
+  getTodayRange,
+  toDateInputValue,
+} from "../../lib/date-range";
+import { useMemo } from "react";
+
+export type PeriodPreset = "today" | "week" | "month" | "custom";
+
+interface PeriodPickerProps {
+  value: DateRangeValue;
+  preset: PeriodPreset;
+  onChange: (value: DateRangeValue) => void;
+  onPresetChange: (preset: PeriodPreset) => void;
+  onRefresh?: () => void;
+  loading?: boolean;
+}
+
+const presets: { label: string; value: PeriodPreset }[] = [
+  { label: "Today", value: "today" },
+  { label: "This Week", value: "week" },
+  { label: "This Month", value: "month" },
+  { label: "Custom", value: "custom" },
+];
+
+const inputClassName =
+  "h-11 rounded-2xl border border-border/60 bg-white/70 px-4 text-sm font-medium shadow-sm ring-offset-background transition focus:border-primary/40 focus:outline-none focus:ring-2 focus:ring-primary/30 dark:bg-zinc-900/70";
+
+const buttonClassName =
+  "flex-1 select-none rounded-2xl px-3 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40";
+
+const segmentedWrapperClassName =
+  "flex w-full flex-wrap gap-2 rounded-2xl border border-border/60 bg-white/70 p-1 shadow-sm backdrop-blur dark:bg-zinc-900/70";
+
+const getPresetRange = (preset: PeriodPreset): DateRangeValue => {
+  switch (preset) {
+    case "today":
+      return getTodayRange();
+    case "week":
+      return getThisWeekRange();
+    case "month":
+      return getThisMonthRange();
+    default:
+      return getThisMonthRange();
+  }
+};
+
+const RefreshButton = ({ onClick, loading }: { onClick?: () => void; loading?: boolean }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    disabled={loading}
+    className="inline-flex h-11 items-center gap-2 rounded-2xl border border-border/60 bg-white/80 px-4 text-sm font-semibold text-muted-foreground shadow-sm transition hover:border-primary/30 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-zinc-900/70"
+  >
+    <RefreshCcw className={clsx("h-4 w-4", loading && "animate-spin")} />
+    Segarkan
+  </button>
+);
+
+const CustomInputs = ({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: DateRangeValue;
+  onChange: (value: DateRangeValue) => void;
+  disabled?: boolean;
+}) => {
+  const startValue = value.start;
+  const endValue = value.end;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <label className="flex flex-col gap-1 text-xs font-medium text-muted-foreground">
+        Dari
+        <input
+          type="date"
+          value={startValue}
+          onChange={(event) => {
+            if (!event.target.value) return;
+            const next = ensureRangeOrder({
+              start: event.target.value,
+              end: endValue,
+            });
+            onChange(next);
+          }}
+          disabled={disabled}
+          className={inputClassName}
+          max={endValue}
+        />
+      </label>
+      <label className="flex flex-col gap-1 text-xs font-medium text-muted-foreground">
+        Sampai
+        <input
+          type="date"
+          value={endValue}
+          onChange={(event) => {
+            if (!event.target.value) return;
+            const next = ensureRangeOrder({
+              start: startValue,
+              end: event.target.value,
+            });
+            onChange(next);
+          }}
+          disabled={disabled}
+          className={inputClassName}
+          min={startValue}
+          max={toDateInputValue(new Date())}
+        />
+      </label>
+    </div>
+  );
+};
+
+const PeriodBadge = ({ value }: { value: DateRangeValue }) => {
+  const label = useMemo(() => formatRangeLabel(value), [value]);
+  return (
+    <span className="inline-flex items-center rounded-full border border-border/60 bg-white/70 px-3 py-1 text-xs font-semibold text-muted-foreground shadow-sm dark:bg-zinc-900/70">
+      {label}
+    </span>
+  );
+};
+
+const PeriodPicker = ({
+  value,
+  preset,
+  onChange,
+  onPresetChange,
+  onRefresh,
+  loading,
+}: PeriodPickerProps) => {
+  const presetRangeLabel = useMemo(() => formatRangeLabel(value), [value]);
+
+  return (
+    <section className="space-y-3">
+      <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-base font-semibold tracking-tight text-foreground">
+            Periode transaksi
+          </h2>
+          <p className="text-sm text-muted-foreground">{presetRangeLabel}</p>
+        </div>
+        <RefreshButton onClick={onRefresh} loading={loading} />
+      </header>
+
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className={segmentedWrapperClassName}>
+          {presets.map((item) => {
+            const isActive = preset === item.value;
+            const rangePreview =
+              item.value !== "custom" ? formatRangeLabel(getPresetRange(item.value)) : undefined;
+            return (
+              <button
+                key={item.value}
+                type="button"
+                className={clsx(
+                  buttonClassName,
+                  isActive
+                    ? "bg-primary text-primary-foreground shadow-sm"
+                    : "bg-transparent text-muted-foreground hover:bg-primary/10 hover:text-foreground"
+                )}
+                onClick={() => {
+                  onPresetChange(item.value);
+                  if (item.value !== "custom") {
+                    onChange(getPresetRange(item.value));
+                  }
+                }}
+                disabled={loading}
+                title={rangePreview}
+              >
+                {item.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {preset === "custom" ? (
+          <CustomInputs value={value} onChange={onChange} disabled={loading} />
+        ) : (
+          <PeriodBadge value={value} />
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default PeriodPicker;
+

--- a/src/hooks/useDashboardBalances.ts
+++ b/src/hooks/useDashboardBalances.ts
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { supabase } from "../lib/supabase";
+import { toQueryDate } from "../lib/date-range";
+
+type AccountRow = {
+  id: string;
+  type: "cash" | "bank" | "ewallet" | "other" | null;
+};
+
+type TransactionRow = {
+  account_id: string | null;
+  to_account_id: string | null;
+  type: "income" | "expense" | null;
+  amount: number | null;
+  date: string | null;
+};
+
+export interface UseDashboardBalancesParams {
+  start: Date;
+  end: Date;
+}
+
+export interface DashboardBalancesResult {
+  income: number;
+  expense: number;
+  cashBalance: number;
+  nonCashBalance: number;
+  totalBalance: number;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+const toNumber = (value: number | null) => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (value == null) return 0;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const increment = (map: Map<string, number>, key: string | null, amount: number) => {
+  if (!key) return;
+  const next = (map.get(key) ?? 0) + amount;
+  map.set(key, next);
+};
+
+const TRANSACTION_COLUMNS =
+  "account_id, to_account_id, type, amount, date" as const;
+
+export default function useDashboardBalances({
+  start,
+  end,
+}: UseDashboardBalancesParams): DashboardBalancesResult {
+  const [income, setIncome] = useState(0);
+  const [expense, setExpense] = useState(0);
+  const [cashBalance, setCashBalance] = useState(0);
+  const [nonCashBalance, setNonCashBalance] = useState(0);
+  const [totalBalance, setTotalBalance] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const startKey = start.getTime();
+  const endKey = end.getTime();
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const [{ data: userData, error: userError }] = await Promise.all([
+        supabase.auth.getUser(),
+      ]);
+
+      if (userError) {
+        throw userError;
+      }
+
+      const user = userData?.user;
+      if (!user) {
+        throw new Error("Pengguna tidak ditemukan");
+      }
+
+      const uid = user.id;
+
+      const [accountsRes, txRangeRes, txAllRes] = await Promise.all([
+        supabase
+          .from("accounts")
+          .select("id, type")
+          .eq("user_id", uid),
+        supabase
+          .from("transactions")
+          .select(TRANSACTION_COLUMNS)
+          .eq("user_id", uid)
+          .is("deleted_at", null)
+          .gte("date", toQueryDate(start))
+          .lte("date", toQueryDate(end)),
+        supabase
+          .from("transactions")
+          .select(TRANSACTION_COLUMNS)
+          .eq("user_id", uid)
+          .is("deleted_at", null),
+      ]);
+
+      if (accountsRes.error) {
+        throw accountsRes.error;
+      }
+      if (txRangeRes.error) {
+        throw txRangeRes.error;
+      }
+      if (txAllRes.error) {
+        throw txAllRes.error;
+      }
+
+      const accounts = (accountsRes.data ?? []) as AccountRow[];
+      const rangeTransactions = (txRangeRes.data ?? []) as TransactionRow[];
+      const allTransactions = (txAllRes.data ?? []) as TransactionRow[];
+
+      const computedIncome = rangeTransactions
+        .filter((tx) => tx.type === "income" && !tx.to_account_id)
+        .reduce((sum, tx) => sum + toNumber(tx.amount), 0);
+
+      const computedExpense = rangeTransactions
+        .filter((tx) => tx.type === "expense" && !tx.to_account_id)
+        .reduce((sum, tx) => sum + toNumber(tx.amount), 0);
+
+      const perAccount = new Map<string, number>();
+      for (const tx of allTransactions) {
+        const amount = toNumber(tx.amount);
+        if (!amount) continue;
+
+        if (tx.type === "income" && !tx.to_account_id) {
+          increment(perAccount, tx.account_id, amount);
+        }
+
+        if (tx.type === "expense" && !tx.to_account_id) {
+          increment(perAccount, tx.account_id, -amount);
+        }
+
+        if (tx.to_account_id) {
+          increment(perAccount, tx.account_id, -amount);
+          increment(perAccount, tx.to_account_id, amount);
+        }
+      }
+
+      const cash = accounts
+        .filter((acc) => acc.type === "cash")
+        .reduce((sum, acc) => sum + (perAccount.get(acc.id) ?? 0), 0);
+
+      const nonCash = accounts
+        .filter((acc) => acc.type !== "cash")
+        .reduce((sum, acc) => sum + (perAccount.get(acc.id) ?? 0), 0);
+
+      if (!mountedRef.current) {
+        return;
+      }
+
+      setIncome(computedIncome);
+      setExpense(computedExpense);
+      setCashBalance(cash);
+      setNonCashBalance(nonCash);
+      setTotalBalance(cash + nonCash);
+      setLoading(false);
+    } catch (err) {
+      if (!mountedRef.current) {
+        return;
+      }
+      setError(err instanceof Error ? err.message : String(err));
+      setLoading(false);
+    }
+  }, [startKey, endKey]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return useMemo(
+    () => ({
+      income,
+      expense,
+      cashBalance,
+      nonCashBalance,
+      totalBalance,
+      loading,
+      error,
+      refresh,
+    }),
+    [income, expense, cashBalance, nonCashBalance, totalBalance, loading, error, refresh]
+  );
+}
+

--- a/src/lib/date-range.ts
+++ b/src/lib/date-range.ts
@@ -1,0 +1,111 @@
+const TIME_ZONE_OFFSET_HOURS = 7; // Asia/Jakarta (UTC+7)
+const OFFSET_MS = TIME_ZONE_OFFSET_HOURS * 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type DateRangeValue = {
+  start: string;
+  end: string;
+};
+
+const pad = (value: number) => String(value).padStart(2, "0");
+
+const toTzDate = (date: Date) => new Date(date.getTime() + OFFSET_MS);
+
+const fromTzDateParts = (year: number, monthIndex: number, day: number) =>
+  new Date(Date.UTC(year, monthIndex, day) - OFFSET_MS);
+
+export const startOfDayInTz = (date: Date) => {
+  const tzDate = toTzDate(date);
+  return fromTzDateParts(
+    tzDate.getUTCFullYear(),
+    tzDate.getUTCMonth(),
+    tzDate.getUTCDate()
+  );
+};
+
+export const toDateInputValue = (date: Date) => {
+  const tzDate = toTzDate(date);
+  const year = tzDate.getUTCFullYear();
+  const month = pad(tzDate.getUTCMonth() + 1);
+  const day = pad(tzDate.getUTCDate());
+  return `${year}-${month}-${day}`;
+};
+
+export const parseDateInput = (value: string) =>
+  new Date(`${value}T00:00:00+07:00`);
+
+export const ensureRangeOrder = ({ start, end }: DateRangeValue): DateRangeValue => {
+  const startDate = parseDateInput(start);
+  const endDate = parseDateInput(end);
+  if (startDate.getTime() <= endDate.getTime()) {
+    return { start, end };
+  }
+  return { start: end, end: start };
+};
+
+export const getTodayRange = (): DateRangeValue => {
+  const today = startOfDayInTz(new Date());
+  const value = toDateInputValue(today);
+  return { start: value, end: value };
+};
+
+export const getThisWeekRange = (): DateRangeValue => {
+  const today = startOfDayInTz(new Date());
+  const tzToday = toTzDate(today);
+  const weekday = tzToday.getUTCDay();
+  const mondayOffset = (weekday + 6) % 7;
+  const start = new Date(today.getTime() - mondayOffset * DAY_MS);
+  return {
+    start: toDateInputValue(start),
+    end: toDateInputValue(today),
+  };
+};
+
+export const getThisMonthRange = (): DateRangeValue => {
+  const today = startOfDayInTz(new Date());
+  const tzToday = toTzDate(today);
+  const start = fromTzDateParts(tzToday.getUTCFullYear(), tzToday.getUTCMonth(), 1);
+  return {
+    start: toDateInputValue(start),
+    end: toDateInputValue(today),
+  };
+};
+
+export const toQueryDate = (date: Date) => toDateInputValue(date);
+
+const monthFormatter = new Intl.DateTimeFormat("id-ID", {
+  month: "short",
+  timeZone: "Asia/Jakarta",
+});
+
+const dayFormatter = new Intl.DateTimeFormat("id-ID", {
+  day: "numeric",
+  timeZone: "Asia/Jakarta",
+});
+
+const yearFormatter = new Intl.DateTimeFormat("id-ID", {
+  year: "numeric",
+  timeZone: "Asia/Jakarta",
+});
+
+export const formatRangeLabel = ({ start, end }: DateRangeValue) => {
+  const startDate = parseDateInput(start);
+  const endDate = parseDateInput(end);
+
+  const startMonth = monthFormatter.format(startDate);
+  const endMonth = monthFormatter.format(endDate);
+  const startYear = yearFormatter.format(startDate);
+  const endYear = yearFormatter.format(endDate);
+  const startDay = dayFormatter.format(startDate);
+  const endDay = dayFormatter.format(endDate);
+
+  if (startYear === endYear) {
+    if (startMonth === endMonth) {
+      return `${startDay}–${endDay} ${startMonth} ${startYear}`;
+    }
+    return `${startDay} ${startMonth} – ${endDay} ${endMonth} ${startYear}`;
+  }
+
+  return `${startDay} ${startMonth} ${startYear} – ${endDay} ${endMonth} ${endYear}`;
+};
+


### PR DESCRIPTION
## Summary
- add timezone-aware date range utilities and a dashboard balance hook powered by Supabase data
- introduce a modern dashboard summary with sparkline plus a period picker for Today/Week/Month/Custom filters
- wire the new hook and components into the dashboard page to display cash, non-cash, and total balances for the selected range

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d52cc387288332a40c875e7a4c5201