### PR TITLE
Remove outdated income and expense KPI cards

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from "react";
-import KpiCards from "../components/KpiCards";
 import QuoteBoard from "../components/QuoteBoard";
 import SavingsProgress from "../components/SavingsProgress";
 import AchievementBadges from "../components/AchievementBadges";
@@ -95,12 +94,6 @@ export default function Dashboard({ stats, txs, budgetStatus = [] }) {
           period={periodRange}
         />
       </section>
-
-      <KpiCards
-        income={stats?.income || 0}
-        expense={stats?.expense || 0}
-        net={stats?.balance || 0}
-      />
 
       <QuoteBoard />
 


### PR DESCRIPTION
## Summary
- remove the legacy KPI cards from the dashboard page now that DashboardSummary replaces them

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d538cc2a5c8332bc6ae4f88db78696