### PR TITLE
Revamp transaction add flow

### DIFF
--- a/src/components/form/AmountInput.tsx
+++ b/src/components/form/AmountInput.tsx
@@ -1,0 +1,60 @@
+import { forwardRef, useMemo } from 'react';
+import clsx from 'clsx';
+
+type AmountInputProps = {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  error?: string | null;
+  helper?: string;
+  className?: string;
+};
+
+function formatRupiah(value: string): string {
+  if (!value) return '';
+  const digits = value.replace(/[^0-9]/g, '');
+  if (!digits) return '';
+  const number = Number.parseInt(digits, 10);
+  if (!Number.isFinite(number)) return '';
+  return new Intl.NumberFormat('id-ID').format(number);
+}
+
+export const AmountInput = forwardRef<HTMLInputElement, AmountInputProps>(
+  ({ id, label, value, onChange, placeholder, error, helper, className }, ref) => {
+    const displayValue = useMemo(() => formatRupiah(value), [value]);
+
+    return (
+      <div className={clsx('space-y-2', className)}>
+        <label htmlFor={id} className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-muted-foreground">{label}</span>
+          <div className="relative overflow-hidden rounded-2xl border bg-background ring-2 ring-transparent focus-within:ring-2 focus-within:ring-primary">
+            <div className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              Rp
+            </div>
+            <input
+              id={id}
+              ref={ref}
+              inputMode="numeric"
+              autoComplete="off"
+              value={displayValue}
+              onChange={(event) => {
+                const next = event.target.value.replace(/[^0-9]/g, '');
+                onChange(next);
+              }}
+              placeholder={placeholder}
+              className="h-14 w-full bg-transparent py-3 pl-12 pr-4 text-3xl font-bold tracking-tight text-foreground outline-none"
+            />
+          </div>
+        </label>
+        {helper && !error ? <p className="text-sm text-muted-foreground">{helper}</p> : null}
+        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      </div>
+    );
+  },
+);
+
+AmountInput.displayName = 'AmountInput';
+
+export default AmountInput;

--- a/src/components/inputs/TagInput.tsx
+++ b/src/components/inputs/TagInput.tsx
@@ -1,0 +1,99 @@
+import { useState, type KeyboardEvent } from 'react';
+import clsx from 'clsx';
+
+type TagInputProps = {
+  id: string;
+  label: string;
+  value: string[];
+  onChange: (tags: string[]) => void;
+  placeholder?: string;
+  helper?: string;
+  error?: string | null;
+};
+
+function normalizeTag(value: string): string | null {
+  const cleaned = value.trim();
+  if (!cleaned) return null;
+  return cleaned.replace(/\s+/g, ' ');
+}
+
+export function TagInput({ id, label, value, onChange, placeholder, helper, error }: TagInputProps) {
+  const [inputValue, setInputValue] = useState('');
+
+  const commitValue = (raw: string) => {
+    const normalized = normalizeTag(raw);
+    if (!normalized) return;
+    if (value.some((item) => item.toLowerCase() === normalized.toLowerCase())) {
+      setInputValue('');
+      return;
+    }
+    onChange([...value, normalized]);
+    setInputValue('');
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' || event.key === ',' || event.key === ' ') {
+      event.preventDefault();
+      commitValue(inputValue);
+    } else if (event.key === 'Backspace' && inputValue === '' && value.length > 0) {
+      event.preventDefault();
+      const next = [...value];
+      next.pop();
+      onChange(next);
+    }
+  };
+
+  const handleBlur = () => {
+    if (inputValue) {
+      commitValue(inputValue);
+    }
+  };
+
+  const removeTag = (tag: string) => {
+    onChange(value.filter((item) => item !== tag));
+  };
+
+  return (
+    <div className="space-y-2">
+      <label htmlFor={id} className="flex flex-col gap-2">
+        <span className="text-sm font-medium text-muted-foreground">{label}</span>
+        <div
+          className={clsx(
+            'flex min-h-[44px] w-full flex-wrap items-center gap-2 rounded-2xl border bg-background px-3 py-2 ring-2 ring-transparent focus-within:ring-2 focus-within:ring-primary',
+            error && 'border-destructive',
+          )}
+        >
+          {value.map((tag) => (
+            <span
+              key={tag}
+              className="flex items-center gap-2 rounded-xl bg-primary/10 px-3 py-1 text-sm font-medium text-primary"
+            >
+              {tag}
+              <button
+                type="button"
+                onClick={() => removeTag(tag)}
+                className="rounded-full p-1 text-primary transition hover:bg-primary/20"
+                aria-label={`Hapus tag ${tag}`}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+          <input
+            id={id}
+            value={inputValue}
+            onChange={(event) => setInputValue(event.target.value)}
+            onKeyDown={handleKeyDown}
+            onBlur={handleBlur}
+            placeholder={value.length === 0 ? placeholder : undefined}
+            className="flex-1 min-w-[120px] bg-transparent py-1 text-sm text-foreground outline-none"
+          />
+        </div>
+      </label>
+      {helper && !error ? <p className="text-sm text-muted-foreground">{helper}</p> : null}
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+    </div>
+  );
+}
+
+export default TagInput;

--- a/src/components/ui/DateChips.tsx
+++ b/src/components/ui/DateChips.tsx
@@ -1,0 +1,52 @@
+import clsx from 'clsx';
+
+const formatter = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'Asia/Jakarta',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+function formatDate(offset: number): string {
+  const base = new Date();
+  const shifted = new Date(base.getTime() + offset * 24 * 60 * 60 * 1000);
+  return formatter.format(shifted);
+}
+
+type DateChipsProps = {
+  value: string;
+  onSelect: (next: string) => void;
+};
+
+export function DateChips({ value, onSelect }: DateChipsProps) {
+  const todayValue = formatDate(0);
+  const yesterdayValue = formatDate(-1);
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <button
+        type="button"
+        data-active={value === todayValue}
+        onClick={() => onSelect(todayValue)}
+        className={clsx(
+          'h-9 rounded-xl px-3 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+          'bg-muted/40 hover:bg-muted/60 data-[active=true]:bg-primary data-[active=true]:text-primary-foreground',
+        )}
+      >
+        Hari ini
+      </button>
+      <button
+        type="button"
+        data-active={value === yesterdayValue}
+        onClick={() => onSelect(yesterdayValue)}
+        className={clsx(
+          'h-9 rounded-xl px-3 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+          'bg-muted/40 hover:bg-muted/60 data-[active=true]:bg-primary data-[active=true]:text-primary-foreground',
+        )}
+      >
+        Kemarin
+      </button>
+    </div>
+  );
+}
+
+export default DateChips;

--- a/src/lib/transactionsApi.ts
+++ b/src/lib/transactionsApi.ts
@@ -1,0 +1,160 @@
+import type { PostgrestError } from '@supabase/supabase-js';
+import { supabase } from './supabase';
+import { getCurrentUserId } from './session';
+
+type TransactionType = 'income' | 'expense' | 'transfer';
+
+type NullableString = string | null | undefined;
+
+type CreateTransactionInput = {
+  date: string;
+  type: TransactionType;
+  amount: number;
+  account_id: string;
+  to_account_id?: NullableString;
+  category_id?: NullableString;
+  merchant_id?: NullableString;
+  title?: NullableString;
+  notes?: NullableString;
+  tags?: string[] | null;
+  receipt_url?: NullableString;
+};
+
+type TransactionRow = {
+  id: string;
+  user_id: string;
+  date: string;
+  type: TransactionType;
+  amount: number;
+  account_id: string | null;
+  to_account_id: string | null;
+  category_id: string | null;
+  merchant_id: string | null;
+  title: string | null;
+  notes: string | null;
+  tags: string[] | null;
+  receipt_url: string | null;
+};
+
+function normalizeType(type: string): TransactionType {
+  if (type === 'income' || type === 'transfer') return type;
+  return 'expense';
+}
+
+function createFriendlyError(error: unknown): Error {
+  if (error instanceof Error && error.message) {
+    return new Error(error.message);
+  }
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = (error as PostgrestError).message;
+    if (typeof message === 'string' && message.trim().length > 0) {
+      return new Error(message);
+    }
+  }
+  return new Error('Gagal menyimpan transaksi. Coba lagi.');
+}
+
+function sanitizeText(value: NullableString): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function sanitizeTags(tags: string[] | null | undefined): string[] | null {
+  if (!Array.isArray(tags)) return null;
+  const cleaned = tags
+    .map((tag) => (typeof tag === 'string' ? tag.trim() : ''))
+    .filter((tag) => tag.length > 0);
+  return cleaned.length > 0 ? cleaned : null;
+}
+
+function validateDate(date: string | null | undefined): string {
+  const value = typeof date === 'string' ? date.trim() : '';
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new Error('Tanggal tidak valid. Gunakan format YYYY-MM-DD.');
+  }
+  return value;
+}
+
+function validateAmount(amount: number): number {
+  const numeric = Number(amount);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    throw new Error('Nominal harus lebih besar dari 0.');
+  }
+  return numeric;
+}
+
+export async function createTransaction(input: CreateTransactionInput): Promise<TransactionRow> {
+  const userId = await getCurrentUserId();
+  if (!userId) {
+    throw new Error('Anda harus login untuk membuat transaksi.');
+  }
+
+  const type = normalizeType(input.type);
+  const date = validateDate(input.date);
+  const amount = validateAmount(input.amount);
+  const accountId = sanitizeText(input.account_id);
+  const toAccountId = sanitizeText(input.to_account_id ?? null);
+  const categoryId = sanitizeText(input.category_id ?? null);
+  const merchantId = sanitizeText(input.merchant_id ?? null);
+  const title = sanitizeText(input.title);
+  const notes = sanitizeText(input.notes);
+  const receiptUrl = sanitizeText(input.receipt_url);
+  const tags = sanitizeTags(input.tags);
+
+  if (!accountId) {
+    throw new Error('Pilih akun sumber terlebih dahulu.');
+  }
+
+  let finalCategoryId: string | null = categoryId;
+  let finalToAccountId: string | null = toAccountId;
+
+  if (type === 'transfer') {
+    if (!toAccountId) {
+      throw new Error('Pilih akun tujuan untuk transfer.');
+    }
+    if (toAccountId === accountId) {
+      throw new Error('Akun tujuan tidak boleh sama dengan akun sumber.');
+    }
+    finalCategoryId = null;
+  } else {
+    finalToAccountId = null;
+    if (type === 'expense' && !categoryId) {
+      throw new Error('Kategori wajib diisi untuk pengeluaran.');
+    }
+  }
+
+  const payload = {
+    user_id: userId,
+    date,
+    type,
+    amount,
+    account_id: accountId,
+    to_account_id: finalToAccountId,
+    category_id: finalCategoryId,
+    merchant_id: merchantId,
+    title,
+    notes,
+    tags,
+    receipt_url: receiptUrl,
+  } as const;
+
+  try {
+    const { data, error } = await supabase
+      .from('transactions')
+      .insert(payload)
+      .select(
+        'id, user_id, date, type, amount, account_id, to_account_id, category_id, merchant_id, title, notes, tags, receipt_url',
+      )
+      .single();
+    if (error) throw error;
+    if (!data) {
+      throw new Error('Transaksi tidak tersimpan. Coba lagi.');
+    }
+    return data as TransactionRow;
+  } catch (error) {
+    throw createFriendlyError(error);
+  }
+}
+
+export type { CreateTransactionInput, TransactionRow };


### PR DESCRIPTION
## Summary
- redesign the transaction creation page with segmented type picker, Jakarta date presets, inline validation, and optional receipt upload while removing time/recurrence controls
- introduce reusable AmountInput, TagInput, and DateChips components to support the new premium form UX
- add a Supabase createTransaction helper with strict validation and update the addTx handler to skip duplicate cloud inserts

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d54ae658088332a2a07b588ce0c77d