### PR TITLE
Modernize transaction add flow

### DIFF
--- a/src/components/inputs/TagInput.tsx
+++ b/src/components/inputs/TagInput.tsx
@@ -1,0 +1,84 @@
+import { useId, useState, type KeyboardEvent } from 'react';
+import { X } from 'lucide-react';
+
+type TagInputProps = {
+  label: string;
+  value: string[];
+  onChange: (tags: string[]) => void;
+  placeholder?: string;
+  helperText?: string;
+  error?: string;
+};
+
+const INPUT_BASE =
+  'h-11 w-full rounded-2xl border bg-background px-3 text-sm text-text ring-2 ring-transparent transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-60';
+
+export default function TagInput({ label, value, onChange, placeholder, helperText, error }: TagInputProps) {
+  const id = useId();
+  const [inputValue, setInputValue] = useState('');
+
+  const commitTag = (raw: string) => {
+    const tag = raw.trim();
+    if (!tag) return;
+    const exists = value.some((item) => item.toLowerCase() === tag.toLowerCase());
+    if (exists) {
+      setInputValue('');
+      return;
+    }
+    onChange([...value, tag]);
+    setInputValue('');
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' || event.key === ',') {
+      event.preventDefault();
+      commitTag(inputValue);
+    } else if (event.key === 'Backspace' && !inputValue) {
+      event.preventDefault();
+      onChange(value.slice(0, -1));
+    }
+  };
+
+  const handleBlur = () => {
+    if (inputValue.trim()) {
+      commitTag(inputValue);
+    }
+  };
+
+  return (
+    <div>
+      <label htmlFor={id} className="mb-2 flex items-center gap-2 text-sm font-medium text-muted">
+        {label}
+      </label>
+      <div className="flex flex-wrap items-center gap-2 rounded-2xl border border-dashed border-border-subtle bg-muted/10 px-3 py-2">
+        {value.map((tag) => (
+          <span
+            key={tag}
+            className="flex items-center gap-1 rounded-xl bg-muted/40 px-2.5 py-1 text-xs font-medium text-muted"
+          >
+            {tag}
+            <button
+              type="button"
+              className="rounded-full p-0.5 text-muted transition hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+              onClick={() => onChange(value.filter((item) => item !== tag))}
+              aria-label={`Hapus tag ${tag}`}
+            >
+              <X className="h-3 w-3" aria-hidden="true" />
+            </button>
+          </span>
+        ))}
+        <input
+          id={id}
+          value={inputValue}
+          onChange={(event) => setInputValue(event.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={handleBlur}
+          placeholder={placeholder}
+          className={`${INPUT_BASE} h-8 min-w-[120px] flex-1 border-none bg-transparent px-0 py-0 text-sm focus-visible:ring-0`}
+        />
+      </div>
+      {helperText ? <p className="mt-1 text-xs text-muted">{helperText}</p> : null}
+      {error ? <p className="mt-1 text-xs text-destructive">{error}</p> : null}
+    </div>
+  );
+}

--- a/src/lib/transactionsApi.ts
+++ b/src/lib/transactionsApi.ts
@@ -1,0 +1,143 @@
+import { supabase } from './supabase';
+import { getCurrentUserId } from './session';
+
+export type TransactionType = 'income' | 'expense' | 'transfer';
+
+export interface CreateTransactionPayload {
+  type: TransactionType;
+  date: string;
+  amount: number;
+  account_id: string;
+  to_account_id?: string | null;
+  category_id?: string | null;
+  merchant_id?: string | null;
+  title?: string | null;
+  notes?: string | null;
+  tags?: string[] | null;
+}
+
+export interface TransactionRecord {
+  id: string;
+  user_id: string;
+  type: TransactionType;
+  date: string;
+  amount: number;
+  account_id: string | null;
+  to_account_id: string | null;
+  category_id: string | null;
+  merchant_id: string | null;
+  title: string | null;
+  notes: string | null;
+  tags: string[] | null;
+  receipt_url: string | null;
+}
+
+function isValidDate(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+function sanitizeTags(input?: string[] | null): string[] | null {
+  if (!Array.isArray(input)) return null;
+  const seen = new Set<string>();
+  const filtered: string[] = [];
+  for (const raw of input) {
+    const tag = raw?.trim();
+    if (!tag) continue;
+    const key = tag.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    filtered.push(tag);
+  }
+  return filtered.length ? filtered : null;
+}
+
+export async function createTransaction(payload: CreateTransactionPayload): Promise<TransactionRecord> {
+  const {
+    type,
+    date,
+    amount,
+    account_id,
+    to_account_id,
+    category_id,
+    merchant_id,
+    title,
+    notes,
+    tags,
+  } = payload;
+
+  if (!['income', 'expense', 'transfer'].includes(type)) {
+    throw new Error('Tipe transaksi tidak valid.');
+  }
+
+  if (!isValidDate(date)) {
+    throw new Error('Tanggal tidak valid.');
+  }
+
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new Error('Jumlah harus lebih besar dari 0.');
+  }
+
+  if (!account_id) {
+    throw new Error('Akun sumber wajib dipilih.');
+  }
+
+  if (type === 'transfer') {
+    if (!to_account_id) {
+      throw new Error('Akun tujuan wajib dipilih untuk transfer.');
+    }
+    if (to_account_id === account_id) {
+      throw new Error('Akun tujuan tidak boleh sama dengan akun sumber.');
+    }
+  } else if (to_account_id) {
+    throw new Error('Akun tujuan hanya digunakan untuk transfer.');
+  }
+
+  if (type === 'expense' && !category_id) {
+    throw new Error('Kategori wajib untuk pengeluaran.');
+  }
+
+  const userId = await getCurrentUserId();
+  if (!userId) {
+    throw new Error('Anda harus masuk untuk membuat transaksi.');
+  }
+
+  const insertPayload = {
+    user_id: userId,
+    type,
+    date,
+    amount,
+    account_id,
+    to_account_id: type === 'transfer' ? to_account_id ?? null : null,
+    category_id: type === 'transfer' ? null : category_id ?? null,
+    merchant_id: merchant_id ?? null,
+    title: title?.trim() || null,
+    notes: notes?.trim() || null,
+    tags: sanitizeTags(tags) ?? null,
+  };
+
+  const { data, error } = await supabase
+    .from('transactions')
+    .insert(insertPayload)
+    .select('id, user_id, type, date, amount, account_id, to_account_id, category_id, merchant_id, title, notes, tags, receipt_url')
+    .single();
+
+  if (error) {
+    throw new Error(error.message || 'Gagal menyimpan transaksi.');
+  }
+
+  return {
+    id: data.id,
+    user_id: data.user_id,
+    type: data.type as TransactionType,
+    date: data.date,
+    amount: Number(data.amount ?? amount),
+    account_id: data.account_id ?? null,
+    to_account_id: data.to_account_id ?? null,
+    category_id: data.category_id ?? null,
+    merchant_id: data.merchant_id ?? null,
+    title: data.title ?? null,
+    notes: data.notes ?? null,
+    tags: Array.isArray(data.tags) ? data.tags : null,
+    receipt_url: data.receipt_url ?? null,
+  };
+}


### PR DESCRIPTION
## Summary
- redesign the transaction add page with segmented type controls, quick date presets, responsive layout, inline validation, tag entry, and receipt upload support
- add a dedicated Supabase transaction creation helper with server-side validation
- introduce a reusable tag input component and update the addTx handler to accept already persisted records

## Testing
- pnpm lint
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68d54ae658088332a2a07b588ce0c77d