### PR TITLE
Refactor categories API and UI for updated schema

### DIFF
--- a/src/components/categories/CategoryList.tsx
+++ b/src/components/categories/CategoryList.tsx
@@ -13,7 +13,7 @@ interface CategoryListProps {
   onCancelEdit: () => void;
   onSubmitEdit: (
     category: CategoryRecord,
-    values: { name: string; color: string; type: CategoryType }
+    values: { name: string; group_name?: string | null; order_index?: number | null; type: CategoryType }
   ) => Promise<void> | void;
   onDelete: (category: CategoryRecord) => void;
   onMoveUp: (id: string) => void;
@@ -24,6 +24,11 @@ const TYPE_TITLES: Record<CategoryType, string> = {
   income: "Income",
   expense: "Expense",
 };
+
+function formatOrder(value: number | null): string {
+  if (value == null || !Number.isFinite(value)) return "-";
+  return String(value);
+}
 
 export default function CategoryList({
   type,
@@ -62,80 +67,104 @@ export default function CategoryList({
           Belum ada kategori {type === "income" ? "pemasukan" : "pengeluaran"}.
         </p>
       ) : (
-        <ul className="flex-1 space-y-3 overflow-y-auto pr-1">
-          {items.map((item, index) => {
-            const isEditing = editingId === item.id;
-            const isFirst = index === 0;
-            const isLast = index === items.length - 1;
-            const isBusy = pendingIds.has(item.id);
-            return (
-              <li
-                key={item.id}
-                className="rounded-xl border border-border/60 bg-surface-1/80 p-3 shadow-sm"
-              >
-                {isEditing ? (
-                  <CategoryForm
-                    mode="edit"
-                    initialValues={{ name: item.name, color: item.color, type: item.type }}
-                    onSubmit={(values) => onSubmitEdit(item, values)}
-                    onCancel={onCancelEdit}
-                    isSubmitting={isBusy}
-                    allowTypeChange={false}
-                  />
-                ) : (
-                  <div className="flex min-w-0 items-center gap-3">
-                    <span
-                      className="h-3.5 w-3.5 rounded-full border border-white/20"
-                      style={{ backgroundColor: item.color || "#64748B" }}
-                      aria-hidden="true"
-                    />
-                    <span className="min-w-0 flex-1 truncate text-sm font-medium text-text">
-                      {item.name || "Tanpa nama"}
-                    </span>
-                    <div className="flex shrink-0 items-center gap-1">
-                      <button
-                        type="button"
-                        onClick={() => onMoveUp(item.id)}
-                        disabled={isFirst || isBusy}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
-                        aria-label="Naikkan urutan"
-                      >
-                        <ArrowUp className="h-4 w-4" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => onMoveDown(item.id)}
-                        disabled={isLast || isBusy}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
-                        aria-label="Turunkan urutan"
-                      >
-                        <ArrowDown className="h-4 w-4" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => onStartEdit(item.id)}
-                        disabled={isBusy}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
-                        aria-label="Edit kategori"
-                      >
-                        <Pencil className="h-4 w-4" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => onDelete(item)}
-                        disabled={isBusy}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-rose-400 transition-colors hover:text-rose-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-50"
-                        aria-label="Hapus kategori"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </button>
-                    </div>
-                  </div>
-                )}
-              </li>
-            );
-          })}
-        </ul>
+        <div className="flex-1 overflow-x-auto">
+          <table className="min-w-full table-fixed border-separate border-spacing-y-3">
+            <thead>
+              <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted">
+                <th className="px-3">Nama</th>
+                <th className="px-3">Grup</th>
+                <th className="px-3 w-20">Urutan</th>
+                <th className="px-3 w-32 text-right">Aksi</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item, index) => {
+                const isEditing = editingId === item.id;
+                const isFirst = index === 0;
+                const isLast = index === items.length - 1;
+                const isBusy = pendingIds.has(item.id);
+                return (
+                  <tr key={item.id} className="rounded-xl border border-border/60 bg-surface-1/80 text-sm shadow-sm">
+                    <td className="align-top px-3 py-3">
+                      {isEditing ? (
+                        <CategoryForm
+                          mode="edit"
+                          initialValues={{
+                            name: item.name,
+                            type: item.type,
+                            group_name: item.group_name ?? "",
+                            order_index: item.order_index ?? undefined,
+                          }}
+                          onSubmit={(values) => onSubmitEdit(item, values)}
+                          onCancel={onCancelEdit}
+                          isSubmitting={isBusy}
+                          allowTypeChange={false}
+                        />
+                      ) : (
+                        <div className="flex flex-col">
+                          <span className="font-medium text-text">{item.name || "Tanpa nama"}</span>
+                          <span className="text-xs text-muted">{item.inserted_at ? new Date(item.inserted_at).toLocaleDateString() : ""}</span>
+                        </div>
+                      )}
+                    </td>
+                    {!isEditing ? (
+                      <td className="align-top px-3 py-3 text-sm text-text">
+                        {item.group_name ? item.group_name : <span className="text-muted">-</span>}
+                      </td>
+                    ) : (
+                      <td className="px-3 py-3 align-top" colSpan={2}></td>
+                    )}
+                    {!isEditing ? (
+                      <td className="align-top px-3 py-3 text-sm text-text">{formatOrder(item.order_index)}</td>
+                    ) : null}
+                    <td className="align-top px-3 py-3 text-right">
+                      {isEditing ? null : (
+                        <div className="flex justify-end gap-1">
+                          <button
+                            type="button"
+                            onClick={() => onMoveUp(item.id)}
+                            disabled={isFirst || isBusy}
+                            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
+                            aria-label="Naikkan urutan"
+                          >
+                            <ArrowUp className="h-4 w-4" />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => onMoveDown(item.id)}
+                            disabled={isLast || isBusy}
+                            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
+                            aria-label="Turunkan urutan"
+                          >
+                            <ArrowDown className="h-4 w-4" />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => onStartEdit(item.id)}
+                            disabled={isBusy}
+                            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
+                            aria-label="Edit kategori"
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => onDelete(item)}
+                            disabled={isBusy}
+                            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-danger transition-colors hover:text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger/60 disabled:cursor-not-allowed disabled:opacity-50"
+                            aria-label="Hapus kategori"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       )}
     </section>
   );

--- a/src/lib/api-subscriptions.ts
+++ b/src/lib/api-subscriptions.ts
@@ -320,7 +320,7 @@ export async function listSubscriptions(
       next_due_date,
       last_charge_at,
       total_charges,
-      category:category_id (id, name, color),
+      category:category_id (id, name),
       account:account_id (id, name, type)
     `;
 
@@ -437,7 +437,7 @@ export async function getSubscription(id: string): Promise<SubscriptionRecord | 
         next_due_date,
         last_charge_at,
         total_charges,
-        category:category_id (id, name, color),
+        category:category_id (id, name),
         account:account_id (id, name, type)
       `,
       )
@@ -526,7 +526,7 @@ export async function createSubscription(
         next_due_date,
         last_charge_at,
         total_charges,
-        category:category_id (id, name, color),
+        category:category_id (id, name),
         account:account_id (id, name, type)
       `,
       )
@@ -612,7 +612,7 @@ export async function updateSubscription(
         next_due_date,
         last_charge_at,
         total_charges,
-        category:category_id (id, name, color),
+        category:category_id (id, name),
         account:account_id (id, name, type)
       `,
       )

--- a/src/pages/DataPage.tsx
+++ b/src/pages/DataPage.tsx
@@ -183,17 +183,27 @@ function sortOptionsFor(tab: string) {
   }
 }
 
+const CATEGORY_EXPORT_COLUMNS = `
+  id,
+  user_id,
+  name,
+  type,
+  order_index,
+  inserted_at,
+  "group" as group_name
+`;
+
 async function fetchCategories(filter, userId) {
   let query = supabase
     .from('categories')
-    .select('*', { count: 'exact' })
+    .select(CATEGORY_EXPORT_COLUMNS, { count: 'exact' })
     .eq('user_id', userId);
   if (filter.q) {
     query = query.ilike('name', `%${filter.q}%`);
   }
   const [sortField, sortDir] = (filter.sort || 'name-asc').split('-');
   const ascending = sortDir !== 'desc';
-  const orderField = sortField === 'created_at' ? 'created_at' : 'name';
+  const orderField = sortField === 'created_at' ? 'inserted_at' : 'name';
   query = query.order(orderField, { ascending });
   const from = (filter.page - 1) * filter.pageSize;
   const to = from + filter.pageSize - 1;


### PR DESCRIPTION
## Summary
- align category data access with the current schema, including group aliases, order handling, and per-user filtering
- refresh the categories management UI to work with group/order fields and remove the obsolete color controls
- update data export and subscription queries to stop requesting removed category columns

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d54e5db54083329332897a5b1dc8ba