### PR TITLE
Refactor categories flow for new schema

### DIFF
--- a/src/components/categories/CategoryList.tsx
+++ b/src/components/categories/CategoryList.tsx
@@ -1,33 +1,37 @@
 import { ArrowDown, ArrowUp, Loader2, Pencil, Trash2 } from "lucide-react";
-import CategoryForm from "./CategoryForm";
-import type { CategoryRecord, CategoryType } from "../../lib/api-categories";
+import CategoryForm, { CategoryFormValues } from "./CategoryForm";
+import type { CategoryRecord } from "../../lib/api-categories";
 
 interface CategoryListProps {
-  type: CategoryType;
-  title?: string;
   items: CategoryRecord[];
   editingId: string | null;
   pendingIds: Set<string>;
   loading?: boolean;
   onStartEdit: (id: string) => void;
   onCancelEdit: () => void;
-  onSubmitEdit: (
-    category: CategoryRecord,
-    values: { name: string; color: string; type: CategoryType }
-  ) => Promise<void> | void;
+  onSubmitEdit: (category: CategoryRecord, values: CategoryFormValues) => Promise<void> | void;
   onDelete: (category: CategoryRecord) => void;
-  onMoveUp: (id: string) => void;
-  onMoveDown: (id: string) => void;
+  onMove: (category: CategoryRecord, direction: "up" | "down") => void;
 }
 
-const TYPE_TITLES: Record<CategoryType, string> = {
-  income: "Income",
-  expense: "Expense",
-};
+function formatTypeLabel(type: string): string {
+  return type === "income" ? "Pemasukan" : "Pengeluaran";
+}
+
+function sortItems(items: CategoryRecord[]): CategoryRecord[] {
+  return [...items].sort((a, b) => {
+    if (a.type !== b.type) {
+      return a.type.localeCompare(b.type);
+    }
+    const orderDiff = (a.order_index ?? Number.POSITIVE_INFINITY) - (b.order_index ?? Number.POSITIVE_INFINITY);
+    if (Number.isFinite(orderDiff) && orderDiff !== 0) {
+      return orderDiff;
+    }
+    return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+  });
+}
 
 export default function CategoryList({
-  type,
-  title,
   items,
   editingId,
   pendingIds,
@@ -36,19 +40,16 @@ export default function CategoryList({
   onCancelEdit,
   onSubmitEdit,
   onDelete,
-  onMoveUp,
-  onMoveDown,
+  onMove,
 }: CategoryListProps) {
-  const resolvedTitle = title ?? TYPE_TITLES[type] ?? "Kategori";
+  const sorted = sortItems(items);
 
   return (
     <section className="flex h-full min-w-0 flex-col rounded-2xl border border-border/60 bg-surface-1/60 p-4 shadow-sm">
       <header className="mb-4 flex items-center justify-between">
         <div className="min-w-0">
-          <h2 className="text-sm font-semibold text-text">{resolvedTitle}</h2>
-          <p className="text-xs text-muted">
-            {loading ? "Memuat..." : `${items.length} kategori`}
-          </p>
+          <h2 className="text-sm font-semibold text-text">Daftar Kategori</h2>
+          <p className="text-xs text-muted">{loading ? "Memuat..." : `${sorted.length} kategori`}</p>
         </div>
       </header>
       {loading ? (
@@ -57,85 +58,116 @@ export default function CategoryList({
             <Loader2 className="h-4 w-4 animate-spin" /> Memuat daftar...
           </div>
         </div>
-      ) : items.length === 0 ? (
-        <p className="mt-4 text-sm text-muted">
-          Belum ada kategori {type === "income" ? "pemasukan" : "pengeluaran"}.
-        </p>
+      ) : sorted.length === 0 ? (
+        <p className="mt-4 text-sm text-muted">Belum ada kategori.</p>
       ) : (
-        <ul className="flex-1 space-y-3 overflow-y-auto pr-1">
-          {items.map((item, index) => {
-            const isEditing = editingId === item.id;
-            const isFirst = index === 0;
-            const isLast = index === items.length - 1;
-            const isBusy = pendingIds.has(item.id);
-            return (
-              <li
-                key={item.id}
-                className="rounded-xl border border-border/60 bg-surface-1/80 p-3 shadow-sm"
-              >
-                {isEditing ? (
-                  <CategoryForm
-                    mode="edit"
-                    initialValues={{ name: item.name, color: item.color, type: item.type }}
-                    onSubmit={(values) => onSubmitEdit(item, values)}
-                    onCancel={onCancelEdit}
-                    isSubmitting={isBusy}
-                    allowTypeChange={false}
-                  />
-                ) : (
-                  <div className="flex min-w-0 items-center gap-3">
-                    <span
-                      className="h-3.5 w-3.5 rounded-full border border-white/20"
-                      style={{ backgroundColor: item.color || "#64748B" }}
-                      aria-hidden="true"
-                    />
-                    <span className="min-w-0 flex-1 truncate text-sm font-medium text-text">
-                      {item.name || "Tanpa nama"}
-                    </span>
-                    <div className="flex shrink-0 items-center gap-1">
-                      <button
-                        type="button"
-                        onClick={() => onMoveUp(item.id)}
-                        disabled={isFirst || isBusy}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
-                        aria-label="Naikkan urutan"
-                      >
-                        <ArrowUp className="h-4 w-4" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => onMoveDown(item.id)}
-                        disabled={isLast || isBusy}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
-                        aria-label="Turunkan urutan"
-                      >
-                        <ArrowDown className="h-4 w-4" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => onStartEdit(item.id)}
-                        disabled={isBusy}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
-                        aria-label="Edit kategori"
-                      >
-                        <Pencil className="h-4 w-4" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => onDelete(item)}
-                        disabled={isBusy}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-rose-400 transition-colors hover:text-rose-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-50"
-                        aria-label="Hapus kategori"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </button>
-                    </div>
-                  </div>
-                )}
-              </li>
-            );
-          })}
-        </ul>
+        <div className="-mx-2 flex-1 overflow-x-auto">
+          <table className="min-w-full divide-y divide-border/60">
+            <thead>
+              <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted">
+                <th className="px-2 py-2">Nama</th>
+                <th className="px-2 py-2">Tipe</th>
+                <th className="px-2 py-2">Group</th>
+                <th className="px-2 py-2 text-center">Urutan</th>
+                <th className="px-2 py-2 text-right">Aksi</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border/40">
+              {sorted.map((item) => {
+                const isEditing = editingId === item.id;
+                const isBusy = pendingIds.has(item.id);
+                const typeItems = sorted.filter((row) => row.type === item.type);
+                const typeIndex = typeItems.findIndex((row) => row.id === item.id);
+                const isFirst = typeIndex === 0;
+                const isLast = typeIndex === typeItems.length - 1;
+
+                if (isEditing) {
+                  return (
+                    <tr key={item.id} className="bg-surface-1">
+                      <td colSpan={5} className="px-2 py-3">
+                        <CategoryForm
+                          mode="edit"
+                          initialValues={{
+                            name: item.name,
+                            type: item.type,
+                            group_name: item.group_name,
+                            order_index: item.order_index ?? undefined,
+                          }}
+                          onSubmit={(values) => onSubmitEdit(item, values)}
+                          onCancel={onCancelEdit}
+                          isSubmitting={isBusy}
+                          allowTypeChange
+                        />
+                      </td>
+                    </tr>
+                  );
+                }
+
+                return (
+                  <tr key={item.id} className="text-sm text-text">
+                    <td className="px-2 py-2">
+                      <div className="flex flex-col">
+                        <span className="font-medium">{item.name || "Tanpa nama"}</span>
+                        {item.inserted_at ? (
+                          <span className="text-xs text-muted">Ditambahkan {new Date(item.inserted_at).toLocaleDateString()}</span>
+                        ) : null}
+                      </div>
+                    </td>
+                    <td className="px-2 py-2 align-top text-xs font-medium text-muted">
+                      {formatTypeLabel(item.type)}
+                    </td>
+                    <td className="px-2 py-2 align-top text-sm text-text">
+                      {item.group_name ?? <span className="text-muted">-</span>}
+                    </td>
+                    <td className="px-2 py-2 text-center text-sm font-semibold text-text">
+                      {Number.isFinite(item.order_index ?? NaN) ? item.order_index : "-"}
+                    </td>
+                    <td className="px-2 py-2">
+                      <div className="flex justify-end gap-2">
+                        <button
+                          type="button"
+                          onClick={() => onMove(item, "up")}
+                          disabled={isFirst || isBusy || typeItems.length <= 1}
+                          className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
+                          aria-label="Naikkan urutan"
+                        >
+                          <ArrowUp className="h-4 w-4" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => onMove(item, "down")}
+                          disabled={isLast || isBusy || typeItems.length <= 1}
+                          className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
+                          aria-label="Turunkan urutan"
+                        >
+                          <ArrowDown className="h-4 w-4" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => onStartEdit(item.id)}
+                          disabled={isBusy}
+                          className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
+                          aria-label="Edit kategori"
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => onDelete(item)}
+                          disabled={isBusy}
+                          className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-danger transition-colors hover:text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger/60 disabled:cursor-not-allowed disabled:opacity-50"
+                          aria-label="Hapus kategori"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       )}
     </section>
   );

--- a/src/lib/api-categories.ts
+++ b/src/lib/api-categories.ts
@@ -1,553 +1,251 @@
 import { supabase } from "./supabase";
-import { dbCache } from "./sync/localdb";
-import { getCurrentUserId } from "./session";
-import { LocalDriver } from "./data-driver";
 
-type CategoryType = "income" | "expense";
-type CategorySortColumn = "sort_order" | "order_index";
-type CategoryCreatedColumn = "created_at" | "inserted_at";
+export type CategoryType = "income" | "expense";
 
 export interface CategoryRecord {
   id: string;
-  user_id: string | null;
+  user_id: string;
   name: string;
   type: CategoryType;
-  color: string;
-  sort_order: number;
-  created_at: string | null;
-  updated_at: string | null;
+  order_index: number | null;
+  inserted_at: string | null;
+  group_name: string | null;
 }
 
-const DEFAULT_COLOR = "#64748B";
+const BASE_SELECT = `
+  id,
+  user_id,
+  name,
+  type,
+  order_index,
+  inserted_at,
+  "group" as group_name
+`;
 
-let categorySortColumn: CategorySortColumn | undefined;
-let categoryCreatedColumn: CategoryCreatedColumn | undefined;
-const guestDriver = new LocalDriver();
-
-function getCategorySortColumn(): CategorySortColumn {
-  return categorySortColumn ?? "sort_order";
-}
-
-function getCategoryBaseColumns(): string {
-  const sortColumn = getCategorySortColumn();
-  const createdColumn = getCategoryCreatedColumn();
-  return [
-    "id",
-    "user_id",
-    "name",
-    "type",
-    sortColumn,
-    ...(createdColumn === "created_at" ? ["created_at"] : []),
-    "updated_at",
-    "inserted_at",
-  ].join(", ");
-}
-
-let categoryColorSupported: boolean | undefined;
-
-function shouldUseCategoryColor(): boolean {
-  return categoryColorSupported !== false;
-}
-
-function getCategoryCreatedColumn(): CategoryCreatedColumn {
-  return categoryCreatedColumn ?? "created_at";
-}
-
-function getCategorySelectColumns(): string {
-  const baseColumns = getCategoryBaseColumns();
-  return shouldUseCategoryColor() ? `${baseColumns}, color` : baseColumns;
-}
-
-function isMissingColumnError(error: unknown, column: string): boolean {
-  if (!error || typeof error !== "object") return false;
-  const maybeCode = (error as { code?: unknown }).code;
-  const maybeMessage = (error as { message?: unknown }).message;
-  if (typeof maybeMessage === "string") {
-    const normalized = maybeMessage.toLowerCase();
-    if (
-      normalized.includes(column.toLowerCase()) &&
-      (normalized.includes("does not exist") || normalized.includes("could not find"))
-    ) {
-      return true;
-    }
-  }
-  if (maybeCode === "42703" || maybeCode === "PGRST204") {
-    if (typeof maybeMessage === "string") {
-      return maybeMessage.toLowerCase().includes(column.toLowerCase());
-    }
-    return true;
-  }
-  return false;
-}
-
-function handleMissingCategoryColor(error: unknown): boolean {
-  if (shouldUseCategoryColor() && isMissingColumnError(error, "color")) {
-    categoryColorSupported = false;
-    return true;
-  }
-  return false;
-}
-
-function handleMissingCategorySortColumn(error: unknown): boolean {
-  const current = getCategorySortColumn();
-  if (current === "sort_order" && isMissingColumnError(error, "sort_order")) {
-    categorySortColumn = "order_index";
-    return true;
-  }
-  if (current === "order_index" && isMissingColumnError(error, "order_index")) {
-    categorySortColumn = "sort_order";
-    return true;
-  }
-  return false;
-}
-
-function handleMissingCategoryCreatedColumn(error: unknown): boolean {
-  const current = getCategoryCreatedColumn();
-  if (current === "created_at" && isMissingColumnError(error, "created_at")) {
-    categoryCreatedColumn = "inserted_at";
-    return true;
-  }
-  return false;
-}
-
-const isDevelopment = Boolean(
-  (typeof import.meta !== "undefined" && import.meta.env?.DEV) ||
-    (typeof process !== "undefined" && process.env?.NODE_ENV === "development")
-);
-
-function logDevError(scope: string, error: unknown) {
-  if (isDevelopment) {
-    console.error(`[HW] ${scope}`, error);
-  }
-}
-
-function nowISO(): string {
-  return new Date().toISOString();
-}
-
-async function resolveUserId(): Promise<string | null> {
-  try {
-    return await getCurrentUserId();
-  } catch (error) {
-    logDevError("resolveUserId", error);
-    return null;
-  }
-}
-
-function toError(error: unknown, fallback: string) {
+function toError(error: unknown, fallback: string): Error {
   if (error instanceof Error && error.message) {
     const wrapped = new Error(error.message);
     (wrapped as { cause?: unknown }).cause = error.cause ?? error;
     return wrapped;
   }
-  if (typeof error === "string") {
+  if (error && typeof error === "object") {
+    const message =
+      typeof (error as { message?: unknown }).message === "string"
+        ? (error as { message: string }).message
+        : undefined;
+    const details =
+      typeof (error as { details?: unknown }).details === "string"
+        ? (error as { details: string }).details
+        : undefined;
+    const hint =
+      typeof (error as { hint?: unknown }).hint === "string"
+        ? (error as { hint: string }).hint
+        : undefined;
+    if (message || details || hint) {
+      return new Error(message ?? details ?? hint ?? fallback);
+    }
+  }
+  if (typeof error === "string" && error) {
     return new Error(error);
   }
   return new Error(fallback);
 }
 
-function normalizeType(value: unknown): CategoryType {
-  return value === "income" ? "income" : "expense";
+function normalizeType(type: unknown): CategoryType {
+  return type === "income" ? "income" : "expense";
 }
 
-function normalizeColor(value: unknown): string {
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    if (/^#[0-9A-Fa-f]{6}$/.test(trimmed)) {
-      return trimmed.toUpperCase();
-    }
+function mapCategoryRow(row: Record<string, unknown>): CategoryRecord {
+  return {
+    id: String(row.id ?? ""),
+    user_id: typeof row.user_id === "string" ? row.user_id : "",
+    name: typeof row.name === "string" ? row.name : "",
+    type: normalizeType(row.type),
+    order_index:
+      typeof row.order_index === "number" && Number.isFinite(row.order_index)
+        ? row.order_index
+        : null,
+    inserted_at:
+      typeof row.inserted_at === "string" ? row.inserted_at : null,
+    group_name:
+      typeof row.group_name === "string" && row.group_name.trim() !== ""
+        ? row.group_name
+        : null,
+  };
+}
+
+function assertValidType(type: string): asserts type is CategoryType {
+  if (type !== "income" && type !== "expense") {
+    throw new Error("Tipe kategori tidak valid.");
   }
-  return DEFAULT_COLOR;
 }
 
-function normalizeSortOrder(value: unknown, fallback = 0): number {
+export async function listCategories(
+  signal?: AbortSignal,
+  options: { type?: CategoryType } = {}
+): Promise<CategoryRecord[]> {
+  const { data: auth } = await supabase.auth.getUser();
+  const user = auth?.user;
+  if (!user) {
+    throw new Error("Harus login.");
+  }
+
+  let query = supabase
+    .from("categories")
+    .select(BASE_SELECT)
+    .eq("user_id", user.id)
+    .order("type", { ascending: true })
+    .order("order_index", { ascending: true, nullsFirst: true })
+    .order("name", { ascending: true });
+
+  if (options.type) {
+    query = query.eq("type", options.type);
+  }
+
+  if (signal) {
+    query = query.abortSignal(signal);
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    throw toError(error, "Gagal memuat kategori.");
+  }
+  return (data ?? []).map((row) =>
+    mapCategoryRow(row as Record<string, unknown>)
+  );
+}
+
+interface CategoryPayload {
+  name: string;
+  type: CategoryType;
+  group_name?: string | null;
+  order_index?: number | null;
+}
+
+function prepareGroup(groupName: string | null | undefined): string | null {
+  if (groupName == null) return null;
+  const trimmed = groupName.trim();
+  return trimmed ? trimmed : null;
+}
+
+function prepareOrder(value: number | null | undefined): number | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
   if (typeof value === "number" && Number.isFinite(value)) {
     return value;
   }
-  const parsed = Number.parseInt(String(value ?? ""), 10);
-  return Number.isFinite(parsed) ? parsed : fallback;
+  return null;
 }
 
-function normalizeName(value: unknown): string {
-  if (typeof value !== "string") return "";
-  return value.trim();
-}
-
-function mapCategoryRow(row: Partial<CategoryRecord> & Record<string, unknown>): CategoryRecord {
-  const sortValue =
-    typeof row.sort_order !== "undefined" ? row.sort_order : row.order_index;
-  return {
-    id: String(row.id ?? ""),
-    user_id: (typeof row.user_id === "string" ? row.user_id : null) ?? null,
-    name: normalizeName(row.name),
-    type: normalizeType(row.type),
-    color: normalizeColor(row.color),
-    sort_order: normalizeSortOrder(sortValue),
-    created_at: (typeof row.created_at === "string" ? row.created_at : row.inserted_at) ?? null,
-    updated_at: (typeof row.updated_at === "string" ? row.updated_at : null),
-  };
-}
-
-function sortCategories(rows: CategoryRecord[]): CategoryRecord[] {
-  return [...rows].sort((a, b) => {
-    if (a.type !== b.type) {
-      return a.type.localeCompare(b.type);
-    }
-    const orderDiff = (a.sort_order ?? 0) - (b.sort_order ?? 0);
-    if (orderDiff !== 0) return orderDiff;
-    return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
-  });
-}
-
-async function listGuestCategories(): Promise<CategoryRecord[]> {
-  const rows = await guestDriver.list("categories");
-  const mapped = (rows ?? []).map((row) =>
-    mapCategoryRow(row as Partial<CategoryRecord> & Record<string, unknown>)
-  );
-  return sortCategories(mapped);
-}
-
-async function ensureGuestUniqueName(
-  type: CategoryType,
-  name: string,
-  excludeId?: string
-): Promise<void> {
-  const normalized = name.trim().toLowerCase();
-  if (!normalized) return;
-  const rows = await listGuestCategories();
-  const conflict = rows.find(
-    (row) =>
-      row.type === type &&
-      row.id !== excludeId &&
-      row.name.trim().toLowerCase() === normalized
-  );
-  if (conflict) {
-    throw new Error("Nama kategori sudah digunakan pada tipe ini.");
+export async function createCategory(payload: CategoryPayload): Promise<CategoryRecord> {
+  const { data: auth } = await supabase.auth.getUser();
+  const user = auth?.user;
+  if (!user) {
+    throw new Error("Harus login.");
   }
-}
 
-async function createGuestCategory(input: {
-  name: string;
-  type: CategoryType;
-  color: string;
-}): Promise<CategoryRecord> {
-  const { name, type, color } = input;
-  await ensureGuestUniqueName(type, name);
-  const existing = await listGuestCategories();
-  const lastOrder = existing
-    .filter((row) => row.type === type)
-    .reduce((max, row) => Math.max(max, row.sort_order ?? 0), -1);
-  const sortOrder = lastOrder + 1;
-  const now = nowISO();
-  const payload: Record<string, unknown> = {
+  const name = (payload.name ?? "").trim();
+  if (!name) {
+    throw new Error("Nama kategori wajib.");
+  }
+
+  assertValidType(payload.type);
+
+  const body: Record<string, unknown> = {
+    user_id: user.id,
     name,
-    type,
-    color,
-    sort_order: sortOrder,
-    created_at: now,
-    updated_at: now,
-    user_id: null,
+    type: payload.type,
   };
-  const inserted = await guestDriver.insert("categories", payload);
-  const record = mapCategoryRow(
-    inserted as Partial<CategoryRecord> & Record<string, unknown>
-  );
-  await dbCache.set("categories", record);
-  return record;
-}
 
-async function updateGuestCategory(
-  id: string,
-  patch: Partial<Pick<CategoryRecord, "name" | "color" | "sort_order">>
-): Promise<CategoryRecord> {
-  const existing = await guestDriver.get("categories", id);
-  if (!existing) {
-    throw new Error("Kategori tidak ditemukan.");
-  }
-  const current = mapCategoryRow(
-    existing as Partial<CategoryRecord> & Record<string, unknown>
-  );
-  const updates: Record<string, unknown> = {};
-
-  if (typeof patch.name === "string") {
-    const normalized = normalizeName(patch.name);
-    if (!normalized || normalized.length > 60) {
-      throw new Error("Nama kategori harus 1-60 karakter.");
-    }
-    await ensureGuestUniqueName(current.type, normalized, current.id);
-    updates.name = normalized;
+  const preparedOrder = prepareOrder(payload.order_index ?? null);
+  if (preparedOrder !== undefined) {
+    body.order_index = preparedOrder;
   }
 
-  if (typeof patch.color === "string") {
-    updates.color = normalizeColor(patch.color);
+  const preparedGroup = prepareGroup(payload.group_name ?? null);
+  if (preparedGroup !== undefined) {
+    body["group"] = preparedGroup;
   }
 
-  if (patch.sort_order != null) {
-    updates.sort_order = normalizeSortOrder(patch.sort_order);
-  }
-
-  if (!Object.keys(updates).length) {
-    return current;
-  }
-
-  updates.updated_at = nowISO();
-  const updated = await guestDriver.update("categories", id, updates);
-  const record = mapCategoryRow(
-    updated as Partial<CategoryRecord> & Record<string, unknown>
-  );
-  await dbCache.set("categories", record);
-  return record;
-}
-
-async function reorderGuestCategories(
-  type: CategoryType,
-  orderedIds: string[]
-): Promise<void> {
-  if (!Array.isArray(orderedIds) || !orderedIds.length) {
-    return;
-  }
-  const normalizedType = normalizeType(type);
-  const now = nowISO();
-  await Promise.all(
-    orderedIds.map((id, index) =>
-      guestDriver.update("categories", id, {
-        type: normalizedType,
-        sort_order: index,
-        updated_at: now,
-      })
-    )
-  );
-  const rows = await listGuestCategories();
-  await dbCache.bulkSet("categories", rows);
-}
-
-async function deleteGuestCategory(id: string): Promise<void> {
-  await guestDriver.softDelete("categories", id);
-  await dbCache.remove("categories", id);
-}
-
-export async function listCategories(signal?: AbortSignal): Promise<CategoryRecord[]> {
-  if (signal?.aborted) {
-    return [];
-  }
-
-  const userId = await resolveUserId();
-  if (!userId) {
-    return listGuestCategories();
-  }
-
-  try {
-    const sortColumn = getCategorySortColumn();
-    const createdColumn = getCategoryCreatedColumn();
-    let query = supabase
-      .from("categories")
-      .select(getCategorySelectColumns())
-      .eq("user_id", userId)
-      .order("type", { ascending: true })
-      .order(sortColumn, { ascending: true })
-      .order(createdColumn, { ascending: true });
-
-    if (signal) {
-      query = query.abortSignal(signal);
-    }
-
-    const { data, error } = await query;
-    if (error) throw error;
-    const rows = sortCategories((data ?? []).map(mapCategoryRow));
-    await dbCache.bulkSet("categories", rows);
-    return rows;
-  } catch (error) {
-    if (handleMissingCategoryColor(error)) {
-      return listCategories(signal);
-    }
-    if (handleMissingCategorySortColumn(error)) {
-      return listCategories(signal);
-    }
-    if (handleMissingCategoryCreatedColumn(error)) {
-      return listCategories(signal);
-    }
-    if (signal?.aborted) {
-      return [];
-    }
-    logDevError("listCategories", error);
-    const cached = await dbCache.list("categories");
-    const filtered = cached
-      .map((row) => mapCategoryRow(row))
-      .filter((row) => row.user_id === userId);
-    if (filtered.length) {
-      return sortCategories(filtered);
-    }
-    throw toError(error, "Gagal memuat kategori.");
-  }
-}
-
-async function assertUniqueName(
-  userId: string,
-  type: CategoryType,
-  name: string,
-  excludeId?: string
-) {
-  const query = supabase
+  const { data, error } = await supabase
     .from("categories")
-    .select("id, name")
-    .eq("user_id", userId)
-    .eq("type", type)
-    .ilike("name", name)
-    .limit(5);
-  const { data, error } = await query;
-  if (error) throw error;
-  const conflict = (data ?? []).find((row) => {
-    if (excludeId && row.id === excludeId) return false;
-    return normalizeName(row.name).toLowerCase() === name.toLowerCase();
-  });
-  if (conflict) {
-    throw new Error("Nama kategori sudah digunakan pada tipe ini.");
-  }
-}
+    .insert([body])
+    .select(BASE_SELECT)
+    .single();
 
-export async function createCategory(input: {
-  name: string;
-  type: CategoryType;
-  color: string;
-}): Promise<CategoryRecord> {
-  const name = normalizeName(input.name);
-  if (!name || name.length > 60) {
-    throw new Error("Nama kategori harus 1-60 karakter.");
-  }
-  const type = normalizeType(input.type);
-  const color = normalizeColor(input.color);
-
-  const userId = await resolveUserId();
-  if (!userId) {
-    return createGuestCategory({ name, type, color });
-  }
-
-  try {
-    await assertUniqueName(userId, type, name);
-
-    const sortColumn = getCategorySortColumn();
-    const { data: orderRows, error: orderError } = await supabase
-      .from("categories")
-      .select(sortColumn)
-      .eq("user_id", userId)
-      .eq("type", type)
-      .order(sortColumn, { ascending: false })
-      .limit(1);
-    if (orderError) throw orderError;
-    const orderRow = (orderRows?.[0] ?? {}) as Partial<
-      Record<CategorySortColumn, unknown>
-    >;
-    const nextOrder = normalizeSortOrder(orderRow[sortColumn], -1) + 1;
-
-    const insertPayload: Record<string, unknown> = {
-      user_id: userId,
-      name,
-      type,
-      [sortColumn]: nextOrder,
-    };
-
-    if (shouldUseCategoryColor()) {
-      insertPayload.color = color;
-    }
-
-    const { data, error } = await supabase
-      .from("categories")
-      .insert(insertPayload)
-      .select(getCategorySelectColumns())
-      .single();
-    if (error) throw error;
-
-    const record = mapCategoryRow(data ?? {});
-    await dbCache.set("categories", record);
-    return record;
-  } catch (error) {
-    if (handleMissingCategoryColor(error)) {
-      return createCategory(input);
-    }
-    if (handleMissingCategorySortColumn(error)) {
-      return createCategory(input);
-    }
-    if (handleMissingCategoryCreatedColumn(error)) {
-      return createCategory(input);
-    }
-    logDevError("createCategory", error);
+  if (error) {
     throw toError(error, "Gagal menambah kategori.");
   }
+
+  return mapCategoryRow((data ?? {}) as Record<string, unknown>);
+}
+
+interface UpdateCategoryPayload {
+  name?: string;
+  type?: CategoryType;
+  group_name?: string | null;
+  order_index?: number | null;
 }
 
 export async function updateCategory(
   id: string,
-  patch: Partial<Pick<CategoryRecord, "name" | "color" | "sort_order">>
+  patch: UpdateCategoryPayload
 ): Promise<CategoryRecord> {
-  const userId = await resolveUserId();
-  if (!userId) {
-    return updateGuestCategory(id, patch);
+  const { data: auth } = await supabase.auth.getUser();
+  const user = auth?.user;
+  if (!user) {
+    throw new Error("Harus login.");
   }
 
   const updates: Record<string, unknown> = {};
-  const nextName =
-    typeof patch.name === "string" ? normalizeName(patch.name) : undefined;
-  if (typeof nextName === "string") {
-    if (!nextName || nextName.length > 60) {
-      throw new Error("Nama kategori harus 1-60 karakter.");
+
+  if (typeof patch.name === "string") {
+    const trimmed = patch.name.trim();
+    if (!trimmed) {
+      throw new Error("Nama kategori wajib.");
     }
-    updates.name = nextName;
+    updates.name = trimmed;
   }
 
-  if (shouldUseCategoryColor() && typeof patch.color === "string") {
-    updates.color = normalizeColor(patch.color);
+  if (patch.type !== undefined) {
+    assertValidType(patch.type);
+    updates.type = patch.type;
   }
 
-  if (patch.sort_order != null) {
-    const sortColumn = getCategorySortColumn();
-    updates[sortColumn] = normalizeSortOrder(patch.sort_order);
+  if (patch.group_name !== undefined) {
+    updates["group"] = prepareGroup(patch.group_name);
+  }
+
+  if (patch.order_index !== undefined) {
+    updates.order_index = prepareOrder(patch.order_index);
   }
 
   if (!Object.keys(updates).length) {
-    const cached = await dbCache.get("categories", id);
-    if (cached) {
-      return mapCategoryRow(cached);
-    }
-  }
-
-  try {
-    if (typeof updates.name === "string") {
-      const current = await supabase
-        .from("categories")
-        .select("type")
-        .eq("id", id)
-        .eq("user_id", userId)
-        .maybeSingle();
-      if (current.error) throw current.error;
-      const type = normalizeType(current.data?.type);
-      await assertUniqueName(userId, type, updates.name as string, id);
-    }
-
     const { data, error } = await supabase
       .from("categories")
-      .update(updates)
+      .select(BASE_SELECT)
       .eq("id", id)
-      .eq("user_id", userId)
-      .select(getCategorySelectColumns())
+      .eq("user_id", user.id)
       .single();
-    if (error) throw error;
+    if (error) {
+      throw toError(error, "Gagal memuat kategori.");
+    }
+    return mapCategoryRow((data ?? {}) as Record<string, unknown>);
+  }
 
-    const record = mapCategoryRow(data ?? {});
-    await dbCache.set("categories", record);
-    return record;
-  } catch (error) {
-    if (handleMissingCategoryColor(error)) {
-      return updateCategory(id, patch);
-    }
-    if (handleMissingCategorySortColumn(error)) {
-      return updateCategory(id, patch);
-    }
-    if (handleMissingCategoryCreatedColumn(error)) {
-      return updateCategory(id, patch);
-    }
-    logDevError("updateCategory", error);
+  const { data, error } = await supabase
+    .from("categories")
+    .update(updates)
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .select(BASE_SELECT)
+    .single();
+
+  if (error) {
     throw toError(error, "Gagal memperbarui kategori.");
   }
+
+  return mapCategoryRow((data ?? {}) as Record<string, unknown>);
 }
 
 export async function reorderCategories(
@@ -556,64 +254,44 @@ export async function reorderCategories(
 ): Promise<void> {
   if (!Array.isArray(orderedIds) || !orderedIds.length) return;
 
-  const userId = await resolveUserId();
-  if (!userId) {
-    await reorderGuestCategories(type, orderedIds);
-    return;
+  const { data: auth } = await supabase.auth.getUser();
+  const user = auth?.user;
+  if (!user) {
+    throw new Error("Harus login.");
   }
 
-  const normalizedType = normalizeType(type);
-  const sortColumn = getCategorySortColumn();
+  assertValidType(type);
+
   const payload = orderedIds.map((id, index) => ({
     id,
-    user_id: userId,
-    type: normalizedType,
-    [sortColumn]: index,
+    user_id: user.id,
+    type,
+    order_index: index,
   }));
 
-  try {
-    const { data, error } = await supabase
-      .from("categories")
-      .upsert(payload, { onConflict: "id" })
-      .select(getCategorySelectColumns());
-    if (error) throw error;
-    if (data) {
-      await dbCache.bulkSet("categories", data.map((row) => mapCategoryRow(row)));
-    }
-  } catch (error) {
-    if (handleMissingCategoryColor(error)) {
-      return reorderCategories(type, orderedIds);
-    }
-    if (handleMissingCategorySortColumn(error)) {
-      return reorderCategories(type, orderedIds);
-    }
-    if (handleMissingCategoryCreatedColumn(error)) {
-      return reorderCategories(type, orderedIds);
-    }
-    logDevError("reorderCategories", error);
+  const { error } = await supabase
+    .from("categories")
+    .upsert(payload, { onConflict: "id" });
+
+  if (error) {
     throw toError(error, "Gagal mengurutkan kategori.");
   }
 }
 
 export async function deleteCategory(id: string): Promise<void> {
-  const userId = await resolveUserId();
-  if (!userId) {
-    await deleteGuestCategory(id);
-    return;
+  const { data: auth } = await supabase.auth.getUser();
+  const user = auth?.user;
+  if (!user) {
+    throw new Error("Harus login.");
   }
 
-  try {
-    const { error } = await supabase
-      .from("categories")
-      .delete()
-      .eq("id", id)
-      .eq("user_id", userId);
-    if (error) throw error;
-    await dbCache.remove("categories", id);
-  } catch (error) {
-    logDevError("deleteCategory", error);
+  const { error } = await supabase
+    .from("categories")
+    .delete()
+    .eq("id", id)
+    .eq("user_id", user.id);
+
+  if (error) {
     throw toError(error, "Gagal menghapus kategori.");
   }
 }
-
-export type { CategoryType };


### PR DESCRIPTION
## Summary
- rebuild categories API helpers to use only valid schema columns and enforce user ownership
- refresh category form and list to capture group/order fields instead of color metadata
- overhaul categories page logic for the new API, validation, ordering, and table UI

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d54e5db54083329332897a5b1dc8ba