### PR TITLE
Refactor categories module for new schema

### DIFF
--- a/src/components/categories/CategoryList.tsx
+++ b/src/components/categories/CategoryList.tsx
@@ -1,142 +1,146 @@
-import { ArrowDown, ArrowUp, Loader2, Pencil, Trash2 } from "lucide-react";
-import CategoryForm from "./CategoryForm";
-import type { CategoryRecord, CategoryType } from "../../lib/api-categories";
+import { Loader2, Pencil, Trash2 } from "lucide-react";
+import type { CategoryRecord } from "../../lib/api-categories";
+import CategoryForm, { type CategoryFormValues } from "./CategoryForm";
 
 interface CategoryListProps {
-  type: CategoryType;
-  title?: string;
   items: CategoryRecord[];
+  loading?: boolean;
   editingId: string | null;
   pendingIds: Set<string>;
-  loading?: boolean;
   onStartEdit: (id: string) => void;
   onCancelEdit: () => void;
-  onSubmitEdit: (
-    category: CategoryRecord,
-    values: { name: string; color: string; type: CategoryType }
-  ) => Promise<void> | void;
+  onSubmitEdit: (id: string, values: CategoryFormValues) => Promise<void> | void;
   onDelete: (category: CategoryRecord) => void;
-  onMoveUp: (id: string) => void;
-  onMoveDown: (id: string) => void;
 }
 
-const TYPE_TITLES: Record<CategoryType, string> = {
-  income: "Income",
-  expense: "Expense",
-};
+function formatTypeLabel(type: CategoryRecord["type"]): string {
+  return type === "income" ? "Pemasukan" : "Pengeluaran";
+}
 
 export default function CategoryList({
-  type,
-  title,
   items,
+  loading = false,
   editingId,
   pendingIds,
-  loading = false,
   onStartEdit,
   onCancelEdit,
   onSubmitEdit,
   onDelete,
-  onMoveUp,
-  onMoveDown,
 }: CategoryListProps) {
-  const resolvedTitle = title ?? TYPE_TITLES[type] ?? "Kategori";
-
   return (
-    <section className="flex h-full min-w-0 flex-col rounded-2xl border border-border/60 bg-surface-1/60 p-4 shadow-sm">
+    <section className="rounded-2xl border border-border/60 bg-surface-1/60 p-4 shadow-sm">
       <header className="mb-4 flex items-center justify-between">
-        <div className="min-w-0">
-          <h2 className="text-sm font-semibold text-text">{resolvedTitle}</h2>
+        <div>
+          <h2 className="text-sm font-semibold text-text">Daftar Kategori</h2>
           <p className="text-xs text-muted">
-            {loading ? "Memuat..." : `${items.length} kategori`}
+            {loading ? "Memuat kategori..." : `${items.length} kategori`}
           </p>
         </div>
       </header>
-      {loading ? (
-        <div className="flex flex-1 items-center justify-center text-muted">
-          <div className="flex items-center gap-2 text-sm">
-            <Loader2 className="h-4 w-4 animate-spin" /> Memuat daftar...
-          </div>
-        </div>
-      ) : items.length === 0 ? (
-        <p className="mt-4 text-sm text-muted">
-          Belum ada kategori {type === "income" ? "pemasukan" : "pengeluaran"}.
-        </p>
-      ) : (
-        <ul className="flex-1 space-y-3 overflow-y-auto pr-1">
-          {items.map((item, index) => {
-            const isEditing = editingId === item.id;
-            const isFirst = index === 0;
-            const isLast = index === items.length - 1;
-            const isBusy = pendingIds.has(item.id);
-            return (
-              <li
-                key={item.id}
-                className="rounded-xl border border-border/60 bg-surface-1/80 p-3 shadow-sm"
-              >
-                {isEditing ? (
-                  <CategoryForm
-                    mode="edit"
-                    initialValues={{ name: item.name, color: item.color, type: item.type }}
-                    onSubmit={(values) => onSubmitEdit(item, values)}
-                    onCancel={onCancelEdit}
-                    isSubmitting={isBusy}
-                    allowTypeChange={false}
-                  />
-                ) : (
-                  <div className="flex min-w-0 items-center gap-3">
-                    <span
-                      className="h-3.5 w-3.5 rounded-full border border-white/20"
-                      style={{ backgroundColor: item.color || "#64748B" }}
-                      aria-hidden="true"
-                    />
-                    <span className="min-w-0 flex-1 truncate text-sm font-medium text-text">
-                      {item.name || "Tanpa nama"}
-                    </span>
-                    <div className="flex shrink-0 items-center gap-1">
-                      <button
-                        type="button"
-                        onClick={() => onMoveUp(item.id)}
-                        disabled={isFirst || isBusy}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
-                        aria-label="Naikkan urutan"
-                      >
-                        <ArrowUp className="h-4 w-4" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => onMoveDown(item.id)}
-                        disabled={isLast || isBusy}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
-                        aria-label="Turunkan urutan"
-                      >
-                        <ArrowDown className="h-4 w-4" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => onStartEdit(item.id)}
-                        disabled={isBusy}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
-                        aria-label="Edit kategori"
-                      >
-                        <Pencil className="h-4 w-4" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => onDelete(item)}
-                        disabled={isBusy}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-rose-400 transition-colors hover:text-rose-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-50"
-                        aria-label="Hapus kategori"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </button>
-                    </div>
-                  </div>
-                )}
-              </li>
-            );
-          })}
-        </ul>
-      )}
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-border/60 text-left text-sm">
+          <thead className="bg-surface-1/70 text-xs font-semibold uppercase tracking-wide text-muted">
+            <tr>
+              <th scope="col" className="px-3 py-2">Nama</th>
+              <th scope="col" className="px-3 py-2">Tipe</th>
+              <th scope="col" className="px-3 py-2">Grup</th>
+              <th scope="col" className="px-3 py-2">Urutan</th>
+              <th scope="col" className="px-3 py-2 text-right">Aksi</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/50 text-sm">
+            {loading ? (
+              Array.from({ length: 3 }).map((_, index) => (
+                <tr key={`skeleton-${index}`} className="animate-pulse">
+                  <td className="px-3 py-3">
+                    <div className="h-4 w-32 rounded bg-border/70" />
+                  </td>
+                  <td className="px-3 py-3">
+                    <div className="h-4 w-20 rounded bg-border/70" />
+                  </td>
+                  <td className="px-3 py-3">
+                    <div className="h-4 w-24 rounded bg-border/70" />
+                  </td>
+                  <td className="px-3 py-3">
+                    <div className="h-4 w-12 rounded bg-border/70" />
+                  </td>
+                  <td className="px-3 py-3 text-right">
+                    <div className="ml-auto h-4 w-16 rounded bg-border/70" />
+                  </td>
+                </tr>
+              ))
+            ) : items.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-3 py-6 text-center text-sm text-muted">
+                  Belum ada kategori yang tersimpan.
+                </td>
+              </tr>
+            ) : (
+              items.map((item) => {
+                const isEditing = editingId === item.id;
+                const isBusy = pendingIds.has(item.id);
+                if (isEditing) {
+                  return (
+                    <tr key={item.id}>
+                      <td colSpan={5} className="px-3 py-3">
+                        <CategoryForm
+                          mode="edit"
+                          initialValues={{
+                            name: item.name,
+                            type: item.type,
+                            group_name: item.group_name ?? null,
+                            order_index: item.order_index ?? null,
+                          }}
+                          onSubmit={(values) => onSubmitEdit(item.id, values)}
+                          onCancel={onCancelEdit}
+                          isSubmitting={isBusy}
+                        />
+                      </td>
+                    </tr>
+                  );
+                }
+
+                return (
+                  <tr key={item.id}>
+                    <td className="px-3 py-3 text-sm font-medium text-text">{item.name || "Tanpa nama"}</td>
+                    <td className="px-3 py-3 text-sm text-muted">{formatTypeLabel(item.type)}</td>
+                    <td className="px-3 py-3 text-sm text-muted">
+                      {item.group_name ? item.group_name : <span className="text-muted">—</span>}
+                    </td>
+                    <td className="px-3 py-3 text-sm text-muted">
+                      {typeof item.order_index === "number" && Number.isFinite(item.order_index)
+                        ? item.order_index
+                        : "—"}
+                    </td>
+                    <td className="px-3 py-3 text-right">
+                      <div className="flex justify-end gap-2">
+                        <button
+                          type="button"
+                          onClick={() => onStartEdit(item.id)}
+                          disabled={isBusy}
+                          className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
+                          aria-label="Edit kategori"
+                        >
+                          {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Pencil className="h-4 w-4" />}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => onDelete(item)}
+                          disabled={isBusy}
+                          className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-rose-400 transition-colors hover:text-rose-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-50"
+                          aria-label="Hapus kategori"
+                        >
+                          {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
     </section>
   );
 }

--- a/src/lib/api-categories.ts
+++ b/src/lib/api-categories.ts
@@ -1,171 +1,85 @@
+import type { User } from "@supabase/supabase-js";
 import { supabase } from "./supabase";
-import { dbCache } from "./sync/localdb";
-import { getCurrentUserId } from "./session";
-import { LocalDriver } from "./data-driver";
 
-type CategoryType = "income" | "expense";
-type CategorySortColumn = "sort_order" | "order_index";
-type CategoryCreatedColumn = "created_at" | "inserted_at";
+export type CategoryType = "income" | "expense";
 
 export interface CategoryRecord {
   id: string;
-  user_id: string | null;
+  user_id: string;
   name: string;
   type: CategoryType;
-  color: string;
-  sort_order: number;
-  created_at: string | null;
-  updated_at: string | null;
+  order_index: number | null;
+  inserted_at: string | null;
+  group_name: string | null;
 }
 
-const DEFAULT_COLOR = "#64748B";
-
-let categorySortColumn: CategorySortColumn | undefined;
-let categoryCreatedColumn: CategoryCreatedColumn | undefined;
-const guestDriver = new LocalDriver();
-
-function getCategorySortColumn(): CategorySortColumn {
-  return categorySortColumn ?? "sort_order";
+export interface CategoryCreatePayload {
+  name: string;
+  type: CategoryType;
+  group_name?: string | null;
+  order_index?: number | null;
 }
 
-function getCategoryBaseColumns(): string {
-  const sortColumn = getCategorySortColumn();
-  const createdColumn = getCategoryCreatedColumn();
-  return [
-    "id",
-    "user_id",
-    "name",
-    "type",
-    sortColumn,
-    ...(createdColumn === "created_at" ? ["created_at"] : []),
-    "updated_at",
-    "inserted_at",
-  ].join(", ");
+export interface CategoryUpdatePayload {
+  name?: string;
+  type?: CategoryType;
+  group_name?: string | null;
+  order_index?: number | null;
 }
 
-let categoryColorSupported: boolean | undefined;
-
-function shouldUseCategoryColor(): boolean {
-  return categoryColorSupported !== false;
+export interface CategoryListOptions {
+  type?: CategoryType;
+  signal?: AbortSignal;
 }
 
-function getCategoryCreatedColumn(): CategoryCreatedColumn {
-  return categoryCreatedColumn ?? "created_at";
+const BASE_SELECT = `
+  id,
+  user_id,
+  name,
+  type,
+  order_index,
+  inserted_at,
+  "group" as group_name
+`;
+
+function isCategoryType(value: unknown): value is CategoryType {
+  return value === "income" || value === "expense";
 }
 
-function getCategorySelectColumns(): string {
-  const baseColumns = getCategoryBaseColumns();
-  return shouldUseCategoryColor() ? `${baseColumns}, color` : baseColumns;
+function mapRow(row: Record<string, unknown>): CategoryRecord {
+  const id = typeof row.id === "string" ? row.id : String(row.id ?? "");
+  const userId = typeof row.user_id === "string" ? row.user_id : String(row.user_id ?? "");
+  const name = typeof row.name === "string" ? row.name : "";
+  const type: CategoryType = row.type === "income" ? "income" : "expense";
+  const orderIndex =
+    typeof row.order_index === "number" && Number.isFinite(row.order_index)
+      ? row.order_index
+      : null;
+  const insertedAt = typeof row.inserted_at === "string" ? row.inserted_at : null;
+  const groupName =
+    typeof row.group_name === "string" && row.group_name.trim().length
+      ? row.group_name
+      : null;
+
+  return {
+    id,
+    user_id: userId,
+    name,
+    type,
+    order_index: orderIndex,
+    inserted_at: insertedAt,
+    group_name: groupName,
+  };
 }
 
-function isMissingColumnError(error: unknown, column: string): boolean {
-  if (!error || typeof error !== "object") return false;
-  const maybeCode = (error as { code?: unknown }).code;
-  const maybeMessage = (error as { message?: unknown }).message;
-  if (typeof maybeMessage === "string") {
-    const normalized = maybeMessage.toLowerCase();
-    if (
-      normalized.includes(column.toLowerCase()) &&
-      (normalized.includes("does not exist") || normalized.includes("could not find"))
-    ) {
-      return true;
-    }
+async function requireUser(): Promise<User> {
+  const { data, error } = await supabase.auth.getUser();
+  if (error) throw error;
+  const user = data?.user;
+  if (!user) {
+    throw new Error("Harus login.");
   }
-  if (maybeCode === "42703" || maybeCode === "PGRST204") {
-    if (typeof maybeMessage === "string") {
-      return maybeMessage.toLowerCase().includes(column.toLowerCase());
-    }
-    return true;
-  }
-  return false;
-}
-
-function handleMissingCategoryColor(error: unknown): boolean {
-  if (shouldUseCategoryColor() && isMissingColumnError(error, "color")) {
-    categoryColorSupported = false;
-    return true;
-  }
-  return false;
-}
-
-function handleMissingCategorySortColumn(error: unknown): boolean {
-  const current = getCategorySortColumn();
-  if (current === "sort_order" && isMissingColumnError(error, "sort_order")) {
-    categorySortColumn = "order_index";
-    return true;
-  }
-  if (current === "order_index" && isMissingColumnError(error, "order_index")) {
-    categorySortColumn = "sort_order";
-    return true;
-  }
-  return false;
-}
-
-function handleMissingCategoryCreatedColumn(error: unknown): boolean {
-  const current = getCategoryCreatedColumn();
-  if (current === "created_at" && isMissingColumnError(error, "created_at")) {
-    categoryCreatedColumn = "inserted_at";
-    return true;
-  }
-  return false;
-}
-
-const isDevelopment = Boolean(
-  (typeof import.meta !== "undefined" && import.meta.env?.DEV) ||
-    (typeof process !== "undefined" && process.env?.NODE_ENV === "development")
-);
-
-function logDevError(scope: string, error: unknown) {
-  if (isDevelopment) {
-    console.error(`[HW] ${scope}`, error);
-  }
-}
-
-function nowISO(): string {
-  return new Date().toISOString();
-}
-
-async function resolveUserId(): Promise<string | null> {
-  try {
-    return await getCurrentUserId();
-  } catch (error) {
-    logDevError("resolveUserId", error);
-    return null;
-  }
-}
-
-function toError(error: unknown, fallback: string) {
-  if (error instanceof Error && error.message) {
-    const wrapped = new Error(error.message);
-    (wrapped as { cause?: unknown }).cause = error.cause ?? error;
-    return wrapped;
-  }
-  if (typeof error === "string") {
-    return new Error(error);
-  }
-  return new Error(fallback);
-}
-
-function normalizeType(value: unknown): CategoryType {
-  return value === "income" ? "income" : "expense";
-}
-
-function normalizeColor(value: unknown): string {
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    if (/^#[0-9A-Fa-f]{6}$/.test(trimmed)) {
-      return trimmed.toUpperCase();
-    }
-  }
-  return DEFAULT_COLOR;
-}
-
-function normalizeSortOrder(value: unknown, fallback = 0): number {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value;
-  }
-  const parsed = Number.parseInt(String(value ?? ""), 10);
-  return Number.isFinite(parsed) ? parsed : fallback;
+  return user;
 }
 
 function normalizeName(value: unknown): string {
@@ -173,19 +87,38 @@ function normalizeName(value: unknown): string {
   return value.trim();
 }
 
-function mapCategoryRow(row: Partial<CategoryRecord> & Record<string, unknown>): CategoryRecord {
-  const sortValue =
-    typeof row.sort_order !== "undefined" ? row.sort_order : row.order_index;
-  return {
-    id: String(row.id ?? ""),
-    user_id: (typeof row.user_id === "string" ? row.user_id : null) ?? null,
-    name: normalizeName(row.name),
-    type: normalizeType(row.type),
-    color: normalizeColor(row.color),
-    sort_order: normalizeSortOrder(sortValue),
-    created_at: (typeof row.created_at === "string" ? row.created_at : row.inserted_at) ?? null,
-    updated_at: (typeof row.updated_at === "string" ? row.updated_at : null),
-  };
+function normalizeGroup(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : null;
+}
+
+function normalizeOrderIndex(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim().length) {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+async function computeNextOrderIndex(
+  userId: string,
+  type: CategoryType
+): Promise<number> {
+  const { data, error } = await supabase
+    .from("categories")
+    .select("order_index")
+    .eq("user_id", userId)
+    .eq("type", type)
+    .order("order_index", { ascending: false, nullsLast: true })
+    .limit(1);
+  if (error) throw error;
+  const current = data?.[0]?.order_index;
+  const base = typeof current === "number" && Number.isFinite(current) ? current : -1;
+  return base + 1;
 }
 
 function sortCategories(rows: CategoryRecord[]): CategoryRecord[] {
@@ -193,427 +126,147 @@ function sortCategories(rows: CategoryRecord[]): CategoryRecord[] {
     if (a.type !== b.type) {
       return a.type.localeCompare(b.type);
     }
-    const orderDiff = (a.sort_order ?? 0) - (b.sort_order ?? 0);
-    if (orderDiff !== 0) return orderDiff;
+    const orderA =
+      typeof a.order_index === "number" && Number.isFinite(a.order_index)
+        ? a.order_index
+        : Number.MIN_SAFE_INTEGER;
+    const orderB =
+      typeof b.order_index === "number" && Number.isFinite(b.order_index)
+        ? b.order_index
+        : Number.MIN_SAFE_INTEGER;
+    if (orderA !== orderB) {
+      return orderA - orderB;
+    }
     return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
   });
 }
 
-async function listGuestCategories(): Promise<CategoryRecord[]> {
-  const rows = await guestDriver.list("categories");
-  const mapped = (rows ?? []).map((row) =>
-    mapCategoryRow(row as Partial<CategoryRecord> & Record<string, unknown>)
-  );
-  return sortCategories(mapped);
-}
-
-async function ensureGuestUniqueName(
-  type: CategoryType,
-  name: string,
-  excludeId?: string
-): Promise<void> {
-  const normalized = name.trim().toLowerCase();
-  if (!normalized) return;
-  const rows = await listGuestCategories();
-  const conflict = rows.find(
-    (row) =>
-      row.type === type &&
-      row.id !== excludeId &&
-      row.name.trim().toLowerCase() === normalized
-  );
-  if (conflict) {
-    throw new Error("Nama kategori sudah digunakan pada tipe ini.");
-  }
-}
-
-async function createGuestCategory(input: {
-  name: string;
-  type: CategoryType;
-  color: string;
-}): Promise<CategoryRecord> {
-  const { name, type, color } = input;
-  await ensureGuestUniqueName(type, name);
-  const existing = await listGuestCategories();
-  const lastOrder = existing
-    .filter((row) => row.type === type)
-    .reduce((max, row) => Math.max(max, row.sort_order ?? 0), -1);
-  const sortOrder = lastOrder + 1;
-  const now = nowISO();
-  const payload: Record<string, unknown> = {
-    name,
-    type,
-    color,
-    sort_order: sortOrder,
-    created_at: now,
-    updated_at: now,
-    user_id: null,
-  };
-  const inserted = await guestDriver.insert("categories", payload);
-  const record = mapCategoryRow(
-    inserted as Partial<CategoryRecord> & Record<string, unknown>
-  );
-  await dbCache.set("categories", record);
-  return record;
-}
-
-async function updateGuestCategory(
-  id: string,
-  patch: Partial<Pick<CategoryRecord, "name" | "color" | "sort_order">>
-): Promise<CategoryRecord> {
-  const existing = await guestDriver.get("categories", id);
-  if (!existing) {
-    throw new Error("Kategori tidak ditemukan.");
-  }
-  const current = mapCategoryRow(
-    existing as Partial<CategoryRecord> & Record<string, unknown>
-  );
-  const updates: Record<string, unknown> = {};
-
-  if (typeof patch.name === "string") {
-    const normalized = normalizeName(patch.name);
-    if (!normalized || normalized.length > 60) {
-      throw new Error("Nama kategori harus 1-60 karakter.");
-    }
-    await ensureGuestUniqueName(current.type, normalized, current.id);
-    updates.name = normalized;
-  }
-
-  if (typeof patch.color === "string") {
-    updates.color = normalizeColor(patch.color);
-  }
-
-  if (patch.sort_order != null) {
-    updates.sort_order = normalizeSortOrder(patch.sort_order);
-  }
-
-  if (!Object.keys(updates).length) {
-    return current;
-  }
-
-  updates.updated_at = nowISO();
-  const updated = await guestDriver.update("categories", id, updates);
-  const record = mapCategoryRow(
-    updated as Partial<CategoryRecord> & Record<string, unknown>
-  );
-  await dbCache.set("categories", record);
-  return record;
-}
-
-async function reorderGuestCategories(
-  type: CategoryType,
-  orderedIds: string[]
-): Promise<void> {
-  if (!Array.isArray(orderedIds) || !orderedIds.length) {
-    return;
-  }
-  const normalizedType = normalizeType(type);
-  const now = nowISO();
-  await Promise.all(
-    orderedIds.map((id, index) =>
-      guestDriver.update("categories", id, {
-        type: normalizedType,
-        sort_order: index,
-        updated_at: now,
-      })
-    )
-  );
-  const rows = await listGuestCategories();
-  await dbCache.bulkSet("categories", rows);
-}
-
-async function deleteGuestCategory(id: string): Promise<void> {
-  await guestDriver.softDelete("categories", id);
-  await dbCache.remove("categories", id);
-}
-
-export async function listCategories(signal?: AbortSignal): Promise<CategoryRecord[]> {
-  if (signal?.aborted) {
-    return [];
-  }
-
-  const userId = await resolveUserId();
-  if (!userId) {
-    return listGuestCategories();
-  }
-
-  try {
-    const sortColumn = getCategorySortColumn();
-    const createdColumn = getCategoryCreatedColumn();
-    let query = supabase
-      .from("categories")
-      .select(getCategorySelectColumns())
-      .eq("user_id", userId)
-      .order("type", { ascending: true })
-      .order(sortColumn, { ascending: true })
-      .order(createdColumn, { ascending: true });
-
-    if (signal) {
-      query = query.abortSignal(signal);
-    }
-
-    const { data, error } = await query;
-    if (error) throw error;
-    const rows = sortCategories((data ?? []).map(mapCategoryRow));
-    await dbCache.bulkSet("categories", rows);
-    return rows;
-  } catch (error) {
-    if (handleMissingCategoryColor(error)) {
-      return listCategories(signal);
-    }
-    if (handleMissingCategorySortColumn(error)) {
-      return listCategories(signal);
-    }
-    if (handleMissingCategoryCreatedColumn(error)) {
-      return listCategories(signal);
-    }
-    if (signal?.aborted) {
-      return [];
-    }
-    logDevError("listCategories", error);
-    const cached = await dbCache.list("categories");
-    const filtered = cached
-      .map((row) => mapCategoryRow(row))
-      .filter((row) => row.user_id === userId);
-    if (filtered.length) {
-      return sortCategories(filtered);
-    }
-    throw toError(error, "Gagal memuat kategori.");
-  }
-}
-
-async function assertUniqueName(
-  userId: string,
-  type: CategoryType,
-  name: string,
-  excludeId?: string
-) {
-  const query = supabase
+export async function listCategories(
+  options: CategoryListOptions = {}
+): Promise<CategoryRecord[]> {
+  const user = await requireUser();
+  let query = supabase
     .from("categories")
-    .select("id, name")
-    .eq("user_id", userId)
-    .eq("type", type)
-    .ilike("name", name)
-    .limit(5);
+    .select(BASE_SELECT)
+    .eq("user_id", user.id)
+    .order("type", { ascending: true })
+    .order("order_index", { ascending: true, nullsFirst: true })
+    .order("name", { ascending: true });
+
+  if (options.type) {
+    if (!isCategoryType(options.type)) {
+      throw new Error("Tipe kategori tidak valid.");
+    }
+    query = query.eq("type", options.type);
+  }
+
+  if (options.signal) {
+    query = query.abortSignal(options.signal);
+  }
+
   const { data, error } = await query;
   if (error) throw error;
-  const conflict = (data ?? []).find((row) => {
-    if (excludeId && row.id === excludeId) return false;
-    return normalizeName(row.name).toLowerCase() === name.toLowerCase();
-  });
-  if (conflict) {
-    throw new Error("Nama kategori sudah digunakan pada tipe ini.");
-  }
+  const rows = (data ?? []).map((row) => mapRow(row as Record<string, unknown>));
+  return sortCategories(rows);
 }
 
-export async function createCategory(input: {
-  name: string;
-  type: CategoryType;
-  color: string;
-}): Promise<CategoryRecord> {
-  const name = normalizeName(input.name);
-  if (!name || name.length > 60) {
-    throw new Error("Nama kategori harus 1-60 karakter.");
+export async function createCategory(
+  payload: CategoryCreatePayload
+): Promise<CategoryRecord> {
+  const user = await requireUser();
+  const name = normalizeName(payload.name);
+  if (!name) {
+    throw new Error("Nama kategori wajib.");
   }
-  const type = normalizeType(input.type);
-  const color = normalizeColor(input.color);
-
-  const userId = await resolveUserId();
-  if (!userId) {
-    return createGuestCategory({ name, type, color });
+  if (!isCategoryType(payload.type)) {
+    throw new Error("Tipe kategori tidak valid.");
   }
 
-  try {
-    await assertUniqueName(userId, type, name);
+  const body: Record<string, unknown> = {
+    user_id: user.id,
+    name,
+    type: payload.type,
+  };
 
-    const sortColumn = getCategorySortColumn();
-    const { data: orderRows, error: orderError } = await supabase
-      .from("categories")
-      .select(sortColumn)
-      .eq("user_id", userId)
-      .eq("type", type)
-      .order(sortColumn, { ascending: false })
-      .limit(1);
-    if (orderError) throw orderError;
-    const orderRow = (orderRows?.[0] ?? {}) as Partial<
-      Record<CategorySortColumn, unknown>
-    >;
-    const nextOrder = normalizeSortOrder(orderRow[sortColumn], -1) + 1;
-
-    const insertPayload: Record<string, unknown> = {
-      user_id: userId,
-      name,
-      type,
-      [sortColumn]: nextOrder,
-    };
-
-    if (shouldUseCategoryColor()) {
-      insertPayload.color = color;
-    }
-
-    const { data, error } = await supabase
-      .from("categories")
-      .insert(insertPayload)
-      .select(getCategorySelectColumns())
-      .single();
-    if (error) throw error;
-
-    const record = mapCategoryRow(data ?? {});
-    await dbCache.set("categories", record);
-    return record;
-  } catch (error) {
-    if (handleMissingCategoryColor(error)) {
-      return createCategory(input);
-    }
-    if (handleMissingCategorySortColumn(error)) {
-      return createCategory(input);
-    }
-    if (handleMissingCategoryCreatedColumn(error)) {
-      return createCategory(input);
-    }
-    logDevError("createCategory", error);
-    throw toError(error, "Gagal menambah kategori.");
+  if (payload.order_index !== undefined) {
+    body.order_index = normalizeOrderIndex(payload.order_index);
+  } else {
+    body.order_index = await computeNextOrderIndex(user.id, payload.type);
   }
+
+  if (payload.group_name !== undefined) {
+    body["group"] = normalizeGroup(payload.group_name);
+  }
+
+  const { data, error } = await supabase
+    .from("categories")
+    .insert([body])
+    .select(BASE_SELECT)
+    .single();
+  if (error) throw error;
+  return mapRow((data ?? {}) as Record<string, unknown>);
 }
 
 export async function updateCategory(
   id: string,
-  patch: Partial<Pick<CategoryRecord, "name" | "color" | "sort_order">>
+  patch: CategoryUpdatePayload
 ): Promise<CategoryRecord> {
-  const userId = await resolveUserId();
-  if (!userId) {
-    return updateGuestCategory(id, patch);
-  }
-
+  const user = await requireUser();
   const updates: Record<string, unknown> = {};
-  const nextName =
-    typeof patch.name === "string" ? normalizeName(patch.name) : undefined;
-  if (typeof nextName === "string") {
-    if (!nextName || nextName.length > 60) {
-      throw new Error("Nama kategori harus 1-60 karakter.");
+
+  if (patch.name !== undefined) {
+    const nextName = normalizeName(patch.name);
+    if (!nextName) {
+      throw new Error("Nama kategori wajib.");
     }
     updates.name = nextName;
   }
 
-  if (shouldUseCategoryColor() && typeof patch.color === "string") {
-    updates.color = normalizeColor(patch.color);
+  if (patch.type !== undefined) {
+    if (!isCategoryType(patch.type)) {
+      throw new Error("Tipe kategori tidak valid.");
+    }
+    updates.type = patch.type;
   }
 
-  if (patch.sort_order != null) {
-    const sortColumn = getCategorySortColumn();
-    updates[sortColumn] = normalizeSortOrder(patch.sort_order);
+  if (patch.group_name !== undefined) {
+    updates["group"] = normalizeGroup(patch.group_name);
+  }
+
+  if (patch.order_index !== undefined) {
+    updates.order_index = normalizeOrderIndex(patch.order_index);
   }
 
   if (!Object.keys(updates).length) {
-    const cached = await dbCache.get("categories", id);
-    if (cached) {
-      return mapCategoryRow(cached);
-    }
-  }
-
-  try {
-    if (typeof updates.name === "string") {
-      const current = await supabase
-        .from("categories")
-        .select("type")
-        .eq("id", id)
-        .eq("user_id", userId)
-        .maybeSingle();
-      if (current.error) throw current.error;
-      const type = normalizeType(current.data?.type);
-      await assertUniqueName(userId, type, updates.name as string, id);
-    }
-
     const { data, error } = await supabase
       .from("categories")
-      .update(updates)
+      .select(BASE_SELECT)
       .eq("id", id)
-      .eq("user_id", userId)
-      .select(getCategorySelectColumns())
+      .eq("user_id", user.id)
       .single();
     if (error) throw error;
-
-    const record = mapCategoryRow(data ?? {});
-    await dbCache.set("categories", record);
-    return record;
-  } catch (error) {
-    if (handleMissingCategoryColor(error)) {
-      return updateCategory(id, patch);
-    }
-    if (handleMissingCategorySortColumn(error)) {
-      return updateCategory(id, patch);
-    }
-    if (handleMissingCategoryCreatedColumn(error)) {
-      return updateCategory(id, patch);
-    }
-    logDevError("updateCategory", error);
-    throw toError(error, "Gagal memperbarui kategori.");
-  }
-}
-
-export async function reorderCategories(
-  type: CategoryType,
-  orderedIds: string[]
-): Promise<void> {
-  if (!Array.isArray(orderedIds) || !orderedIds.length) return;
-
-  const userId = await resolveUserId();
-  if (!userId) {
-    await reorderGuestCategories(type, orderedIds);
-    return;
+    return mapRow((data ?? {}) as Record<string, unknown>);
   }
 
-  const normalizedType = normalizeType(type);
-  const sortColumn = getCategorySortColumn();
-  const payload = orderedIds.map((id, index) => ({
-    id,
-    user_id: userId,
-    type: normalizedType,
-    [sortColumn]: index,
-  }));
-
-  try {
-    const { data, error } = await supabase
-      .from("categories")
-      .upsert(payload, { onConflict: "id" })
-      .select(getCategorySelectColumns());
-    if (error) throw error;
-    if (data) {
-      await dbCache.bulkSet("categories", data.map((row) => mapCategoryRow(row)));
-    }
-  } catch (error) {
-    if (handleMissingCategoryColor(error)) {
-      return reorderCategories(type, orderedIds);
-    }
-    if (handleMissingCategorySortColumn(error)) {
-      return reorderCategories(type, orderedIds);
-    }
-    if (handleMissingCategoryCreatedColumn(error)) {
-      return reorderCategories(type, orderedIds);
-    }
-    logDevError("reorderCategories", error);
-    throw toError(error, "Gagal mengurutkan kategori.");
-  }
+  const { data, error } = await supabase
+    .from("categories")
+    .update(updates)
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .select(BASE_SELECT)
+    .single();
+  if (error) throw error;
+  return mapRow((data ?? {}) as Record<string, unknown>);
 }
 
 export async function deleteCategory(id: string): Promise<void> {
-  const userId = await resolveUserId();
-  if (!userId) {
-    await deleteGuestCategory(id);
-    return;
-  }
-
-  try {
-    const { error } = await supabase
-      .from("categories")
-      .delete()
-      .eq("id", id)
-      .eq("user_id", userId);
-    if (error) throw error;
-    await dbCache.remove("categories", id);
-  } catch (error) {
-    logDevError("deleteCategory", error);
-    throw toError(error, "Gagal menghapus kategori.");
+  const user = await requireUser();
+  const { error } = await supabase
+    .from("categories")
+    .delete()
+    .eq("id", id)
+    .eq("user_id", user.id);
+  if (error) {
+    throw new Error(error.message || "Gagal menghapus kategori");
   }
 }
-
-export type { CategoryType };


### PR DESCRIPTION
## Summary
- align the Supabase categories API with the new schema, including safe "group" aliasing, order sorting, and stricter validation
- rebuild the category form and list components to manage name, type, group, and order without deprecated fields
- refresh the categories page with the new API flow, table-based listing, and improved create/update/delete handling

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d54e5db54083329332897a5b1dc8ba