### PR TITLE
Refactor categories module to match Supabase schema

### DIFF
--- a/src/components/categories/CategoryForm.tsx
+++ b/src/components/categories/CategoryForm.tsx
@@ -1,20 +1,21 @@
 import { useEffect, useId, useState } from "react";
 import type { CategoryType } from "../../lib/api-categories";
-import ColorSwatch from "./ColorSwatch";
 
 interface CategoryFormValues {
   name: string;
-  color: string;
   type: CategoryType;
+  group_name: string | null;
+  order_index: number | null;
 }
 
 interface CategoryFormProps {
   mode?: "create" | "edit";
-  initialValues?: CategoryFormValues;
+  initialValues?: Partial<CategoryFormValues>;
   onSubmit: (values: CategoryFormValues) => Promise<void> | void;
   onCancel?: () => void;
   isSubmitting?: boolean;
   allowTypeChange?: boolean;
+  submitLabel?: string;
 }
 
 const TYPE_OPTIONS: { value: CategoryType; label: string }[] = [
@@ -22,8 +23,14 @@ const TYPE_OPTIONS: { value: CategoryType; label: string }[] = [
   { value: "expense", label: "Pengeluaran" },
 ];
 
-function normalizeType(value?: CategoryType): CategoryType {
+function normalizeType(value?: CategoryType | string | null): CategoryType {
   return value === "income" ? "income" : "expense";
+}
+
+function toNumber(value: string): number | null {
+  if (!value.trim()) return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 export default function CategoryForm({
@@ -33,51 +40,66 @@ export default function CategoryForm({
   onCancel,
   isSubmitting = false,
   allowTypeChange = mode === "create",
+  submitLabel,
 }: CategoryFormProps) {
-  const defaultName = initialValues?.name ?? "";
-  const defaultColor = initialValues?.color ?? "#64748B";
-  const defaultType = normalizeType(initialValues?.type);
+  const [name, setName] = useState(initialValues?.name ?? "");
+  const [type, setType] = useState<CategoryType>(
+    normalizeType(initialValues?.type)
+  );
+  const [groupName, setGroupName] = useState(initialValues?.group_name ?? "");
+  const [orderInput, setOrderInput] = useState(
+    initialValues?.order_index != null ? String(initialValues.order_index) : ""
+  );
 
-  const [name, setName] = useState(defaultName);
-  const [color, setColor] = useState(defaultColor);
-  const [type, setType] = useState<CategoryType>(defaultType);
   const [nameError, setNameError] = useState<string | null>(null);
-  const [colorError, setColorError] = useState<string | null>(null);
+  const [orderError, setOrderError] = useState<string | null>(null);
 
   const nameId = useId();
   const typeId = useId();
+  const groupId = useId();
+  const orderId = useId();
 
   useEffect(() => {
-    setName(defaultName);
-    setColor(defaultColor);
-    setType(defaultType);
+    setName(initialValues?.name ?? "");
+    setType(normalizeType(initialValues?.type));
+    setGroupName(initialValues?.group_name ?? "");
+    setOrderInput(
+      initialValues?.order_index != null ? String(initialValues.order_index) : ""
+    );
     setNameError(null);
-    setColorError(null);
-  }, [defaultName, defaultColor, defaultType]);
+    setOrderError(null);
+  }, [initialValues?.name, initialValues?.type, initialValues?.group_name, initialValues?.order_index]);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const trimmed = name.trim();
-    let hasError = false;
+    const trimmedName = name.trim();
+    const trimmedGroup = groupName.trim();
+    const parsedOrder = toNumber(orderInput);
 
-    if (!trimmed || trimmed.length < 1 || trimmed.length > 60) {
+    let hasError = false;
+    if (!trimmedName || trimmedName.length > 60) {
       setNameError("Nama harus 1-60 karakter.");
       hasError = true;
     } else {
       setNameError(null);
     }
 
-    if (!/^#[0-9A-F]{6}$/i.test(color)) {
-      setColorError("Gunakan format #RRGGBB.");
+    if (orderInput.trim() && parsedOrder === null) {
+      setOrderError("Urutan harus berupa angka.");
       hasError = true;
     } else {
-      setColorError(null);
+      setOrderError(null);
     }
 
     if (hasError) return;
 
     try {
-      await onSubmit({ name: trimmed, color: color.toUpperCase(), type });
+      await onSubmit({
+        name: trimmedName,
+        type,
+        group_name: trimmedGroup ? trimmedGroup : null,
+        order_index: parsedOrder,
+      });
     } catch (error) {
       if (import.meta.env?.DEV || process.env?.NODE_ENV === "development") {
         console.error("[HW] category form submit failed", error);
@@ -87,9 +109,12 @@ export default function CategoryForm({
 
   return (
     <form className="space-y-4" onSubmit={handleSubmit} noValidate>
-      <div className="grid gap-3 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+      <div className="grid gap-3 md:grid-cols-2">
         <div className="min-w-0">
-          <label htmlFor={nameId} className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted">
+          <label
+            htmlFor={nameId}
+            className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted"
+          >
             Nama kategori
           </label>
           <input
@@ -98,14 +123,18 @@ export default function CategoryForm({
             value={name}
             onChange={(event) => setName(event.target.value)}
             disabled={isSubmitting}
-            className="h-10 w-full min-w-0 rounded-xl border border-border bg-surface-1/80 px-3 text-sm text-text placeholder:text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed"
+            className="h-10 w-full rounded-xl border border-border bg-surface-1/80 px-3 text-sm text-text placeholder:text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed"
             placeholder="Contoh: Gaji"
+            autoComplete="off"
           />
           {nameError ? <p className="mt-1 text-xs text-danger">{nameError}</p> : null}
         </div>
         {allowTypeChange ? (
           <div className="min-w-0">
-            <label htmlFor={typeId} className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted">
+            <label
+              htmlFor={typeId}
+              className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted"
+            >
               Tipe
             </label>
             <select
@@ -113,7 +142,7 @@ export default function CategoryForm({
               value={type}
               onChange={(event) => setType(normalizeType(event.target.value as CategoryType))}
               disabled={isSubmitting}
-              className="h-10 w-full min-w-0 rounded-xl border border-border bg-surface-1/80 px-3 text-sm text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed"
+              className="h-10 w-full rounded-xl border border-border bg-surface-1/80 px-3 text-sm text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed"
             >
               {TYPE_OPTIONS.map((option) => (
                 <option key={option.value} value={option.value}>
@@ -124,15 +153,42 @@ export default function CategoryForm({
           </div>
         ) : null}
       </div>
-      <div className="min-w-0">
-        <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted">Warna</p>
-        <ColorSwatch
-          value={color}
-          onChange={setColor}
-          disabled={isSubmitting}
-          name="category-color"
-        />
-        {colorError ? <p className="mt-1 text-xs text-danger">{colorError}</p> : null}
+      <div className="grid gap-3 md:grid-cols-2">
+        <div className="min-w-0">
+          <label
+            htmlFor={groupId}
+            className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted"
+          >
+            Grup (opsional)
+          </label>
+          <input
+            id={groupId}
+            value={groupName}
+            onChange={(event) => setGroupName(event.target.value)}
+            disabled={isSubmitting}
+            className="h-10 w-full rounded-xl border border-border bg-surface-1/80 px-3 text-sm text-text placeholder:text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed"
+            placeholder="Contoh: Kebutuhan Pokok"
+            autoComplete="off"
+          />
+        </div>
+        <div className="min-w-0">
+          <label
+            htmlFor={orderId}
+            className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted"
+          >
+            Urutan (opsional)
+          </label>
+          <input
+            id={orderId}
+            inputMode="numeric"
+            value={orderInput}
+            onChange={(event) => setOrderInput(event.target.value.replace(/[^0-9-]/g, ""))}
+            disabled={isSubmitting}
+            className="h-10 w-full rounded-xl border border-border bg-surface-1/80 px-3 text-sm text-text placeholder:text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed"
+            placeholder="Contoh: 1"
+          />
+          {orderError ? <p className="mt-1 text-xs text-danger">{orderError}</p> : null}
+        </div>
       </div>
       <div className="flex justify-end gap-2">
         {onCancel ? (
@@ -150,7 +206,7 @@ export default function CategoryForm({
           disabled={isSubmitting}
           className="inline-flex h-10 items-center justify-center rounded-xl bg-brand px-4 text-sm font-semibold text-white shadow transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-60"
         >
-          {mode === "edit" ? "Simpan" : "Tambah"}
+          {isSubmitting ? "Menyimpan..." : submitLabel ?? (mode === "edit" ? "Simpan" : "Tambah")}
         </button>
       </div>
     </form>

--- a/src/components/categories/CategoryList.tsx
+++ b/src/components/categories/CategoryList.tsx
@@ -1,142 +1,271 @@
-import { ArrowDown, ArrowUp, Loader2, Pencil, Trash2 } from "lucide-react";
-import CategoryForm from "./CategoryForm";
+import { Loader2, Pencil, Trash2 } from "lucide-react";
+import { useId, useState } from "react";
 import type { CategoryRecord, CategoryType } from "../../lib/api-categories";
 
 interface CategoryListProps {
-  type: CategoryType;
-  title?: string;
   items: CategoryRecord[];
-  editingId: string | null;
-  pendingIds: Set<string>;
   loading?: boolean;
+  pendingIds: Set<string>;
+  editingId: string | null;
   onStartEdit: (id: string) => void;
   onCancelEdit: () => void;
   onSubmitEdit: (
-    category: CategoryRecord,
-    values: { name: string; color: string; type: CategoryType }
+    id: string,
+    values: {
+      name: string;
+      type: CategoryType;
+      group_name: string | null;
+      order_index: number | null;
+    }
   ) => Promise<void> | void;
-  onDelete: (category: CategoryRecord) => void;
-  onMoveUp: (id: string) => void;
-  onMoveDown: (id: string) => void;
+  onDelete: (item: CategoryRecord) => void;
 }
 
-const TYPE_TITLES: Record<CategoryType, string> = {
-  income: "Income",
-  expense: "Expense",
+const TYPE_LABEL: Record<CategoryType, string> = {
+  income: "Pemasukan",
+  expense: "Pengeluaran",
 };
 
+function toNumber(value: string): number | null {
+  if (!value.trim()) return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeType(value: string | CategoryType): CategoryType {
+  return value === "income" ? "income" : "expense";
+}
+
+interface EditableRowProps {
+  item: CategoryRecord;
+  onSubmit: (values: {
+    name: string;
+    type: CategoryType;
+    group_name: string | null;
+    order_index: number | null;
+  }) => Promise<void> | void;
+  onCancel: () => void;
+  isSubmitting: boolean;
+}
+
+function EditableRow({ item, onSubmit, onCancel, isSubmitting }: EditableRowProps) {
+  const [name, setName] = useState(item.name);
+  const [type, setType] = useState<CategoryType>(item.type);
+  const [groupName, setGroupName] = useState(item.group_name ?? "");
+  const [orderInput, setOrderInput] = useState(
+    item.order_index != null ? String(item.order_index) : ""
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const nameId = useId();
+  const typeId = useId();
+  const groupId = useId();
+  const orderId = useId();
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedName = name.trim();
+    if (!trimmedName || trimmedName.length > 60) {
+      setError("Nama harus 1-60 karakter.");
+      return;
+    }
+    const parsedOrder = toNumber(orderInput);
+    if (orderInput.trim() && parsedOrder === null) {
+      setError("Urutan harus berupa angka.");
+      return;
+    }
+    setError(null);
+    await onSubmit({
+      name: trimmedName,
+      type,
+      group_name: groupName.trim() ? groupName.trim() : null,
+      order_index: parsedOrder,
+    });
+  };
+
+  return (
+    <tr className="bg-surface-1/80">
+      <td colSpan={5} className="p-3">
+        <form onSubmit={handleSubmit} className="grid gap-3 md:grid-cols-5" noValidate>
+          <div className="md:col-span-2">
+            <label
+              htmlFor={nameId}
+              className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted"
+            >
+              Nama
+            </label>
+            <input
+              id={nameId}
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              disabled={isSubmitting}
+              className="h-10 w-full rounded-xl border border-border bg-surface-1 px-3 text-sm text-text placeholder:text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor={typeId}
+              className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted"
+            >
+              Tipe
+            </label>
+            <select
+              id={typeId}
+              value={type}
+              onChange={(event) => setType(normalizeType(event.target.value as CategoryType))}
+              disabled={isSubmitting}
+              className="h-10 w-full rounded-xl border border-border bg-surface-1 px-3 text-sm text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed"
+            >
+              <option value="income">Pemasukan</option>
+              <option value="expense">Pengeluaran</option>
+            </select>
+          </div>
+          <div>
+            <label
+              htmlFor={groupId}
+              className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted"
+            >
+              Grup
+            </label>
+            <input
+              id={groupId}
+              value={groupName}
+              onChange={(event) => setGroupName(event.target.value)}
+              disabled={isSubmitting}
+              className="h-10 w-full rounded-xl border border-border bg-surface-1 px-3 text-sm text-text placeholder:text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor={orderId}
+              className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted"
+            >
+              Urutan
+            </label>
+            <input
+              id={orderId}
+              inputMode="numeric"
+              value={orderInput}
+              onChange={(event) => setOrderInput(event.target.value.replace(/[^0-9-]/g, ""))}
+              disabled={isSubmitting}
+              className="h-10 w-full rounded-xl border border-border bg-surface-1 px-3 text-sm text-text placeholder:text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed"
+            />
+          </div>
+          <div className="flex items-end justify-end gap-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={isSubmitting}
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-border/60 px-4 text-sm font-medium text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed"
+            >
+              Batal
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="inline-flex h-10 items-center justify-center rounded-xl bg-brand px-4 text-sm font-semibold text-white shadow transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isSubmitting ? "Menyimpan..." : "Simpan"}
+            </button>
+          </div>
+          {error ? (
+            <div className="md:col-span-5">
+              <p className="text-xs text-danger">{error}</p>
+            </div>
+          ) : null}
+        </form>
+      </td>
+    </tr>
+  );
+}
+
 export default function CategoryList({
-  type,
-  title,
   items,
-  editingId,
-  pendingIds,
   loading = false,
+  pendingIds,
+  editingId,
   onStartEdit,
   onCancelEdit,
   onSubmitEdit,
   onDelete,
-  onMoveUp,
-  onMoveDown,
 }: CategoryListProps) {
-  const resolvedTitle = title ?? TYPE_TITLES[type] ?? "Kategori";
+  if (loading) {
+    return (
+      <div className="flex min-h-[200px] items-center justify-center rounded-2xl border border-border/60 bg-surface-1/60 p-6 text-muted">
+        <div className="flex items-center gap-2 text-sm">
+          <Loader2 className="h-4 w-4 animate-spin" /> Memuat kategori...
+        </div>
+      </div>
+    );
+  }
+
+  if (!items.length) {
+    return (
+      <div className="rounded-2xl border border-border/60 bg-surface-1/60 p-6 text-sm text-muted">
+        Belum ada kategori.
+      </div>
+    );
+  }
 
   return (
-    <section className="flex h-full min-w-0 flex-col rounded-2xl border border-border/60 bg-surface-1/60 p-4 shadow-sm">
-      <header className="mb-4 flex items-center justify-between">
-        <div className="min-w-0">
-          <h2 className="text-sm font-semibold text-text">{resolvedTitle}</h2>
-          <p className="text-xs text-muted">
-            {loading ? "Memuat..." : `${items.length} kategori`}
-          </p>
-        </div>
-      </header>
-      {loading ? (
-        <div className="flex flex-1 items-center justify-center text-muted">
-          <div className="flex items-center gap-2 text-sm">
-            <Loader2 className="h-4 w-4 animate-spin" /> Memuat daftar...
-          </div>
-        </div>
-      ) : items.length === 0 ? (
-        <p className="mt-4 text-sm text-muted">
-          Belum ada kategori {type === "income" ? "pemasukan" : "pengeluaran"}.
-        </p>
-      ) : (
-        <ul className="flex-1 space-y-3 overflow-y-auto pr-1">
-          {items.map((item, index) => {
-            const isEditing = editingId === item.id;
-            const isFirst = index === 0;
-            const isLast = index === items.length - 1;
+    <div className="overflow-x-auto rounded-2xl border border-border/60 bg-surface-1/60 shadow-sm">
+      <table className="min-w-full divide-y divide-border/60 text-sm">
+        <thead className="bg-surface-1/70 text-xs uppercase tracking-wide text-muted">
+          <tr>
+            <th className="px-4 py-3 text-left font-semibold">Nama</th>
+            <th className="px-4 py-3 text-left font-semibold">Tipe</th>
+            <th className="px-4 py-3 text-left font-semibold">Grup</th>
+            <th className="px-4 py-3 text-left font-semibold">Urutan</th>
+            <th className="px-4 py-3 text-right font-semibold">Aksi</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border/40">
+          {items.map((item) => {
+            if (editingId === item.id) {
+              return (
+                <EditableRow
+                  key={item.id}
+                  item={item}
+                  onSubmit={(values) => onSubmitEdit(item.id, values)}
+                  onCancel={onCancelEdit}
+                  isSubmitting={pendingIds.has(item.id)}
+                />
+              );
+            }
             const isBusy = pendingIds.has(item.id);
             return (
-              <li
-                key={item.id}
-                className="rounded-xl border border-border/60 bg-surface-1/80 p-3 shadow-sm"
-              >
-                {isEditing ? (
-                  <CategoryForm
-                    mode="edit"
-                    initialValues={{ name: item.name, color: item.color, type: item.type }}
-                    onSubmit={(values) => onSubmitEdit(item, values)}
-                    onCancel={onCancelEdit}
-                    isSubmitting={isBusy}
-                    allowTypeChange={false}
-                  />
-                ) : (
-                  <div className="flex min-w-0 items-center gap-3">
-                    <span
-                      className="h-3.5 w-3.5 rounded-full border border-white/20"
-                      style={{ backgroundColor: item.color || "#64748B" }}
-                      aria-hidden="true"
-                    />
-                    <span className="min-w-0 flex-1 truncate text-sm font-medium text-text">
-                      {item.name || "Tanpa nama"}
-                    </span>
-                    <div className="flex shrink-0 items-center gap-1">
-                      <button
-                        type="button"
-                        onClick={() => onMoveUp(item.id)}
-                        disabled={isFirst || isBusy}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
-                        aria-label="Naikkan urutan"
-                      >
-                        <ArrowUp className="h-4 w-4" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => onMoveDown(item.id)}
-                        disabled={isLast || isBusy}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
-                        aria-label="Turunkan urutan"
-                      >
-                        <ArrowDown className="h-4 w-4" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => onStartEdit(item.id)}
-                        disabled={isBusy}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
-                        aria-label="Edit kategori"
-                      >
-                        <Pencil className="h-4 w-4" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => onDelete(item)}
-                        disabled={isBusy}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-transparent text-rose-400 transition-colors hover:text-rose-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-50"
-                        aria-label="Hapus kategori"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </button>
-                    </div>
+              <tr key={item.id} className="bg-surface-1/80">
+                <td className="px-4 py-3 font-medium text-text">{item.name || "(Tanpa nama)"}</td>
+                <td className="px-4 py-3 text-muted">{TYPE_LABEL[item.type]}</td>
+                <td className="px-4 py-3 text-muted">{item.group_name || "-"}</td>
+                <td className="px-4 py-3 text-muted">{item.order_index ?? "-"}</td>
+                <td className="px-4 py-3">
+                  <div className="flex justify-end gap-2">
+                    <button
+                      type="button"
+                      onClick={() => onStartEdit(item.id)}
+                      disabled={isBusy}
+                      className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/60 text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed"
+                      aria-label="Edit kategori"
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onDelete(item)}
+                      disabled={isBusy}
+                      className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/60 text-danger transition-colors hover:text-danger/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger/50 disabled:cursor-not-allowed"
+                      aria-label="Hapus kategori"
+                    >
+                      {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+                    </button>
                   </div>
-                )}
-              </li>
+                </td>
+              </tr>
             );
           })}
-        </ul>
-      )}
-    </section>
+        </tbody>
+      </table>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- align the categories supabase API with the current table schema, including safe "group" aliasing, user checks, and new validation logic
- refresh the categories management page to handle group/order metadata, remove color usage, and surface cleaner messaging
- rebuild the category form and list components into a table workflow with inline editing for name, type, group, and order

## Testing
- pnpm lint
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68d54e5db54083329332897a5b1dc8ba