### PR TITLE
refactor: rebuild budgets page with modern ui and supabase api

### DIFF
--- a/src/hooks/useBudgets.ts
+++ b/src/hooks/useBudgets.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  assembleBudgets,
+  buildSummary,
+  type BudgetSummary,
+  type BudgetWithSpent,
+} from '../repo/budgetApi';
+
+interface UseBudgetsResult {
+  rows: BudgetWithSpent[];
+  summary: BudgetSummary;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+const EMPTY_SUMMARY: BudgetSummary = {
+  planned: 0,
+  spent: 0,
+  remaining: 0,
+  percentage: 0,
+};
+
+export default function useBudgets(period: string): UseBudgetsResult {
+  const [rows, setRows] = useState<BudgetWithSpent[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const summary = useMemo(() => buildSummary(rows), [rows]);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await assembleBudgets(period);
+      setRows(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Gagal memuat anggaran';
+      setError(message);
+      setRows([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [period]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return {
+    rows,
+    summary: rows.length ? summary : EMPTY_SUMMARY,
+    loading,
+    error,
+    refresh,
+  };
+}

--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -1,705 +1,654 @@
-import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
-import { supabase } from '../../lib/supabase';
+import { useEffect, useMemo, useState } from 'react';
+import { Calendar, PiggyBank, PieChart, Plus, Target, Trash2, Wallet, PencilLine } from 'lucide-react';
 import Page from '../../layout/Page';
-import Section from '../../layout/Section';
-import { useToast } from '../../context/ToastContext';
+import Section from '../../layout/Section.jsx';
+import { useToast } from '../../context/ToastContext.jsx';
+import useBudgets from '../../hooks/useBudgets';
 import {
-  applyRolloverToNext,
-  bulkUpsertBudgets,
-  computeRollover,
-  copyBudgets,
+  buildSummary,
   deleteBudget,
-  formatBudgetAmount,
-  getPeriods,
-  getSummary,
-  listBudgets,
-  listRules,
-  type BudgetRecord,
-  type BudgetRuleRecord,
-  type CarryRule,
-  type BudgetSummary,
+  listCategoriesExpense,
+  type BudgetCategory,
+  type BudgetWithSpent,
+  type BudgetInput,
   upsertBudget,
-} from '../../lib/api-budgets';
-import BudgetsSummary from '../../components/budgets/BudgetsSummary';
-import BudgetsFilterBar, {
-  type BudgetsFilterState,
-} from '../../components/budgets/BudgetsFilterBar';
-import BudgetsTable from '../../components/budgets/BudgetsTable';
-import BudgetCard from '../../components/budgets/BudgetCard';
-import BudgetDetailDrawer from '../../components/budgets/BudgetDetailDrawer';
-import BudgetRuleForm from '../../components/budgets/BudgetRuleForm';
-import AutoAllocateDialog from '../../components/budgets/AutoAllocateDialog';
+} from '../../repo/budgetApi';
 import Modal from '../../components/Modal.jsx';
-import BudgetForm from '../../components/budgets/BudgetForm';
-import type { BudgetViewModel } from '../../components/budgets/types';
+import { formatCurrency } from '../../lib/format.js';
 
-export interface BudgetsPageProps {
-  currentMonth?: string;
-  data?: {
-    budgets?: BudgetRecord[];
-  };
+interface PeriodOption {
+  label: string;
+  value: 'current' | 'previous' | 'custom';
 }
 
-interface UndoItem {
-  id: string;
-  previous: BudgetRecord;
-  timeoutId: number;
-  expiresAt: number;
+const PERIOD_OPTIONS: PeriodOption[] = [
+  { label: 'Bulan ini', value: 'current' },
+  { label: 'Bulan lalu', value: 'previous' },
+  { label: 'Custom', value: 'custom' },
+];
+
+function getCurrentPeriod(): string {
+  return new Date().toISOString().slice(0, 7);
 }
 
-interface CategoryOption {
-  id: string;
-  name: string;
-  type: 'income' | 'expense';
+function getPreviousPeriod(): string {
+  const date = new Date();
+  date.setMonth(date.getMonth() - 1);
+  return date.toISOString().slice(0, 7);
 }
 
-const DEFAULT_SUMMARY: BudgetSummary = {
-  planned: 0,
-  actual: 0,
-  remaining: 0,
-  overspend: 0,
-  coverageDays: null,
-};
-
-function determineStatus(view: BudgetViewModel): BudgetViewModel['status'] {
-  if (view.remaining < 0) return 'overspend';
-  const ceiling = view.planned + view.rolloverIn;
-  if (ceiling <= 0) return 'on-track';
-  const ratio = view.actual / ceiling;
-  if (ratio >= 0.8) return 'warning';
-  return 'on-track';
-}
-
-function buildViewModel(record: BudgetRecord, summary: BudgetSummary): BudgetViewModel {
-  const actual = record.activity?.actual ?? 0;
-  const inflow = record.activity?.inflow ?? 0;
-  const outflow = record.activity?.outflow ?? 0;
-  const remaining = record.planned + record.rollover_in - actual;
-  const coverageDays = summary.coverageDays;
-  const progressBase = record.planned + record.rollover_in;
-  const progress = progressBase > 0 ? Math.min(actual / progressBase, 1) : 0;
-  const label = record.category_id ? record.name ?? 'Kategori' : record.name ?? 'Envelope';
-  const view: BudgetViewModel = {
-    id: record.id,
-    label,
-    categoryId: record.category_id ?? null,
-    period: record.period_month,
-    planned: record.planned,
-    rolloverIn: record.rollover_in,
-    rolloverOut: record.rollover_out,
-    actual,
-    inflow,
-    outflow,
-    remaining,
-    carryRule: record.carry_rule,
-    note: record.note ?? null,
-    activity: record.activity,
-    status: 'on-track',
-    progress,
-    coverageDays,
-    raw: record,
-  };
-  view.status = determineStatus(view);
-  return view;
-}
-
-function buildTip(summary: BudgetSummary, views: BudgetViewModel[]): string {
-  if (!views.length) return 'Belum ada anggaran untuk periode ini.';
-  if (summary.remaining <= 0) {
-    const highest = [...views].sort((a, b) => b.actual - a.actual)[0];
-    if (!highest) return 'Periksa pengeluaran Anda untuk tetap on-track.';
-    const need = formatBudgetAmount(Math.abs(summary.remaining));
-    return `Overspend ${need}. Pertimbangkan kurangi ${highest.label} minggu ini.`;
+function resolvePeriod(preset: PeriodOption['value'], custom: string): string {
+  switch (preset) {
+    case 'current':
+      return getCurrentPeriod();
+    case 'previous':
+      return getPreviousPeriod();
+    case 'custom':
+    default:
+      return custom || getCurrentPeriod();
   }
-  const suggestion = formatBudgetAmount(summary.remaining);
-  return `Saran alokasi ${suggestion} agar on-track bulan ini.`;
 }
 
-export default function BudgetsPage({ currentMonth }: BudgetsPageProps) {
-  const { addToast } = useToast();
-  const [periods, setPeriods] = useState<string[]>([]);
-  const [period, setPeriod] = useState(() => currentMonth ?? new Date().toISOString().slice(0, 7));
-  const [filters, setFilters] = useState<BudgetsFilterState>({
-    q: '',
-    categoryId: 'all',
-    status: 'all',
-    sort: 'name',
-    open: false,
-  });
-  const [budgets, setBudgets] = useState<BudgetRecord[]>([]);
-  const [views, setViews] = useState<BudgetViewModel[]>([]);
-  const [summary, setSummary] = useState<BudgetSummary>(DEFAULT_SUMMARY);
-  const [loading, setLoading] = useState(false);
-  const [rules, setRules] = useState<BudgetRuleRecord[]>([]);
-  const [categories, setCategories] = useState<CategoryOption[]>([]);
-  const [selected, setSelected] = useState<BudgetViewModel | null>(null);
-  const [ruleEditing, setRuleEditing] = useState<BudgetRuleRecord | null>(null);
-  const [ruleBudget, setRuleBudget] = useState<BudgetViewModel | null>(null);
-  const [autoAllocateOpen, setAutoAllocateOpen] = useState(false);
-  const [exporting, setExporting] = useState(false);
-  const [budgetFormOpen, setBudgetFormOpen] = useState(false);
-  const undoStack = useRef<UndoItem[]>([]);
-  const [, forceRerenderUndo] = useState(0);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
+interface BudgetFormModalProps {
+  open: boolean;
+  onClose: () => void;
+  categories: BudgetCategory[];
+  period: string;
+  initialBudget?: BudgetWithSpent | null;
+  onSubmit: (payload: BudgetInput) => Promise<void>;
+}
+
+function BudgetFormModal({ open, onClose, categories, period, initialBudget, onSubmit }: BudgetFormModalProps) {
+  const [formPeriod, setFormPeriod] = useState(period);
+  const [categoryId, setCategoryId] = useState(initialBudget?.category_id ?? '');
+  const [amount, setAmount] = useState(() =>
+    initialBudget ? String(initialBudget.amount_planned) : ''
+  );
+  const [carryover, setCarryover] = useState(initialBudget?.carryover_enabled ?? false);
+  const [notes, setNotes] = useState(initialBudget?.notes ?? '');
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
 
   useEffect(() => {
-    let mounted = true;
-    (async () => {
-      try {
-        const fetched = await getPeriods({ months: 18, anchor: period });
-        if (mounted) setPeriods(fetched);
-      } catch (error) {
-        addToast(`Gagal memuat daftar periode: ${error instanceof Error ? error.message : 'tidak diketahui'}`, 'error');
-      }
-    })();
-    return () => {
-      mounted = false;
+    if (!open) return;
+    setFormPeriod(initialBudget ? initialBudget.period_month.slice(0, 7) : period);
+    setCategoryId(initialBudget?.category_id ?? '');
+    setAmount(initialBudget ? String(initialBudget.amount_planned) : '');
+    setCarryover(initialBudget?.carryover_enabled ?? false);
+    setNotes(initialBudget?.notes ?? '');
+    setFormError(null);
+  }, [open, initialBudget, period]);
+
+  const title = initialBudget ? 'Edit Anggaran' : 'Tambah Anggaran';
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFormError(null);
+
+    if (!formPeriod) {
+      setFormError('Periode wajib dipilih.');
+      return;
+    }
+    if (!categoryId) {
+      setFormError('Kategori wajib dipilih.');
+      return;
+    }
+    const amountNumber = Number(amount);
+    if (!Number.isFinite(amountNumber) || amountNumber <= 0) {
+      setFormError('Nominal anggaran harus lebih besar dari 0.');
+      return;
+    }
+
+    const payload: BudgetInput = {
+      period: formPeriod,
+      category_id: categoryId,
+      amount_planned: amountNumber,
+      carryover_enabled: carryover,
+      notes: notes.trim() ? notes.trim() : undefined,
     };
-  }, [period, addToast]);
+
+    setSubmitting(true);
+    try {
+      await onSubmit(payload);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Gagal menyimpan anggaran';
+      setFormError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal open={open} title={title} onClose={onClose}>
+      <form className="space-y-5" onSubmit={handleSubmit}>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-300">
+            Periode
+            <input
+              type="month"
+              value={formPeriod}
+              onChange={(event) => setFormPeriod(event.target.value)}
+              className="h-11 rounded-2xl border border-white/40 bg-white/80 px-4 text-sm text-slate-900 shadow-sm ring-2 ring-transparent transition focus:border-indigo-500 focus:ring-indigo-400 dark:border-white/10 dark:bg-zinc-900/60 dark:text-slate-100"
+              required
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-300">
+            Kategori
+            <select
+              value={categoryId}
+              onChange={(event) => setCategoryId(event.target.value)}
+              className="h-11 rounded-2xl border border-white/40 bg-white/80 px-4 text-sm text-slate-900 shadow-sm ring-2 ring-transparent transition focus:border-indigo-500 focus:ring-indigo-400 dark:border-white/10 dark:bg-zinc-900/60 dark:text-slate-100"
+              required
+            >
+              <option value="">Pilih kategori</option>
+              {categories.map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-300">
+            Nominal anggaran
+            <input
+              type="number"
+              min="0"
+              step="1000"
+              inputMode="decimal"
+              value={amount}
+              onChange={(event) => setAmount(event.target.value)}
+              className="h-11 rounded-2xl border border-white/40 bg-white/80 px-4 text-sm text-slate-900 shadow-sm ring-2 ring-transparent transition focus:border-indigo-500 focus:ring-indigo-400 dark:border-white/10 dark:bg-zinc-900/60 dark:text-slate-100"
+              required
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-300">
+            Catatan
+            <input
+              type="text"
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+              placeholder="Opsional"
+              className="h-11 rounded-2xl border border-white/40 bg-white/80 px-4 text-sm text-slate-900 shadow-sm ring-2 ring-transparent transition focus:border-indigo-500 focus:ring-indigo-400 dark:border-white/10 dark:bg-zinc-900/60 dark:text-slate-100"
+            />
+          </label>
+        </div>
+        <label className="flex items-center justify-between gap-3 rounded-2xl border border-white/40 bg-white/70 px-4 py-3 text-sm font-medium text-slate-700 shadow-sm ring-2 ring-transparent transition dark:border-white/10 dark:bg-zinc-900/50 dark:text-slate-200">
+          Aktifkan carryover
+          <button
+            type="button"
+            role="switch"
+            aria-checked={carryover}
+            onClick={() => setCarryover((value) => !value)}
+            className={`relative h-8 w-14 rounded-full border border-transparent bg-gradient-to-r p-1 transition ${
+              carryover
+                ? 'from-emerald-500 to-emerald-400 text-white shadow-inner'
+                : 'from-slate-200 to-slate-200 text-slate-600 dark:from-zinc-700 dark:to-zinc-700'
+            }`}
+          >
+            <span
+              className={`block h-6 w-6 rounded-full bg-white shadow transition-transform duration-200 ${
+                carryover ? 'translate-x-6' : 'translate-x-0'
+              }`}
+            />
+          </button>
+        </label>
+        {formError ? (
+          <p className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-2 text-sm text-rose-600 dark:border-rose-500/50 dark:bg-rose-500/10 dark:text-rose-200">
+            {formError}
+          </p>
+        ) : null}
+        <div className="flex items-center justify-end gap-3">
+          <button
+            type="button"
+            className="h-11 rounded-2xl border border-transparent bg-slate-200/80 px-5 text-sm font-medium text-slate-600 transition hover:bg-slate-200 dark:bg-zinc-700 dark:text-slate-100 dark:hover:bg-zinc-600"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Batal
+          </button>
+          <button
+            type="submit"
+            className="inline-flex h-11 items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-indigo-500 to-violet-500 px-5 text-sm font-semibold text-white shadow transition hover:from-indigo-600 hover:to-violet-600 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={submitting}
+          >
+            {submitting ? 'Menyimpan…' : 'Simpan anggaran'}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+function BudgetSummaryCards({
+  planned,
+  spent,
+  remaining,
+}: {
+  planned: number;
+  spent: number;
+  remaining: number;
+}) {
+  const percentageValue = planned > 0 ? (spent / planned) * 100 : 0;
+  const percentageRatio = Math.max(0, Math.min(percentageValue, 100));
+  const items = [
+    {
+      label: 'Total Anggaran',
+      value: formatCurrency(planned, 'IDR'),
+      icon: Wallet,
+    },
+    {
+      label: 'Realisasi',
+      value: formatCurrency(spent, 'IDR'),
+      icon: PiggyBank,
+    },
+    {
+      label: 'Sisa',
+      value: formatCurrency(remaining, 'IDR'),
+      icon: Target,
+    },
+  ];
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      {items.map((item) => (
+        <div
+          key={item.label}
+          className="flex h-full flex-col justify-between gap-4 rounded-2xl border border-white/40 bg-gradient-to-b from-white/80 to-white/50 p-5 shadow-sm backdrop-blur dark:border-white/10 dark:from-zinc-900/60 dark:to-zinc-900/30"
+        >
+          <div className="flex items-center gap-3">
+            <span className="flex h-11 w-11 items-center justify-center rounded-full bg-indigo-500/10 text-indigo-500">
+              <item.icon size={22} strokeWidth={1.5} />
+            </span>
+            <div>
+              <p className="text-sm font-medium text-slate-500 dark:text-slate-400">{item.label}</p>
+              <p className="text-xl font-semibold text-slate-900 dark:text-slate-50">{item.value}</p>
+            </div>
+          </div>
+        </div>
+      ))}
+      <div className="flex h-full flex-col justify-between gap-4 rounded-2xl border border-white/40 bg-gradient-to-b from-white/80 to-white/50 p-5 shadow-sm backdrop-blur dark:border-white/10 dark:from-zinc-900/60 dark:to-zinc-900/30">
+        <div className="flex items-center gap-3">
+          <span className="flex h-11 w-11 items-center justify-center rounded-full bg-indigo-500/10 text-indigo-500">
+            <PieChart size={22} strokeWidth={1.5} />
+          </span>
+          <div>
+            <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Persentase</p>
+            <p className="text-xl font-semibold text-slate-900 dark:text-slate-50">{Math.round(percentageValue)}%</p>
+          </div>
+        </div>
+        <div className="space-y-2">
+          <div className="flex items-center justify-between text-xs font-medium text-slate-500 dark:text-slate-400">
+            <span>Realisasi</span>
+            <span>{formatCurrency(spent, 'IDR')}</span>
+          </div>
+          <div className="flex items-center justify-between text-xs font-medium text-slate-500 dark:text-slate-400">
+            <span>Target</span>
+            <span>{formatCurrency(planned, 'IDR')}</span>
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-slate-200/80 dark:bg-zinc-800">
+            <div
+              className="h-full rounded-full bg-gradient-to-r from-indigo-500 via-violet-500 to-fuchsia-500"
+              style={{ width: `${percentageRatio}%` }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BudgetsTable({
+  rows,
+  onEdit,
+  onDelete,
+  onToggleCarryover,
+  busyId,
+}: {
+  rows: BudgetWithSpent[];
+  onEdit: (budget: BudgetWithSpent) => void;
+  onDelete: (budget: BudgetWithSpent) => void;
+  onToggleCarryover: (budget: BudgetWithSpent) => void;
+  busyId: string | null;
+}) {
+  const formattedRows = useMemo(
+    () =>
+      rows.map((row) => ({
+        ...row,
+        remaining: row.amount_planned - row.spent,
+      })),
+    [rows]
+  );
+
+  if (!formattedRows.length) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-slate-300/60 bg-white/70 px-6 py-12 text-center shadow-sm dark:border-zinc-700 dark:bg-zinc-900/40">
+        <Calendar className="h-10 w-10 text-slate-400" strokeWidth={1.5} />
+        <div className="space-y-1">
+          <p className="text-base font-semibold text-slate-700 dark:text-slate-200">Belum ada anggaran</p>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Mulai dengan menambahkan kategori anggaran untuk periode ini.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-white/40 bg-white/70 shadow-sm backdrop-blur dark:border-white/10 dark:bg-zinc-900/40">
+      <div className="max-h-[520px] overflow-auto">
+        <table className="min-w-full text-left text-sm">
+          <thead className="sticky top-0 z-10 bg-white/90 text-xs font-semibold uppercase tracking-wide text-slate-500 backdrop-blur dark:bg-zinc-900/80 dark:text-slate-400">
+            <tr>
+              <th className="px-6 py-4">Kategori</th>
+              <th className="px-6 py-4 text-right">Planned</th>
+              <th className="px-6 py-4 text-right">Spent</th>
+              <th className="px-6 py-4 text-right">Remaining</th>
+              <th className="px-6 py-4 text-center">Carryover</th>
+              <th className="px-6 py-4">Catatan</th>
+              <th className="px-6 py-4 text-right">Aksi</th>
+            </tr>
+          </thead>
+          <tbody>
+            {formattedRows.map((row, index) => (
+              <tr
+                key={row.id}
+                className={`${
+                  index % 2 === 0
+                    ? 'bg-white/70 dark:bg-zinc-900/40'
+                    : 'bg-white/40 dark:bg-zinc-900/30'
+                } transition hover:bg-indigo-50/60 dark:hover:bg-indigo-500/10`}
+              >
+                <td className="px-6 py-4 font-medium text-slate-700 dark:text-slate-100">
+                  {row.category?.name ?? 'Kategori tidak tersedia'}
+                </td>
+                <td className="px-6 py-4 text-right text-slate-600 dark:text-slate-300">
+                  {formatCurrency(row.amount_planned, 'IDR')}
+                </td>
+                <td className="px-6 py-4 text-right text-slate-600 dark:text-slate-300">
+                  {formatCurrency(row.spent, 'IDR')}
+                </td>
+                <td
+                  className={`px-6 py-4 text-right font-semibold ${
+                    row.remaining < 0
+                      ? 'text-rose-500 dark:text-rose-400'
+                      : 'text-emerald-600 dark:text-emerald-400'
+                  }`}
+                >
+                  {formatCurrency(row.remaining, 'IDR')}
+                </td>
+                <td className="px-6 py-4">
+                  <div className="flex justify-center">
+                    <button
+                      type="button"
+                      role="switch"
+                      aria-checked={row.carryover_enabled}
+                      onClick={() => onToggleCarryover(row)}
+                      disabled={busyId === row.id || !row.category_id}
+                      className={`relative h-8 w-14 rounded-full border border-transparent p-1 transition ${
+                        row.carryover_enabled
+                          ? 'from-emerald-500 to-emerald-400 text-white shadow-inner'
+                          : 'from-slate-200 to-slate-200 text-slate-600 dark:from-zinc-700 dark:to-zinc-700'
+                      } bg-gradient-to-r disabled:cursor-not-allowed disabled:opacity-50`}
+                    >
+                      <span
+                        className={`block h-6 w-6 rounded-full bg-white shadow transition-transform duration-200 ${
+                          row.carryover_enabled ? 'translate-x-6' : 'translate-x-0'
+                        }`}
+                      />
+                    </button>
+                  </div>
+                </td>
+                <td className="px-6 py-4 text-slate-500 dark:text-slate-300">
+                  {row.notes ?? '—'}
+                </td>
+                <td className="px-6 py-4">
+                  <div className="flex justify-end gap-2">
+                    <button
+                      type="button"
+                      onClick={() => onEdit(row)}
+                      className="inline-flex h-9 items-center justify-center gap-1 rounded-full bg-slate-200/70 px-3 text-xs font-medium text-slate-600 transition hover:bg-slate-200 dark:bg-zinc-700 dark:text-slate-100 dark:hover:bg-zinc-600"
+                    >
+                      <PencilLine size={16} />
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onDelete(row)}
+                      className="inline-flex h-9 items-center justify-center gap-1 rounded-full bg-rose-500/10 px-3 text-xs font-semibold text-rose-500 transition hover:bg-rose-500/20 dark:bg-rose-500/10 dark:text-rose-300"
+                    >
+                      <Trash2 size={16} />
+                      Hapus
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default function BudgetsPage() {
+  const { addToast } = useToast();
+  const [preset, setPreset] = useState<PeriodOption['value']>('current');
+  const [customPeriod, setCustomPeriod] = useState<string>(getCurrentPeriod());
+  const period = resolvePeriod(preset, customPeriod);
+  const { rows, loading, error, refresh } = useBudgets(period);
+  const [categories, setCategories] = useState<BudgetCategory[]>([]);
+  const [categoriesLoading, setCategoriesLoading] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [modalState, setModalState] = useState<{ open: boolean; editing: BudgetWithSpent | null }>(
+    { open: false, editing: null }
+  );
 
   useEffect(() => {
     let mounted = true;
-    (async () => {
-      try {
-        const { data, error } = await supabase
-          .from('categories')
-          .select('id, name, type')
-          .order('name');
-        if (error) throw error;
+    setCategoriesLoading(true);
+    listCategoriesExpense()
+      .then((data) => {
         if (mounted) {
-          const normalized = (data ?? [])
-            .filter((row) => row?.id && row?.name)
-            .map((row) => ({
-              id: row.id as string,
-              name: row.name as string,
-              type: (row.type as 'income' | 'expense') ?? 'expense',
-            }));
-          setCategories(normalized);
+          setCategories(data);
         }
-      } catch (error) {
-        addToast(`Gagal memuat kategori: ${error instanceof Error ? error.message : 'tidak diketahui'}`, 'error');
-      }
-    })();
+      })
+      .catch((err) => {
+        const message = err instanceof Error ? err.message : 'Gagal memuat kategori';
+        addToast(message, 'error');
+      })
+      .finally(() => {
+        if (mounted) setCategoriesLoading(false);
+      });
     return () => {
       mounted = false;
     };
   }, [addToast]);
 
-  const refreshRules = async () => {
-    try {
-      const rows = await listRules();
-      setRules(rows);
-    } catch (error) {
-      addToast(`Gagal memuat aturan: ${error instanceof Error ? error.message : 'tidak diketahui'}`, 'error');
-    }
-  };
-
-  useEffect(() => {
-    refreshRules();
-  }, []);
-
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    (async () => {
-      try {
-        const [rows, summaryData] = await Promise.all([
-          listBudgets({ period, q: filters.q || undefined, categoryId: filters.categoryId === 'all' ? undefined : filters.categoryId, withActivity: true, sort: filters.sort }),
-          getSummary({ period }),
-        ]);
-        if (!cancelled) {
-          setBudgets(rows);
-          setSummary(summaryData);
-        }
-      } catch (error) {
-        if (!cancelled) {
-          addToast(`Gagal memuat anggaran: ${error instanceof Error ? error.message : 'tidak diketahui'}`, 'error');
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [period, filters.q, filters.categoryId, filters.sort, addToast]);
-
-  useEffect(() => {
-    const filtered = budgets
-      .map((record) => buildViewModel(record, summary))
-      .filter((item) => {
-        if (filters.status === 'overspend' && item.remaining >= 0) return false;
-        if (filters.status === 'on-track' && item.remaining < 0) return false;
-        if (filters.categoryId && filters.categoryId !== 'all') {
-          return item.categoryId === filters.categoryId;
-        }
-        return true;
-      })
-      .filter((item) => {
-        if (!filters.q) return true;
-        return item.label.toLowerCase().includes(filters.q.toLowerCase());
-      });
-    setViews(filtered);
-  }, [budgets, summary, filters]);
-
-  useEffect(() => {
-    if (!budgets.length) {
-      setSummary(DEFAULT_SUMMARY);
+  const handleToggleCarryover = async (budget: BudgetWithSpent) => {
+    if (!budget.category_id) {
+      addToast('Kategori tidak ditemukan untuk anggaran ini.', 'error');
       return;
     }
-    const totalPlanned = budgets.reduce((sum, row) => sum + Number(row.planned ?? 0), 0);
-    const totalRolloverIn = budgets.reduce((sum, row) => sum + Number(row.rollover_in ?? 0), 0);
-    const totalActual = budgets.reduce(
-      (sum, row) => sum + Number(row.activity?.actual ?? 0),
-      0
-    );
-    const remaining = totalPlanned + totalRolloverIn - totalActual;
-    const base = new Date(`${period}-01T00:00:00Z`);
-    const daysInMonth = Number.isNaN(base.getTime())
-      ? 30
-      : new Date(Date.UTC(base.getUTCFullYear(), base.getUTCMonth() + 1, 0)).getUTCDate();
-    const coverage = totalActual > 0 ? Math.max(Math.floor(remaining / (totalActual / daysInMonth)), 0) : null;
-    setSummary({
-      planned: totalPlanned,
-      actual: totalActual,
-      remaining,
-      overspend: remaining < 0 ? Math.abs(remaining) : 0,
-      coverageDays: coverage,
-    });
-  }, [budgets, period]);
-
-  const tip = useMemo(() => buildTip(summary, views), [summary, views]);
-
-  const handleUndo = (id: string) => {
-    const existingIndex = undoStack.current.findIndex((item) => item.id === id);
-    if (existingIndex === -1) return;
-    const [target] = undoStack.current.splice(existingIndex, 1);
-    window.clearTimeout(target.timeoutId);
-    forceRerenderUndo((x) => x + 1);
-    (async () => {
-      try {
-        await upsertBudget({
-          id: target.previous.id,
-          period: target.previous.period_month.slice(0, 7),
-          category_id: target.previous.category_id ?? undefined,
-          name: target.previous.name ?? undefined,
-          planned: target.previous.planned,
-          carry_rule: target.previous.carry_rule,
-          note: target.previous.note ?? undefined,
-          rollover_in: target.previous.rollover_in,
-          rollover_out: target.previous.rollover_out,
-        });
-        setBudgets((prev) =>
-          prev.map((row) => (row.id === target.previous.id ? { ...target.previous } : row))
-        );
-        addToast('Perubahan dibatalkan', 'success');
-      } catch (error) {
-        addToast(`Gagal membatalkan perubahan: ${error instanceof Error ? error.message : 'tidak diketahui'}`, 'error');
-      }
-    })();
-  };
-
-  const pushUndo = (previous: BudgetRecord) => {
-    const timeoutId = window.setTimeout(() => {
-      undoStack.current = undoStack.current.filter((item) => item.id !== previous.id);
-      forceRerenderUndo((x) => x + 1);
-    }, 6000);
-    undoStack.current.push({
-      id: previous.id,
-      previous,
-      timeoutId,
-      expiresAt: Date.now() + 6000,
-    });
-    forceRerenderUndo((x) => x + 1);
-  };
-
-  const handleInlineUpdate = async (
-    id: string,
-    payload: Partial<Pick<BudgetRecord, 'planned' | 'rollover_in' | 'carry_rule'>>
-  ) => {
-    const target = budgets.find((item) => item.id === id);
-    if (!target) return;
-    const previous = { ...target };
-    const next: BudgetRecord = {
-      ...target,
-      ...('planned' in payload ? { planned: payload.planned ?? target.planned } : {}),
-      ...('rollover_in' in payload
-        ? { rollover_in: payload.rollover_in ?? target.rollover_in }
-        : {}),
-      ...('carry_rule' in payload
-        ? { carry_rule: (payload.carry_rule ?? target.carry_rule) as CarryRule }
-        : {}),
-    };
-    setBudgets((prev) => prev.map((row) => (row.id === id ? next : row)));
-    pushUndo(previous);
+    setBusyId(budget.id);
     try {
       await upsertBudget({
-        id: next.id,
-        period: next.period_month.slice(0, 7),
-        category_id: next.category_id ?? undefined,
-        name: next.name ?? undefined,
-        planned: next.planned,
-        carry_rule: next.carry_rule,
-        note: next.note ?? undefined,
-        rollover_in: next.rollover_in,
-        rollover_out: next.rollover_out,
+        period: budget.period_month.slice(0, 7),
+        category_id: budget.category_id,
+        amount_planned: budget.amount_planned,
+        carryover_enabled: !budget.carryover_enabled,
+        notes: budget.notes ?? undefined,
       });
-    } catch (error) {
-      setBudgets((prev) => prev.map((row) => (row.id === id ? previous : row)));
-      addToast(`Gagal menyimpan perubahan: ${error instanceof Error ? error.message : 'tidak diketahui'}`, 'error');
-    }
-  };
-
-  const handleDelete = async (id: string) => {
-    try {
-      await deleteBudget(id);
-      setBudgets((prev) => prev.filter((row) => row.id !== id));
-      addToast('Anggaran dihapus', 'success');
-    } catch (error) {
-      addToast(`Gagal menghapus anggaran: ${error instanceof Error ? error.message : 'tidak diketahui'}`, 'error');
-    }
-  };
-
-  const handleCopy = async () => {
-    if (periods.length < 2) return;
-    const fromPeriod = periods[1];
-    try {
-      await copyBudgets({ fromPeriod, toPeriod: period, strategy: 'clone', includeRolloverIn: false });
-      addToast('Anggaran bulan lalu disalin', 'success');
-      const rows = await listBudgets({ period, withActivity: true, sort: filters.sort });
-      setBudgets(rows);
-    } catch (error) {
-      addToast(`Gagal menyalin anggaran: ${error instanceof Error ? error.message : 'tidak diketahui'}`, 'error');
-    }
-  };
-
-  const handleComputeRollover = async () => {
-    try {
-      const rows = await computeRollover({ period });
-      setBudgets(rows);
-      addToast('Rollover berhasil dihitung', 'success');
-    } catch (error) {
-      addToast(`Gagal menghitung rollover: ${error instanceof Error ? error.message : 'tidak diketahui'}`, 'error');
-    }
-  };
-
-  const handleApplyRollover = async () => {
-    try {
-      await applyRolloverToNext({ period });
-      addToast('Rollover diterapkan ke bulan berikut', 'success');
-    } catch (error) {
-      addToast(`Gagal menerapkan rollover: ${error instanceof Error ? error.message : 'tidak diketahui'}`, 'error');
-    }
-  };
-
-  const handleExportCsv = async () => {
-    setExporting(true);
-    try {
-      const header = ['category_or_name', 'planned', 'rollover_in', 'carry_rule', 'note'];
-      const lines = [header.join(',')];
-      budgets.forEach((row) => {
-        const label = row.category_id ? row.name ?? '' : row.name ?? '';
-        const cells = [
-          `"${label.replace(/"/g, '""')}"`,
-          row.planned.toFixed(2),
-          row.rollover_in.toFixed(2),
-          row.carry_rule,
-          row.note ? `"${row.note.replace(/"/g, '""')}"` : '',
-        ];
-        lines.push(cells.join(','));
-      });
-      const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8;' });
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      link.setAttribute('download', `budgets-${period}.csv`);
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      URL.revokeObjectURL(url);
-      addToast('Data anggaran diekspor', 'success');
-    } catch (error) {
-      addToast(`Gagal mengekspor CSV: ${error instanceof Error ? error.message : 'tidak diketahui'}`, 'error');
+      addToast('Pengaturan carryover diperbarui.', 'success');
+      await refresh();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Gagal memperbarui carryover';
+      addToast(message, 'error');
     } finally {
-      setExporting(false);
+      setBusyId(null);
     }
   };
 
-  const parseCsv = (content: string) => {
-    const rows = content
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter(Boolean);
-    if (!rows.length) return [];
-    const [, ...dataRows] = rows;
-    return dataRows.map((row) => {
-      const parts: string[] = [];
-      let buffer = '';
-      let inQuotes = false;
-      for (let i = 0; i < row.length; i += 1) {
-        const char = row[i];
-        if (char === '"') {
-          if (inQuotes && row[i + 1] === '"') {
-            buffer += '"';
-            i += 1;
-          } else {
-            inQuotes = !inQuotes;
-          }
-        } else if (char === ',' && !inQuotes) {
-          parts.push(buffer);
-          buffer = '';
-        } else {
-          buffer += char;
-        }
-      }
-      parts.push(buffer);
-      return parts;
-    });
-  };
-
-  const handleImportCsv = async (event: ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (!file) return;
+  const handleDelete = async (budget: BudgetWithSpent) => {
+    const confirmed = window.confirm(`Hapus anggaran ${budget.category?.name ?? ''}?`);
+    if (!confirmed) return;
     try {
-      const text = await file.text();
-      const rows = parseCsv(text);
-      if (!rows.length) {
-        addToast('File kosong atau tidak valid', 'warning');
-        return;
-      }
-      const payloads = rows
-        .map((cols) => {
-          const [label, plannedStr, rolloverInStr, carryRule, note] = cols;
-          const planned = Number.parseFloat(plannedStr ?? '0');
-          const rolloverIn = Number.parseFloat(rolloverInStr ?? '0');
-          const carry = (carryRule as CarryRule) ?? 'carry-positive';
-          return {
-            period,
-            name: label || undefined,
-            planned: Number.isFinite(planned) ? planned : 0,
-            rollover_in: Number.isFinite(rolloverIn) ? rolloverIn : 0,
-            carry_rule: ['none', 'carry-positive', 'carry-all', 'reset-zero'].includes(carry)
-              ? (carry as CarryRule)
-              : 'carry-positive',
-            note: note || undefined,
-          };
-        })
-        .filter((item) => item.name);
-      const saved = await bulkUpsertBudgets(payloads);
-      setBudgets(saved);
-      addToast('CSV berhasil diimpor', 'success');
-    } catch (error) {
-      addToast(`Gagal mengimpor CSV: ${error instanceof Error ? error.message : 'tidak diketahui'}`, 'error');
-    } finally {
-      event.target.value = '';
+      await deleteBudget(budget.id);
+      addToast('Anggaran dihapus.', 'success');
+      await refresh();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Gagal menghapus anggaran';
+      addToast(message, 'error');
     }
   };
 
-  const filteredViews = useMemo(() => {
-    if (filters.status === 'warning') {
-      return views.filter((item) => item.status === 'warning');
+  const handleFormSubmit = async (payload: BudgetInput) => {
+    try {
+      await upsertBudget(payload);
+      addToast('Anggaran tersimpan.', 'success');
+      setModalState({ open: false, editing: null });
+      await refresh();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Gagal menyimpan anggaran';
+      addToast(message, 'error');
+      throw err;
     }
-    return views;
-  }, [views, filters.status]);
+  };
+
+  const handleOpenCreate = () => {
+    setModalState({ open: true, editing: null });
+  };
+
+  const handleEdit = (budget: BudgetWithSpent) => {
+    setModalState({ open: true, editing: budget });
+  };
+
+  const closeModal = () => {
+    setModalState({ open: false, editing: null });
+  };
+
+  const isLoadingTable = loading;
+  const expenseCategorySet = useMemo(() => new Set(categories.map((item) => item.id)), [categories]);
+  const tableRows = useMemo(() => {
+    if (!categories.length) return rows;
+    return rows.filter((row) => !row.category_id || expenseCategorySet.has(row.category_id));
+  }, [categories.length, expenseCategorySet, rows]);
+  const summaryForDisplay = useMemo(() => buildSummary(tableRows), [tableRows]);
 
   return (
     <Page>
       <Section first>
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-          <div className="flex flex-wrap items-center gap-2">
-            <label className="text-sm font-medium" htmlFor="period-picker">
-              Periode
-            </label>
-            <select
-              id="period-picker"
-              className="h-11 rounded-2xl border border-border bg-surface-1 px-4 text-sm"
-              value={period}
-              onChange={(event) => setPeriod(event.target.value)}
+        <div className="flex flex-col gap-6 rounded-2xl border border-white/40 bg-gradient-to-b from-white/90 to-white/60 p-6 shadow-sm backdrop-blur dark:border-white/10 dark:from-zinc-900/70 dark:to-zinc-900/40">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold text-slate-900 dark:text-slate-50">Anggaran</h1>
+              <p className="text-sm text-slate-500 dark:text-slate-400">
+                Kelola anggaran pengeluaran per kategori dan pantau progresnya.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleOpenCreate}
+              className="inline-flex h-11 items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-indigo-500 to-violet-500 px-5 text-sm font-semibold text-white shadow transition hover:from-indigo-600 hover:to-violet-600"
             >
-              {periods.map((item) => (
-                <option key={item} value={item}>
-                  {item}
-                </option>
-              ))}
-            </select>
+              <Plus size={18} />
+              Tambah anggaran
+            </button>
           </div>
-          <div className="flex flex-wrap gap-2">
-            <button
-              type="button"
-              className="h-11 rounded-2xl bg-[var(--brand)] px-4 text-sm font-semibold text-white shadow"
-              onClick={() => setBudgetFormOpen(true)}
-            >
-              Tambah Anggaran
-            </button>
-            <button
-              type="button"
-              className="h-11 rounded-2xl border border-border px-4 text-sm font-medium"
-              onClick={() => setAutoAllocateOpen(true)}
-            >
-              Template
-            </button>
-            <button
-              type="button"
-              className="h-11 rounded-2xl border border-border px-4 text-sm font-medium"
-              onClick={handleCopy}
-            >
-              Salin dari …
-            </button>
-            <button
-              type="button"
-              className="h-11 rounded-2xl border border-border px-4 text-sm font-medium"
-              onClick={handleExportCsv}
-              disabled={exporting}
-            >
-              Ekspor CSV
-            </button>
-            <button
-              type="button"
-              className="h-11 rounded-2xl border border-border px-4 text-sm font-medium"
-              onClick={() => fileInputRef.current?.click()}
-            >
-              Impor CSV
-            </button>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept=".csv,text/csv"
-              className="hidden"
-              onChange={handleImportCsv}
-            />
-          </div>
-        </div>
-        <div className="rounded-2xl border border-border bg-surface-1 p-4 text-sm text-muted">
-          {tip}
-        </div>
-      </Section>
-
-      <Section>
-        <BudgetsSummary summary={summary} loading={loading} />
-      </Section>
-
-      <Section>
-        <BudgetsFilterBar
-          filters={filters}
-          onChange={setFilters}
-          categories={categories}
-        />
-      </Section>
-
-      {undoStack.current.length > 0 && (
-        <Section>
-          <div className="rounded-2xl border border-dashed border-border bg-surface-1 p-4 text-sm">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <span>Perubahan tersimpan. Anda dapat membatalkan dalam 6 detik.</span>
-              <div className="flex flex-wrap gap-2">
-                {undoStack.current.map((item) => (
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="inline-flex items-center gap-2 rounded-2xl bg-white/60 p-1 ring-2 ring-white/60 backdrop-blur dark:bg-zinc-900/60 dark:ring-white/10">
+              {PERIOD_OPTIONS.map((option) => {
+                const active = preset === option.value;
+                return (
                   <button
-                    key={item.id}
+                    key={option.value}
                     type="button"
-                    className="rounded-xl border border-border px-3 py-1 text-xs font-medium"
-                    onClick={() => handleUndo(item.id)}
+                    onClick={() => setPreset(option.value)}
+                    className={`flex h-11 items-center rounded-2xl px-4 text-sm font-semibold transition ${
+                      active
+                        ? 'bg-gradient-to-r from-indigo-500 to-violet-500 text-white shadow'
+                        : 'text-slate-600 hover:bg-white/70 dark:text-slate-300 dark:hover:bg-zinc-800/80'
+                    }`}
                   >
-                    Undo {formatBudgetAmount(item.previous.planned)}
+                    {option.label}
                   </button>
-                ))}
-              </div>
+                );
+              })}
+            </div>
+            <div className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <Calendar size={18} />
+              {preset === 'custom' ? (
+                <input
+                  type="month"
+                  value={customPeriod}
+                  onChange={(event) => setCustomPeriod(event.target.value)}
+                  className="h-11 rounded-2xl border border-white/40 bg-white/80 px-4 text-sm shadow-sm ring-2 ring-transparent transition focus:border-indigo-500 focus:ring-indigo-400 dark:border-white/10 dark:bg-zinc-900/60 dark:text-slate-100"
+                />
+              ) : (
+                <span className="font-semibold">{period}</span>
+              )}
             </div>
           </div>
-        </Section>
-      )}
-
-      <Section>
-        <div className="hidden lg:block">
-          <BudgetsTable
-            budgets={filteredViews}
-            loading={loading}
-            onInlineUpdate={handleInlineUpdate}
-            onOpenDetail={setSelected}
-            onDelete={handleDelete}
-            onManageRule={(budget) => {
-              const target = rules.find((rule) => rule.category_id === budget.categoryId) ?? null;
-              setRuleBudget(budget);
-              setRuleEditing(target);
-            }}
-            onComputeRollover={handleComputeRollover}
-            onApplyRollover={handleApplyRollover}
-          />
-        </div>
-        <div className="space-y-4 lg:hidden">
-          {filteredViews.map((budget) => (
-            <BudgetCard
-              key={budget.id}
-              budget={budget}
-              onOpenDetail={() => setSelected(budget)}
-              onEdit={(field, value) =>
-                handleInlineUpdate(budget.id, { [field]: value } as Partial<BudgetRecord>)
-              }
-              onRule={() => {
-                const target = rules.find((rule) => rule.category_id === budget.categoryId) ?? null;
-                setRuleBudget(budget);
-                setRuleEditing(target);
-              }}
-              onDelete={() => handleDelete(budget.id)}
+          {error ? (
+            <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-600 dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-200">
+              {error}
+            </div>
+          ) : null}
+          {isLoadingTable ? (
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="h-32 rounded-2xl border border-white/40 bg-white/60 shadow-sm backdrop-blur animate-pulse dark:border-white/10 dark:bg-zinc-900/40"
+                />
+              ))}
+            </div>
+          ) : (
+            <BudgetSummaryCards
+              planned={summaryForDisplay.planned}
+              spent={summaryForDisplay.spent}
+              remaining={summaryForDisplay.remaining}
             />
-          ))}
+          )}
         </div>
       </Section>
 
-      <BudgetDetailDrawer
-        budget={selected}
-        onClose={() => setSelected(null)}
-        period={period}
-      />
-
-      <Modal
-        open={budgetFormOpen}
-        title="Tambah Anggaran"
-        onClose={() => setBudgetFormOpen(false)}
-      >
-        <BudgetForm
-          period={period}
-          categories={categories}
-          onCancel={() => setBudgetFormOpen(false)}
-          onSaved={async () => {
-            setBudgetFormOpen(false);
-            const rows = await listBudgets({ period, withActivity: true, sort: filters.sort });
-            setBudgets(rows);
-          }}
-        />
-      </Modal>
-
-      <Modal
-        open={!!ruleBudget}
-        title={ruleEditing?.id ? 'Edit Aturan' : 'Buat Aturan'}
-        onClose={() => {
-          setRuleEditing(null);
-          setRuleBudget(null);
-        }}
-      >
-        {ruleBudget && (
-          <BudgetRuleForm
-            budget={ruleBudget}
-            rule={ruleEditing ?? undefined}
-            onSaved={() => {
-              setRuleEditing(null);
-              setRuleBudget(null);
-              refreshRules();
-            }}
+      <Section>
+        {isLoadingTable ? (
+          <div className="space-y-3">
+            {Array.from({ length: 5 }).map((_, index) => (
+              <div
+                key={index}
+                className="h-16 rounded-2xl border border-white/40 bg-white/60 shadow-sm backdrop-blur animate-pulse dark:border-white/10 dark:bg-zinc-900/40"
+              />
+            ))}
+          </div>
+        ) : (
+          <BudgetsTable
+            rows={tableRows}
+            onEdit={handleEdit}
+            onDelete={handleDelete}
+            onToggleCarryover={handleToggleCarryover}
+            busyId={busyId}
           />
         )}
-      </Modal>
+      </Section>
 
-      <AutoAllocateDialog
-        open={autoAllocateOpen}
-        onClose={() => setAutoAllocateOpen(false)}
+      <BudgetFormModal
+        open={modalState.open}
+        onClose={closeModal}
+        categories={categories}
         period={period}
-        budgets={budgets.map((record) => buildViewModel(record, summary))}
-        onApplied={async () => {
-          setAutoAllocateOpen(false);
-          const rows = await listBudgets({ period, withActivity: true, sort: filters.sort });
-          setBudgets(rows);
-        }}
+        initialBudget={modalState.editing}
+        onSubmit={handleFormSubmit}
       />
+
+      {categoriesLoading ? (
+        <div className="sr-only" aria-live="polite">
+          Memuat kategori…
+        </div>
+      ) : null}
     </Page>
   );
 }

--- a/src/repo/budgetApi.ts
+++ b/src/repo/budgetApi.ts
@@ -1,0 +1,194 @@
+import { supabase } from '../lib/supabase';
+import { getCurrentUserId } from '../lib/session';
+
+export interface BudgetCategory {
+  id: string;
+  user_id: string;
+  type: 'income' | 'expense';
+  name: string;
+  inserted_at: string | null;
+  group_name: string | null;
+  order_index: number | null;
+}
+
+export interface BudgetRow {
+  id: string;
+  user_id: string;
+  category_id: string | null;
+  amount_planned: number;
+  carryover_enabled: boolean;
+  notes: string | null;
+  period_month: string;
+  created_at: string;
+  updated_at: string;
+  category?: {
+    id: string;
+    name: string;
+  } | null;
+}
+
+export interface BudgetWithSpent extends BudgetRow {
+  spent: number;
+}
+
+export interface BudgetSummary {
+  planned: number;
+  spent: number;
+  remaining: number;
+  percentage: number;
+}
+
+export interface BudgetInput {
+  id?: string;
+  period: string; // YYYY-MM
+  category_id: string;
+  amount_planned: number;
+  carryover_enabled: boolean;
+  notes?: string;
+}
+
+function ensurePeriodDate(periodYYYYMM: string): string {
+  if (!periodYYYYMM) {
+    throw new Error('Periode wajib diisi');
+  }
+  if (periodYYYYMM.length === 7) {
+    return `${periodYYYYMM}-01`;
+  }
+  return periodYYYYMM;
+}
+
+export async function listCategoriesExpense(): Promise<BudgetCategory[]> {
+  const userId = await getCurrentUserId();
+  if (!userId) throw new Error('Tidak dapat menemukan user');
+
+  const { data, error } = await supabase
+    .from('categories')
+    .select('id,user_id,type,name,inserted_at,group_name:group,order_index')
+    .eq('user_id', userId)
+    .eq('type', 'expense')
+    .order('order_index', { ascending: true, nullsFirst: true })
+    .order('name', { ascending: true });
+
+  if (error) throw error;
+
+  return (data ?? []).map((row: any) => ({
+    id: row.id,
+    user_id: row.user_id,
+    type: row.type,
+    name: row.name,
+    inserted_at: row.inserted_at ?? null,
+    group_name: row.group_name ?? null,
+    order_index: row.order_index ?? null,
+  }));
+}
+
+export async function listBudgets(periodYYYYMM: string): Promise<BudgetRow[]> {
+  const userId = await getCurrentUserId();
+  if (!userId) throw new Error('Tidak dapat menemukan user');
+
+  const period_month = ensurePeriodDate(periodYYYYMM);
+
+  const { data, error } = await supabase
+    .from('budgets')
+    .select('id,user_id,category_id,amount_planned,carryover_enabled,notes,period_month,created_at,updated_at,category:categories(id,name)')
+    .eq('user_id', userId)
+    .eq('period_month', period_month)
+    .order('created_at', { ascending: false });
+
+  if (error) throw error;
+
+  return (data ?? []).map((row: any) => ({
+    id: row.id,
+    user_id: row.user_id,
+    category_id: row.category_id,
+    amount_planned: Number(row.amount_planned ?? 0),
+    carryover_enabled: Boolean(row.carryover_enabled),
+    notes: row.notes ?? null,
+    period_month: row.period_month,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    category: row.category ?? null,
+  }));
+}
+
+function getPeriodRange(periodMonth: string): { from: string; to: string } {
+  const date = new Date(`${ensurePeriodDate(periodMonth)}T00:00:00`);
+  const from = date.toISOString().slice(0, 10);
+  const next = new Date(date);
+  next.setMonth(next.getMonth() + 1);
+  const to = next.toISOString().slice(0, 10);
+  return { from, to };
+}
+
+export async function computeSpent(periodMonth: string): Promise<Record<string, number>> {
+  const userId = await getCurrentUserId();
+  if (!userId) throw new Error('Tidak dapat menemukan user');
+
+  const { from, to } = getPeriodRange(periodMonth);
+
+  const { data, error } = await supabase
+    .from('transactions')
+    .select('category_id, amount, date')
+    .eq('user_id', userId)
+    .is('deleted_at', null)
+    .eq('type', 'expense')
+    .gte('date', from)
+    .lt('date', to);
+
+  if (error) throw error;
+
+  const totals: Record<string, number> = {};
+  for (const row of data ?? []) {
+    const categoryId = row.category_id;
+    if (!categoryId) continue;
+    const amount = Number(row.amount ?? 0);
+    totals[categoryId] = (totals[categoryId] ?? 0) + amount;
+  }
+  return totals;
+}
+
+export function buildSummary(rows: BudgetWithSpent[]): BudgetSummary {
+  const planned = rows.reduce((acc, item) => acc + item.amount_planned, 0);
+  const spent = rows.reduce((acc, item) => acc + item.spent, 0);
+  const remaining = planned - spent;
+  const percentage = planned > 0 ? Math.min(spent / planned, 1) : 0;
+  return { planned, spent, remaining, percentage };
+}
+
+export async function upsertBudget(input: BudgetInput): Promise<void> {
+  const userId = await getCurrentUserId();
+  if (!userId) throw new Error('Tidak dapat menemukan user');
+
+  const period_month = ensurePeriodDate(input.period);
+
+  const payload = {
+    category_id: input.category_id,
+    amount_planned: input.amount_planned,
+    period_month,
+    carryover_enabled: input.carryover_enabled,
+    notes: input.notes ?? null,
+  };
+
+  const { error } = await supabase.rpc('bud_upsert', payload);
+  if (error) throw error;
+}
+
+export async function deleteBudget(id: string): Promise<void> {
+  const userId = await getCurrentUserId();
+  if (!userId) throw new Error('Tidak dapat menemukan user');
+
+  const { error } = await supabase
+    .from('budgets')
+    .delete()
+    .eq('user_id', userId)
+    .eq('id', id);
+  if (error) throw error;
+}
+
+export async function assembleBudgets(period: string): Promise<BudgetWithSpent[]> {
+  const [budgets, spentMap] = await Promise.all([listBudgets(period), computeSpent(period)]);
+  return budgets.map((row) => ({
+    ...row,
+    spent: row.category_id ? spentMap[row.category_id] ?? 0 : 0,
+  }));
+}


### PR DESCRIPTION
## Summary
- rebuild the /budgets page with a modern glassmorphism layout, period filters, summary cards, and responsive table
- add dedicated Supabase budget repository helpers and a reusable useBudgets hook to load, aggregate, and refresh data per month
- support add/edit forms, carryover toggles, deletion, and live progress with safe validation and loading states

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d55e30e05c83329c109edcff805581