### PR TITLE
feat: redesign budgets page with modern ui

### DIFF
--- a/src/components/budgets/BudgetFormDialog.tsx
+++ b/src/components/budgets/BudgetFormDialog.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useMemo, useState } from 'react';
+import clsx from 'clsx';
+import { Calendar, NotebookPen } from 'lucide-react';
+import type { BudgetRowView } from '../../hooks/useBudgets';
+import type { ExpenseCategory } from '../../lib/budgetApi';
+
+export interface BudgetFormValues {
+  period: string;
+  categoryId: string;
+  amountPlanned: number;
+  carryoverEnabled: boolean;
+  notes: string;
+}
+
+interface BudgetFormDialogProps {
+  open: boolean;
+  categories: ExpenseCategory[];
+  loading?: boolean;
+  busy?: boolean;
+  defaultPeriod: string;
+  budget?: BudgetRowView | null;
+  onClose: () => void;
+  onSubmit: (values: BudgetFormValues) => void;
+}
+
+const controlClass =
+  'h-11 w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 text-sm text-slate-700 shadow-sm transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-100 dark:border-white/10 dark:bg-zinc-900/70 dark:text-slate-100';
+
+export default function BudgetFormDialog({
+  open,
+  categories,
+  loading = false,
+  busy = false,
+  defaultPeriod,
+  budget,
+  onClose,
+  onSubmit,
+}: BudgetFormDialogProps) {
+  const [values, setValues] = useState<BudgetFormValues>({
+    period: defaultPeriod,
+    categoryId: '',
+    amountPlanned: 0,
+    carryoverEnabled: false,
+    notes: '',
+  });
+  const [errors, setErrors] = useState<{ period?: string; categoryId?: string; amountPlanned?: string }>({});
+
+  useEffect(() => {
+    if (!open) return;
+    setErrors({});
+    if (budget) {
+      setValues({
+        period: budget.periodMonth.slice(0, 7),
+        categoryId: budget.categoryId ?? '',
+        amountPlanned: budget.amountPlanned,
+        carryoverEnabled: budget.carryoverEnabled,
+        notes: budget.notes ?? '',
+      });
+    } else {
+      setValues({
+        period: defaultPeriod,
+        categoryId: '',
+        amountPlanned: 0,
+        carryoverEnabled: false,
+        notes: '',
+      });
+    }
+  }, [open, budget, defaultPeriod]);
+
+  const groupedCategories = useMemo(() => {
+    const groups = new Map<string, ExpenseCategory[]>();
+    categories.forEach((category) => {
+      const key = category.group_name ?? 'Lainnya';
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key)?.push(category);
+    });
+    return Array.from(groups.entries());
+  }, [categories]);
+
+  if (!open) return null;
+
+  const handleChange = (key: keyof BudgetFormValues, value: string | number | boolean) => {
+    setValues((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    const nextErrors: typeof errors = {};
+    if (!values.period) nextErrors.period = 'Periode wajib diisi';
+    if (!values.categoryId) nextErrors.categoryId = 'Kategori wajib dipilih';
+    if (!values.amountPlanned || values.amountPlanned <= 0) nextErrors.amountPlanned = 'Nilai harus lebih dari 0';
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) return;
+    onSubmit(values);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 px-4 py-6 backdrop-blur-sm">
+      <div className="w-full max-w-xl overflow-hidden rounded-3xl border border-white/20 bg-gradient-to-b from-white/90 to-white/60 shadow-2xl backdrop-blur dark:border-white/10 dark:from-zinc-950/90 dark:to-zinc-900/70">
+        <div className="flex items-center justify-between border-b border-white/40 px-6 py-4 dark:border-white/10">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
+              {budget ? 'Edit Anggaran' : 'Tambah Anggaran'}
+            </h2>
+            <p className="text-sm text-slate-500 dark:text-slate-400">Sesuaikan rencana pengeluaran periode ini.</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex h-9 w-9 items-center justify-center rounded-full bg-white/80 text-slate-500 shadow hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 dark:bg-white/10 dark:text-slate-200"
+            aria-label="Tutup"
+          >
+            ×
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-6 px-6 py-6">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="flex flex-col gap-2 text-sm font-medium text-slate-600 dark:text-slate-300">
+              Periode
+              <div className="relative">
+                <Calendar className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+                <input
+                  type="month"
+                  value={values.period}
+                  onChange={(event) => handleChange('period', event.target.value)}
+                  className={`${controlClass} pl-10`}
+                  disabled={busy}
+                  required
+                />
+              </div>
+              {errors.period && <span className="text-xs text-rose-500">{errors.period}</span>}
+            </label>
+            <label className="flex flex-col gap-2 text-sm font-medium text-slate-600 dark:text-slate-300">
+              Kategori
+              <select
+                value={values.categoryId}
+                onChange={(event) => handleChange('categoryId', event.target.value)}
+                className={controlClass}
+                disabled={busy || loading}
+                required
+              >
+                <option value="" disabled>
+                  Pilih kategori pengeluaran
+                </option>
+                {groupedCategories.map(([group, items]) => (
+                  <optgroup key={group} label={group}>
+                    {items.map((item) => (
+                      <option key={item.id} value={item.id}>
+                        {item.name}
+                      </option>
+                    ))}
+                  </optgroup>
+                ))}
+              </select>
+              {errors.categoryId && <span className="text-xs text-rose-500">{errors.categoryId}</span>}
+            </label>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="flex flex-col gap-2 text-sm font-medium text-slate-600 dark:text-slate-300">
+              Planned (IDR)
+              <input
+                type="number"
+                min="0"
+                step="1000"
+                value={values.amountPlanned}
+                onChange={(event) => handleChange('amountPlanned', Number(event.target.value))}
+                className={controlClass}
+                placeholder="0"
+                disabled={busy}
+                required
+              />
+              {errors.amountPlanned && <span className="text-xs text-rose-500">{errors.amountPlanned}</span>}
+            </label>
+
+            <div className="flex flex-col gap-2 text-sm font-medium text-slate-600 dark:text-slate-300">
+              Carryover
+              <button
+                type="button"
+                onClick={() => handleChange('carryoverEnabled', !values.carryoverEnabled)}
+                className={clsx(
+                  'flex h-11 w-full items-center justify-between rounded-2xl border px-4 text-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 dark:border-white/10',
+                  values.carryoverEnabled
+                    ? 'border-emerald-200 bg-emerald-500/10 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-200'
+                    : 'border-slate-200 bg-white text-slate-600 dark:border-white/10 dark:bg-zinc-900/70 dark:text-slate-200'
+                )}
+                disabled={busy}
+              >
+                <span>{values.carryoverEnabled ? 'Aktif' : 'Nonaktif'}</span>
+                <span
+                  className={clsx(
+                    'inline-flex h-8 w-14 items-center rounded-full border px-1 transition',
+                    values.carryoverEnabled
+                      ? 'justify-end border-emerald-400 bg-emerald-500/20'
+                      : 'justify-start border-slate-200 bg-slate-100 dark:border-white/10 dark:bg-slate-700/60'
+                  )}
+                >
+                  <span
+                    className={clsx(
+                      'inline-flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold shadow-sm transition',
+                      values.carryoverEnabled
+                        ? 'bg-emerald-500 text-white'
+                        : 'bg-white text-slate-600 dark:bg-slate-500 dark:text-white'
+                    )}
+                  >
+                    {values.carryoverEnabled ? 'On' : 'Off'}
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-600 dark:text-slate-300">
+            Catatan
+            <div className="relative">
+              <NotebookPen className="pointer-events-none absolute left-4 top-3 h-4 w-4 text-slate-400" />
+              <textarea
+                rows={3}
+                value={values.notes}
+                onChange={(event) => handleChange('notes', event.target.value)}
+                className={`${controlClass} resize-none pl-10`}
+                placeholder="Catatan opsional"
+                disabled={busy}
+              />
+            </div>
+          </label>
+
+          <div className="flex items-center justify-end gap-3 border-t border-white/40 pt-4 dark:border-white/10">
+            <button
+              type="button"
+              onClick={onClose}
+              className="h-11 rounded-2xl border border-slate-200/70 px-6 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300 dark:border-white/10 dark:text-slate-200 dark:hover:bg-white/10"
+              disabled={busy}
+            >
+              Batal
+            </button>
+            <button
+              type="submit"
+              className="h-11 rounded-2xl bg-gradient-to-r from-sky-500 to-emerald-500 px-6 text-sm font-semibold text-white shadow-lg shadow-sky-500/25 transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={busy || loading}
+            >
+              {busy ? 'Menyimpan...' : budget ? 'Simpan Perubahan' : 'Tambah Anggaran'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/budgets/BudgetSummaryCards.tsx
+++ b/src/components/budgets/BudgetSummaryCards.tsx
@@ -1,0 +1,115 @@
+import { Wallet, TrendingDown, PiggyBank, Target } from 'lucide-react';
+import { formatCurrency } from '../../lib/format';
+import type { BudgetsSummary } from '../../hooks/useBudgets';
+
+interface BudgetSummaryCardsProps {
+  summary: BudgetsSummary;
+  loading?: boolean;
+}
+
+const cardBaseClass =
+  'flex flex-col gap-4 rounded-2xl border border-white/40 bg-gradient-to-b from-white/80 to-white/50 p-5 shadow-sm backdrop-blur dark:border-white/5 dark:from-zinc-900/60 dark:to-zinc-900/30';
+
+const iconWrapperClass =
+  'flex h-12 w-12 items-center justify-center rounded-2xl bg-white/70 text-sky-600 shadow-sm dark:bg-white/10 dark:text-sky-300';
+
+export default function BudgetSummaryCards({ summary, loading = false }: BudgetSummaryCardsProps) {
+  if (loading) {
+    return (
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div
+            // eslint-disable-next-line react/no-array-index-key
+            key={index}
+            className={`${cardBaseClass} animate-pulse`}
+          >
+            <div className="h-5 w-24 rounded-full bg-black/10 dark:bg-white/10" />
+            <div className="h-10 w-32 rounded-full bg-black/10 dark:bg-white/10" />
+            <div className="h-2 w-full rounded-full bg-black/5 dark:bg-white/5" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  const percentage = Number.isFinite(summary.percentage) ? summary.percentage : 0;
+  const boundedProgress = Math.min(Math.abs(percentage), 100);
+  const overspend = percentage > 100;
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <article className={cardBaseClass}>
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Total Anggaran</p>
+            <p className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">
+              {formatCurrency(summary.planned ?? 0)}
+            </p>
+          </div>
+          <div className={`${iconWrapperClass} bg-sky-500/10 text-sky-600 dark:bg-sky-500/20 dark:text-sky-200`}>
+            <Wallet className="h-6 w-6" />
+          </div>
+        </div>
+      </article>
+
+      <article className={cardBaseClass}>
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Realisasi</p>
+            <p className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">
+              {formatCurrency(summary.spent ?? 0)}
+            </p>
+          </div>
+          <div className={`${iconWrapperClass} bg-emerald-500/10 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-200`}>
+            <PiggyBank className="h-6 w-6" />
+          </div>
+        </div>
+      </article>
+
+      <article className={cardBaseClass}>
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Sisa</p>
+            <p className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">
+              {formatCurrency(summary.remaining ?? 0)}
+            </p>
+          </div>
+          <div className={`${iconWrapperClass} bg-violet-500/10 text-violet-600 dark:bg-violet-500/20 dark:text-violet-200`}>
+            <TrendingDown className="h-6 w-6" />
+          </div>
+        </div>
+      </article>
+
+      <article className={cardBaseClass}>
+        <div className="flex flex-1 flex-col gap-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Persentase</p>
+              <p className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">
+                {percentage.toFixed(0)}%
+              </p>
+            </div>
+            <div className={`${iconWrapperClass} bg-amber-500/10 text-amber-600 dark:bg-amber-500/20 dark:text-amber-200`}>
+              <Target className="h-6 w-6" />
+            </div>
+          </div>
+          <div className="h-2 rounded-full bg-slate-200/70 dark:bg-slate-700/60">
+            <div
+              className={`h-full rounded-full transition-all ${
+                overspend ? 'bg-rose-500 dark:bg-rose-400' : 'bg-gradient-to-r from-emerald-500 to-sky-500'
+              }`}
+              style={{ width: `${boundedProgress}%` }}
+            />
+          </div>
+          {overspend ? (
+            <p className="text-xs font-medium text-rose-600 dark:text-rose-300">Pengeluaran melebihi rencana.</p>
+          ) : (
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              {percentage > 0 ? 'Pengeluaran masih dalam kendali.' : 'Belum ada transaksi pada periode ini.'}
+            </p>
+          )}
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/src/components/budgets/BudgetTable.tsx
+++ b/src/components/budgets/BudgetTable.tsx
@@ -1,0 +1,158 @@
+import { Fragment } from 'react';
+import { PencilLine, Trash2 } from 'lucide-react';
+import clsx from 'clsx';
+import { formatCurrency } from '../../lib/format';
+import type { BudgetRowView } from '../../hooks/useBudgets';
+
+interface BudgetTableProps {
+  data: BudgetRowView[];
+  loading?: boolean;
+  processingId?: string | null;
+  onEdit: (row: BudgetRowView) => void;
+  onDelete: (row: BudgetRowView) => void;
+  onToggleCarryover: (row: BudgetRowView, value: boolean) => void;
+}
+
+export default function BudgetTable({
+  data,
+  loading = false,
+  processingId = null,
+  onEdit,
+  onDelete,
+  onToggleCarryover,
+}: BudgetTableProps) {
+  return (
+    <div className="overflow-hidden rounded-2xl border border-white/40 bg-white/60 shadow-sm backdrop-blur dark:border-white/5 dark:bg-zinc-900/40">
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-slate-200/70 text-left text-sm text-slate-600 dark:divide-white/10 dark:text-slate-300">
+          <thead className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            <tr className="bg-white/80 backdrop-blur dark:bg-zinc-950/60">
+              <th scope="col" className="sticky top-0 z-10 px-6 py-4 font-semibold">
+                Kategori
+              </th>
+              <th scope="col" className="sticky top-0 z-10 px-6 py-4 font-semibold">
+                Planned
+              </th>
+              <th scope="col" className="sticky top-0 z-10 px-6 py-4 font-semibold">
+                Spent
+              </th>
+              <th scope="col" className="sticky top-0 z-10 px-6 py-4 font-semibold">
+                Remaining
+              </th>
+              <th scope="col" className="sticky top-0 z-10 px-6 py-4 font-semibold">
+                Carryover
+              </th>
+              <th scope="col" className="sticky top-0 z-10 px-6 py-4 font-semibold">
+                Catatan
+              </th>
+              <th scope="col" className="sticky top-0 z-10 px-6 py-4 font-semibold">
+                Aksi
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              Array.from({ length: 5 }).map((_, index) => (
+                <tr
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={index}
+                  className="animate-pulse border-b border-slate-100/70 bg-white/50 dark:border-white/5 dark:bg-white/5"
+                >
+                  {Array.from({ length: 7 }).map((__, cellIndex) => (
+                    <td key={cellIndex} className="px-6 py-4">
+                      <div className="h-4 w-full max-w-[160px] rounded-full bg-slate-200 dark:bg-slate-700/80" />
+                    </td>
+                  ))}
+                </tr>
+              ))
+            ) : data.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="px-6 py-12 text-center text-slate-500 dark:text-slate-400">
+                  <div className="mx-auto max-w-md rounded-2xl border border-dashed border-slate-300/60 bg-white/40 p-6 dark:border-white/10 dark:bg-white/5">
+                    <p className="font-semibold text-slate-700 dark:text-slate-200">Belum ada anggaran di periode ini.</p>
+                    <p className="mt-2 text-sm">Tambahkan kategori pengeluaran untuk mulai mengatur anggaran Anda.</p>
+                  </div>
+                </td>
+              </tr>
+            ) : (
+              data.map((row) => {
+                const disabled = processingId === row.id;
+                const remainingClass = clsx('font-semibold', {
+                  'text-rose-500 dark:text-rose-400': row.remaining < 0,
+                  'text-emerald-600 dark:text-emerald-300': row.remaining >= 0,
+                });
+                return (
+                  <Fragment key={row.id}>
+                    <tr className="group border-b border-slate-100/70 bg-white/50 transition hover:bg-sky-50/70 dark:border-white/5 dark:bg-white/5 dark:hover:bg-sky-500/10">
+                      <td className="px-6 py-4">
+                        <div className="font-medium text-slate-900 dark:text-white">{row.categoryName}</div>
+                      </td>
+                      <td className="px-6 py-4 font-medium text-slate-900 dark:text-white">
+                        {formatCurrency(row.amountPlanned)}
+                      </td>
+                      <td className="px-6 py-4 text-slate-700 dark:text-slate-200">
+                        {formatCurrency(row.currentSpent)}
+                      </td>
+                      <td className={`px-6 py-4 ${remainingClass}`}>
+                        {formatCurrency(row.remaining)}
+                      </td>
+                      <td className="px-6 py-4">
+                        <button
+                          type="button"
+                          onClick={() => onToggleCarryover(row, !row.carryoverEnabled)}
+                          className={clsx(
+                            'flex h-9 w-16 items-center rounded-full border px-1 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 disabled:cursor-not-allowed disabled:opacity-60 dark:border-white/10',
+                            row.carryoverEnabled
+                              ? 'justify-end border-emerald-200 bg-emerald-500/10 dark:bg-emerald-500/20'
+                              : 'justify-start border-slate-200 bg-white dark:border-white/10 dark:bg-zinc-900'
+                          )}
+                          aria-pressed={row.carryoverEnabled}
+                          disabled={disabled}
+                        >
+                          <span
+                            className={clsx(
+                              'inline-flex h-7 w-7 items-center justify-center rounded-full text-xs font-semibold transition',
+                              row.carryoverEnabled
+                                ? 'bg-emerald-500 text-white shadow'
+                                : 'bg-slate-300 text-slate-700 dark:bg-slate-600 dark:text-white'
+                            )}
+                          >
+                            {row.carryoverEnabled ? 'On' : 'Off'}
+                          </span>
+                        </button>
+                      </td>
+                      <td className="px-6 py-4 text-sm text-slate-500 dark:text-slate-300">
+                        {row.notes ? row.notes : <span className="text-slate-400">—</span>}
+                      </td>
+                      <td className="px-6 py-4">
+                        <div className="flex items-center gap-2">
+                          <button
+                            type="button"
+                            onClick={() => onEdit(row)}
+                            className="flex h-9 w-9 items-center justify-center rounded-full bg-white/80 text-sky-600 shadow-sm transition hover:bg-sky-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-white/10 dark:text-sky-300"
+                            aria-label="Edit anggaran"
+                          >
+                            <PencilLine className="h-4 w-4" />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => onDelete(row)}
+                            className="flex h-9 w-9 items-center justify-center rounded-full bg-rose-500/10 text-rose-600 transition hover:bg-rose-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-rose-500/15 dark:text-rose-300"
+                            aria-label="Hapus anggaran"
+                            disabled={disabled}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  </Fragment>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useBudgets.ts
+++ b/src/hooks/useBudgets.ts
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  computeSpentByCategory,
+  listBudgets,
+  type BudgetRecord,
+  type SpentByCategoryMap,
+} from '../lib/budgetApi';
+
+export interface BudgetRowView {
+  id: string;
+  categoryId: string | null;
+  categoryName: string;
+  amountPlanned: number;
+  carryoverEnabled: boolean;
+  notes: string | null;
+  periodMonth: string;
+  currentSpent: number;
+  remaining: number;
+}
+
+export interface BudgetsSummary {
+  planned: number;
+  spent: number;
+  remaining: number;
+  percentage: number;
+}
+
+const EMPTY_SUMMARY: BudgetsSummary = {
+  planned: 0,
+  spent: 0,
+  remaining: 0,
+  percentage: 0,
+};
+
+function mapRows(
+  budgets: BudgetRecord[],
+  spentMap: SpentByCategoryMap,
+): BudgetRowView[] {
+  return budgets
+    .filter((row) => row.category_id && (row.category?.type === 'expense' || !row.category?.type))
+    .map((row) => {
+      const categoryId = row.category_id ?? null;
+      const spent = categoryId ? spentMap[categoryId] ?? 0 : 0;
+      return {
+        id: row.id,
+        categoryId,
+        categoryName: row.category?.name ?? 'Tanpa kategori',
+        amountPlanned: Number.isFinite(row.amount_planned) ? row.amount_planned : 0,
+        carryoverEnabled: Boolean(row.carryover_enabled),
+        notes: row.notes ?? null,
+        periodMonth: row.period_month,
+        currentSpent: spent,
+        remaining: (Number.isFinite(row.amount_planned) ? row.amount_planned : 0) - spent,
+      } satisfies BudgetRowView;
+    });
+}
+
+function computeSummary(rows: BudgetRowView[]): BudgetsSummary {
+  if (!rows.length) return EMPTY_SUMMARY;
+  const planned = rows.reduce((total, row) => total + row.amountPlanned, 0);
+  const spent = rows.reduce((total, row) => total + row.currentSpent, 0);
+  const remaining = planned - spent;
+  const percentage = planned > 0 ? (spent / planned) * 100 : 0;
+  return { planned, spent, remaining, percentage };
+}
+
+export function useBudgets(period: string) {
+  const [rows, setRows] = useState<BudgetRowView[]>([]);
+  const [summary, setSummary] = useState<BudgetsSummary>(EMPTY_SUMMARY);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!period) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const [budgets, spentMap] = await Promise.all([
+        listBudgets(period),
+        computeSpentByCategory(period),
+      ]);
+      const normalized = mapRows(budgets, spentMap);
+      setRows(normalized);
+      setSummary(computeSummary(normalized));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Gagal memuat data anggaran';
+      setError(message);
+      setRows([]);
+      setSummary(EMPTY_SUMMARY);
+    } finally {
+      setLoading(false);
+    }
+  }, [period]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      if (cancelled) return;
+      await refresh();
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [refresh]);
+
+  const memoSummary = useMemo(() => summary, [summary]);
+
+  return { rows, summary: memoSummary, loading, error, refresh };
+}

--- a/src/lib/budgetApi.ts
+++ b/src/lib/budgetApi.ts
@@ -1,0 +1,188 @@
+import { supabase } from './supabase';
+import { getCurrentUserId } from './session';
+
+export interface ExpenseCategory {
+  id: string;
+  user_id: string;
+  type: 'income' | 'expense';
+  name: string;
+  inserted_at: string | null;
+  group_name: string | null;
+  order_index: number | null;
+}
+
+export interface BudgetRecord {
+  id: string;
+  user_id: string;
+  category_id: string | null;
+  amount_planned: number;
+  carryover_enabled: boolean;
+  notes: string | null;
+  period_month: string;
+  created_at: string | null;
+  updated_at: string | null;
+  category?: {
+    id: string;
+    name: string;
+    type?: 'income' | 'expense';
+  } | null;
+}
+
+export interface SpentByCategoryMap {
+  [categoryId: string]: number;
+}
+
+export interface BudgetUpsertInput {
+  id?: string;
+  period: string; // YYYY-MM
+  categoryId: string;
+  amountPlanned: number;
+  carryoverEnabled: boolean;
+  notes?: string;
+  userId?: string;
+}
+
+function ensurePeriodMonth(period: string): string {
+  if (!period) throw new Error('Periode wajib diisi');
+  if (/^\d{4}-\d{2}-\d{2}$/.test(period)) return `${period.slice(0, 7)}-01`;
+  if (/^\d{4}-\d{2}$/.test(period)) return `${period}-01`;
+  throw new Error('Format periode tidak valid. Gunakan YYYY-MM');
+}
+
+function getNextMonth(periodMonth: string): string {
+  const [yearRaw, monthRaw] = periodMonth.split('-');
+  const year = Number.parseInt(yearRaw, 10);
+  const month = Number.parseInt(monthRaw, 10);
+  if (!Number.isFinite(year) || !Number.isFinite(month)) {
+    throw new Error('Periode tidak valid');
+  }
+  const base = new Date(Date.UTC(year, month - 1, 1));
+  base.setUTCMonth(base.getUTCMonth() + 1);
+  return base.toISOString().slice(0, 10);
+}
+
+export async function listCategoriesExpense(userId?: string): Promise<ExpenseCategory[]> {
+  const uid = userId ?? (await getCurrentUserId());
+  if (!uid) throw new Error('Pengguna belum masuk');
+  const { data, error } = await supabase
+    .from('categories')
+    .select('id,user_id,type,name,inserted_at,"group" as group_name,order_index')
+    .eq('user_id', uid)
+    .eq('type', 'expense')
+    .order('order_index', { ascending: true, nullsFirst: true })
+    .order('name', { ascending: true });
+  if (error) throw error;
+  return (data ?? []).map((row) => ({
+    id: String(row.id),
+    user_id: String(row.user_id),
+    type: (row.type ?? 'expense') as 'income' | 'expense',
+    name: String(row.name ?? ''),
+    inserted_at: row.inserted_at ?? null,
+    group_name: row.group_name ?? null,
+    order_index: row.order_index ?? null,
+  }));
+}
+
+export async function listBudgets(period: string, userId?: string): Promise<BudgetRecord[]> {
+  const uid = userId ?? (await getCurrentUserId());
+  if (!uid) throw new Error('Pengguna belum masuk');
+  const periodMonth = ensurePeriodMonth(period);
+  const { data, error } = await supabase
+    .from('budgets')
+    .select(
+      'id,user_id,category_id,amount_planned,carryover_enabled,notes,period_month,created_at,updated_at,category:categories(id,name,type)'
+    )
+    .eq('user_id', uid)
+    .eq('period_month', periodMonth)
+    .order('created_at', { ascending: false });
+  if (error) throw error;
+  return (data ?? []).map((row) => ({
+    id: String(row.id),
+    user_id: String(row.user_id),
+    category_id: row.category_id ?? null,
+    amount_planned: Number(row.amount_planned ?? 0),
+    carryover_enabled: Boolean(row.carryover_enabled),
+    notes: row.notes ?? null,
+    period_month: row.period_month ?? periodMonth,
+    created_at: row.created_at ?? null,
+    updated_at: row.updated_at ?? null,
+    category: row.category
+      ? {
+          id: String(row.category.id),
+          name: String(row.category.name ?? ''),
+          type: (row.category.type ?? 'expense') as 'income' | 'expense',
+        }
+      : null,
+  }));
+}
+
+export async function computeSpentByCategory(period: string, userId?: string): Promise<SpentByCategoryMap> {
+  const uid = userId ?? (await getCurrentUserId());
+  if (!uid) throw new Error('Pengguna belum masuk');
+  const periodMonth = ensurePeriodMonth(period);
+  const endExclusive = getNextMonth(periodMonth);
+  const { data, error } = await supabase
+    .from('transactions')
+    .select('category_id, amount, date')
+    .eq('user_id', uid)
+    .eq('type', 'expense')
+    .is('deleted_at', null)
+    .gte('date', periodMonth)
+    .lt('date', endExclusive);
+  if (error) throw error;
+  const totals: SpentByCategoryMap = {};
+  for (const row of data ?? []) {
+    const amount = Number(row.amount ?? 0);
+    const key = row.category_id ? String(row.category_id) : '__uncategorized__';
+    totals[key] = (totals[key] ?? 0) + (Number.isFinite(amount) ? amount : 0);
+  }
+  return totals;
+}
+
+function isMissingFunctionError(error: { code?: string; message?: string }): boolean {
+  if (!error) return false;
+  const code = error.code ?? '';
+  if (code === '42883') return true;
+  const message = (error.message ?? '').toLowerCase();
+  return message.includes('bud_upsert') && message.includes('function') && message.includes('does not exist');
+}
+
+export async function upsertBudget(input: BudgetUpsertInput): Promise<void> {
+  const periodMonth = ensurePeriodMonth(input.period);
+  const payload = {
+    budget_id: input.id ?? null,
+    category_id: input.categoryId,
+    amount_planned: input.amountPlanned,
+    period_month: periodMonth,
+    carryover_enabled: input.carryoverEnabled,
+    notes: input.notes ?? null,
+  };
+  const { error } = await supabase.rpc('bud_upsert', payload);
+  if (error && !isMissingFunctionError(error)) {
+    throw error;
+  }
+  if (!error) return;
+  const uid = input.userId ?? (await getCurrentUserId());
+  if (!uid) throw new Error('Pengguna belum masuk');
+  const { error: fallbackError } = await supabase
+    .from('budgets')
+    .upsert(
+      {
+        id: input.id ?? undefined,
+        user_id: uid,
+        category_id: input.categoryId,
+        amount_planned: input.amountPlanned,
+        period_month: periodMonth,
+        carryover_enabled: input.carryoverEnabled,
+        notes: input.notes ?? null,
+      },
+      { onConflict: 'user_id,category_id,period_month' }
+    );
+  if (fallbackError) throw fallbackError;
+}
+
+export async function deleteBudget(id: string): Promise<void> {
+  if (!id) throw new Error('ID anggaran tidak valid');
+  const { error } = await supabase.from('budgets').delete().eq('id', id);
+  if (error) throw error;
+}


### PR DESCRIPTION
## Summary
- replace the legacy budgets screen with a modern glassmorphism layout and segmented period filter
- add reusable budgets data hooks, Supabase API helpers, and UI building blocks for summary cards, tables, and forms
- support idempotent RPC-based budget upserts, carryover toggles, and accurate spent aggregation from transactions

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d55e30e05c83329c109edcff805581