### PR TITLE
Fix categories select alias encoding

### DIFF
--- a/src/lib/budgetApi.ts
+++ b/src/lib/budgetApi.ts
@@ -96,7 +96,7 @@ export async function listCategoriesExpense(): Promise<ExpenseCategory[]> {
   ensureAuth(userId);
   const { data, error } = await supabase
     .from('categories')
-    .select('id,user_id,type,name,inserted_at,"group" as group_name,order_index')
+    .select('id,user_id,type,name,inserted_at,"group":group_name,order_index')
     .eq('user_id', userId)
     .eq('type', 'expense')
     .order('order_index', { ascending: true, nullsFirst: true })


### PR DESCRIPTION
## Summary
- update the categories select clause to use PostgREST alias syntax for the `group` column
- ensure the generated request encodes correctly by replacing the `AS` alias with the colon form

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5638d7c6883329ef642b234421a7e