### PR TITLE
Improve budgets page styling and category selector

### DIFF
--- a/src/lib/budgetApi.ts
+++ b/src/lib/budgetApi.ts
@@ -1,5 +1,6 @@
 import { supabase } from './supabase';
 import { getCurrentUserId } from './session';
+import { listCategories } from './api-categories';
 
 type UUID = string;
 
@@ -7,10 +8,10 @@ type Nullable<T> = T | null;
 
 export interface ExpenseCategory {
   id: UUID;
-  user_id: UUID;
+  user_id: UUID | null;
   type: 'income' | 'expense';
   name: string;
-  inserted_at: string;
+  inserted_at: string | null;
   group_name: Nullable<string>;
   order_index: Nullable<number>;
 }
@@ -91,9 +92,30 @@ function getMonthRange(period: string): { start: string; end: string } {
   };
 }
 
+async function mapFallbackCategories(): Promise<ExpenseCategory[]> {
+  const records = await listCategories();
+  return records
+    .filter((category) => category.type === 'expense')
+    .map((category) => ({
+      id: category.id,
+      user_id: category.user_id,
+      type: 'expense',
+      name: category.name,
+      inserted_at: category.created_at,
+      group_name: null,
+      order_index: category.sort_order,
+    }));
+}
+
 export async function listCategoriesExpense(): Promise<ExpenseCategory[]> {
-  const userId = await getCurrentUserId();
-  ensureAuth(userId);
+  let userId: string | null = null;
+  try {
+    userId = await getCurrentUserId();
+    ensureAuth(userId);
+  } catch (error) {
+    return mapFallbackCategories();
+  }
+
   const { data, error } = await supabase
     .from('categories')
     .select('id,user_id,type,name,inserted_at,"group" as group_name,order_index')
@@ -101,7 +123,9 @@ export async function listCategoriesExpense(): Promise<ExpenseCategory[]> {
     .eq('type', 'expense')
     .order('order_index', { ascending: true, nullsFirst: true })
     .order('name', { ascending: true });
-  if (error) throw error;
+  if (error) {
+    return mapFallbackCategories();
+  }
   return (data ?? []) as ExpenseCategory[];
 }
 

--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Calendar, Plus, RefreshCw } from 'lucide-react';
 import Page from '../../layout/Page';
 import Section from '../../layout/Section';
+import PageHeader from '../../layout/PageHeader.jsx';
 import { useToast } from '../../context/ToastContext';
 import SummaryCards from './components/SummaryCards';
 import BudgetTable from './components/BudgetTable';
@@ -198,71 +199,64 @@ export default function BudgetsPage() {
   return (
     <Page>
       <Section first>
-        <div className="flex flex-col gap-6">
-          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div>
-              <h1 className="text-3xl font-semibold text-zinc-900 dark:text-zinc-50">Anggaran</h1>
-              <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
-                Atur dan pantau alokasi pengeluaranmu tiap bulan.
-              </p>
-            </div>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={refresh}
-                className="hidden h-11 items-center gap-2 rounded-2xl border border-white/50 px-4 text-sm font-semibold text-zinc-600 shadow-sm transition hover:-translate-y-0.5 hover:bg-white dark:border-white/20 dark:text-zinc-200 md:inline-flex"
-              >
-                <RefreshCw className="h-4 w-4" />
-                Segarkan
-              </button>
-              <button
-                type="button"
-                disabled={categoriesLoading}
-                onClick={handleOpenCreate}
-                className="inline-flex h-11 items-center gap-2 rounded-2xl bg-gradient-to-r from-emerald-500 via-emerald-500 to-emerald-600 px-5 text-sm font-semibold text-white shadow-lg shadow-emerald-500/30 transition hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-70"
-              >
-                <Plus className="h-4 w-4" />
-                Tambah anggaran
-              </button>
-            </div>
+        <PageHeader
+          title="Anggaran"
+          description="Atur dan pantau alokasi pengeluaranmu tiap bulan."
+        >
+          <button
+            type="button"
+            onClick={refresh}
+            className="hidden h-10 items-center gap-2 rounded-xl border border-border-subtle bg-surface px-3 text-sm font-semibold text-muted transition hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 md:inline-flex"
+          >
+            <RefreshCw className="h-4 w-4" />
+            Segarkan
+          </button>
+          <button
+            type="button"
+            disabled={categoriesLoading}
+            onClick={handleOpenCreate}
+            className="inline-flex h-10 items-center gap-2 rounded-xl bg-brand px-4 text-sm font-semibold text-brand-foreground shadow transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <Plus className="h-4 w-4" />
+            Tambah anggaran
+          </button>
+        </PageHeader>
+
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div className="flex flex-wrap gap-2">
+            {SEGMENTS.map(({ value, label }) => {
+              const active = value === segment;
+              return (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => handleSegmentChange(value)}
+                  className={`h-10 rounded-xl px-4 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 ${
+                    active
+                      ? 'bg-brand text-brand-foreground shadow'
+                      : 'border border-border-subtle bg-surface text-muted hover:text-text'
+                  }`}
+                >
+                  {label}
+                </button>
+              );
+            })}
           </div>
 
-          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div className="flex flex-wrap gap-2">
-              {SEGMENTS.map(({ value, label }) => {
-                const active = value === segment;
-                return (
-                  <button
-                    key={value}
-                    type="button"
-                    onClick={() => handleSegmentChange(value)}
-                    className={`h-11 rounded-2xl px-5 text-sm font-semibold transition ${
-                      active
-                        ? 'bg-zinc-900 text-white shadow-lg shadow-zinc-900/20 dark:bg-zinc-100 dark:text-zinc-900'
-                        : 'border border-white/50 bg-white/70 text-zinc-600 shadow-sm hover:-translate-y-0.5 hover:bg-white dark:border-white/10 dark:bg-zinc-900/60 dark:text-zinc-200'
-                    }`}
-                  >
-                    {label}
-                  </button>
-                );
-              })}
+          {segment === 'custom' ? (
+            <input
+              type="month"
+              value={customPeriod}
+              onChange={(event) => handleCustomPeriodChange(event.target.value)}
+              className="h-10 rounded-xl border border-border-subtle bg-surface px-3 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+              aria-label="Pilih periode custom"
+            />
+          ) : (
+            <div className="flex items-center gap-2 rounded-xl border border-border-subtle bg-surface px-3 py-2 text-sm font-medium text-muted">
+              <Calendar className="h-4 w-4" />
+              <span>{toHumanReadable(period)}</span>
             </div>
-
-            {segment === 'custom' ? (
-              <input
-                type="month"
-                value={customPeriod}
-                onChange={(event) => handleCustomPeriodChange(event.target.value)}
-                className="h-11 rounded-2xl border-0 bg-white/80 px-4 text-sm text-zinc-900 shadow-inner shadow-white/20 ring-2 ring-white/50 transition focus:outline-none focus:ring-emerald-400 dark:bg-zinc-900/60 dark:text-zinc-50 dark:ring-white/10"
-                aria-label="Pilih periode custom"
-              />
-            ) : (
-              <div className="flex items-center gap-2 rounded-2xl border border-white/50 bg-white/70 px-4 py-2 text-sm font-medium text-zinc-600 shadow-sm dark:border-white/10 dark:bg-zinc-900/60 dark:text-zinc-200">
-                <Calendar className="h-4 w-4" />
-                <span>{toHumanReadable(period)}</span>
-              </div>
-            )}
-          </div>
+          )}
         </div>
       </Section>
 

--- a/src/pages/budgets/components/BudgetFormModal.tsx
+++ b/src/pages/budgets/components/BudgetFormModal.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { FormEvent, Fragment, useEffect, useMemo, useState } from 'react';
 import { Calendar, PiggyBank } from 'lucide-react';
 import type { ExpenseCategory } from '../../../lib/budgetApi';
 
@@ -133,7 +133,7 @@ export default function BudgetFormModal({
                   type="month"
                   value={values.period}
                   onChange={(event) => handleChange('period', event.target.value)}
-                  className="h-11 w-full rounded-2xl border-0 bg-white/80 pl-11 pr-4 text-sm text-zinc-900 shadow-inner shadow-white/20 ring-2 ring-white/50 transition focus:outline-none focus:ring-emerald-400 dark:bg-zinc-900/60 dark:text-zinc-50 dark:ring-white/10"
+                  className="h-11 w-full rounded-2xl border border-white/40 bg-white/80 pl-11 pr-4 text-sm text-zinc-900 shadow-inner shadow-white/20 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 dark:border-white/10 dark:bg-zinc-900/60 dark:text-zinc-50"
                   required
                 />
               </div>
@@ -149,21 +149,29 @@ export default function BudgetFormModal({
                 <select
                   value={values.category_id}
                   onChange={(event) => handleChange('category_id', event.target.value)}
-                  className="h-11 w-full rounded-2xl border-0 bg-white/80 pl-11 pr-10 text-sm text-zinc-900 shadow-inner shadow-white/20 ring-2 ring-white/50 transition focus:outline-none focus:ring-emerald-400 dark:bg-zinc-900/60 dark:text-zinc-50 dark:ring-white/10"
+                  className="h-11 w-full rounded-2xl border border-white/40 bg-white/80 pl-11 pr-10 text-sm text-zinc-900 shadow-inner shadow-white/20 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 dark:border-white/10 dark:bg-zinc-900/60 dark:text-zinc-50"
                   required
                 >
-                  <option value="" disabled>
-                    Pilih kategori
-                  </option>
-                  {groupedCategories.map(([groupName, groupCategories]) => (
-                    <optgroup key={groupName} label={groupName}>
-                      {groupCategories.map((category) => (
-                        <option key={category.id} value={category.id}>
-                          {category.name}
-                        </option>
+                  {groupedCategories.length === 0 ? (
+                    <option value="" disabled>
+                      Belum ada kategori pengeluaran
+                    </option>
+                  ) : (
+                    <Fragment>
+                      <option value="" disabled>
+                        Pilih kategori
+                      </option>
+                      {groupedCategories.map(([groupName, groupCategories]) => (
+                        <optgroup key={groupName} label={groupName}>
+                          {groupCategories.map((category) => (
+                            <option key={category.id} value={category.id}>
+                              {category.name}
+                            </option>
+                          ))}
+                        </optgroup>
                       ))}
-                    </optgroup>
-                  ))}
+                    </Fragment>
+                  )}
                 </select>
               </div>
               {errors.category_id ? <span className="text-xs font-medium text-rose-500">{errors.category_id}</span> : null}
@@ -178,7 +186,7 @@ export default function BudgetFormModal({
               step="1000"
               value={values.amount_planned}
               onChange={(event) => handleChange('amount_planned', Number(event.target.value))}
-              className="h-11 w-full rounded-2xl border-0 bg-white/80 px-4 text-sm text-zinc-900 shadow-inner shadow-white/20 ring-2 ring-white/50 transition focus:outline-none focus:ring-emerald-400 dark:bg-zinc-900/60 dark:text-zinc-50 dark:ring-white/10"
+              className="h-11 w-full rounded-2xl border border-white/40 bg-white/80 px-4 text-sm text-zinc-900 shadow-inner shadow-white/20 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 dark:border-white/10 dark:bg-zinc-900/60 dark:text-zinc-50"
               required
             />
             {errors.amount_planned ? <span className="text-xs font-medium text-rose-500">{errors.amount_planned}</span> : null}
@@ -189,9 +197,9 @@ export default function BudgetFormModal({
             <button
               type="button"
               onClick={() => handleChange('carryover_enabled', !values.carryover_enabled)}
-              className={`relative inline-flex h-6 w-12 cursor-pointer items-center rounded-full ${
+              className={`relative inline-flex h-6 w-12 cursor-pointer items-center rounded-full transition ${
                 values.carryover_enabled
-                  ? 'bg-emerald-500/80 dark:bg-emerald-500/70'
+                  ? 'bg-brand/90 dark:bg-brand/80'
                   : 'bg-zinc-200/70 dark:bg-zinc-800/70'
               }`}
             >
@@ -209,7 +217,7 @@ export default function BudgetFormModal({
               rows={3}
               value={values.notes}
               onChange={(event) => handleChange('notes', event.target.value)}
-              className="min-h-[96px] rounded-2xl border-0 bg-white/80 px-4 py-3 text-sm text-zinc-900 shadow-inner shadow-white/20 ring-2 ring-white/50 transition focus:outline-none focus:ring-emerald-400 dark:bg-zinc-900/60 dark:text-zinc-50 dark:ring-white/10"
+              className="min-h-[96px] rounded-2xl border border-white/40 bg-white/80 px-4 py-3 text-sm text-zinc-900 shadow-inner shadow-white/20 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 dark:border-white/10 dark:bg-zinc-900/60 dark:text-zinc-50"
               placeholder="Catatan tambahan untuk anggaran ini"
             />
           </label>
@@ -225,7 +233,7 @@ export default function BudgetFormModal({
             <button
               type="submit"
               disabled={submitting}
-              className="inline-flex h-11 items-center justify-center rounded-2xl bg-gradient-to-r from-emerald-500 via-emerald-500 to-emerald-600 px-6 text-sm font-semibold text-white shadow-lg shadow-emerald-500/30 transition hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-70"
+              className="inline-flex h-11 items-center justify-center rounded-2xl bg-brand px-6 text-sm font-semibold text-brand-foreground shadow transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {submitting ? 'Menyimpan...' : 'Simpan anggaran'}
             </button>

--- a/src/pages/budgets/components/BudgetTable.tsx
+++ b/src/pages/budgets/components/BudgetTable.tsx
@@ -64,7 +64,8 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
           ) : (
             <tbody className="divide-y divide-white/10 text-sm text-zinc-700 dark:text-zinc-200">
               {rows.map((row) => {
-                const remainingClass = row.remaining < 0 ? 'text-rose-500 dark:text-rose-400' : 'text-emerald-600 dark:text-emerald-400';
+                const remainingClass =
+                  row.remaining < 0 ? 'text-rose-500 dark:text-rose-400' : 'text-brand';
                 return (
                   <tr
                     key={row.id}
@@ -86,7 +87,7 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
                           onChange={(event) => onToggleCarryover(row, event.target.checked)}
                           className="peer sr-only"
                         />
-                        <span className="absolute inset-0 rounded-full bg-zinc-200/70 transition peer-checked:bg-emerald-500/80 dark:bg-zinc-800/70 dark:peer-checked:bg-emerald-500/70" />
+                        <span className="absolute inset-0 rounded-full bg-zinc-200/70 transition peer-checked:bg-brand/90 dark:bg-zinc-800/70 dark:peer-checked:bg-brand/80" />
                         <span className="relative ml-1 h-4 w-4 rounded-full bg-white shadow-sm transition-transform peer-checked:translate-x-6" />
                       </label>
                     </td>

--- a/src/pages/budgets/components/SummaryCards.tsx
+++ b/src/pages/budgets/components/SummaryCards.tsx
@@ -40,25 +40,25 @@ export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
       label: 'Total Anggaran',
       value: formatCurrency(summary.planned, 'IDR'),
       icon: Wallet,
-      accent: 'text-sky-600 dark:text-sky-400',
+      accent: 'text-brand',
     },
     {
       label: 'Realisasi',
       value: formatCurrency(summary.spent, 'IDR'),
       icon: TrendingDown,
-      accent: 'text-emerald-600 dark:text-emerald-400',
+      accent: 'text-brand',
     },
     {
       label: 'Sisa',
       value: formatCurrency(summary.remaining, 'IDR'),
       icon: PiggyBank,
-      accent: 'text-purple-600 dark:text-purple-400',
+      accent: 'text-brand',
     },
     {
       label: 'Persentase',
       value: `${(progress * 100).toFixed(0)}%`,
       icon: Target,
-      accent: 'text-orange-600 dark:text-orange-400',
+      accent: 'text-brand',
       progress,
     },
   ];
@@ -81,7 +81,7 @@ export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
                 </div>
                 <div className="mt-2 h-2 rounded-full bg-zinc-200/70 dark:bg-zinc-800/70">
                   <div
-                    className="h-full rounded-full bg-gradient-to-r from-sky-500 via-sky-400 to-sky-300 dark:from-sky-400 dark:via-sky-500 dark:to-sky-600 transition-all"
+                    className="h-full rounded-full bg-brand transition-all"
                     style={{ width: `${cardProgress * 100}%` }}
                   />
                 </div>


### PR DESCRIPTION
## Summary
- add breadcrumb navigation to the budgets page and restyle the header actions to match the brand palette
- update budgets widgets, tables, and modals to use brand accent colors consistently
- ensure budget category options load for all users by falling back to local categories and show a helpful empty state in the selector

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d564b2febc8332be3b6317f63bf812