### PR TITLE
Revamp budgets page styling and improve category selection

### DIFF
--- a/src/pages/budgets/components/BudgetFormModal.tsx
+++ b/src/pages/budgets/components/BudgetFormModal.tsx
@@ -1,5 +1,6 @@
-import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { FormEvent, useEffect, useId, useMemo, useState } from 'react';
 import { Calendar, PiggyBank } from 'lucide-react';
+import Modal from '../../../components/Modal.jsx';
 import type { ExpenseCategory } from '../../../lib/budgetApi';
 
 export interface BudgetFormValues {
@@ -19,9 +20,6 @@ interface BudgetFormModalProps {
   onClose: () => void;
   onSubmit: (values: BudgetFormValues) => Promise<void> | void;
 }
-
-const MODAL_CLASS =
-  'fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-10 backdrop-blur-sm';
 
 function validate(values: BudgetFormValues) {
   const errors: Partial<Record<keyof BudgetFormValues, string>> = {};
@@ -49,6 +47,11 @@ export default function BudgetFormModal({
   const [values, setValues] = useState<BudgetFormValues>(initialValues);
   const [errors, setErrors] = useState<Partial<Record<keyof BudgetFormValues, string>>>({});
 
+  const periodId = useId();
+  const categoryId = useId();
+  const amountId = useId();
+  const notesId = useId();
+
   useEffect(() => {
     if (open) {
       setValues(initialValues);
@@ -70,13 +73,20 @@ export default function BudgetFormModal({
   const groupedCategories = useMemo(() => {
     const groups = new Map<string, ExpenseCategory[]>();
     for (const category of categories) {
-      const key = category.group_name ?? 'Ungrouped';
+      const key = category.group_name ?? 'Tanpa grup';
       const list = groups.get(key) ?? [];
       list.push(category);
       groups.set(key, list);
     }
-    return Array.from(groups.entries());
+    return Array.from(groups.entries())
+      .map(([groupName, groupCategories]) => [
+        groupName,
+        groupCategories.slice().sort((a, b) => a.name.localeCompare(b.name, 'id-ID')),
+      ] as const)
+      .sort((a, b) => a[0].localeCompare(b[0], 'id-ID'));
   }, [categories]);
+
+  const hasCategories = groupedCategories.some(([, items]) => items.length > 0);
 
   const handleChange = (field: keyof BudgetFormValues, value: string | number | boolean) => {
     setValues((prev) => ({ ...prev, [field]: value }));
@@ -97,142 +107,128 @@ export default function BudgetFormModal({
   if (!open) return null;
 
   return (
-    <div className={MODAL_CLASS} onClick={onClose}>
-      <div
-        role="dialog"
-        aria-modal="true"
-        className="w-full max-w-xl rounded-3xl border border-white/20 bg-gradient-to-b from-white/90 to-white/60 p-6 shadow-[0_40px_120px_-60px_rgba(15,23,42,0.65)] backdrop-blur dark:border-white/10 dark:from-zinc-950/80 dark:to-zinc-900/70"
-        onClick={(event) => event.stopPropagation()}
-      >
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-50">{title}</h2>
-            <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
-              Tetapkan target anggaran untuk kategori pengeluaranmu.
-            </p>
+    <Modal open={open} title={title} onClose={onClose}>
+      <form className="flex flex-col gap-5" onSubmit={handleSubmit}>
+        <p className="text-sm text-muted">
+          Tetapkan target anggaran untuk kategori pengeluaranmu.
+        </p>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <label htmlFor={periodId} className="form-label">
+              Periode
+            </label>
+            <div className="relative">
+              <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-muted">
+                <Calendar className="h-4 w-4" />
+              </span>
+              <input
+                id={periodId}
+                type="month"
+                value={values.period}
+                onChange={(event) => handleChange('period', event.target.value)}
+                className="pl-9"
+                required
+              />
+            </div>
+            {errors.period ? <p className="form-error">{errors.period}</p> : null}
           </div>
+
+          <div className="space-y-2">
+            <label htmlFor={categoryId} className="form-label">
+              Kategori
+            </label>
+            <div className="relative">
+              <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-muted">
+                <PiggyBank className="h-4 w-4" />
+              </span>
+              <select
+                id={categoryId}
+                value={values.category_id}
+                onChange={(event) => handleChange('category_id', event.target.value)}
+                className="pl-9 pr-10"
+                required
+                disabled={!hasCategories}
+              >
+                <option value="" disabled>
+                  {hasCategories ? 'Pilih kategori' : 'Belum ada kategori pengeluaran'}
+                </option>
+                {groupedCategories.map(([groupName, groupCategories]) => (
+                  <optgroup key={groupName} label={groupName}>
+                    {groupCategories.map((category) => (
+                      <option key={category.id} value={category.id}>
+                        {category.name}
+                      </option>
+                    ))}
+                  </optgroup>
+                ))}
+              </select>
+            </div>
+            {!hasCategories ? (
+              <p className="text-xs text-muted">
+                Tambahkan kategori pengeluaran baru di halaman Kategori sebelum membuat anggaran.
+              </p>
+            ) : null}
+            {errors.category_id ? <p className="form-error">{errors.category_id}</p> : null}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor={amountId} className="form-label">
+            Nominal Anggaran (IDR)
+          </label>
+          <input
+            id={amountId}
+            type="number"
+            min="0"
+            step="1000"
+            value={values.amount_planned}
+            onChange={(event) => handleChange('amount_planned', Number(event.target.value))}
+            required
+          />
+          {errors.amount_planned ? <p className="form-error">{errors.amount_planned}</p> : null}
+        </div>
+
+        <div className="flex items-center justify-between gap-4 rounded-2xl border border-border-subtle bg-surface-alt px-4 py-3 text-sm text-text">
+          <span>Aktifkan carryover ke bulan berikutnya</span>
           <button
             type="button"
-            onClick={onClose}
-            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/40 bg-white/70 text-zinc-500 shadow-sm transition hover:-translate-y-0.5 hover:bg-white dark:border-white/10 dark:bg-zinc-900/70 dark:text-zinc-300"
-            aria-label="Tutup"
+            onClick={() => handleChange('carryover_enabled', !values.carryover_enabled)}
+            className={`relative inline-flex h-6 w-12 cursor-pointer items-center rounded-full transition ${
+              values.carryover_enabled ? 'bg-primary' : 'bg-border-subtle'
+            }`}
           >
-            ✕
+            <span
+              className={`relative ml-1 h-4 w-4 rounded-full bg-surface shadow-sm transition-transform ${
+                values.carryover_enabled ? 'translate-x-6' : 'translate-x-0'
+              }`}
+            />
           </button>
         </div>
 
-        <form className="mt-6 flex flex-col gap-5" onSubmit={handleSubmit}>
-          <div className="grid gap-4 md:grid-cols-2">
-            <label className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">
-              Periode
-              <div className="relative">
-                <span className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-zinc-400">
-                  <Calendar className="h-4 w-4" />
-                </span>
-                <input
-                  type="month"
-                  value={values.period}
-                  onChange={(event) => handleChange('period', event.target.value)}
-                  className="h-11 w-full rounded-2xl border-0 bg-white/80 pl-11 pr-4 text-sm text-zinc-900 shadow-inner shadow-white/20 ring-2 ring-white/50 transition focus:outline-none focus:ring-emerald-400 dark:bg-zinc-900/60 dark:text-zinc-50 dark:ring-white/10"
-                  required
-                />
-              </div>
-              {errors.period ? <span className="text-xs font-medium text-rose-500">{errors.period}</span> : null}
-            </label>
-
-            <label className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">
-              Kategori
-              <div className="relative">
-                <span className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-zinc-400">
-                  <PiggyBank className="h-4 w-4" />
-                </span>
-                <select
-                  value={values.category_id}
-                  onChange={(event) => handleChange('category_id', event.target.value)}
-                  className="h-11 w-full rounded-2xl border-0 bg-white/80 pl-11 pr-10 text-sm text-zinc-900 shadow-inner shadow-white/20 ring-2 ring-white/50 transition focus:outline-none focus:ring-emerald-400 dark:bg-zinc-900/60 dark:text-zinc-50 dark:ring-white/10"
-                  required
-                >
-                  <option value="" disabled>
-                    Pilih kategori
-                  </option>
-                  {groupedCategories.map(([groupName, groupCategories]) => (
-                    <optgroup key={groupName} label={groupName}>
-                      {groupCategories.map((category) => (
-                        <option key={category.id} value={category.id}>
-                          {category.name}
-                        </option>
-                      ))}
-                    </optgroup>
-                  ))}
-                </select>
-              </div>
-              {errors.category_id ? <span className="text-xs font-medium text-rose-500">{errors.category_id}</span> : null}
-            </label>
-          </div>
-
-          <label className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">
-            Nominal Anggaran (IDR)
-            <input
-              type="number"
-              min="0"
-              step="1000"
-              value={values.amount_planned}
-              onChange={(event) => handleChange('amount_planned', Number(event.target.value))}
-              className="h-11 w-full rounded-2xl border-0 bg-white/80 px-4 text-sm text-zinc-900 shadow-inner shadow-white/20 ring-2 ring-white/50 transition focus:outline-none focus:ring-emerald-400 dark:bg-zinc-900/60 dark:text-zinc-50 dark:ring-white/10"
-              required
-            />
-            {errors.amount_planned ? <span className="text-xs font-medium text-rose-500">{errors.amount_planned}</span> : null}
-          </label>
-
-          <label className="flex items-center justify-between gap-4 rounded-2xl bg-white/70 px-4 py-3 text-sm font-medium text-zinc-600 shadow-inner ring-1 ring-white/40 transition dark:bg-zinc-900/50 dark:text-zinc-200 dark:ring-white/10">
-            <span>Aktifkan carryover ke bulan berikutnya</span>
-            <button
-              type="button"
-              onClick={() => handleChange('carryover_enabled', !values.carryover_enabled)}
-              className={`relative inline-flex h-6 w-12 cursor-pointer items-center rounded-full ${
-                values.carryover_enabled
-                  ? 'bg-emerald-500/80 dark:bg-emerald-500/70'
-                  : 'bg-zinc-200/70 dark:bg-zinc-800/70'
-              }`}
-            >
-              <span
-                className={`ml-1 h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
-                  values.carryover_enabled ? 'translate-x-6' : 'translate-x-0'
-                }`}
-              />
-            </button>
-          </label>
-
-          <label className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">
+        <div className="space-y-2">
+          <label htmlFor={notesId} className="form-label">
             Catatan (opsional)
-            <textarea
-              rows={3}
-              value={values.notes}
-              onChange={(event) => handleChange('notes', event.target.value)}
-              className="min-h-[96px] rounded-2xl border-0 bg-white/80 px-4 py-3 text-sm text-zinc-900 shadow-inner shadow-white/20 ring-2 ring-white/50 transition focus:outline-none focus:ring-emerald-400 dark:bg-zinc-900/60 dark:text-zinc-50 dark:ring-white/10"
-              placeholder="Catatan tambahan untuk anggaran ini"
-            />
           </label>
+          <textarea
+            id={notesId}
+            rows={3}
+            value={values.notes}
+            onChange={(event) => handleChange('notes', event.target.value)}
+            placeholder="Catatan tambahan untuk anggaran ini"
+          />
+        </div>
 
-          <div className="mt-2 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
-            <button
-              type="button"
-              onClick={onClose}
-              className="h-11 rounded-2xl border border-white/50 px-6 text-sm font-semibold text-zinc-600 shadow-sm transition hover:-translate-y-0.5 hover:bg-white dark:border-white/20 dark:text-zinc-200"
-            >
-              Batal
-            </button>
-            <button
-              type="submit"
-              disabled={submitting}
-              className="inline-flex h-11 items-center justify-center rounded-2xl bg-gradient-to-r from-emerald-500 via-emerald-500 to-emerald-600 px-6 text-sm font-semibold text-white shadow-lg shadow-emerald-500/30 transition hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-70"
-            >
-              {submitting ? 'Menyimpan...' : 'Simpan anggaran'}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
+        <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          <button type="button" onClick={onClose} className="btn btn-secondary">
+            Batal
+          </button>
+          <button type="submit" disabled={submitting} className="btn btn-primary">
+            {submitting ? 'Menyimpan...' : 'Simpan anggaran'}
+          </button>
+        </div>
+      </form>
+    </Modal>
   );
 }
 

--- a/src/pages/budgets/components/BudgetTable.tsx
+++ b/src/pages/budgets/components/BudgetTable.tsx
@@ -10,8 +10,7 @@ interface BudgetTableProps {
   onToggleCarryover: (row: BudgetWithSpent, carryover: boolean) => void;
 }
 
-const TABLE_WRAPPER_CLASS =
-  'rounded-2xl border border-white/20 dark:border-white/5 bg-gradient-to-b from-white/80 to-white/50 dark:from-zinc-900/60 dark:to-zinc-900/30 backdrop-blur shadow-sm overflow-hidden';
+const TABLE_WRAPPER_CLASS = 'card overflow-hidden p-0';
 
 function LoadingRows() {
   return (
@@ -62,15 +61,15 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
           ) : rows.length === 0 ? (
             <EmptyState />
           ) : (
-            <tbody className="divide-y divide-white/10 text-sm text-zinc-700 dark:text-zinc-200">
+            <tbody className="divide-y divide-border-subtle text-sm text-text">
               {rows.map((row) => {
-                const remainingClass = row.remaining < 0 ? 'text-rose-500 dark:text-rose-400' : 'text-emerald-600 dark:text-emerald-400';
+                const remainingClass = row.remaining < 0 ? 'text-danger' : 'text-success';
                 return (
                   <tr
                     key={row.id}
-                    className="transition-colors odd:bg-white/50 even:bg-white/40 hover:bg-white/70 dark:odd:bg-zinc-900/40 dark:even:bg-zinc-900/20 dark:hover:bg-zinc-900/60"
+                    className="transition-colors odd:bg-surface-alt/40 even:bg-surface-alt/60 hover:bg-surface-alt"
                   >
-                    <td className="px-4 py-4 font-medium text-zinc-900 dark:text-zinc-50">
+                    <td className="px-4 py-4 font-medium text-text">
                       {row.category?.name ?? 'Tanpa kategori'}
                     </td>
                     <td className="px-4 py-4">{formatCurrency(row.amount_planned, 'IDR')}</td>
@@ -86,11 +85,11 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
                           onChange={(event) => onToggleCarryover(row, event.target.checked)}
                           className="peer sr-only"
                         />
-                        <span className="absolute inset-0 rounded-full bg-zinc-200/70 transition peer-checked:bg-emerald-500/80 dark:bg-zinc-800/70 dark:peer-checked:bg-emerald-500/70" />
-                        <span className="relative ml-1 h-4 w-4 rounded-full bg-white shadow-sm transition-transform peer-checked:translate-x-6" />
+                        <span className="absolute inset-0 rounded-full bg-surface-alt transition peer-checked:bg-primary" />
+                        <span className="relative ml-1 h-4 w-4 rounded-full bg-surface shadow-sm transition-transform peer-checked:translate-x-6" />
                       </label>
                     </td>
-                    <td className="px-4 py-4 text-sm text-zinc-500 dark:text-zinc-400">
+                    <td className="px-4 py-4 text-sm text-muted">
                       {row.notes?.trim() ? row.notes : '—'}
                     </td>
                     <td className="px-4 py-4">
@@ -98,18 +97,16 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
                         <button
                           type="button"
                           onClick={() => onEdit(row)}
-                          className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-white/30 bg-white/60 text-zinc-600 shadow-sm transition hover:-translate-y-0.5 hover:bg-white dark:border-white/10 dark:bg-zinc-900/60 dark:text-zinc-200"
-                          aria-label={`Edit ${row.category?.name ?? 'budget'}`}
+                          className="btn btn-secondary btn-sm"
                         >
-                          <Pencil className="h-4 w-4" />
+                          <Pencil className="h-4 w-4" /> Edit
                         </button>
                         <button
                           type="button"
                           onClick={() => onDelete(row)}
-                          className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-rose-200/50 bg-rose-50/60 text-rose-500 shadow-sm transition hover:-translate-y-0.5 hover:bg-rose-100 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-300"
-                          aria-label={`Hapus ${row.category?.name ?? 'budget'}`}
+                          className="btn btn-danger btn-sm"
                         >
-                          <Trash2 className="h-4 w-4" />
+                          <Trash2 className="h-4 w-4" /> Hapus
                         </button>
                       </div>
                     </td>

--- a/src/pages/budgets/components/SummaryCards.tsx
+++ b/src/pages/budgets/components/SummaryCards.tsx
@@ -7,16 +7,15 @@ interface SummaryCardsProps {
   loading?: boolean;
 }
 
-const CARD_BASE_CLASS =
-  'rounded-2xl border border-white/20 dark:border-white/5 bg-gradient-to-b from-white/80 to-white/50 dark:from-zinc-900/60 dark:to-zinc-900/30 backdrop-blur shadow-sm';
+const CARD_BASE_CLASS = 'card h-full';
 
 function SummarySkeleton() {
   return (
     <div className={CARD_BASE_CLASS}>
       <div className="flex h-full flex-col gap-4 p-5">
-        <div className="h-4 w-32 animate-pulse rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
-        <div className="h-8 w-24 animate-pulse rounded-lg bg-zinc-200/70 dark:bg-zinc-700/70" />
-        <div className="h-2 w-full animate-pulse rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
+        <div className="h-4 w-32 animate-pulse rounded-full bg-surface-alt" />
+        <div className="h-8 w-24 animate-pulse rounded-lg bg-surface-alt" />
+        <div className="h-2 w-full animate-pulse rounded-full bg-surface-alt" />
       </div>
     </div>
   );
@@ -40,25 +39,25 @@ export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
       label: 'Total Anggaran',
       value: formatCurrency(summary.planned, 'IDR'),
       icon: Wallet,
-      accent: 'text-sky-600 dark:text-sky-400',
+      accent: 'text-primary',
     },
     {
       label: 'Realisasi',
       value: formatCurrency(summary.spent, 'IDR'),
       icon: TrendingDown,
-      accent: 'text-emerald-600 dark:text-emerald-400',
+      accent: 'text-info',
     },
     {
       label: 'Sisa',
       value: formatCurrency(summary.remaining, 'IDR'),
       icon: PiggyBank,
-      accent: 'text-purple-600 dark:text-purple-400',
+      accent: 'text-success',
     },
     {
       label: 'Persentase',
       value: `${(progress * 100).toFixed(0)}%`,
       icon: Target,
-      accent: 'text-orange-600 dark:text-orange-400',
+      accent: 'text-warning',
       progress,
     },
   ];
@@ -68,20 +67,20 @@ export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
       {cards.map(({ label, value, icon: Icon, accent, progress: cardProgress }) => (
         <div key={label} className={CARD_BASE_CLASS}>
           <div className="flex h-full flex-col gap-4 p-5">
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400">{label}</span>
+            <div className="flex items-center justify-between text-sm text-muted">
+              <span>{label}</span>
               <Icon className={`h-5 w-5 ${accent}`} />
             </div>
-            <span className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">{value}</span>
+            <span className="text-2xl font-semibold text-text">{value}</span>
             {typeof cardProgress === 'number' ? (
-              <div className="mt-auto">
-                <div className="flex items-center justify-between text-xs font-medium text-zinc-500 dark:text-zinc-400">
+              <div className="mt-auto space-y-2">
+                <div className="flex items-center justify-between text-xs font-medium text-muted">
                   <span>0%</span>
                   <span>100%</span>
                 </div>
-                <div className="mt-2 h-2 rounded-full bg-zinc-200/70 dark:bg-zinc-800/70">
+                <div className="h-2 rounded-full bg-surface-alt">
                   <div
-                    className="h-full rounded-full bg-gradient-to-r from-sky-500 via-sky-400 to-sky-300 dark:from-sky-400 dark:via-sky-500 dark:to-sky-600 transition-all"
+                    className="h-full rounded-full bg-primary transition-all"
                     style={{ width: `${cardProgress * 100}%` }}
                   />
                 </div>


### PR DESCRIPTION
## Summary
- use the shared page header to introduce breadcrumbs, refresh/add actions, and brand-aligned period controls while backfilling categories from existing budget rows when the API response is empty
- rebuild the budget form modal on top of the shared modal component, grouping categories, handling empty states gracefully, and updating inputs, toggles, and buttons to the primary theme
- refresh summary cards and the budget table to use consistent card surfaces, brand accent colours, and button styles for clearer calls to action

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d564b2febc8332be3b6317f63bf812