### PR TITLE
Add branded placeholder logo asset

### DIFF
--- a/src/assets/logo-placeholder.svg
+++ b/src/assets/logo-placeholder.svg
@@ -1,0 +1,18 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="hwLogoGradient" x1="12" y1="12" x2="52" y2="52" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#3F63F3" />
+      <stop offset="100%" stop-color="#738AE8" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="16" fill="url(#hwLogoGradient)" />
+  <path
+    fill="#F9FAFF"
+    d="M18 18h8v28h-8zM26 30h12v8H26zM38 18h8v28h-8z"
+  />
+  <path
+    opacity="0.16"
+    fill="#0B1F61"
+    d="M18 46h28c0 5.523-4.477 10-10 10H28c-5.523 0-10-4.477-10-10z"
+  />
+</svg>

--- a/src/components/Logo.jsx
+++ b/src/components/Logo.jsx
@@ -1,8 +1,14 @@
-export default function Logo() {
+import clsx from "clsx";
+
+import logoPlaceholder from "../assets/logo-placeholder.svg";
+
+export default function Logo({ className, ...props }) {
   return (
-    <div className="w-10 h-10 flex items-center justify-center bg-brand-var text-white rounded-lg font-bold">
-      HW
-      <span className="sr-only">HematWoi</span>
-    </div>
+    <img
+      src={logoPlaceholder}
+      alt="HematWoi"
+      className={clsx("h-10 w-10", className)}
+      {...props}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- replace the Logo component to render a reusable image element
- add a branded placeholder SVG asset that matches the application's accent colors

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d573269f448332b08239069db5bb69