### PR TITLE
Use budget RPC and view with searchable expense categories

### DIFF
--- a/src/pages/budgets/components/BudgetFormModal.tsx
+++ b/src/pages/budgets/components/BudgetFormModal.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react';
-import { Calendar, PiggyBank } from 'lucide-react';
+import { Calendar, PiggyBank, Search } from 'lucide-react';
 import type { ExpenseCategory } from '../../../lib/budgetApi';
 
 export interface BudgetFormValues {
@@ -48,11 +48,13 @@ export default function BudgetFormModal({
 }: BudgetFormModalProps) {
   const [values, setValues] = useState<BudgetFormValues>(initialValues);
   const [errors, setErrors] = useState<Partial<Record<keyof BudgetFormValues, string>>>({});
+  const [searchTerm, setSearchTerm] = useState('');
 
   useEffect(() => {
     if (open) {
       setValues(initialValues);
       setErrors({});
+      setSearchTerm('');
     }
   }, [open, initialValues]);
 
@@ -67,16 +69,25 @@ export default function BudgetFormModal({
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [open, onClose]);
 
+  const filteredCategories = useMemo(() => {
+    const normalized = searchTerm.trim().toLowerCase();
+    if (!normalized) return categories;
+    return categories.filter((category) => category.name.toLowerCase().includes(normalized));
+  }, [categories, searchTerm]);
+
   const groupedCategories = useMemo(() => {
     const groups = new Map<string, ExpenseCategory[]>();
-    for (const category of categories) {
+    for (const category of filteredCategories) {
       const key = category.group_name ?? 'Ungrouped';
       const list = groups.get(key) ?? [];
       list.push(category);
       groups.set(key, list);
     }
     return Array.from(groups.entries());
-  }, [categories]);
+  }, [filteredCategories]);
+
+  const hasCategories = categories.length > 0;
+  const hasFilteredCategories = filteredCategories.length > 0;
 
   const handleChange = (field: keyof BudgetFormValues, value: string | number | boolean) => {
     setValues((prev) => ({ ...prev, [field]: value }));
@@ -142,31 +153,53 @@ export default function BudgetFormModal({
 
             <label className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">
               Kategori
-              <div className="relative">
-                <span className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-zinc-400">
-                  <PiggyBank className="h-4 w-4" />
-                </span>
-                <select
-                  value={values.category_id}
-                  onChange={(event) => handleChange('category_id', event.target.value)}
-                  className="h-11 w-full rounded-2xl border border-border bg-surface pl-11 pr-10 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-                  required
-                >
-                  <option value="" disabled>
-                    Pilih kategori
-                  </option>
-                  {groupedCategories.map(([groupName, groupCategories]) => (
-                    <optgroup key={groupName} label={groupName}>
-                      {groupCategories.map((category) => (
-                        <option key={category.id} value={category.id}>
-                          {category.name}
-                        </option>
-                      ))}
-                    </optgroup>
-                  ))}
-                </select>
+              <div className="space-y-2">
+                <div className="relative">
+                  <span className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-zinc-400">
+                    <Search className="h-4 w-4" />
+                  </span>
+                  <input
+                    type="search"
+                    value={searchTerm}
+                    onChange={(event) => setSearchTerm(event.target.value)}
+                    placeholder="Cari kategori"
+                    className="h-10 w-full rounded-2xl border border-border bg-surface pl-11 pr-4 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+                  />
+                </div>
+                <div className="relative">
+                  <span className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-zinc-400">
+                    <PiggyBank className="h-4 w-4" />
+                  </span>
+                  <select
+                    value={values.category_id}
+                    onChange={(event) => handleChange('category_id', event.target.value)}
+                    className="h-11 w-full rounded-2xl border border-border bg-surface pl-11 pr-10 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 disabled:cursor-not-allowed disabled:opacity-60"
+                    required
+                    disabled={!hasFilteredCategories}
+                  >
+                    <option value="" disabled>
+                      Pilih kategori
+                    </option>
+                    {groupedCategories.map(([groupName, groupCategories]) => (
+                      <optgroup key={groupName} label={groupName}>
+                        {groupCategories.map((category) => (
+                          <option key={category.id} value={category.id}>
+                            {category.name}
+                          </option>
+                        ))}
+                      </optgroup>
+                    ))}
+                  </select>
+                </div>
               </div>
               {errors.category_id ? <span className="text-xs font-medium text-rose-500">{errors.category_id}</span> : null}
+              {!hasFilteredCategories ? (
+                <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">
+                  {hasCategories
+                    ? 'Tidak ada kategori yang cocok dengan pencarian.'
+                    : 'Belum ada kategori pengeluaran.'}
+                </span>
+              ) : null}
             </label>
           </div>
 


### PR DESCRIPTION
## Summary
- switch the budget data layer to call the v_categories_budget view and new bud_upsert RPC with REST headers and admin-friendly error handling
- expose firstDayOfMonth plus category fetching helpers and reuse them across budgets and transactions while excluding transfers from spent totals
- refresh the budget and transaction category pickers with search, empty states, and clearer fallbacks when metadata is missing

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d572f44de08332b5a600b5d6d74ef4