### PR TITLE
Use budget view and RPC for categories and budgets

### DIFF
--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -20,3 +20,5 @@ if (!supabaseUrl || !supabaseKey) {
 }
 
 export const supabase = createClient(supabaseUrl, supabaseKey)
+export const SUPABASE_URL = supabaseUrl
+export const SUPABASE_ANON_KEY = supabaseKey

--- a/src/lib/supabaseRest.ts
+++ b/src/lib/supabaseRest.ts
@@ -1,0 +1,69 @@
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from './supabase';
+
+type SupabaseRestHeaders = Record<string, string>;
+
+const isDevelopment = Boolean(
+  (typeof import.meta !== 'undefined' && import.meta.env?.DEV) ||
+    (typeof process !== 'undefined' && process.env?.NODE_ENV === 'development')
+);
+
+function ensureSupabaseEnv() {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    throw new Error('Supabase environment variables are missing');
+  }
+}
+
+export function buildSupabaseHeaders(asJson = false): SupabaseRestHeaders {
+  ensureSupabaseEnv();
+  const headers: SupabaseRestHeaders = {
+    apikey: SUPABASE_ANON_KEY!,
+    Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+  };
+  if (asJson) {
+    headers['Content-Type'] = 'application/json';
+  }
+  return headers;
+}
+
+export function createRestUrl(path: string, params?: URLSearchParams): string {
+  ensureSupabaseEnv();
+  const base = SUPABASE_URL!.replace(/\/$/, '');
+  if (!params || Array.from(params.keys()).length === 0) {
+    return `${base}${path.startsWith('/') ? '' : '/'}${path}`;
+  }
+  return `${base}${path.startsWith('/') ? '' : '/'}${path}?${params.toString()}`;
+}
+
+export async function fetchJson<T = unknown>(
+  url: string,
+  init?: RequestInit
+): Promise<T> {
+  const response = await fetch(url, init);
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  if (!response.ok) {
+    let message = `HTTP ${response.status}`;
+    try {
+      const body = await response.json();
+      if (body?.message) {
+        message = body.message;
+      }
+    } catch (error) {
+      if (isDevelopment) {
+        console.warn('[HW] Failed to parse error response', error);
+      }
+    }
+    const err = new Error(message);
+    throw err;
+  }
+  try {
+    return (await response.json()) as T;
+  } catch (error) {
+    if (isDevelopment) {
+      console.warn('[HW] Failed to parse JSON response', error);
+    }
+    throw error;
+  }
+}
+

--- a/src/pages/budgets/components/BudgetFormModal.tsx
+++ b/src/pages/budgets/components/BudgetFormModal.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react';
-import { Calendar, PiggyBank } from 'lucide-react';
+import { Calendar, PiggyBank, Search } from 'lucide-react';
 import type { ExpenseCategory } from '../../../lib/budgetApi';
 
 export interface BudgetFormValues {
@@ -48,11 +48,13 @@ export default function BudgetFormModal({
 }: BudgetFormModalProps) {
   const [values, setValues] = useState<BudgetFormValues>(initialValues);
   const [errors, setErrors] = useState<Partial<Record<keyof BudgetFormValues, string>>>({});
+  const [categoryQuery, setCategoryQuery] = useState('');
 
   useEffect(() => {
     if (open) {
       setValues(initialValues);
       setErrors({});
+      setCategoryQuery('');
     }
   }, [open, initialValues]);
 
@@ -67,16 +69,35 @@ export default function BudgetFormModal({
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [open, onClose]);
 
+  const filteredCategories = useMemo(() => {
+    const keyword = categoryQuery.trim().toLowerCase();
+    if (!keyword) return categories;
+    return categories.filter((category) => category.name.toLowerCase().includes(keyword));
+  }, [categories, categoryQuery]);
+
   const groupedCategories = useMemo(() => {
     const groups = new Map<string, ExpenseCategory[]>();
-    for (const category of categories) {
+    for (const category of filteredCategories) {
       const key = category.group_name ?? 'Ungrouped';
       const list = groups.get(key) ?? [];
       list.push(category);
       groups.set(key, list);
     }
     return Array.from(groups.entries());
-  }, [categories]);
+  }, [filteredCategories]);
+
+  const emptyMessage = useMemo(() => {
+    if (categories.length === 0) {
+      return 'Belum ada kategori pengeluaran';
+    }
+    if (filteredCategories.length === 0 && categoryQuery.trim()) {
+      return 'Tidak ada kategori yang cocok dengan pencarian';
+    }
+    if (filteredCategories.length === 0) {
+      return 'Belum ada kategori pengeluaran';
+    }
+    return null;
+  }, [categories.length, filteredCategories.length, categoryQuery]);
 
   const handleChange = (field: keyof BudgetFormValues, value: string | number | boolean) => {
     setValues((prev) => ({ ...prev, [field]: value }));
@@ -142,31 +163,54 @@ export default function BudgetFormModal({
 
             <label className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">
               Kategori
-              <div className="relative">
-                <span className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-zinc-400">
-                  <PiggyBank className="h-4 w-4" />
-                </span>
-                <select
-                  value={values.category_id}
-                  onChange={(event) => handleChange('category_id', event.target.value)}
-                  className="h-11 w-full rounded-2xl border border-border bg-surface pl-11 pr-10 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-                  required
-                >
-                  <option value="" disabled>
-                    Pilih kategori
-                  </option>
-                  {groupedCategories.map(([groupName, groupCategories]) => (
-                    <optgroup key={groupName} label={groupName}>
-                      {groupCategories.map((category) => (
-                        <option key={category.id} value={category.id}>
-                          {category.name}
-                        </option>
-                      ))}
-                    </optgroup>
-                  ))}
-                </select>
+              <div className="flex flex-col gap-2">
+                <div className="relative">
+                  <span className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-zinc-400">
+                    <Search className="h-4 w-4" aria-hidden="true" />
+                  </span>
+                  <label htmlFor="budget-category-search" className="sr-only">
+                    Cari kategori pengeluaran
+                  </label>
+                  <input
+                    id="budget-category-search"
+                    type="search"
+                    value={categoryQuery}
+                    onChange={(event) => setCategoryQuery(event.target.value)}
+                    placeholder="Cari kategori…"
+                    className="h-10 w-full rounded-2xl border border-border bg-surface pl-11 pr-4 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+                  />
+                </div>
+                <div className="relative">
+                  <span className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-zinc-400">
+                    <PiggyBank className="h-4 w-4" aria-hidden="true" />
+                  </span>
+                  <select
+                    value={values.category_id}
+                    onChange={(event) => handleChange('category_id', event.target.value)}
+                    className="h-11 w-full rounded-2xl border border-border bg-surface pl-11 pr-10 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+                    required
+                    disabled={filteredCategories.length === 0}
+                  >
+                    <option value="" disabled>
+                      Pilih kategori
+                    </option>
+                    {groupedCategories.map(([groupName, groupCategories]) => (
+                      <optgroup key={groupName} label={groupName}>
+                        {groupCategories.map((category) => (
+                          <option key={category.id} value={category.id}>
+                            {category.name}
+                          </option>
+                        ))}
+                      </optgroup>
+                    ))}
+                  </select>
+                </div>
               </div>
-              {errors.category_id ? <span className="text-xs font-medium text-rose-500">{errors.category_id}</span> : null}
+              {errors.category_id ? (
+                <span className="text-xs font-medium text-rose-500">{errors.category_id}</span>
+              ) : emptyMessage ? (
+                <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">{emptyMessage}</span>
+              ) : null}
             </label>
           </div>
 


### PR DESCRIPTION
## Summary
- add a shared Supabase REST helper and expose Supabase env values for reuse
- fetch expense categories through the v_categories_budget view with graceful fallback, update budget RPC usage, and skip transfers when computing spent
- refresh the budgets and add-transaction forms with category search, friendly empty messaging, and the new budget upsert flow

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d572f44de08332b5a600b5d6d74ef4