### PR TITLE
Use budget view and RPC for expense categories

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -612,7 +612,8 @@ export async function deleteTransaction(id) {
 // -- CATEGORIES ----------------------------------------
 
 function mapCategoryRow(row = {}, userId) {
-  const typeFromGroup = typeof row.group === "string" ? row.group.toLowerCase() : "";
+  const rawGroup = row.group_name ?? row.group ?? null;
+  const typeFromGroup = typeof rawGroup === "string" ? rawGroup.toLowerCase() : "";
   const rawType = row.type ?? row.category_type;
   const inferredType = rawType
     ? rawType
@@ -638,7 +639,7 @@ function mapCategoryRow(row = {}, userId) {
     user_id: row.user_id ?? userId ?? null,
     name: row.name ?? row.title ?? row.label ?? "",
     type: normalizedType,
-    group: row.group ?? null,
+    group: rawGroup,
     order_index: orderIndex,
     inserted_at: row.inserted_at ?? row.created_at ?? null,
   };
@@ -658,7 +659,7 @@ export async function listCategories(type) {
   try {
     const { data, error } = await supabase
       .from("categories")
-      .select('id, user_id, type, name, order_index, inserted_at, "group"')
+      .select('id, user_id, type, name, order_index, inserted_at, group_name')
       .eq("user_id", userId);
     if (error) throw error;
     const rows = (data || []).map((row) => mapCategoryRow(row, userId));

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -6,8 +6,8 @@ const nodeEnv =
     ? globalThis.process.env
     : {}
 
-const supabaseUrl = browserEnv.VITE_SUPABASE_URL ?? nodeEnv.VITE_SUPABASE_URL
-const supabaseKey =
+export const supabaseUrl = browserEnv.VITE_SUPABASE_URL ?? nodeEnv.VITE_SUPABASE_URL
+export const supabaseKey =
   browserEnv.VITE_SUPABASE_PUBLISHABLE_KEY ??
   browserEnv.VITE_SUPABASE_ANON_KEY ??
   nodeEnv.VITE_SUPABASE_PUBLISHABLE_KEY ??
@@ -19,4 +19,4 @@ if (!supabaseUrl || !supabaseKey) {
   )
 }
 
-export const supabase = createClient(supabaseUrl, supabaseKey)
+export const supabase = createClient(supabaseUrl ?? '', supabaseKey ?? '')

--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -288,6 +288,7 @@ export default function BudgetsPage() {
         open={modalOpen}
         title={editing ? 'Edit anggaran' : 'Tambah anggaran'}
         categories={categories}
+        categoriesLoading={categoriesLoading}
         initialValues={initialFormValues}
         submitting={submitting}
         onClose={() => {


### PR DESCRIPTION
## Summary
- switch expense category loading to the v_categories_budget view with REST fallback and shared firstDayOfMonth helper
- upsert budgets through the bud_upsert RPC with clearer error handling and exclude transfers from spent totals
- refresh budget and transaction category pickers with search, empty states, and consistent messaging

## Testing
- pnpm lint
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68d572f44de08332b5a600b5d6d74ef4