### PR TITLE
Fix bud_upsert RPC authentication handling

### DIFF
--- a/src/lib/budgetApi.ts
+++ b/src/lib/budgetApi.ts
@@ -1,5 +1,5 @@
 import { supabase } from './supabase';
-import { getCurrentUserId } from './session';
+import { getCurrentUserId, getUserToken } from './session';
 import { listCategories as listAllCategories } from './api-categories';
 
 type UUID = string;
@@ -208,15 +208,32 @@ export async function computeSpent(period: string): Promise<Record<string, numbe
 export async function upsertBudget(input: UpsertBudgetInput): Promise<void> {
   const userId = await getCurrentUserId();
   ensureAuth(userId);
+  try {
+    await getUserToken();
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Not signed in') {
+      throw new Error('Silakan login untuk menyimpan anggaran');
+    }
+    throw error;
+  }
   const payload = {
-    category_id: input.category_id,
-    amount_planned: input.amount_planned,
-    period_month: toMonthStart(input.period),
-    carryover_enabled: input.carryover_enabled,
-    notes: input.notes ?? null,
+    p_category_id: input.category_id,
+    p_amount_planned: Number(input.amount_planned ?? 0),
+    p_period_month: toMonthStart(input.period),
+    p_carryover_enabled: Boolean(input.carryover_enabled),
+    p_notes: input.notes ?? null,
   };
   const { error } = await supabase.rpc('bud_upsert', payload);
-  if (error) throw error;
+  if (error) {
+    if (error.message === 'Unauthorized' || error.code === '401' || error.code === 'PGRST301') {
+      throw new Error('Silakan login untuk menyimpan anggaran');
+    }
+    const message = error.message?.toLowerCase?.() ?? '';
+    if (error.code === '404' || message.includes('bud_upsert')) {
+      throw new Error('Fungsi bud_upsert belum tersedia, jalankan migrasi SQL di server');
+    }
+    throw error;
+  }
 }
 
 export async function deleteBudget(id: UUID): Promise<void> {

--- a/src/lib/session.js
+++ b/src/lib/session.js
@@ -17,3 +17,13 @@ export async function getCurrentUserId() {
 export function clearCachedUser() {
   cachedUserId = null;
 }
+
+export async function getUserToken() {
+  const { data, error } = await supabase.auth.getSession();
+  if (error) throw error;
+  const accessToken = data.session?.access_token ?? null;
+  if (!accessToken) {
+    throw new Error("Not signed in");
+  }
+  return accessToken;
+}


### PR DESCRIPTION
## Summary
- add a helper to retrieve the current user's access token from Supabase auth
- send bud_upsert RPC requests with the correct argument names and user session messaging

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d5cef223208332aaac1e18e4e06da7