### PR TITLE
Fix bud_upsert RPC authentication for budgets

### DIFF
--- a/src/lib/session.js
+++ b/src/lib/session.js
@@ -17,3 +17,13 @@ export async function getCurrentUserId() {
 export function clearCachedUser() {
   cachedUserId = null;
 }
+
+export async function getUserToken() {
+  const { data, error } = await supabase.auth.getSession();
+  if (error) throw error;
+  const token = data?.session?.access_token ?? null;
+  if (!token) {
+    throw new Error("Not signed in");
+  }
+  return token;
+}


### PR DESCRIPTION
## Summary
- add a reusable helper to fetch the current user's access token and raise when unauthenticated
- refactor budget RPC upsert to validate the session, call the stored procedure with expected arguments, and normalize auth/missing RPC errors

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d5cef223208332aaac1e18e4e06da7