### PR TITLE
Add per-user accent color customization

### DIFF
--- a/src/components/AccentPicker.tsx
+++ b/src/components/AccentPicker.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useMemo, useState } from "react";
+import type { ChangeEvent, FormEvent } from "react";
+import clsx from "clsx";
+import { Check } from "lucide-react";
+import { useAccent } from "../context/AccentContext";
+import { useToast } from "../context/ToastContext";
+import { normalizeAccentHex } from "../lib/api-user-settings";
+
+const PRESET_COLORS = [
+  "#3898f8",
+  "#2584e4",
+  "#50b6ff",
+  "#10b981",
+  "#f59e0b",
+  "#ef4444",
+  "#8b5cf6",
+  "#14b8a6",
+] as const;
+
+type AccentResult = { ok: boolean; error?: string };
+
+export default function AccentPicker() {
+  const { accent, setAccent, loading, saving, error } = useAccent();
+  const toast = useToast();
+  const [inputValue, setInputValue] = useState<string>(accent);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setInputValue(accent);
+  }, [accent]);
+
+  const normalizedInput = useMemo(() => {
+    try {
+      return normalizeAccentHex(inputValue);
+    } catch {
+      return null;
+    }
+  }, [inputValue]);
+
+  const colorPickerValue = normalizedInput ?? accent;
+  const activeAccent = accent.toUpperCase();
+  const combinedError = formError ?? error;
+  const isBusy = saving || loading;
+
+  const handlePreset = async (hex: string) => {
+    if (isBusy) return;
+    setFormError(null);
+    setInputValue(hex.toUpperCase());
+    const result = await persistAccent(hex);
+    handleResult(result);
+  };
+
+  const persistAccent = async (hex: string): Promise<AccentResult> => {
+    setFormError(null);
+    const result = await setAccent(hex);
+    return result;
+  };
+
+  const handleResult = (result: AccentResult, successMessage = "Warna aksen diperbarui") => {
+    if (result.ok) {
+      toast?.addToast(successMessage, "success");
+      setFormError(null);
+    } else {
+      const message = result.error ?? "Gagal memperbarui warna";
+      setFormError(message);
+      toast?.addToast("Gagal memperbarui warna aksen", "error");
+    }
+  };
+
+  const handleColorInput = (event: ChangeEvent<HTMLInputElement>) => {
+    setFormError(null);
+    setInputValue(event.target.value.toUpperCase());
+  };
+
+  const handleTextInput = (event: ChangeEvent<HTMLInputElement>) => {
+    setFormError(null);
+    const raw = event.target.value.trim().replace(/\s+/g, "");
+    if (!raw) {
+      setInputValue("");
+      return;
+    }
+    const prefixed = raw.startsWith("#") ? raw : `#${raw}`;
+    setInputValue(prefixed.toUpperCase());
+  };
+
+  const handleBlur = () => {
+    if (!inputValue) return;
+    try {
+      setInputValue(normalizeAccentHex(inputValue));
+    } catch {
+      // keep current invalid value until corrected
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isBusy) return;
+    const hex = inputValue || accent;
+    const result = await persistAccent(hex);
+    handleResult(result, "Warna aksen disimpan");
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-4" aria-hidden>
+        <div className="h-4 w-32 rounded-lg bg-surface-2 animate-pulse" />
+        <div className="flex flex-wrap gap-3">
+          {PRESET_COLORS.map((color) => (
+            <div
+              key={color}
+              className="h-10 w-10 rounded-full bg-surface-2 animate-pulse"
+            />
+          ))}
+        </div>
+        <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
+          <div className="h-12 rounded-xl bg-surface-2 animate-pulse" />
+          <div className="h-12 rounded-xl bg-surface-2 animate-pulse" />
+          <div className="h-12 rounded-xl bg-surface-2 animate-pulse" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form className="space-y-5" onSubmit={handleSubmit}>
+      <div>
+        <p className="text-sm font-medium text-muted">Pilih warna aksen</p>
+        <div className="mt-3 flex flex-wrap gap-3">
+          {PRESET_COLORS.map((color) => {
+            const selected = activeAccent === color.toUpperCase();
+            return (
+              <button
+                key={color}
+                type="button"
+                className={clsx(
+                  "relative flex h-10 w-10 items-center justify-center rounded-full border-2 transition",
+                  selected
+                    ? "border-[var(--accent,#3898f8)]"
+                    : "border-transparent hover:border-[var(--accent-ring,rgba(56,152,248,0.35))]",
+                  isBusy && "pointer-events-none opacity-60"
+                )}
+                style={{ backgroundColor: color }}
+                onClick={() => handlePreset(color)}
+                aria-label={`Pilih warna aksen ${color}`}
+              >
+                {selected ? (
+                  <Check
+                    className="h-5 w-5"
+                    style={{ color: "var(--accent-foreground, #ffffff)" }}
+                  />
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] sm:items-end">
+        <label className="flex flex-col gap-2 text-sm font-medium text-muted">
+          <span>Pemilih warna</span>
+          <input
+            type="color"
+            value={colorPickerValue}
+            onChange={handleColorInput}
+            disabled={isBusy}
+            className="h-12 w-full cursor-pointer rounded-xl border border-border-subtle bg-surface"
+            aria-label="Pilih warna aksen"
+          />
+        </label>
+        <label className="flex flex-col gap-2 text-sm font-medium text-muted">
+          <span>Kode hex</span>
+          <input
+            type="text"
+            value={inputValue}
+            onChange={handleTextInput}
+            onBlur={handleBlur}
+            placeholder="#3898F8"
+            className="h-12 rounded-xl border border-border-subtle bg-surface px-3 font-mono text-sm uppercase tracking-wide text-text"
+            aria-label="Masukkan kode warna hex"
+            disabled={isBusy}
+          />
+        </label>
+        <button
+          type="submit"
+          className="btn btn-primary h-12 px-6"
+          disabled={isBusy}
+          aria-label="Simpan warna aksen"
+        >
+          {saving ? "Menyimpan..." : "Simpan"}
+        </button>
+      </div>
+      {combinedError ? (
+        <p className="form-error" role="alert">
+          {combinedError}
+        </p>
+      ) : null}
+    </form>
+  );
+}

--- a/src/components/sidebar/SidebarItem.tsx
+++ b/src/components/sidebar/SidebarItem.tsx
@@ -28,14 +28,14 @@ export default function SidebarItem({
       title={collapsed ? label : undefined}
       className={({ isActive }) =>
         clsx(
-          "relative isolate flex h-11 min-w-0 items-center gap-3 rounded-xl px-3 text-sm font-medium tracking-tight text-muted transition-[background-color,color,box-shadow] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60",
-          "before:absolute before:left-0 before:top-1.5 before:bottom-1.5 before:w-1 before:rounded-full before:bg-brand before:opacity-0 before:transition-opacity before:content-['']",
+          "relative isolate flex h-11 min-w-0 items-center gap-3 rounded-xl px-3 text-sm font-medium tracking-tight text-muted transition-[background-color,color,box-shadow] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-ring,rgba(56,152,248,0.35))]",
+          "before:absolute before:left-0 before:top-1.5 before:bottom-1.5 before:w-1 before:rounded-full before:bg-[var(--accent,#3898f8)] before:opacity-0 before:transition-opacity before:content-['']",
           !collapsed && "justify-start",
           collapsed && "justify-center px-2",
           disabled && "pointer-events-none opacity-40",
-          !disabled && "hover:bg-muted/20",
+          !disabled && "hover:bg-[var(--accent-soft,rgba(56,152,248,0.12))]",
           isActive &&
-            "bg-brand/10 text-brand ring-1 ring-brand/20 before:opacity-100"
+            "bg-[var(--accent-soft,rgba(56,152,248,0.12))] text-[var(--accent,#3898f8)] shadow-[inset_0_0_0_1px_var(--accent-ring,rgba(56,152,248,0.35))] before:opacity-100"
         )
       }
       onClick={onNavigate}

--- a/src/context/AccentContext.tsx
+++ b/src/context/AccentContext.tsx
@@ -1,0 +1,263 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import type { ReactNode } from "react";
+import {
+  getUserSettings,
+  normalizeAccentHex,
+  upsertAccentColor,
+} from "../lib/api-user-settings";
+import { supabase } from "../lib/supabase";
+
+const DEFAULT_ACCENT = "#3898F8";
+const STORAGE_KEY = "hw:accent-color";
+
+type AccentContextValue = {
+  accent: string;
+  loading: boolean;
+  saving: boolean;
+  error: string | null;
+  setAccent: (hex: string) => Promise<{ ok: boolean; error?: string }>;
+  refresh: () => Promise<void>;
+};
+
+const AccentContext = createContext<AccentContextValue | undefined>(undefined);
+
+const fallbackValue: AccentContextValue = {
+  accent: DEFAULT_ACCENT,
+  loading: false,
+  saving: false,
+  error: null,
+  setAccent: async () => ({ ok: true as const }),
+  refresh: async () => {},
+};
+
+function readStoredAccent(): string | null {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return null;
+    }
+    try {
+      return normalizeAccentHex(stored);
+    } catch {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+}
+
+type RgbColor = { r: number; g: number; b: number };
+
+function hexToRgb(hex: string): RgbColor {
+  const normalized = hex.slice(1);
+  const full =
+    normalized.length === 3
+      ? `${normalized[0]}${normalized[0]}${normalized[1]}${normalized[1]}${normalized[2]}${normalized[2]}`
+      : normalized;
+  const r = parseInt(full.slice(0, 2), 16);
+  const g = parseInt(full.slice(2, 4), 16);
+  const b = parseInt(full.slice(4, 6), 16);
+  return { r, g, b };
+}
+
+function rgbChannelToHex(channel: number): string {
+  const clamped = Math.max(0, Math.min(255, Math.round(channel)));
+  return clamped.toString(16).padStart(2, "0");
+}
+
+function rgbToHex(color: RgbColor): string {
+  return `#${rgbChannelToHex(color.r)}${rgbChannelToHex(color.g)}${rgbChannelToHex(color.b)}`.toUpperCase();
+}
+
+function mixColors(base: string, target: string, amount: number): string {
+  const t = Math.max(0, Math.min(1, amount));
+  const source = hexToRgb(base);
+  const mix = hexToRgb(target);
+  return rgbToHex({
+    r: source.r * (1 - t) + mix.r * t,
+    g: source.g * (1 - t) + mix.g * t,
+    b: source.b * (1 - t) + mix.b * t,
+  });
+}
+
+function lighten(hex: string, amount: number): string {
+  return mixColors(hex, "#ffffff", amount);
+}
+
+function darken(hex: string, amount: number): string {
+  return mixColors(hex, "#000000", amount);
+}
+
+function channelToLinear(value: number): number {
+  const v = value / 255;
+  return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+}
+
+function getContrastText(color: RgbColor): string {
+  const luminance =
+    0.2126 * channelToLinear(color.r) +
+    0.7152 * channelToLinear(color.g) +
+    0.0722 * channelToLinear(color.b);
+  return luminance > 0.58 ? "#0B1220" : "#FFFFFF";
+}
+
+export function useAccent(): AccentContextValue {
+  const context = useContext(AccentContext);
+  return context ?? fallbackValue;
+}
+
+export function AccentProvider({ children }: { children: ReactNode }) {
+  const [accent, setAccentState] = useState<string>(DEFAULT_ACCENT);
+  const [userId, setUserId] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [saving, setSaving] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const applyAccent = useCallback((hex: string) => {
+    const normalized = normalizeAccentHex(hex);
+    setAccentState(normalized);
+
+    try {
+      localStorage.setItem(STORAGE_KEY, normalized);
+    } catch {
+      /* ignore quota errors */
+    }
+
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    const root = document.documentElement;
+    const rgb = hexToRgb(normalized);
+    root.style.setProperty("--accent", normalized);
+    root.style.setProperty("--accent-rgb", `${rgb.r} ${rgb.g} ${rgb.b}`);
+    root.style.setProperty("--accent-soft", `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, 0.12)`);
+    root.style.setProperty("--accent-ring", `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, 0.35)`);
+    root.style.setProperty("--accent-hover", lighten(normalized, 0.12));
+    root.style.setProperty("--accent-active", darken(normalized, 0.18));
+    root.style.setProperty("--accent-foreground", getContrastText(rgb));
+  }, []);
+
+  const resolveAccent = useCallback(
+    async (uid: string | null): Promise<string> => {
+      const stored = readStoredAccent();
+      let next = stored ?? DEFAULT_ACCENT;
+
+      if (uid) {
+        try {
+          const settings = await getUserSettings(uid);
+          if (settings?.accent_color) {
+            try {
+              next = normalizeAccentHex(settings.accent_color);
+            } catch {
+              next = stored ?? DEFAULT_ACCENT;
+            }
+          } else if (stored) {
+            next = stored;
+            try {
+              await upsertAccentColor(uid, stored);
+            } catch {
+              /* ignore sync failure - will retry later */
+            }
+          }
+        } catch {
+          next = stored ?? DEFAULT_ACCENT;
+        }
+      }
+
+      return next;
+    },
+    []
+  );
+
+  useEffect(() => {
+    let active = true;
+    supabase.auth.getSession().then(({ data }) => {
+      if (!active) return;
+      setUserId(data.session?.user?.id ?? null);
+    });
+
+    const { data } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUserId(session?.user?.id ?? null);
+    });
+
+    return () => {
+      active = false;
+      data.subscription?.unsubscribe?.();
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setLoading(true);
+      const nextAccent = await resolveAccent(userId);
+      if (cancelled) return;
+      applyAccent(nextAccent);
+      setError(null);
+      setLoading(false);
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, resolveAccent, applyAccent]);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    const nextAccent = await resolveAccent(userId);
+    applyAccent(nextAccent);
+    setError(null);
+    setLoading(false);
+  }, [applyAccent, resolveAccent, userId]);
+
+  const setAccent = useCallback(
+    async (hex: string) => {
+      try {
+        const normalized = normalizeAccentHex(hex);
+        setError(null);
+        applyAccent(normalized);
+
+        if (userId) {
+          setSaving(true);
+          try {
+            await upsertAccentColor(userId, normalized);
+          } catch {
+            setSaving(false);
+            const message = "Gagal menyimpan warna aksen";
+            setError(message);
+            return { ok: false as const, error: message };
+          }
+          setSaving(false);
+        }
+
+        return { ok: true as const };
+      } catch (err) {
+        const message =
+          err instanceof Error
+            ? err.message
+            : "Format warna harus #RGB atau #RRGGBB";
+        setError(message);
+        return { ok: false as const, error: message };
+      }
+    },
+    [applyAccent, userId]
+  );
+
+  const value = useMemo(
+    () => ({ accent, loading, saving, error, setAccent, refresh }),
+    [accent, loading, saving, error, setAccent, refresh]
+  );
+
+  return <AccentContext.Provider value={value}>{children}</AccentContext.Provider>;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -27,6 +27,14 @@
     --color-surface-alt-hover: 241 238 232;
     --color-surface-elevated: 255 255 255;
 
+    --accent: #3898f8;
+    --accent-rgb: 56 152 248;
+    --accent-soft: rgba(56, 152, 248, 0.12);
+    --accent-ring: rgba(56, 152, 248, 0.35);
+    --accent-hover: #2584e4;
+    --accent-active: #1f6ecc;
+    --accent-foreground: #ffffff;
+
     --color-border-subtle: 228 231 236;
     --color-border-strong: 102 112 133;
 
@@ -83,6 +91,9 @@
     --color-surface-alt: 36 41 55;
     --color-surface-alt-hover: 42 47 62;
     --color-surface-elevated: 33 37 49;
+
+    --accent-soft: rgba(56, 152, 248, 0.18);
+    --accent-ring: rgba(56, 152, 248, 0.5);
 
     --color-border-subtle: 46 51 64;
     --color-border-strong: 100 108 136;
@@ -270,19 +281,27 @@
   }
 
   .btn {
-    @apply inline-flex min-h-[44px] items-center justify-center gap-2 rounded-2xl border border-border-subtle bg-surface-alt px-4 text-sm font-semibold text-text transition-colors duration-200 ease-out shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/45 disabled:cursor-not-allowed disabled:opacity-60;
+    @apply inline-flex min-h-[44px] items-center justify-center gap-2 rounded-2xl border border-border-subtle bg-surface-alt px-4 text-sm font-semibold text-text transition-colors duration-200 ease-out shadow-sm disabled:cursor-not-allowed disabled:opacity-60;
+  }
+
+  .btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--accent-ring, rgba(56, 152, 248, 0.35));
   }
 
   .btn-primary {
-    @apply border-transparent bg-primary text-text-inverse shadow-sm;
+    border-color: transparent;
+    background-color: var(--accent, #3898f8);
+    color: var(--accent-foreground, #ffffff);
+    box-shadow: 0 1px 2px 0 rgb(15 23 42 / 0.12);
   }
 
   .btn-primary:hover:not(:disabled) {
-    background-color: hsl(var(--color-primary-hover));
+    background-color: var(--accent-hover, #2584e4);
   }
 
   .btn-primary:active:not(:disabled) {
-    background-color: hsl(var(--color-primary-active));
+    background-color: var(--accent-active, #1f6ecc);
   }
 
   .btn-secondary {
@@ -298,7 +317,8 @@
   }
 
   .btn-ghost:hover:not(:disabled) {
-    @apply bg-primary/10 text-text;
+    background-color: var(--accent-soft, rgba(56, 152, 248, 0.12));
+    color: var(--accent, #3898f8);
   }
 
   .btn-danger {
@@ -314,7 +334,10 @@
   }
 
   .badge {
-    @apply inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/15 px-3 py-1 text-xs font-medium text-primary;
+    @apply inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium;
+    border: 1px solid var(--accent-ring, rgba(56, 152, 248, 0.35));
+    background-color: var(--accent-soft, rgba(56, 152, 248, 0.12));
+    color: var(--accent, #3898f8);
   }
 
   .badge-muted {
@@ -342,7 +365,10 @@
   }
 
   .chip {
-    @apply inline-flex items-center gap-1 rounded-full border border-border-subtle bg-primary/10 px-3 py-1 text-xs font-medium text-primary ring-1 ring-primary/20;
+    @apply inline-flex items-center gap-1 rounded-full border border-border-subtle px-3 py-1 text-xs font-medium;
+    background-color: var(--accent-soft, rgba(56, 152, 248, 0.12));
+    color: var(--accent, #3898f8);
+    box-shadow: 0 0 0 1px var(--accent-ring, rgba(56, 152, 248, 0.2));
   }
 }
 

--- a/src/layout/Breadcrumbs.jsx
+++ b/src/layout/Breadcrumbs.jsx
@@ -13,7 +13,7 @@ export default function Breadcrumbs() {
     <nav aria-label="Breadcrumb" className="mb-2 text-xs text-muted">
       <ol className="flex items-center gap-1">
         <li>
-          <NavLink to="/" className="hover:text-brand">
+          <NavLink to="/" className="hover:text-[var(--accent,#3898f8)]">
             Home
           </NavLink>
         </li>
@@ -26,7 +26,7 @@ export default function Breadcrumbs() {
               {isLast ? (
                 <span>{capitalize(seg)}</span>
               ) : (
-                <NavLink to={path} className="hover:text-brand">
+                <NavLink to={path} className="hover:text-[var(--accent,#3898f8)]">
                   {capitalize(seg)}
                 </NavLink>
               )}

--- a/src/lib/api-user-settings.ts
+++ b/src/lib/api-user-settings.ts
@@ -1,0 +1,57 @@
+import { supabase } from "./supabase";
+
+export interface UserSettings {
+  user_id: string;
+  accent_color: string | null;
+}
+
+export const ACCENT_HEX_PATTERN = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+export function normalizeAccentHex(input: string): string {
+  const trimmed = (input ?? "").trim();
+  if (!trimmed) {
+    throw new Error("Warna aksen wajib diisi");
+  }
+
+  const prefixed = trimmed.startsWith("#") ? trimmed : `#${trimmed}`;
+
+  if (!ACCENT_HEX_PATTERN.test(prefixed)) {
+    throw new Error("Format warna harus #RGB atau #RRGGBB");
+  }
+
+  const hex = prefixed.length === 4
+    ? `#${prefixed[1]}${prefixed[1]}${prefixed[2]}${prefixed[2]}${prefixed[3]}${prefixed[3]}`
+    : prefixed;
+
+  return hex.toUpperCase();
+}
+
+export async function getUserSettings(userId: string): Promise<UserSettings | null> {
+  const { data, error } = await supabase
+    .from("user_settings")
+    .select("user_id, accent_color")
+    .eq("user_id", userId)
+    .maybeSingle<UserSettings>();
+
+  if (error) {
+    throw error;
+  }
+
+  return data ?? null;
+}
+
+export async function upsertAccentColor(userId: string, hex: string): Promise<UserSettings | null> {
+  const normalized = normalizeAccentHex(hex);
+
+  const { data, error } = await supabase
+    .from("user_settings")
+    .upsert({ user_id: userId, accent_color: normalized }, { onConflict: "user_id" })
+    .select("user_id, accent_color")
+    .maybeSingle<UserSettings>();
+
+  if (error) {
+    throw error;
+  }
+
+  return data ?? null;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
 import "./index.css";
 import { initSyncEngine } from "./lib/sync/SyncEngine";
+import { AccentProvider } from "./context/AccentContext";
 
 const queryClient = new QueryClient();
 
@@ -11,7 +12,9 @@ initSyncEngine();
 createRoot(document.getElementById("root")).render(
   <BrowserRouter>
     <QueryClientProvider client={queryClient}>
-      <App />
+      <AccentProvider>
+        <App />
+      </AccentProvider>
     </QueryClientProvider>
   </BrowserRouter>
 );

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -5,6 +5,7 @@ import Toggle from '../components/settings/Toggle';
 import Select from '../components/settings/Select';
 import NumberField from '../components/settings/NumberField';
 import DangerZone from '../components/settings/DangerZone';
+import AccentPicker from '../components/AccentPicker';
 import { getPrefs, setPrefs, resetPrefs } from '../lib/preferences';
 import { useDataMode, useRepo } from '../context/DataContext';
 
@@ -74,6 +75,9 @@ export default function SettingsPage() {
           ]}
           onChange={(v) => setLocalPrefs({ ...prefs, language: v })}
         />
+      </SettingsGroup>
+      <SettingsGroup title="Warna Aksen">
+        <AccentPicker />
       </SettingsGroup>
       <SettingsGroup title="Gamification">
         <Toggle


### PR DESCRIPTION
## Summary
- add Supabase helper utilities and an accent context to manage persisted user accent colors
- expose a reusable AccentPicker with presets and custom hex input wired into the settings page
- update global styles and navigation components to honor the new --accent CSS variable and provider

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d5e36a2bc483328cb72c5cbae0d7dc