### PR TITLE
Add user accent color customization

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -51,6 +51,7 @@ import { removeTransaction as apiDelete } from "./lib/api-transactions";
 import CategoryProvider from "./context/CategoryContext";
 import ToastProvider, { useToast } from "./context/ToastContext";
 import UserProfileProvider from "./context/UserProfileContext.jsx";
+import { AccentProvider } from "./context/AccentContext";
 import { loadSubscriptions, findUpcoming } from "./lib/subscriptions";
 import { allocateIncome } from "./lib/goals";
 import MoneyTalkProvider, {
@@ -1188,9 +1189,11 @@ export default function App() {
     <ModeProvider>
       <UserProfileProvider>
         <ToastProvider>
-          <DataProvider>
-            <AppContent />
-          </DataProvider>
+          <AccentProvider>
+            <DataProvider>
+              <AppContent />
+            </DataProvider>
+          </AccentProvider>
         </ToastProvider>
       </UserProfileProvider>
     </ModeProvider>

--- a/src/components/settings/AccentPicker.tsx
+++ b/src/components/settings/AccentPicker.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useMemo, useState } from 'react';
+import clsx from 'clsx';
+import { useAccent } from '../../context/AccentContext';
+import { useToast } from '../../context/ToastContext';
+import { normalizeAccentHex } from '../../lib/api-user-settings';
+
+const PRESET_COLORS = [
+  '#3898f8',
+  '#2584e4',
+  '#50b6ff',
+  '#10b981',
+  '#f59e0b',
+  '#ef4444',
+  '#8b5cf6',
+  '#14b8a6',
+] as const;
+
+function toUpperHex(value: string) {
+  return value.startsWith('#') ? value.toUpperCase() : `#${value}`.toUpperCase();
+}
+
+export default function AccentPicker() {
+  const { accent, loading, setAccent } = useAccent();
+  const { addToast } = useToast();
+  const [textValue, setTextValue] = useState(accent);
+  const [colorValue, setColorValue] = useState(accent);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const normalizedTextValue = useMemo(() => {
+    try {
+      return normalizeAccentHex(textValue);
+    } catch {
+      return null;
+    }
+  }, [textValue]);
+
+  useEffect(() => {
+    setTextValue(accent);
+    setColorValue(accent);
+  }, [accent]);
+
+  useEffect(() => {
+    try {
+      const normalized = normalizeAccentHex(textValue);
+      setColorValue(normalized);
+    } catch {
+      // ignore invalid typing, keep last valid color
+    }
+  }, [textValue]);
+
+  const previewStyle = useMemo(() => ({
+    backgroundColor: colorValue,
+    color: '#fff',
+  }), [colorValue]);
+
+  const handleSave = async (value?: string) => {
+    setSaving(true);
+    setError(null);
+    try {
+      const normalized = normalizeAccentHex(value ?? textValue);
+      setTextValue(normalized);
+      setColorValue(normalized);
+      const result = await setAccent(normalized);
+      if (result.error) {
+        addToast('Warna tersimpan lokal. Sinkronisasi akan dicoba lagi (ACC-32).', 'warning');
+      } else if (result.synced) {
+        addToast('Warna aksen berhasil disimpan!', 'success');
+      } else {
+        addToast('Warna aksen disimpan di perangkat ini.', 'info');
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Format warna tidak valid (ACC-02).';
+      setError(message);
+      addToast(message, 'error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-3" aria-live="polite">
+        <div className="h-4 w-32 animate-pulse rounded-full bg-border/70" />
+        <div className="grid grid-cols-4 gap-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={`accent-skeleton-${index}`} className="h-9 rounded-full bg-border/60 animate-pulse" />
+          ))}
+        </div>
+        <div className="h-24 rounded-2xl bg-border/50 animate-pulse" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4" aria-live="polite">
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-text">Pilih warna aksen</p>
+        <div className="grid grid-cols-4 gap-2 sm:grid-cols-8" role="group" aria-label="Preset warna aksen">
+          {PRESET_COLORS.map((preset) => {
+            const normalized = toUpperHex(preset);
+            const isActive = normalizedTextValue === normalized;
+            return (
+              <button
+                key={preset}
+                type="button"
+                onClick={() => {
+                  setTextValue(normalized);
+                  setColorValue(normalized);
+                  setError(null);
+                }}
+                aria-label={`Gunakan warna ${normalized}`}
+                className={clsx(
+                  'relative h-9 w-full rounded-full border transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]',
+                  isActive
+                    ? 'border-[var(--accent)] ring-2 ring-[var(--accent)]'
+                    : 'border-border-subtle hover:border-[var(--accent)]'
+                )}
+              >
+                <span className="absolute inset-1 rounded-full" style={{ backgroundColor: normalized }} />
+                <span className="sr-only">{normalized}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-[auto,1fr]">
+        <label className="flex flex-col gap-2 text-sm font-medium text-text" htmlFor="accent-color-input">
+          Warna custom
+          <input
+            id="accent-color-input"
+            type="color"
+            value={colorValue}
+            onChange={(event) => {
+              const value = event.target.value.toUpperCase();
+              setTextValue(value);
+              setColorValue(value);
+              setError(null);
+            }}
+            className="h-11 w-24 cursor-pointer rounded-2xl border border-border-subtle bg-surface-alt"
+            aria-label="Pilih warna aksen custom"
+          />
+        </label>
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-text" htmlFor="accent-hex-input">
+            Hex kode
+          </label>
+          <input
+            id="accent-hex-input"
+            type="text"
+            value={textValue}
+            onChange={(event) => setTextValue(event.target.value)}
+            placeholder="#3898F8"
+            aria-invalid={error ? 'true' : 'false'}
+            aria-describedby={error ? 'accent-error' : undefined}
+          />
+          {error ? (
+            <p id="accent-error" className="form-error" role="alert">
+              {error}
+            </p>
+          ) : null}
+        </div>
+      </div>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div
+          className="flex h-16 flex-1 items-center justify-center rounded-2xl border border-border-subtle"
+          style={previewStyle}
+          aria-label="Pratinjau warna aksen"
+        >
+          <span className="text-sm font-semibold uppercase tracking-wide">Accent preview</span>
+        </div>
+        <button
+          type="button"
+          className="btn btn-primary sm:w-40"
+          onClick={() => handleSave()}
+          disabled={saving}
+          aria-label="Simpan warna aksen"
+        >
+          {saving ? 'Menyimpan…' : 'Simpan'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -394,7 +394,7 @@ export default function Sidebar({
                       className={clsx(
                         "flex items-center justify-center gap-2 rounded-xl border border-border px-2 py-2 text-xs font-medium transition-colors duration-200",
                         isActive
-                          ? "border-brand/60 bg-brand/15 text-brand"
+                          ? "border-[var(--accent)] bg-[color:rgb(var(--accent-rgb)/0.12)] text-[var(--accent)]"
                           : "bg-transparent text-muted hover:border-border/80 hover:bg-muted/10",
                         collapsed && "flex-col gap-1 px-1 py-1 text-[11px]"
                       )}
@@ -437,7 +437,7 @@ export default function Sidebar({
                       className={clsx(
                         "relative flex h-8 w-full items-center justify-center rounded-full border border-border transition-all duration-200",
                         isActive
-                          ? "ring-2 ring-brand/70"
+                          ? "ring-2 ring-[var(--accent)]"
                           : "hover:border-border/70"
                       )}
                     >
@@ -473,7 +473,7 @@ export default function Sidebar({
                     className={clsx(
                       "flex items-center justify-center gap-2 rounded-xl border border-border px-2 py-2 text-xs font-semibold transition-colors duration-200",
                       isActive
-                        ? "border-brand/60 bg-brand/15 text-brand"
+                        ? "border-[var(--accent)] bg-[color:rgb(var(--accent-rgb)/0.12)] text-[var(--accent)]"
                         : "bg-transparent text-muted hover:border-border/80 hover:bg-muted/10"
                     )}
                   >
@@ -519,7 +519,7 @@ export default function Sidebar({
                 <button
                   type="button"
                   onClick={handleLogout}
-                  className="inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-border px-3 text-sm font-medium text-text transition-colors duration-200 hover:border-brand/50 hover:text-brand"
+                  className="inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-border px-3 text-sm font-medium text-text transition-colors duration-200 hover:border-[var(--accent)] hover:text-[var(--accent)]"
                 >
                   <LogOut className="h-4 w-4" />
                   {!collapsed && <span>Keluar</span>}
@@ -532,7 +532,7 @@ export default function Sidebar({
                     navigate("/auth");
                     onNavigate?.();
                   }}
-                  className="inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-border px-3 text-sm font-medium text-text transition-colors duration-200 hover:border-brand/50 hover:text-brand"
+                  className="inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-border px-3 text-sm font-medium text-text transition-colors duration-200 hover:border-[var(--accent)] hover:text-[var(--accent)]"
                 >
                   <LogIn className="h-4 w-4" />
                   {!collapsed && <span>Masuk</span>}
@@ -542,7 +542,7 @@ export default function Sidebar({
               <button
                 type="button"
                 onClick={() => onToggle?.(!collapsed)}
-                className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-border bg-surface-2 text-text transition-colors duration-200 hover:border-brand/40 hover:text-brand"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-border bg-surface-2 text-text transition-colors duration-200 hover:border-[var(--accent)] hover:text-[var(--accent)]"
                 title={collapsed ? "Perluas" : "Ciutkan"}
                 aria-label={collapsed ? "Perluas sidebar" : "Ciutkan sidebar"}
               >

--- a/src/components/sidebar/SidebarItem.tsx
+++ b/src/components/sidebar/SidebarItem.tsx
@@ -28,14 +28,14 @@ export default function SidebarItem({
       title={collapsed ? label : undefined}
       className={({ isActive }) =>
         clsx(
-          "relative isolate flex h-11 min-w-0 items-center gap-3 rounded-xl px-3 text-sm font-medium tracking-tight text-muted transition-[background-color,color,box-shadow] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60",
-          "before:absolute before:left-0 before:top-1.5 before:bottom-1.5 before:w-1 before:rounded-full before:bg-brand before:opacity-0 before:transition-opacity before:content-['']",
+          "relative isolate flex h-11 min-w-0 items-center gap-3 rounded-xl px-3 text-sm font-medium tracking-tight text-muted transition-[background-color,color,box-shadow] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]",
+          "before:absolute before:left-0 before:top-1.5 before:bottom-1.5 before:w-1 before:rounded-full before:bg-[var(--accent)] before:opacity-0 before:transition-opacity before:content-['']",
           !collapsed && "justify-start",
           collapsed && "justify-center px-2",
           disabled && "pointer-events-none opacity-40",
           !disabled && "hover:bg-muted/20",
           isActive &&
-            "bg-brand/10 text-brand ring-1 ring-brand/20 before:opacity-100"
+            "bg-[color:rgb(var(--accent-rgb)/0.12)] text-[var(--accent)] ring-1 ring-[color:rgb(var(--accent-rgb)/0.35)] before:opacity-100"
         )
       }
       onClick={onNavigate}

--- a/src/context/AccentContext.tsx
+++ b/src/context/AccentContext.tsx
@@ -1,0 +1,211 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import { supabase } from '../lib/supabase';
+import {
+  getUserSettings,
+  normalizeAccentHex,
+  upsertAccentColor,
+} from '../lib/api-user-settings';
+
+const STORAGE_KEY = 'hw:accent';
+export const DEFAULT_ACCENT = '#3898F8';
+
+type AccentUpdateResult = {
+  hex: string;
+  synced: boolean;
+  error?: Error;
+};
+
+type AccentContextValue = {
+  accent: string;
+  loading: boolean;
+  lastErrorId: string | null;
+  setAccent: (hex: string) => Promise<AccentUpdateResult>;
+};
+
+const AccentContext = createContext<AccentContextValue | undefined>(undefined);
+
+function expandHex(value: string) {
+  const clean = value.replace('#', '');
+  if (clean.length === 3) {
+    return `#${clean[0]}${clean[0]}${clean[1]}${clean[1]}${clean[2]}${clean[2]}`.toUpperCase();
+  }
+  if (clean.length === 6) {
+    return `#${clean}`.toUpperCase();
+  }
+  return value.toUpperCase();
+}
+
+function readLocalAccent(): string | null {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return null;
+    return normalizeAccentHex(stored);
+  } catch {
+    return null;
+  }
+}
+
+function writeLocalAccent(hex: string) {
+  try {
+    localStorage.setItem(STORAGE_KEY, hex);
+  } catch {
+    /* ignore */
+  }
+}
+
+function parseHexToRgb(hex: string): string | null {
+  const normalized = expandHex(hex);
+  if (!normalized.startsWith('#') || normalized.length !== 7) {
+    return null;
+  }
+  const value = Number.parseInt(normalized.slice(1), 16);
+  if (Number.isNaN(value)) {
+    return null;
+  }
+  const r = (value >> 16) & 255;
+  const g = (value >> 8) & 255;
+  const b = value & 255;
+  return `${r} ${g} ${b}`;
+}
+
+function applyToDocument(hex: string) {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  root.style.setProperty('--accent', hex);
+  const rgb = parseHexToRgb(hex);
+  if (rgb) {
+    root.style.setProperty('--accent-rgb', rgb);
+  }
+}
+
+export function AccentProvider({ children }: { children: ReactNode }) {
+  const [accent, setAccentState] = useState<string>(() => readLocalAccent() ?? DEFAULT_ACCENT);
+  const [loading, setLoading] = useState(true);
+  const [sessionUserId, setSessionUserId] = useState<string | null>(null);
+  const [lastErrorId, setLastErrorId] = useState<string | null>(null);
+
+  const commitAccent = useCallback((hex: string) => {
+    const normalized = normalizeAccentHex(hex);
+    setAccentState(normalized);
+    applyToDocument(normalized);
+    writeLocalAccent(normalized);
+    return normalized;
+  }, []);
+
+  const syncForUser = useCallback(
+    async (userId: string) => {
+      const localAccent = readLocalAccent();
+      let resolved = localAccent ?? DEFAULT_ACCENT;
+      try {
+        const remote = await getUserSettings(userId);
+        const remoteAccent = remote?.accent_color ? normalizeAccentHex(remote.accent_color) : null;
+        if (remoteAccent) {
+          resolved = remoteAccent;
+        } else if (localAccent) {
+          resolved = normalizeAccentHex(localAccent);
+          await upsertAccentColor(userId, resolved);
+        }
+      } catch {
+        setLastErrorId('ACC-31');
+      }
+      commitAccent(resolved);
+    },
+    [commitAccent],
+  );
+
+  useEffect(() => {
+    let active = true;
+
+    const bootstrap = async () => {
+      setLoading(true);
+      commitAccent(readLocalAccent() ?? DEFAULT_ACCENT);
+      try {
+        const { data, error } = await supabase.auth.getSession();
+        if (!active) return;
+        if (error) throw error;
+        const userId = data.session?.user?.id ?? null;
+        setSessionUserId(userId);
+        if (userId) {
+          await syncForUser(userId);
+        }
+      } catch {
+        if (active) {
+          setLastErrorId('ACC-30');
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void bootstrap();
+
+    const { data: subscription } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!active) return;
+      const userId = session?.user?.id ?? null;
+      setSessionUserId(userId);
+      if (userId) {
+        void syncForUser(userId);
+      } else {
+        const local = readLocalAccent() ?? DEFAULT_ACCENT;
+        commitAccent(local);
+      }
+    });
+
+    return () => {
+      active = false;
+      subscription.subscription?.unsubscribe();
+    };
+  }, [commitAccent, syncForUser]);
+
+  const setAccent = useCallback(
+    async (hex: string): Promise<AccentUpdateResult> => {
+      setLastErrorId(null);
+      const normalized = commitAccent(hex);
+      if (!sessionUserId) {
+        return { hex: normalized, synced: false };
+      }
+      try {
+        await upsertAccentColor(sessionUserId, normalized);
+        return { hex: normalized, synced: true };
+      } catch (error) {
+        setLastErrorId('ACC-32');
+        return {
+          hex: normalized,
+          synced: false,
+          error: error instanceof Error ? error : new Error('ACC-32'),
+        };
+      }
+    },
+    [commitAccent, sessionUserId],
+  );
+
+  const value = useMemo(
+    () => ({
+      accent,
+      loading,
+      lastErrorId,
+      setAccent,
+    }),
+    [accent, lastErrorId, loading, setAccent],
+  );
+
+  return <AccentContext.Provider value={value}>{children}</AccentContext.Provider>;
+}
+
+export function useAccent(): AccentContextValue {
+  const ctx = useContext(AccentContext);
+  if (!ctx) {
+    throw new Error('useAccent harus dipakai di dalam AccentProvider');
+  }
+  return ctx;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -69,6 +69,9 @@
     --tx-income: #34d399;
     --tx-transfer: #38bdf8;
 
+    --accent: #3898f8;
+    --accent-rgb: 56 152 248;
+
     --page-y: clamp(16px, 4vw, 28px);
     --section-y: clamp(12px, 3vw, 24px);
     --block-y: clamp(8px, 2vw, 16px);
@@ -108,6 +111,9 @@
     --tx-expense: #fda4af;
     --tx-income: #4ade80;
     --tx-transfer: #38bdf8;
+
+    --accent: #3898f8;
+    --accent-rgb: 56 152 248;
   }
 
   body {
@@ -274,15 +280,18 @@
   }
 
   .btn-primary {
-    @apply border-transparent bg-primary text-text-inverse shadow-sm;
+    @apply border-transparent shadow-sm;
+    background-color: var(--accent);
+    border-color: var(--accent);
+    color: rgb(var(--color-text-inverse));
   }
 
   .btn-primary:hover:not(:disabled) {
-    background-color: hsl(var(--color-primary-hover));
+    filter: brightness(1.05);
   }
 
   .btn-primary:active:not(:disabled) {
-    background-color: hsl(var(--color-primary-active));
+    filter: brightness(0.95);
   }
 
   .btn-secondary {
@@ -314,7 +323,10 @@
   }
 
   .badge {
-    @apply inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/15 px-3 py-1 text-xs font-medium text-primary;
+    @apply inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium;
+    border-color: rgb(var(--accent-rgb) / 0.35);
+    background-color: rgb(var(--accent-rgb) / 0.15);
+    color: var(--accent);
   }
 
   .badge-muted {

--- a/src/lib/api-user-settings.ts
+++ b/src/lib/api-user-settings.ts
@@ -1,0 +1,69 @@
+import { supabase } from './supabase';
+
+export interface UserSettingsRow {
+  user_id: string;
+  accent_color: string | null;
+}
+
+const HEX_REGEX = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+function normalizeHex(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error('Warna aksen wajib diisi (ACC-01).');
+  }
+  const prefixed = trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+  if (!HEX_REGEX.test(prefixed)) {
+    throw new Error('Format warna tidak valid (ACC-02).');
+  }
+  const hex = prefixed.length === 4
+    ? `#${prefixed[1]}${prefixed[1]}${prefixed[2]}${prefixed[2]}${prefixed[3]}${prefixed[3]}`
+    : prefixed;
+  return hex.toUpperCase();
+}
+
+export function normalizeAccentHex(input: string): string {
+  return normalizeHex(input);
+}
+
+export async function getUserSettings(userId: string): Promise<UserSettingsRow | null> {
+  if (!userId?.trim()) {
+    throw new Error('ID pengguna tidak valid (ACC-10).');
+  }
+
+  const { data, error } = await supabase
+    .from('user_settings')
+    .select('user_id, accent_color')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error('Gagal memuat pengaturan warna (ACC-11).');
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return {
+    user_id: String(data.user_id),
+    accent_color: typeof data.accent_color === 'string' ? data.accent_color : null,
+  };
+}
+
+export async function upsertAccentColor(userId: string, hex: string): Promise<string> {
+  if (!userId?.trim()) {
+    throw new Error('ID pengguna tidak valid (ACC-20).');
+  }
+  const normalized = normalizeHex(hex);
+
+  const { error } = await supabase
+    .from('user_settings')
+    .upsert({ user_id: userId, accent_color: normalized }, { onConflict: 'user_id' });
+
+  if (error) {
+    throw new Error('Gagal menyimpan warna aksen (ACC-21).');
+  }
+
+  return normalized;
+}

--- a/src/pages/SettingsPage.test.tsx
+++ b/src/pages/SettingsPage.test.tsx
@@ -5,9 +5,21 @@ import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom/vitest';
 import SettingsPage from './SettingsPage';
 import { DataProvider } from '../context/DataContext';
+import { AccentProvider } from '../context/AccentContext';
+import ToastProvider from '../context/ToastContext';
 import { vi } from 'vitest';
 
-vi.mock('../lib/supabase', () => ({ supabase: {} }));
+vi.mock('../lib/supabase', () => {
+  const unsubscribe = vi.fn();
+  return {
+    supabase: {
+      auth: {
+        getSession: vi.fn().mockResolvedValue({ data: { session: null }, error: null }),
+        onAuthStateChange: vi.fn().mockReturnValue({ data: { subscription: { unsubscribe } } }),
+      },
+    },
+  };
+});
 
 const store: Record<string, string> = {};
 (global as any).localStorage = {
@@ -23,9 +35,13 @@ const renderWithMode = (mode: 'online' | 'local') => {
   localStorage.setItem('hw:connectionMode', mode);
   return render(
     <MemoryRouter>
-      <DataProvider initialMode={mode}>
-        <SettingsPage />
-      </DataProvider>
+      <ToastProvider>
+        <AccentProvider>
+          <DataProvider initialMode={mode}>
+            <SettingsPage />
+          </DataProvider>
+        </AccentProvider>
+      </ToastProvider>
     </MemoryRouter>
   );
 };

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -7,6 +7,7 @@ import NumberField from '../components/settings/NumberField';
 import DangerZone from '../components/settings/DangerZone';
 import { getPrefs, setPrefs, resetPrefs } from '../lib/preferences';
 import { useDataMode, useRepo } from '../context/DataContext';
+import AccentPicker from '../components/settings/AccentPicker';
 
 export default function SettingsPage() {
   const { mode, setMode } = useDataMode();
@@ -74,6 +75,7 @@ export default function SettingsPage() {
           ]}
           onChange={(v) => setLocalPrefs({ ...prefs, language: v })}
         />
+        <AccentPicker />
       </SettingsGroup>
       <SettingsGroup title="Gamification">
         <Toggle


### PR DESCRIPTION
## Summary
- add Supabase helpers and a global AccentProvider that keeps the `--accent` CSS variable in sync with local storage and authenticated users
- introduce an AccentPicker settings UI with presets, custom hex entry, validation, and toast feedback plus supporting test wrappers
- update App, sidebar elements, and button styles to consume the new accent color variable by default

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68d5e36a2bc483328cb72c5cbae0d7dc