### PR TITLE
Add breadcrumbs to category, profile, and transaction pages

### DIFF
--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -14,6 +14,7 @@ import {
   updateCategory,
 } from "../lib/api-categories";
 import { useLockBodyScroll } from "../hooks/useLockBodyScroll";
+import Breadcrumbs from "../layout/Breadcrumbs";
 
 function toMessage(error: unknown, fallback: string) {
   if (error instanceof Error && error.message) return error.message;
@@ -371,6 +372,7 @@ export default function Categories() {
 
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-4">
+      <Breadcrumbs />
       <div className="rounded-2xl border border-border/60 bg-surface-1/70 p-6 shadow-sm">
         <h1 className="text-lg font-semibold text-text">Manajemen Kategori</h1>
         <p className="mt-2 text-sm text-muted">

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -10,6 +10,7 @@ import PrivacyDataCard from '../components/profile/PrivacyDataCard';
 import IntegrationsCard from '../components/profile/IntegrationsCard';
 import useNetworkStatus from '../hooks/useNetworkStatus';
 import { useToast } from '../context/ToastContext';
+import Breadcrumbs from '../layout/Breadcrumbs';
 import {
   changePassword,
   checkUsernameAvailability,
@@ -540,6 +541,7 @@ export default function ProfilePage() {
 
   return (
     <div className="space-y-6">
+      <Breadcrumbs />
       <div>
         <h1 className="text-2xl font-semibold text-foreground">Profil</h1>
         <p className="mt-1 text-sm text-muted">Kelola akun &amp; preferensi kamu dalam satu tempat.</p>

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -33,6 +33,7 @@ import {
 import { formatCurrency } from "../lib/format";
 import { flushQueue, onStatusChange, pending } from "../lib/sync/SyncEngine";
 import { parseCSV } from "../lib/statement";
+import Breadcrumbs from "../layout/Breadcrumbs";
 
 const TYPE_LABELS = {
   income: "Pemasukan",
@@ -724,6 +725,7 @@ export default function Transactions() {
   return (
     <main className="mx-auto w-full max-w-[1280px] px-4 pb-10 sm:px-6 lg:px-8">
       <div className="space-y-6 sm:space-y-7 lg:space-y-8">
+        <Breadcrumbs />
         <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h1 className="text-2xl font-semibold text-text">Transaksi</h1>


### PR DESCRIPTION
## Summary
- import the shared Breadcrumbs component into the category, profile, and transaction views
- render the breadcrumb trail ahead of each page header for consistent navigation cues

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68d6174640988332badadc0997f33a57