### PR TITLE
Add breadcrumbs to category, profile, and transaction pages

### DIFF
--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -4,6 +4,7 @@ import { createPortal } from "react-dom";
 import CategoryForm from "../components/categories/CategoryForm";
 import CategoryList from "../components/categories/CategoryList";
 import { useToast } from "../context/ToastContext";
+import Breadcrumbs from "../layout/Breadcrumbs";
 import {
   CategoryRecord,
   CategoryType,
@@ -371,11 +372,14 @@ export default function Categories() {
 
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-4">
-      <div className="rounded-2xl border border-border/60 bg-surface-1/70 p-6 shadow-sm">
-        <h1 className="text-lg font-semibold text-text">Manajemen Kategori</h1>
-        <p className="mt-2 text-sm text-muted">
-          Buat, ubah, hapus, dan atur urutan kategori pemasukan dan pengeluaran.
-        </p>
+      <div className="space-y-2">
+        <Breadcrumbs />
+        <div className="rounded-2xl border border-border/60 bg-surface-1/70 p-6 shadow-sm">
+          <h1 className="text-lg font-semibold text-text">Manajemen Kategori</h1>
+          <p className="mt-2 text-sm text-muted">
+            Buat, ubah, hapus, dan atur urutan kategori pemasukan dan pengeluaran.
+          </p>
+        </div>
       </div>
       <section className="rounded-2xl border border-border/60 bg-surface-1/70 p-6 shadow-sm">
         <h2 className="text-base font-semibold text-text">Tambah kategori baru</h2>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -10,6 +10,7 @@ import PrivacyDataCard from '../components/profile/PrivacyDataCard';
 import IntegrationsCard from '../components/profile/IntegrationsCard';
 import useNetworkStatus from '../hooks/useNetworkStatus';
 import { useToast } from '../context/ToastContext';
+import Breadcrumbs from '../layout/Breadcrumbs';
 import {
   changePassword,
   checkUsernameAvailability,
@@ -540,9 +541,12 @@ export default function ProfilePage() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold text-foreground">Profil</h1>
-        <p className="mt-1 text-sm text-muted">Kelola akun &amp; preferensi kamu dalam satu tempat.</p>
+      <div className="space-y-2">
+        <Breadcrumbs />
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">Profil</h1>
+          <p className="mt-1 text-sm text-muted">Kelola akun &amp; preferensi kamu dalam satu tempat.</p>
+        </div>
       </div>
       {renderContent()}
     </div>

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -33,6 +33,7 @@ import {
 import { formatCurrency } from "../lib/format";
 import { flushQueue, onStatusChange, pending } from "../lib/sync/SyncEngine";
 import { parseCSV } from "../lib/statement";
+import Breadcrumbs from "../layout/Breadcrumbs";
 
 const TYPE_LABELS = {
   income: "Pemasukan",
@@ -724,39 +725,42 @@ export default function Transactions() {
   return (
     <main className="mx-auto w-full max-w-[1280px] px-4 pb-10 sm:px-6 lg:px-8">
       <div className="space-y-6 sm:space-y-7 lg:space-y-8">
-        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h1 className="text-2xl font-semibold text-text">Transaksi</h1>
-            <p className="text-sm text-muted">{PAGE_DESCRIPTION}</p>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <button
-              type="button"
-              onClick={handleNavigateToAdd}
-              className="inline-flex items-center gap-2 rounded-xl bg-brand px-4 py-2 text-sm font-semibold text-white shadow focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60"
-              aria-label="Tambah transaksi (Ctrl+T)"
-            >
-              <Plus className="h-4 w-4" /> Tambah Transaksi
-            </button>
-            <button
-              type="button"
-              onClick={() => setImportOpen(true)}
-              className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 backdrop-blur focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60"
-              aria-label="Import CSV (Ctrl+I)"
-            >
-              <Upload className="h-4 w-4" /> Import CSV
-            </button>
-            <button
-              type="button"
-              onClick={handleExport}
-              disabled={exporting}
-              className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 backdrop-blur focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
-              aria-label="Export CSV (Ctrl+E)"
-            >
-              {exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />} Export CSV
-            </button>
-          </div>
-        </header>
+        <div className="space-y-2">
+          <Breadcrumbs />
+          <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold text-text">Transaksi</h1>
+              <p className="text-sm text-muted">{PAGE_DESCRIPTION}</p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={handleNavigateToAdd}
+                className="inline-flex items-center gap-2 rounded-xl bg-brand px-4 py-2 text-sm font-semibold text-white shadow focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60"
+                aria-label="Tambah transaksi (Ctrl+T)"
+              >
+                <Plus className="h-4 w-4" /> Tambah Transaksi
+              </button>
+              <button
+                type="button"
+                onClick={() => setImportOpen(true)}
+                className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 backdrop-blur focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60"
+                aria-label="Import CSV (Ctrl+I)"
+              >
+                <Upload className="h-4 w-4" /> Import CSV
+              </button>
+              <button
+                type="button"
+                onClick={handleExport}
+                disabled={exporting}
+                className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 backdrop-blur focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label="Export CSV (Ctrl+E)"
+              >
+                {exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />} Export CSV
+              </button>
+            </div>
+          </header>
+        </div>
 
         <div
           ref={filterBarRef}


### PR DESCRIPTION
## Summary
- import and render the shared breadcrumb component on the categories, profile, and transactions pages
- adjust the header layout on each page so the breadcrumb trail sits above the existing page titles

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d6174640988332badadc0997f33a57