### PR TITLE
Add breadcrumbs to category, profile, and transactions pages

### DIFF
--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -4,7 +4,9 @@ import { createPortal } from "react-dom";
 import CategoryForm from "../components/categories/CategoryForm";
 import CategoryList from "../components/categories/CategoryList";
 import { useToast } from "../context/ToastContext";
-import Breadcrumbs from "../layout/Breadcrumbs";
+import Page from "../layout/Page";
+import PageHeader from "../layout/PageHeader";
+import Section from "../layout/Section";
 import {
   CategoryRecord,
   CategoryType,
@@ -371,73 +373,96 @@ export default function Categories() {
   }, [confirming, handleDeleteCategory]);
 
   return (
-    <main className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-4">
-      <div className="rounded-2xl border border-border/60 bg-surface-1/70 p-6 shadow-sm">
-        <Breadcrumbs />
-        <h1 className="text-lg font-semibold text-text">Manajemen Kategori</h1>
-        <p className="mt-2 text-sm text-muted">
-          Buat, ubah, hapus, dan atur urutan kategori pemasukan dan pengeluaran.
-        </p>
-      </div>
-      <section className="rounded-2xl border border-border/60 bg-surface-1/70 p-6 shadow-sm">
-        <h2 className="text-base font-semibold text-text">Tambah kategori baru</h2>
-        <p className="mt-1 text-sm text-muted">
-          Pilih tipe kategori, beri nama, dan sesuaikan warnanya.
-        </p>
-        <div className="mt-4">
-          <CategoryForm
-            key={createFormKey}
-            mode="create"
-            initialValues={{ name: "", color: "#0EA5E9", type: "expense" }}
-            onSubmit={handleCreate}
-            isSubmitting={creating}
-          />
-        </div>
-      </section>
-      {error ? (
-        <div className="rounded-2xl border border-danger/40 bg-danger/10 p-4 text-sm text-danger">
-          <div className="flex items-center justify-between gap-3">
-            <span>{error}</span>
-            <button
-              type="button"
-              onClick={() => reload()}
-              className="inline-flex items-center gap-2 rounded-full border border-danger/40 px-3 py-1 text-xs font-semibold text-danger transition-colors hover:bg-danger/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger/60"
-            >
-              Coba lagi
-            </button>
+    <Page>
+      <PageHeader
+        title="Manajemen Kategori"
+        description="Buat, ubah, hapus, dan atur urutan kategori pemasukan dan pengeluaran."
+      />
+      <Section first>
+        <div className="rounded-2xl border border-border/60 bg-surface-1/70 p-6 shadow-sm">
+          <h2 className="text-base font-semibold text-text">Tambah kategori baru</h2>
+          <p className="mt-1 text-sm text-muted">
+            Pilih tipe kategori, beri nama, dan sesuaikan warnanya.
+          </p>
+          <div className="mt-4">
+            <CategoryForm
+              key={createFormKey}
+              mode="create"
+              initialValues={{ name: "", color: "#0EA5E9", type: "expense" }}
+              onSubmit={handleCreate}
+              isSubmitting={creating}
+            />
           </div>
         </div>
+      </Section>
+      {error ? (
+        <Section>
+          <div className="rounded-2xl border border-danger/40 bg-danger/10 p-4 text-sm text-danger">
+            <div className="flex items-center justify-between gap-3">
+              <span>{error}</span>
+              <button
+                type="button"
+                onClick={() => reload()}
+                className="inline-flex items-center gap-2 rounded-full border border-danger/40 px-3 py-1 text-xs font-semibold text-danger transition-colors hover:bg-danger/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger/60"
+              >
+                Coba lagi
+              </button>
+            </div>
+          </div>
+        </Section>
       ) : null}
-      <div className="grid gap-4 md:grid-cols-2">
-        <CategoryList
-          type="income"
-          title="Pemasukan"
-          items={grouped.income}
-          editingId={editingId}
-          pendingIds={pendingIds}
-          loading={loading}
-          onStartEdit={setEditingId}
-          onCancelEdit={() => setEditingId(null)}
-          onSubmitEdit={handleSubmitEdit}
-          onDelete={(category) => setConfirming(category)}
-          onMoveUp={(id) => handleMove("income", id, "up")}
-          onMoveDown={(id) => handleMove("income", id, "down")}
-        />
-        <CategoryList
-          type="expense"
-          title="Pengeluaran"
-          items={grouped.expense}
-          editingId={editingId}
-          pendingIds={pendingIds}
-          loading={loading}
-          onStartEdit={setEditingId}
-          onCancelEdit={() => setEditingId(null)}
-          onSubmitEdit={handleSubmitEdit}
-          onDelete={(category) => setConfirming(category)}
-          onMoveUp={(id) => handleMove("expense", id, "up")}
-          onMoveDown={(id) => handleMove("expense", id, "down")}
-        />
-      </div>
+      <Section>
+        <div className="grid gap-4 md:grid-cols-2">
+          <CategoryList
+            type="income"
+            title="Pemasukan"
+            items={grouped.income}
+            editingId={editingId}
+            pendingIds={pendingIds}
+            loading={loading}
+            onStartEdit={setEditingId}
+            onCancelEdit={() => setEditingId(null)}
+            onSubmitEdit={handleSubmitEdit}
+            onDelete={(category) => setConfirming(category)}
+            onMoveUp={(id) => handleMove("income", id, "up")}
+            onMoveDown={(id) => handleMove("income", id, "down")}
+          />
+          <CategoryList
+            type="expense"
+            title="Pengeluaran"
+            items={grouped.expense}
+            editingId={editingId}
+            pendingIds={pendingIds}
+            loading={loading}
+            onStartEdit={setEditingId}
+            onCancelEdit={() => setEditingId(null)}
+            onSubmitEdit={handleSubmitEdit}
+            onDelete={(category) => setConfirming(category)}
+            onMoveUp={(id) => handleMove("expense", id, "up")}
+            onMoveDown={(id) => handleMove("expense", id, "down")}
+          />
+        </div>
+      </Section>
+      <CategoryForm
+        key={`modal-${editingId ?? "new"}`}
+        mode="edit"
+        dialog
+        open={Boolean(editingId)}
+        initialValues={(() => {
+          if (!editingId) return null;
+          const original = categories.find((cat) => cat.id === editingId);
+          if (!original) return null;
+          return {
+            id: original.id,
+            name: original.name,
+            color: original.color,
+            type: original.type,
+          };
+        })()}
+        onSubmit={handleSubmitEdit}
+        onDismiss={() => setEditingId(null)}
+        isSubmitting={Boolean(editingId && pendingIds.has(editingId))}
+      />
       <ConfirmDialog
         open={Boolean(confirming)}
         title="Hapus kategori?"
@@ -446,6 +471,6 @@ export default function Categories() {
         onConfirm={handleConfirmDelete}
         onCancel={() => setConfirming(null)}
       />
-    </main>
+    </Page>
   );
 }

--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -4,6 +4,7 @@ import { createPortal } from "react-dom";
 import CategoryForm from "../components/categories/CategoryForm";
 import CategoryList from "../components/categories/CategoryList";
 import { useToast } from "../context/ToastContext";
+import Breadcrumbs from "../layout/Breadcrumbs";
 import {
   CategoryRecord,
   CategoryType,
@@ -372,6 +373,7 @@ export default function Categories() {
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-4">
       <div className="rounded-2xl border border-border/60 bg-surface-1/70 p-6 shadow-sm">
+        <Breadcrumbs />
         <h1 className="text-lg font-semibold text-text">Manajemen Kategori</h1>
         <p className="mt-2 text-sm text-muted">
           Buat, ubah, hapus, dan atur urutan kategori pemasukan dan pengeluaran.

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -10,6 +10,7 @@ import PrivacyDataCard from '../components/profile/PrivacyDataCard';
 import IntegrationsCard from '../components/profile/IntegrationsCard';
 import useNetworkStatus from '../hooks/useNetworkStatus';
 import { useToast } from '../context/ToastContext';
+import Breadcrumbs from '../layout/Breadcrumbs';
 import {
   changePassword,
   checkUsernameAvailability,
@@ -541,6 +542,7 @@ export default function ProfilePage() {
   return (
     <div className="space-y-6">
       <div>
+        <Breadcrumbs />
         <h1 className="text-2xl font-semibold text-foreground">Profil</h1>
         <p className="mt-1 text-sm text-muted">Kelola akun &amp; preferensi kamu dalam satu tempat.</p>
       </div>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -10,7 +10,8 @@ import PrivacyDataCard from '../components/profile/PrivacyDataCard';
 import IntegrationsCard from '../components/profile/IntegrationsCard';
 import useNetworkStatus from '../hooks/useNetworkStatus';
 import { useToast } from '../context/ToastContext';
-import Breadcrumbs from '../layout/Breadcrumbs';
+import Page from '../layout/Page';
+import PageHeader from '../layout/PageHeader';
 import {
   changePassword,
   checkUsernameAvailability,
@@ -540,13 +541,12 @@ export default function ProfilePage() {
   };
 
   return (
-    <div className="space-y-6">
-      <div>
-        <Breadcrumbs />
-        <h1 className="text-2xl font-semibold text-foreground">Profil</h1>
-        <p className="mt-1 text-sm text-muted">Kelola akun &amp; preferensi kamu dalam satu tempat.</p>
-      </div>
+    <Page>
+      <PageHeader
+        title="Profil"
+        description="Kelola akun & preferensi kamu dalam satu tempat."
+      />
       {renderContent()}
-    </div>
+    </Page>
   );
 }

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -22,7 +22,7 @@ import {
 import useTransactionsQuery from "../hooks/useTransactionsQuery";
 import useNetworkStatus from "../hooks/useNetworkStatus";
 import { useToast } from "../context/ToastContext";
-import Breadcrumbs from "../layout/Breadcrumbs";
+import PageHeader from "../layout/PageHeader";
 import { addTransaction, listAccounts, listMerchants, updateTransaction } from "../lib/api";
 import {
   listTransactions,
@@ -724,42 +724,34 @@ export default function Transactions() {
 
   return (
     <main className="mx-auto w-full max-w-[1280px] px-4 pb-10 sm:px-6 lg:px-8">
+      <PageHeader title="Transaksi" description={PAGE_DESCRIPTION}>
+        <button
+          type="button"
+          onClick={handleNavigateToAdd}
+          className="inline-flex items-center gap-2 rounded-xl bg-brand px-4 py-2 text-sm font-semibold text-white shadow focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60"
+          aria-label="Tambah transaksi (Ctrl+T)"
+        >
+          <Plus className="h-4 w-4" /> Tambah Transaksi
+        </button>
+        <button
+          type="button"
+          onClick={() => setImportOpen(true)}
+          className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 backdrop-blur focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60"
+          aria-label="Import CSV (Ctrl+I)"
+        >
+          <Upload className="h-4 w-4" /> Import CSV
+        </button>
+        <button
+          type="button"
+          onClick={handleExport}
+          disabled={exporting}
+          className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 backdrop-blur focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label="Export CSV (Ctrl+E)"
+        >
+          {exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />} Export CSV
+        </button>
+      </PageHeader>
       <div className="space-y-6 sm:space-y-7 lg:space-y-8">
-        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex-1">
-            <Breadcrumbs />
-            <h1 className="text-2xl font-semibold text-text">Transaksi</h1>
-            <p className="text-sm text-muted">{PAGE_DESCRIPTION}</p>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <button
-              type="button"
-              onClick={handleNavigateToAdd}
-              className="inline-flex items-center gap-2 rounded-xl bg-brand px-4 py-2 text-sm font-semibold text-white shadow focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60"
-              aria-label="Tambah transaksi (Ctrl+T)"
-            >
-              <Plus className="h-4 w-4" /> Tambah Transaksi
-            </button>
-            <button
-              type="button"
-              onClick={() => setImportOpen(true)}
-              className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 backdrop-blur focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60"
-              aria-label="Import CSV (Ctrl+I)"
-            >
-              <Upload className="h-4 w-4" /> Import CSV
-            </button>
-            <button
-              type="button"
-              onClick={handleExport}
-              disabled={exporting}
-              className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 backdrop-blur focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
-              aria-label="Export CSV (Ctrl+E)"
-            >
-              {exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />} Export CSV
-            </button>
-          </div>
-        </header>
-
         <div
           ref={filterBarRef}
           className="sticky z-20"

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -22,6 +22,7 @@ import {
 import useTransactionsQuery from "../hooks/useTransactionsQuery";
 import useNetworkStatus from "../hooks/useNetworkStatus";
 import { useToast } from "../context/ToastContext";
+import Breadcrumbs from "../layout/Breadcrumbs";
 import { addTransaction, listAccounts, listMerchants, updateTransaction } from "../lib/api";
 import {
   listTransactions,
@@ -725,7 +726,8 @@ export default function Transactions() {
     <main className="mx-auto w-full max-w-[1280px] px-4 pb-10 sm:px-6 lg:px-8">
       <div className="space-y-6 sm:space-y-7 lg:space-y-8">
         <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
+          <div className="flex-1">
+            <Breadcrumbs />
             <h1 className="text-2xl font-semibold text-text">Transaksi</h1>
             <p className="text-sm text-muted">{PAGE_DESCRIPTION}</p>
           </div>


### PR DESCRIPTION
## Summary
- add breadcrumb navigation to the category, profile, and transactions pages
- ensure breadcrumb component appears alongside existing page headers without altering functionality

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d6174640988332badadc0997f33a57