### PR TITLE
Align breadcrumbs with PageHeader across management pages

### DIFF
--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -4,6 +4,7 @@ import { createPortal } from "react-dom";
 import CategoryForm from "../components/categories/CategoryForm";
 import CategoryList from "../components/categories/CategoryList";
 import { useToast } from "../context/ToastContext";
+import PageHeader from "../layout/PageHeader";
 import {
   CategoryRecord,
   CategoryType,
@@ -370,71 +371,71 @@ export default function Categories() {
   }, [confirming, handleDeleteCategory]);
 
   return (
-    <main className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-4">
-      <div className="rounded-2xl border border-border/60 bg-surface-1/70 p-6 shadow-sm">
-        <h1 className="text-lg font-semibold text-text">Manajemen Kategori</h1>
-        <p className="mt-2 text-sm text-muted">
-          Buat, ubah, hapus, dan atur urutan kategori pemasukan dan pengeluaran.
-        </p>
-      </div>
-      <section className="rounded-2xl border border-border/60 bg-surface-1/70 p-6 shadow-sm">
-        <h2 className="text-base font-semibold text-text">Tambah kategori baru</h2>
-        <p className="mt-1 text-sm text-muted">
-          Pilih tipe kategori, beri nama, dan sesuaikan warnanya.
-        </p>
-        <div className="mt-4">
-          <CategoryForm
-            key={createFormKey}
-            mode="create"
-            initialValues={{ name: "", color: "#0EA5E9", type: "expense" }}
-            onSubmit={handleCreate}
-            isSubmitting={creating}
+    <main className="mx-auto w-full max-w-6xl px-4 py-6">
+      <div className="space-y-6">
+        <PageHeader
+          title="Manajemen Kategori"
+          description="Buat, ubah, hapus, dan atur urutan kategori pemasukan dan pengeluaran."
+        />
+        <section className="rounded-2xl border border-border/60 bg-surface-1/70 p-6 shadow-sm">
+          <h2 className="text-base font-semibold text-text">Tambah kategori baru</h2>
+          <p className="mt-1 text-sm text-muted">
+            Pilih tipe kategori, beri nama, dan sesuaikan warnanya.
+          </p>
+          <div className="mt-4">
+            <CategoryForm
+              key={createFormKey}
+              mode="create"
+              initialValues={{ name: "", color: "#0EA5E9", type: "expense" }}
+              onSubmit={handleCreate}
+              isSubmitting={creating}
+            />
+          </div>
+        </section>
+        {error ? (
+          <div className="rounded-2xl border border-danger/40 bg-danger/10 p-4 text-sm text-danger">
+            <div className="flex items-center justify-between gap-3">
+              <span>{error}</span>
+              <button
+                type="button"
+                onClick={() => reload()}
+                className="inline-flex items-center gap-2 rounded-full border border-danger/40 px-3 py-1 text-xs font-semibold text-danger transition-colors hover:bg-danger/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger/60"
+              >
+                Coba lagi
+              </button>
+            </div>
+          </div>
+        ) : null}
+        <div className="grid gap-4 md:grid-cols-2">
+          <CategoryList
+            type="income"
+            title="Pemasukan"
+            items={grouped.income}
+            editingId={editingId}
+            pendingIds={pendingIds}
+            loading={loading}
+            onStartEdit={setEditingId}
+            onCancelEdit={() => setEditingId(null)}
+            onSubmitEdit={handleSubmitEdit}
+            onDelete={(category) => setConfirming(category)}
+            onMoveUp={(id) => handleMove("income", id, "up")}
+            onMoveDown={(id) => handleMove("income", id, "down")}
+          />
+          <CategoryList
+            type="expense"
+            title="Pengeluaran"
+            items={grouped.expense}
+            editingId={editingId}
+            pendingIds={pendingIds}
+            loading={loading}
+            onStartEdit={setEditingId}
+            onCancelEdit={() => setEditingId(null)}
+            onSubmitEdit={handleSubmitEdit}
+            onDelete={(category) => setConfirming(category)}
+            onMoveUp={(id) => handleMove("expense", id, "up")}
+            onMoveDown={(id) => handleMove("expense", id, "down")}
           />
         </div>
-      </section>
-      {error ? (
-        <div className="rounded-2xl border border-danger/40 bg-danger/10 p-4 text-sm text-danger">
-          <div className="flex items-center justify-between gap-3">
-            <span>{error}</span>
-            <button
-              type="button"
-              onClick={() => reload()}
-              className="inline-flex items-center gap-2 rounded-full border border-danger/40 px-3 py-1 text-xs font-semibold text-danger transition-colors hover:bg-danger/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger/60"
-            >
-              Coba lagi
-            </button>
-          </div>
-        </div>
-      ) : null}
-      <div className="grid gap-4 md:grid-cols-2">
-        <CategoryList
-          type="income"
-          title="Pemasukan"
-          items={grouped.income}
-          editingId={editingId}
-          pendingIds={pendingIds}
-          loading={loading}
-          onStartEdit={setEditingId}
-          onCancelEdit={() => setEditingId(null)}
-          onSubmitEdit={handleSubmitEdit}
-          onDelete={(category) => setConfirming(category)}
-          onMoveUp={(id) => handleMove("income", id, "up")}
-          onMoveDown={(id) => handleMove("income", id, "down")}
-        />
-        <CategoryList
-          type="expense"
-          title="Pengeluaran"
-          items={grouped.expense}
-          editingId={editingId}
-          pendingIds={pendingIds}
-          loading={loading}
-          onStartEdit={setEditingId}
-          onCancelEdit={() => setEditingId(null)}
-          onSubmitEdit={handleSubmitEdit}
-          onDelete={(category) => setConfirming(category)}
-          onMoveUp={(id) => handleMove("expense", id, "up")}
-          onMoveDown={(id) => handleMove("expense", id, "down")}
-        />
       </div>
       <ConfirmDialog
         open={Boolean(confirming)}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -10,6 +10,9 @@ import PrivacyDataCard from '../components/profile/PrivacyDataCard';
 import IntegrationsCard from '../components/profile/IntegrationsCard';
 import useNetworkStatus from '../hooks/useNetworkStatus';
 import { useToast } from '../context/ToastContext';
+import Page from '../layout/Page';
+import Section from '../layout/Section';
+import PageHeader from '../layout/PageHeader';
 import {
   changePassword,
   checkUsernameAvailability,
@@ -539,12 +542,14 @@ export default function ProfilePage() {
   };
 
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold text-foreground">Profil</h1>
-        <p className="mt-1 text-sm text-muted">Kelola akun &amp; preferensi kamu dalam satu tempat.</p>
+    <Page>
+      <div className="space-y-6 min-w-0">
+        <PageHeader
+          title="Profil"
+          description="Kelola akun &amp; preferensi kamu dalam satu tempat."
+        />
+        <Section first>{renderContent()}</Section>
       </div>
-      {renderContent()}
-    </div>
+    </Page>
   );
 }

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -22,6 +22,7 @@ import {
 import useTransactionsQuery from "../hooks/useTransactionsQuery";
 import useNetworkStatus from "../hooks/useNetworkStatus";
 import { useToast } from "../context/ToastContext";
+import PageHeader from "../layout/PageHeader";
 import { addTransaction, listAccounts, listMerchants, updateTransaction } from "../lib/api";
 import {
   listTransactions,
@@ -724,39 +725,33 @@ export default function Transactions() {
   return (
     <main className="mx-auto w-full max-w-[1280px] px-4 pb-10 sm:px-6 lg:px-8">
       <div className="space-y-6 sm:space-y-7 lg:space-y-8">
-        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h1 className="text-2xl font-semibold text-text">Transaksi</h1>
-            <p className="text-sm text-muted">{PAGE_DESCRIPTION}</p>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <button
-              type="button"
-              onClick={handleNavigateToAdd}
-              className="inline-flex items-center gap-2 rounded-xl bg-brand px-4 py-2 text-sm font-semibold text-white shadow focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60"
-              aria-label="Tambah transaksi (Ctrl+T)"
-            >
-              <Plus className="h-4 w-4" /> Tambah Transaksi
-            </button>
-            <button
-              type="button"
-              onClick={() => setImportOpen(true)}
-              className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 backdrop-blur focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60"
-              aria-label="Import CSV (Ctrl+I)"
-            >
-              <Upload className="h-4 w-4" /> Import CSV
-            </button>
-            <button
-              type="button"
-              onClick={handleExport}
-              disabled={exporting}
-              className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 backdrop-blur focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
-              aria-label="Export CSV (Ctrl+E)"
-            >
-              {exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />} Export CSV
-            </button>
-          </div>
-        </header>
+        <PageHeader title="Transaksi" description={PAGE_DESCRIPTION}>
+          <button
+            type="button"
+            onClick={handleNavigateToAdd}
+            className="inline-flex items-center gap-2 rounded-xl bg-brand px-4 py-2 text-sm font-semibold text-white shadow focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60"
+            aria-label="Tambah transaksi (Ctrl+T)"
+          >
+            <Plus className="h-4 w-4" /> Tambah Transaksi
+          </button>
+          <button
+            type="button"
+            onClick={() => setImportOpen(true)}
+            className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 backdrop-blur focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60"
+            aria-label="Import CSV (Ctrl+I)"
+          >
+            <Upload className="h-4 w-4" /> Import CSV
+          </button>
+          <button
+            type="button"
+            onClick={handleExport}
+            disabled={exporting}
+            className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 backdrop-blur focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="Export CSV (Ctrl+E)"
+          >
+            {exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />} Export CSV
+          </button>
+        </PageHeader>
 
         <div
           ref={filterBarRef}


### PR DESCRIPTION
## Summary
- replace ad-hoc breadcrumb renders on the categories, profile, and transactions pages with the shared PageHeader component
- refresh local layouts to preserve existing spacing while adopting the global breadcrumb presentation

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d6174640988332badadc0997f33a57