### PR TITLE
Use shared page header for category, profile, and transactions

### DIFF
--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -4,6 +4,8 @@ import { createPortal } from "react-dom";
 import CategoryForm from "../components/categories/CategoryForm";
 import CategoryList from "../components/categories/CategoryList";
 import { useToast } from "../context/ToastContext";
+import Page from "../layout/Page";
+import PageHeader from "../layout/PageHeader";
 import {
   CategoryRecord,
   CategoryType,
@@ -370,71 +372,71 @@ export default function Categories() {
   }, [confirming, handleDeleteCategory]);
 
   return (
-    <main className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-4">
-      <div className="rounded-2xl border border-border/60 bg-surface-1/70 p-6 shadow-sm">
-        <h1 className="text-lg font-semibold text-text">Manajemen Kategori</h1>
-        <p className="mt-2 text-sm text-muted">
-          Buat, ubah, hapus, dan atur urutan kategori pemasukan dan pengeluaran.
-        </p>
-      </div>
-      <section className="rounded-2xl border border-border/60 bg-surface-1/70 p-6 shadow-sm">
-        <h2 className="text-base font-semibold text-text">Tambah kategori baru</h2>
-        <p className="mt-1 text-sm text-muted">
-          Pilih tipe kategori, beri nama, dan sesuaikan warnanya.
-        </p>
-        <div className="mt-4">
-          <CategoryForm
-            key={createFormKey}
-            mode="create"
-            initialValues={{ name: "", color: "#0EA5E9", type: "expense" }}
-            onSubmit={handleCreate}
-            isSubmitting={creating}
+    <Page>
+      <div className="space-y-[var(--section-y)]">
+        <PageHeader
+          title="Manajemen Kategori"
+          description="Buat, ubah, hapus, dan atur urutan kategori pemasukan dan pengeluaran."
+        />
+        <section className="rounded-2xl border border-border/60 bg-surface-1/70 p-6 shadow-sm">
+          <h2 className="text-base font-semibold text-text">Tambah kategori baru</h2>
+          <p className="mt-1 text-sm text-muted">
+            Pilih tipe kategori, beri nama, dan sesuaikan warnanya.
+          </p>
+          <div className="mt-4">
+            <CategoryForm
+              key={createFormKey}
+              mode="create"
+              initialValues={{ name: "", color: "#0EA5E9", type: "expense" }}
+              onSubmit={handleCreate}
+              isSubmitting={creating}
+            />
+          </div>
+        </section>
+        {error ? (
+          <div className="rounded-2xl border border-danger/40 bg-danger/10 p-4 text-sm text-danger">
+            <div className="flex items-center justify-between gap-3">
+              <span>{error}</span>
+              <button
+                type="button"
+                onClick={() => reload()}
+                className="inline-flex items-center gap-2 rounded-full border border-danger/40 px-3 py-1 text-xs font-semibold text-danger transition-colors hover:bg-danger/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger/60"
+              >
+                Coba lagi
+              </button>
+            </div>
+          </div>
+        ) : null}
+        <div className="grid gap-4 md:grid-cols-2">
+          <CategoryList
+            type="income"
+            title="Pemasukan"
+            items={grouped.income}
+            editingId={editingId}
+            pendingIds={pendingIds}
+            loading={loading}
+            onStartEdit={setEditingId}
+            onCancelEdit={() => setEditingId(null)}
+            onSubmitEdit={handleSubmitEdit}
+            onDelete={(category) => setConfirming(category)}
+            onMoveUp={(id) => handleMove("income", id, "up")}
+            onMoveDown={(id) => handleMove("income", id, "down")}
+          />
+          <CategoryList
+            type="expense"
+            title="Pengeluaran"
+            items={grouped.expense}
+            editingId={editingId}
+            pendingIds={pendingIds}
+            loading={loading}
+            onStartEdit={setEditingId}
+            onCancelEdit={() => setEditingId(null)}
+            onSubmitEdit={handleSubmitEdit}
+            onDelete={(category) => setConfirming(category)}
+            onMoveUp={(id) => handleMove("expense", id, "up")}
+            onMoveDown={(id) => handleMove("expense", id, "down")}
           />
         </div>
-      </section>
-      {error ? (
-        <div className="rounded-2xl border border-danger/40 bg-danger/10 p-4 text-sm text-danger">
-          <div className="flex items-center justify-between gap-3">
-            <span>{error}</span>
-            <button
-              type="button"
-              onClick={() => reload()}
-              className="inline-flex items-center gap-2 rounded-full border border-danger/40 px-3 py-1 text-xs font-semibold text-danger transition-colors hover:bg-danger/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger/60"
-            >
-              Coba lagi
-            </button>
-          </div>
-        </div>
-      ) : null}
-      <div className="grid gap-4 md:grid-cols-2">
-        <CategoryList
-          type="income"
-          title="Pemasukan"
-          items={grouped.income}
-          editingId={editingId}
-          pendingIds={pendingIds}
-          loading={loading}
-          onStartEdit={setEditingId}
-          onCancelEdit={() => setEditingId(null)}
-          onSubmitEdit={handleSubmitEdit}
-          onDelete={(category) => setConfirming(category)}
-          onMoveUp={(id) => handleMove("income", id, "up")}
-          onMoveDown={(id) => handleMove("income", id, "down")}
-        />
-        <CategoryList
-          type="expense"
-          title="Pengeluaran"
-          items={grouped.expense}
-          editingId={editingId}
-          pendingIds={pendingIds}
-          loading={loading}
-          onStartEdit={setEditingId}
-          onCancelEdit={() => setEditingId(null)}
-          onSubmitEdit={handleSubmitEdit}
-          onDelete={(category) => setConfirming(category)}
-          onMoveUp={(id) => handleMove("expense", id, "up")}
-          onMoveDown={(id) => handleMove("expense", id, "down")}
-        />
       </div>
       <ConfirmDialog
         open={Boolean(confirming)}
@@ -444,6 +446,6 @@ export default function Categories() {
         onConfirm={handleConfirmDelete}
         onCancel={() => setConfirming(null)}
       />
-    </main>
+    </Page>
   );
 }

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -10,6 +10,8 @@ import PrivacyDataCard from '../components/profile/PrivacyDataCard';
 import IntegrationsCard from '../components/profile/IntegrationsCard';
 import useNetworkStatus from '../hooks/useNetworkStatus';
 import { useToast } from '../context/ToastContext';
+import Page from '../layout/Page';
+import PageHeader from '../layout/PageHeader';
 import {
   changePassword,
   checkUsernameAvailability,
@@ -539,12 +541,14 @@ export default function ProfilePage() {
   };
 
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold text-foreground">Profil</h1>
-        <p className="mt-1 text-sm text-muted">Kelola akun &amp; preferensi kamu dalam satu tempat.</p>
+    <Page>
+      <div className="space-y-[var(--section-y)]">
+        <PageHeader
+          title="Profil"
+          description="Kelola akun &amp; preferensi kamu dalam satu tempat."
+        />
+        {renderContent()}
       </div>
-      {renderContent()}
-    </div>
+    </Page>
   );
 }

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -22,6 +22,7 @@ import {
 import useTransactionsQuery from "../hooks/useTransactionsQuery";
 import useNetworkStatus from "../hooks/useNetworkStatus";
 import { useToast } from "../context/ToastContext";
+import PageHeader from "../layout/PageHeader";
 import { addTransaction, listAccounts, listMerchants, updateTransaction } from "../lib/api";
 import {
   listTransactions,
@@ -723,41 +724,35 @@ export default function Transactions() {
 
   return (
     <main className="mx-auto w-full max-w-[1280px] px-4 pb-10 sm:px-6 lg:px-8">
-      <div className="space-y-6 sm:space-y-7 lg:space-y-8">
-        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h1 className="text-2xl font-semibold text-text">Transaksi</h1>
-            <p className="text-sm text-muted">{PAGE_DESCRIPTION}</p>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <button
-              type="button"
-              onClick={handleNavigateToAdd}
-              className="inline-flex items-center gap-2 rounded-xl bg-brand px-4 py-2 text-sm font-semibold text-white shadow focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60"
-              aria-label="Tambah transaksi (Ctrl+T)"
-            >
-              <Plus className="h-4 w-4" /> Tambah Transaksi
-            </button>
-            <button
-              type="button"
-              onClick={() => setImportOpen(true)}
-              className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 backdrop-blur focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60"
-              aria-label="Import CSV (Ctrl+I)"
-            >
-              <Upload className="h-4 w-4" /> Import CSV
-            </button>
-            <button
-              type="button"
-              onClick={handleExport}
-              disabled={exporting}
-              className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 backdrop-blur focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
-              aria-label="Export CSV (Ctrl+E)"
-            >
-              {exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />} Export CSV
-            </button>
-          </div>
-        </header>
+      <PageHeader title="Transaksi" description={PAGE_DESCRIPTION}>
+        <button
+          type="button"
+          onClick={handleNavigateToAdd}
+          className="inline-flex items-center gap-2 rounded-xl bg-brand px-4 py-2 text-sm font-semibold text-white shadow focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60"
+          aria-label="Tambah transaksi (Ctrl+T)"
+        >
+          <Plus className="h-4 w-4" /> Tambah Transaksi
+        </button>
+        <button
+          type="button"
+          onClick={() => setImportOpen(true)}
+          className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 backdrop-blur focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60"
+          aria-label="Import CSV (Ctrl+I)"
+        >
+          <Upload className="h-4 w-4" /> Import CSV
+        </button>
+        <button
+          type="button"
+          onClick={handleExport}
+          disabled={exporting}
+          className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 backdrop-blur focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label="Export CSV (Ctrl+E)"
+        >
+          {exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />} Export CSV
+        </button>
+      </PageHeader>
 
+      <div className="space-y-6 sm:space-y-7 lg:space-y-8">
         <div
           ref={filterBarRef}
           className="sticky z-20"
@@ -810,20 +805,20 @@ export default function Transactions() {
               WebkitBackdropFilter: "blur(6px)",
             }}
           >
-          <TransactionsFilterBar
-            filter={filter}
-            categories={categories}
-            searchTerm={searchTerm}
-            onSearchChange={setSearchTerm}
-            onFilterChange={setFilter}
-            searchInputRef={searchInputRef}
-            onOpenAdd={handleNavigateToAdd}
-          />
+            <TransactionsFilterBar
+              filter={filter}
+              categories={categories}
+              searchTerm={searchTerm}
+              onSearchChange={setSearchTerm}
+              onFilterChange={setFilter}
+              searchInputRef={searchInputRef}
+              onOpenAdd={handleNavigateToAdd}
+            />
+          </div>
         </div>
-      </div>
 
-      {showSyncBadge && (
-        <div className="flex items-center justify-between rounded-2xl border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
+        {showSyncBadge && (
+          <div className="flex items-center justify-between rounded-2xl border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
             <div className="flex items-center gap-2">
               <AlertTriangle className="h-4 w-4" />
               <span>
@@ -844,133 +839,133 @@ export default function Transactions() {
           </div>
         )}
 
-      <SummaryCards summary={summary} loading={loading && items.length === 0} />
+        <SummaryCards summary={summary} loading={loading && items.length === 0} />
 
-      {activeChips.length > 0 && (
-        <ActiveFilterChips chips={activeChips} onRemove={handleRemoveChip} />
-      )}
+        {activeChips.length > 0 && (
+          <ActiveFilterChips chips={activeChips} onRemove={handleRemoveChip} />
+        )}
 
-      {selectedIds.size > 0 && (
-        <SelectionToolbar
-          count={selectedIds.size}
-          onClear={() => {
-            setSelectedIds(new Set());
-            lastSelectedIdRef.current = null;
-          }}
-          onDelete={handleRequestBulkDelete}
-          onEditCategory={() => setBulkEditMode("category")}
-          onEditAccount={() => setBulkEditMode("account")}
-          deleting={deleteInProgress}
-          updating={bulkUpdating}
-          topOffset={selectionToolbarOffset}
+        {selectedIds.size > 0 && (
+          <SelectionToolbar
+            count={selectedIds.size}
+            onClear={() => {
+              setSelectedIds(new Set());
+              lastSelectedIdRef.current = null;
+            }}
+            onDelete={handleRequestBulkDelete}
+            onEditCategory={() => setBulkEditMode("category")}
+            onEditAccount={() => setBulkEditMode("account")}
+            deleting={deleteInProgress}
+            updating={bulkUpdating}
+            topOffset={selectionToolbarOffset}
+          />
+        )}
+
+        <TransactionsTable
+          items={items}
+          loading={loading}
+          error={error}
+          onRetry={() => refresh({ keepPage: true })}
+          onLoadMore={loadMore}
+          hasMore={hasMore}
+          onToggleSelect={toggleSelect}
+          onToggleSelectAll={toggleSelectAll}
+          allSelected={allSelected}
+          selectedIds={selectedIds}
+          onDelete={handleRequestDelete}
+          onEdit={handleEditTransaction}
+          tableStickyTop={tableStickyTop}
+          variant={tableVariant}
+          onResetFilters={handleResetFilters}
+          total={total}
+          onOpenAdd={handleNavigateToAdd}
+          deleteDisabled={deleteInProgress}
         />
-      )}
 
-      <TransactionsTable
-        items={items}
-        loading={loading}
-        error={error}
-        onRetry={() => refresh({ keepPage: true })}
-        onLoadMore={loadMore}
-        hasMore={hasMore}
-        onToggleSelect={toggleSelect}
-        onToggleSelectAll={toggleSelectAll}
-        allSelected={allSelected}
-        selectedIds={selectedIds}
-        onDelete={handleRequestDelete}
-        onEdit={handleEditTransaction}
-        tableStickyTop={tableStickyTop}
-        variant={tableVariant}
-        onResetFilters={handleResetFilters}
-        total={total}
-        onOpenAdd={handleNavigateToAdd}
-        deleteDisabled={deleteInProgress}
-      />
-
-      {confirmState && (
-        <Modal open={Boolean(confirmState)} onClose={handleCloseConfirm} title="Konfirmasi Hapus">
-          <div className="space-y-4 text-white">
-            <p className="text-sm text-white/80">
-              {confirmState.ids.length === 1
-                ? 'Hapus transaksi ini? Tindakan dapat diurungkan selama 6 detik.'
-                : `Hapus ${confirmState.ids.length} transaksi? Tindakan dapat diurungkan selama 6 detik.`}
-            </p>
-            <div className="flex justify-end gap-3">
-              <button
-                type="button"
-                onClick={handleCloseConfirm}
-                disabled={deleteInProgress}
-                className="inline-flex h-11 items-center justify-center rounded-2xl border border-border px-4 text-sm font-medium text-text transition hover:bg-border/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                Batal
-              </button>
-              <button
-                type="button"
-                onClick={handleConfirmDelete}
-                disabled={deleteInProgress}
-                className="inline-flex h-11 items-center justify-center rounded-2xl bg-danger px-4 text-sm font-semibold text-white shadow transition hover:bg-[color:var(--color-danger-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-ring-danger)] disabled:cursor-not-allowed disabled:opacity-70"
-              >
-                {deleteInProgress ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : 'Hapus'}
-              </button>
+        {confirmState && (
+          <Modal open={Boolean(confirmState)} onClose={handleCloseConfirm} title="Konfirmasi Hapus">
+            <div className="space-y-4 text-white">
+              <p className="text-sm text-white/80">
+                {confirmState.ids.length === 1
+                  ? 'Hapus transaksi ini? Tindakan dapat diurungkan selama 6 detik.'
+                  : `Hapus ${confirmState.ids.length} transaksi? Tindakan dapat diurungkan selama 6 detik.`}
+              </p>
+              <div className="flex justify-end gap-3">
+                <button
+                  type="button"
+                  onClick={handleCloseConfirm}
+                  disabled={deleteInProgress}
+                  className="inline-flex h-11 items-center justify-center rounded-2xl border border-border px-4 text-sm font-medium text-text transition hover:bg-border/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Batal
+                </button>
+                <button
+                  type="button"
+                  onClick={handleConfirmDelete}
+                  disabled={deleteInProgress}
+                  className="inline-flex h-11 items-center justify-center rounded-2xl bg-danger px-4 text-sm font-semibold text-white shadow transition hover:bg-[color:var(--color-danger-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-ring-danger)] disabled:cursor-not-allowed disabled:opacity-70"
+                >
+                  {deleteInProgress ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : 'Hapus'}
+                </button>
+              </div>
             </div>
-          </div>
-        </Modal>
-      )}
+          </Modal>
+        )}
 
-      {snackbar && (
-        <UndoSnackbar
-          open
-          message={snackbar.message}
-          onUndo={handleUndoClick}
-          loading={undoLoading}
-        />
-      )}
+        {snackbar && (
+          <UndoSnackbar
+            open
+            message={snackbar.message}
+            onUndo={handleUndoClick}
+            loading={undoLoading}
+          />
+        )}
 
-      {bulkEditMode && (
-        <BulkEditDialog
-          open={Boolean(bulkEditMode)}
-          mode={bulkEditMode}
-          onClose={() => {
-            if (!bulkUpdating) setBulkEditMode(null);
-          }}
-          onSubmit={(selectedValue) => {
-            const field = bulkEditMode === "category" ? "category_id" : "account_id";
-            handleBulkUpdateField(field, selectedValue);
-          }}
-          categories={categories}
-          submitting={bulkUpdating}
-          addToast={addToast}
-        />
-      )}
+        {bulkEditMode && (
+          <BulkEditDialog
+            open={Boolean(bulkEditMode)}
+            mode={bulkEditMode}
+            onClose={() => {
+              if (!bulkUpdating) setBulkEditMode(null);
+            }}
+            onSubmit={(selectedValue) => {
+              const field = bulkEditMode === "category" ? "category_id" : "account_id";
+              handleBulkUpdateField(field, selectedValue);
+            }}
+            categories={categories}
+            submitting={bulkUpdating}
+            addToast={addToast}
+          />
+        )}
 
-      {editTarget && (
-        <TransactionFormDialog
-          open={Boolean(editTarget)}
-          onClose={() => setEditTarget(null)}
-          initialData={editTarget}
-          categories={categories}
-          onSuccess={() => {
-            refresh({ keepPage: true });
-            setSelectedIds(new Set());
-            lastSelectedIdRef.current = null;
-            setEditTarget(null);
-          }}
-          addToast={addToast}
-        />
-      )}
+        {editTarget && (
+          <TransactionFormDialog
+            open={Boolean(editTarget)}
+            onClose={() => setEditTarget(null)}
+            initialData={editTarget}
+            categories={categories}
+            onSuccess={() => {
+              refresh({ keepPage: true });
+              setSelectedIds(new Set());
+              lastSelectedIdRef.current = null;
+              setEditTarget(null);
+            }}
+            addToast={addToast}
+          />
+        )}
 
-      {importOpen && (
-        <ImportCSVDialog
-          open={importOpen}
-          onClose={() => setImportOpen(false)}
-          categories={categories}
-          onImported={() => {
-            refresh();
-            setImportOpen(false);
-          }}
-          addToast={addToast}
-        />
-      )}
+        {importOpen && (
+          <ImportCSVDialog
+            open={importOpen}
+            onClose={() => setImportOpen(false)}
+            categories={categories}
+            onImported={() => {
+              refresh();
+              setImportOpen(false);
+            }}
+            addToast={addToast}
+          />
+        )}
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- replace direct breadcrumb usage on the category, profile, and transactions pages with the shared PageHeader component for consistent styling
- keep existing page actions while letting the common header supply breadcrumb navigation on each screen

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d6174640988332badadc0997f33a57