### PR TITLE
Fix transactions table header behavior

### DIFF
--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -1649,14 +1649,18 @@ function TransactionsTable({
               Array.from({ length: 2 }).map((_, index) => <TransactionSkeletonCard key={`card-fetch-${index}`} />)}
           </div>
         ) : (
-          <div className="overflow-x-auto">
+          <div className="max-h-[70vh] overflow-auto">
             <table className="w-full table-fixed border-separate border-spacing-0" aria-label="Daftar transaksi">
               <thead
-                className="sticky top-0 z-10 border-b border-border/70 bg-surface-1/95 text-xs font-semibold uppercase tracking-wide text-muted backdrop-blur"
+                className="sticky top-0 z-10 bg-slate-900"
                 style={stickyHeaderStyle}
               >
-                <tr>
-                  <th scope="col" className="w-12 px-3 py-3 text-center">
+                <tr className="border-b border-slate-800">
+                  <th
+                    scope="col"
+                    className="w-12 px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted"
+                  >
+                    <span className="sr-only">Pilih transaksi</span>
                     <input
                       type="checkbox"
                       checked={allSelected}
@@ -1665,16 +1669,51 @@ function TransactionsTable({
                       aria-label="Pilih semua transaksi"
                     />
                   </th>
-                  <th scope="col" className="min-w-[200px] px-3 py-3 text-left">Kategori</th>
-                  <th scope="col" className="min-w-[160px] px-3 py-3 text-left">Tanggal</th>
-                  <th scope="col" className="min-w-[240px] px-3 py-3 text-left">Catatan</th>
-                  <th scope="col" className="min-w-[180px] px-3 py-3 text-left">Akun</th>
-                  <th scope="col" className="min-w-[200px] px-3 py-3 text-left">Tags</th>
-                  <th scope="col" className="min-w-[140px] px-3 py-3 text-right">Jumlah</th>
-                  <th scope="col" className="w-[120px] px-3 py-3 text-right">Aksi</th>
+                  <th
+                    scope="col"
+                    className="min-w-[200px] px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted"
+                  >
+                    Kategori
+                  </th>
+                  <th
+                    scope="col"
+                    className="min-w-[160px] px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted"
+                  >
+                    Tanggal
+                  </th>
+                  <th
+                    scope="col"
+                    className="min-w-[240px] px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted"
+                  >
+                    Catatan
+                  </th>
+                  <th
+                    scope="col"
+                    className="min-w-[180px] px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted"
+                  >
+                    Akun
+                  </th>
+                  <th
+                    scope="col"
+                    className="min-w-[200px] px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted"
+                  >
+                    Tags
+                  </th>
+                  <th
+                    scope="col"
+                    className="min-w-[140px] px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-muted"
+                  >
+                    Jumlah
+                  </th>
+                  <th
+                    scope="col"
+                    className="w-[120px] px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-muted"
+                  >
+                    Aksi
+                  </th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody className="divide-y divide-slate-800">
                 {items.map((item) => (
                   <TransactionItem
                     key={item.id}
@@ -1745,9 +1784,9 @@ function UndoSnackbar({ open, message, onUndo, loading }) {
 
 function TransactionSkeletonRow() {
   return (
-    <tr className="border-b border-border/60 last:border-b-0">
+    <tr>
       {Array.from({ length: 8 }).map((_, index) => (
-        <td key={index} className="px-3 py-3 align-middle">
+        <td key={index} className="px-4 py-3 align-middle">
           <div className="h-4 w-full animate-pulse rounded-full bg-border/60" />
         </td>
       ))}
@@ -1899,17 +1938,17 @@ function TransactionItem({
   return (
     <tr
       className={clsx(
-        "border-b border-border/60 last:border-b-0 transition-colors",
+        "transition-colors",
         isSelected
           ? "bg-brand/10 shadow-[inset_0_0_0_1px_hsl(var(--color-primary)/0.35)]"
           : "hover:bg-surface-2/60",
       )}
       onDoubleClick={onEdit}
     >
-      <td className="px-3 py-3 align-middle">
+      <td className="px-4 py-3 align-middle text-center">
         <div className="flex items-center justify-center">{selectionCheckbox}</div>
       </td>
-      <td className="px-3 py-3 align-middle">
+      <td className="px-4 py-3 align-middle">
         <div className="flex items-center gap-3">
           <span
             className="h-2.5 w-2.5 rounded-full"
@@ -1924,10 +1963,10 @@ function TransactionItem({
           </div>
         </div>
       </td>
-      <td className="px-3 py-3 align-middle text-sm text-muted">
+      <td className="px-4 py-3 align-middle text-sm text-muted">
         <time dateTime={dateValue}>{formattedDate}</time>
       </td>
-      <td className="px-3 py-3 align-middle">
+      <td className="px-4 py-3 align-middle">
         <div className="flex items-start gap-2">
           <p className="line-clamp-2 text-sm text-text" title={noteDisplay}>
             {noteDisplay}
@@ -1935,7 +1974,7 @@ function TransactionItem({
           {hasAttachments && <Paperclip className="mt-0.5 h-4 w-4 text-muted" aria-hidden="true" />}
         </div>
       </td>
-      <td className="px-3 py-3 align-middle text-sm text-text">
+      <td className="px-4 py-3 align-middle text-sm text-text">
         {item.type === "transfer" ? (
           <div className="flex flex-wrap items-center gap-1">
             <span className="truncate">{item.account || "—"}</span>
@@ -1946,7 +1985,7 @@ function TransactionItem({
           <span className="truncate">{item.account || "—"}</span>
         )}
       </td>
-      <td className="px-3 py-3 align-middle">
+      <td className="px-4 py-3 align-middle">
         {tags.length > 0 ? (
           <div className="flex flex-wrap gap-2">
             {tags.map((tag) => (
@@ -1962,10 +2001,10 @@ function TransactionItem({
           <span className="text-sm text-muted">—</span>
         )}
       </td>
-      <td className="px-3 py-3 align-middle">
-        <span className={clsx("block", amountClass)}>{formatIDR(item.amount)}</span>
+      <td className="px-4 py-3 align-middle text-right">
+        <span className={amountClass}>{formatIDR(item.amount)}</span>
       </td>
-      <td className="px-3 py-3 align-middle">
+      <td className="px-4 py-3 align-middle text-right">
         <div className="flex items-center justify-end gap-2">
           <button
             type="button"


### PR DESCRIPTION
## Summary
- refactor the transactions table markup to keep a single sticky table header above the scrollable body
- apply consistent Tailwind spacing, typography, and alignment rules for header and body cells
- update skeleton rows to match the new table spacing and divider styling

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d660b3dfbc8332846d917ad2e51ebb