### PR TITLE
feat: redesign daily digest dashboard summary

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,6 @@ import {
 import AppSidebar from "./layout/AppSidebar";
 import MainLayout from "./layout/MainLayout";
 import SettingsPanel from "./components/SettingsPanel";
-import DailyDigest from "./components/DailyDigest";
 import SyncBanner from "./components/SyncBanner";
 import BootGate from "./components/BootGate";
 
@@ -57,7 +56,6 @@ import MoneyTalkProvider, {
   useMoneyTalk,
 } from "./context/MoneyTalkContext.jsx";
 import { ModeProvider, useMode } from "./hooks/useMode";
-import useDailyDigest from "./hooks/useDailyDigest";
 
 const uid = () =>
   globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
@@ -83,23 +81,6 @@ const BRAND_PRESETS = {
   amber: { h: 38, s: 92, l: 50 },
   rose: { h: 347, s: 77, l: 60 },
 };
-
-function DailyDigestLayer({ transactions }) {
-  const digest = useDailyDigest({ transactions });
-
-  if (!digest.open || !digest.data || !digest.userId) {
-    return null;
-  }
-
-  return (
-    <DailyDigest
-      open={digest.open}
-      data={digest.data}
-      variant={digest.variant}
-      onClose={digest.close}
-    />
-  );
-}
 
 function normalizeBudgetRecord(budget, overrides = {}) {
   if (!budget) return null;
@@ -1018,7 +999,6 @@ function AppShell({ prefs, setPrefs }) {
     <CategoryProvider catMeta={catMeta}>
       <BootGate>
         <>
-          <DailyDigestLayer transactions={data.txs} />
           <Routes>
             <Route path="/auth" element={<AuthLogin />} />
             <Route element={<AuthGuard />}>

--- a/src/components/DailyDigestCard.tsx
+++ b/src/components/DailyDigestCard.tsx
@@ -1,0 +1,340 @@
+import { useMemo } from "react";
+import { createSearchParams, useNavigate } from "react-router-dom";
+import clsx from "clsx";
+import type {
+  BalanceSummary,
+  DailyDigestData,
+  PeriodSummary,
+  TodayExpenseSummary,
+  TopCategoryItem,
+} from "../hooks/useDailyDigest";
+import { formatCurrency } from "../lib/format";
+
+interface DailyDigestCardProps {
+  data: DailyDigestData | null;
+  loading: boolean;
+  error?: Error | null;
+  onRetry?: () => void;
+}
+
+interface KPIItemProps {
+  title: string;
+  value: string;
+  description?: string;
+  accent?: "positive" | "negative" | "neutral";
+}
+
+interface BadgeProps {
+  label: string;
+  value: string;
+  ratioLabel: string;
+}
+
+interface UpcomingItem {
+  id: string;
+  label: string;
+  hint: string;
+  amount: number;
+  tone: "info" | "warn";
+}
+
+function KPIItem({ title, value, description, accent = "neutral" }: KPIItemProps) {
+  return (
+    <div className="rounded-2xl bg-white/70 p-4 shadow-sm ring-1 ring-border/60 transition dark:bg-slate-900/60">
+      <div className="text-xs font-medium uppercase tracking-wide text-muted">{title}</div>
+      <div
+        className={clsx(
+          "mt-1 text-2xl font-bold sm:text-3xl",
+          accent === "positive" && "text-emerald-600 dark:text-emerald-400",
+          accent === "negative" && "text-rose-600 dark:text-rose-400",
+        )}
+      >
+        {value}
+      </div>
+      {description ? <p className="mt-1 text-xs text-muted sm:text-sm">{description}</p> : null}
+    </div>
+  );
+}
+
+function RatioBadge({ label, value, ratioLabel }: BadgeProps) {
+  return (
+    <div className="flex min-w-0 items-center gap-2 rounded-xl bg-[var(--accent)]/10 px-2.5 py-1 text-sm font-medium text-[var(--accent)] ring-1 ring-[var(--accent)]/30">
+      <span className="truncate">{label}</span>
+      <span className="truncate text-xs text-[var(--accent)]/70">{value}</span>
+      <span className="truncate text-xs text-[var(--accent)]/70">{ratioLabel}</span>
+    </div>
+  );
+}
+
+function formatRatio(ratio: number | null | undefined): string {
+  if (!ratio || !Number.isFinite(ratio)) return "–";
+  return `${Math.round(ratio * 100)}%`;
+}
+
+function describeToday(today: TodayExpenseSummary): string {
+  if (!today || today.avgDaily <= 0) return "vs rata-rata harian bulan ini";
+  const ratio = formatRatio(today.ratio);
+  return `vs rata-rata harian bulan ini (${ratio})`;
+}
+
+function describeBalance(balance: BalanceSummary): { label: string; accent: "positive" | "negative" | "neutral" } {
+  if (Math.abs(balance.diff) < 1) {
+    return { label: "Tidak berubah dari kemarin", accent: "neutral" };
+  }
+  const diffText = `${balance.diff > 0 ? "▲" : "▼"} ${formatCurrency(Math.abs(balance.diff))}`;
+  return {
+    label: `${diffText} vs kemarin`,
+    accent: balance.diff > 0 ? "positive" : "negative",
+  };
+}
+
+function formatBadgeValue(summary: PeriodSummary): string {
+  return formatCurrency(summary.total);
+}
+
+function formatBudgetRatio(ratio: number | null | undefined): string {
+  if (ratio == null || !Number.isFinite(ratio)) return "–";
+  return `${Math.round(ratio * 100)}% dari budget`;
+}
+
+function buildUpcomingItems(data: DailyDigestData | null): UpcomingItem[] {
+  if (!data) return [];
+  const items: UpcomingItem[] = [];
+  for (const warning of data.upcoming.budgets) {
+    items.push({
+      id: `budget-${warning.id}`,
+      label: warning.name,
+      hint: `${Math.round(warning.progressPct)}% dari ${formatCurrency(warning.planned)}`,
+      amount: warning.actual,
+      tone: warning.progressPct >= 100 ? "warn" : "info",
+    });
+  }
+  for (const sub of data.upcoming.subscriptions) {
+    items.push({
+      id: `subscription-${sub.id}`,
+      label: `${sub.name} • ${sub.dueDate}`,
+      hint: "Langganan jatuh tempo",
+      amount: sub.amount,
+      tone: "info",
+    });
+  }
+  for (const debt of data.upcoming.debts) {
+    items.push({
+      id: `debt-${debt.id}`,
+      label: `${debt.name} • ${debt.dueDate}`,
+      hint: "Pengingat pembayaran",
+      amount: debt.amount,
+      tone: "warn",
+    });
+  }
+  return items.slice(0, 6);
+}
+
+function TopCategoryChip({
+  category,
+  onSelect,
+}: {
+  category: TopCategoryItem;
+  onSelect: (category: TopCategoryItem) => void;
+}) {
+  const disabled = !category.id;
+  return (
+    <button
+      type="button"
+      onClick={() => !disabled && onSelect(category)}
+      disabled={disabled}
+      className={clsx(
+        "flex w-full items-center justify-between gap-3 rounded-2xl border border-border/60 bg-white/70 px-3 py-2 text-left text-sm transition hover:shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-900/60",
+      )}
+      aria-label={disabled ? undefined : `Lihat transaksi kategori ${category.name}`}
+    >
+      <div className="flex min-w-0 items-center gap-3">
+        <span className="rounded-lg bg-[var(--accent)]/15 px-2 py-1 text-xs font-semibold text-[var(--accent)]">
+          {Math.round(category.pctOfMonth)}%
+        </span>
+        <span className="min-w-0 truncate font-medium">{category.name}</span>
+      </div>
+      <span className="shrink-0 text-sm text-muted">{formatCurrency(category.total)}</span>
+    </button>
+  );
+}
+
+function InsightCard({ insight }: { insight: string }) {
+  return (
+    <div className="rounded-2xl bg-[var(--accent)]/8 p-4 text-sm text-[var(--accent)] ring-1 ring-[var(--accent)]/30">
+      <span className="font-medium">Insight cepat:</span> {insight}
+    </div>
+  );
+}
+
+function SkeletonBlock() {
+  return (
+    <div className="animate-pulse space-y-4">
+      <div className="h-4 w-32 rounded bg-muted/40" />
+      <div className="h-10 w-48 rounded bg-muted/30" />
+      <div className="h-3 w-40 rounded bg-muted/30" />
+      <div className="h-20 rounded-2xl bg-muted/20" />
+      <div className="h-16 rounded-2xl bg-muted/20" />
+      <div className="h-10 rounded-2xl bg-muted/20" />
+    </div>
+  );
+}
+
+export default function DailyDigestCard({ data, loading, error, onRetry }: DailyDigestCardProps) {
+  const navigate = useNavigate();
+
+  const upcomingItems = useMemo(() => buildUpcomingItems(data), [data]);
+  const balanceDescription = data ? describeBalance(data.balance) : null;
+  const emptyToday = data && !data.hasTodayTransactions && data.todayExpense.total <= 0;
+
+  const handleAdd = () => navigate("/transaction/add");
+  const handleMonthly = () => navigate("/budgets");
+  const handleExport = () => {
+    const params = createSearchParams({ tab: "transactions" });
+    navigate({ pathname: "/data", search: params.toString() });
+  };
+  const handleCategorySelect = (item: TopCategoryItem) => {
+    if (!item.id) return;
+    const params = createSearchParams({ range: "month", categories: item.id });
+    navigate({ pathname: "/transactions", search: params.toString() });
+  };
+
+  return (
+    <section className="rounded-2xl bg-white/60 p-4 shadow-sm ring-1 ring-border/60 backdrop-blur dark:bg-slate-950/40 sm:p-6">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-text">Daily Digest</h2>
+          <p className="text-xs text-muted sm:text-sm">Ringkasan singkat finansialmu</p>
+        </div>
+        {onRetry ? (
+          <button
+            type="button"
+            onClick={onRetry}
+            className="rounded-lg border border-border/60 px-3 py-1.5 text-xs font-medium text-muted transition hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]"
+            aria-label="Muat ulang Daily Digest"
+          >
+            Muat ulang
+          </button>
+        ) : null}
+      </header>
+
+      {loading ? (
+        <div className="mt-4">
+          <SkeletonBlock />
+        </div>
+      ) : error ? (
+        <div className="mt-4 rounded-2xl border border-rose-200 bg-rose-50/70 p-4 text-sm text-rose-700 dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-200">
+          Gagal memuat ringkasan. {onRetry ? "Coba muat ulang." : "Silakan coba lagi nanti."}
+        </div>
+      ) : data ? (
+        <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,1fr)] lg:gap-6">
+          <div className="flex flex-col gap-4">
+            <KPIItem
+              title="Saldo akun aktif"
+              value={formatCurrency(data.balance.total)}
+              description={balanceDescription?.label}
+              accent={balanceDescription?.accent ?? "neutral"}
+            />
+            <KPIItem
+              title="Pengeluaran hari ini"
+              value={formatCurrency(data.todayExpense.total)}
+              description={describeToday(data.todayExpense)}
+              accent={data.todayExpense.ratio > 1 ? "negative" : "positive"}
+            />
+            <div className="flex flex-wrap gap-2">
+              <RatioBadge
+                label="Week-to-date"
+                value={formatBadgeValue(data.wtd)}
+                ratioLabel={`${formatRatio(data.wtd.ratio)} dari rata-rata 3 bulan`}
+              />
+              <RatioBadge
+                label="Month-to-date"
+                value={formatCurrency(data.mtd.total)}
+                ratioLabel={formatBudgetRatio(data.mtd.ratioToBudget)}
+              />
+            </div>
+            <InsightCard insight={data.insight} />
+            <div className="flex flex-wrap gap-2" aria-label="Aksi cepat Daily Digest">
+              <button
+                type="button"
+                onClick={handleAdd}
+                className="rounded-xl bg-[var(--accent)]/20 px-3 py-2 text-sm font-semibold text-[var(--accent)] transition hover:bg-[var(--accent)]/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]"
+                aria-label="Tambah transaksi baru"
+              >
+                ➕ Tambah Transaksi
+              </button>
+              <button
+                type="button"
+                onClick={handleMonthly}
+                className="rounded-xl border border-border/60 px-3 py-2 text-sm font-medium text-muted transition hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]"
+                aria-label="Lihat detail bulanan"
+              >
+                📊 Detail Bulanan
+              </button>
+              <button
+                type="button"
+                onClick={handleExport}
+                className="rounded-xl border border-border/60 px-3 py-2 text-sm font-medium text-muted transition hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]"
+                aria-label="Ekspor transaksi"
+              >
+                ⬇️ Ekspor
+              </button>
+            </div>
+          </div>
+          <div className="flex flex-col gap-4">
+            <section aria-label="Kategori teratas bulan ini" className="space-y-3">
+              <h3 className="text-sm font-semibold text-text">Top kategori bulan ini</h3>
+              {data.topCategories.length > 0 ? (
+                <div className="space-y-2">
+                  {data.topCategories.map((category) => (
+                    <TopCategoryChip key={`${category.id ?? "uncategorized"}`} category={category} onSelect={handleCategorySelect} />
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-muted">Belum ada kategori yang dominan.</p>
+              )}
+            </section>
+            <section aria-label="Pengingat dan agenda keuangan" className="space-y-3">
+              <h3 className="text-sm font-semibold text-text">Upcoming & peringatan</h3>
+              {upcomingItems.length > 0 ? (
+                <ul className="divide-y divide-border/60 rounded-2xl ring-1 ring-border/40" role="list">
+                  {upcomingItems.map((item) => (
+                    <li key={item.id} className="flex min-h-[44px] items-center justify-between gap-3 bg-white/60 px-3 py-2 text-sm dark:bg-slate-900/60">
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span>{item.tone === "warn" ? "⚠️" : "🔔"}</span>
+                          <span className="truncate font-medium">{item.label}</span>
+                        </div>
+                        <p className="ml-6 text-xs text-muted">{item.hint}</p>
+                      </div>
+                      <span className="shrink-0 text-sm font-semibold text-text">{formatCurrency(item.amount)}</span>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-sm text-muted">Tidak ada peringatan 7 hari ke depan.</p>
+              )}
+            </section>
+          </div>
+        </div>
+      ) : null}
+
+      {!loading && !error && emptyToday ? (
+        <div className="mt-4 rounded-2xl border border-dashed border-border/60 bg-white/40 p-4 text-sm text-muted dark:bg-slate-900/40">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <span>Belum ada transaksi hari ini.</span>
+            <button
+              type="button"
+              onClick={handleAdd}
+              className="rounded-lg bg-[var(--accent)]/20 px-3 py-1.5 text-sm font-semibold text-[var(--accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]"
+              aria-label="Tambah transaksi pertama hari ini"
+            >
+              Catat sekarang
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+

--- a/src/hooks/useDailyDigest.ts
+++ b/src/hooks/useDailyDigest.ts
@@ -1,404 +1,756 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { PostgrestError } from "@supabase/supabase-js";
 import { supabase } from "../lib/supabase";
+import { buildSupabaseHeaders, createRestUrl, fetchJson } from "../lib/supabaseRest";
+import { useToast } from "../context/ToastContext";
 
 const TIMEZONE = "Asia/Jakarta";
-const STORAGE_PREFIX = "hw:digest:last:";
+const CACHE_PREFIX = "hw:daily-digest:v2:";
+const CACHE_TTL_MS = 90_000;
 const DATE_FORMATTER = new Intl.DateTimeFormat("en-CA", {
   timeZone: TIMEZONE,
   year: "numeric",
   month: "2-digit",
   day: "2-digit",
 });
-const HUMAN_DATE_FORMATTER = new Intl.DateTimeFormat("id-ID", {
+const WEEKDAY_FORMATTER = new Intl.DateTimeFormat("en-US", {
   timeZone: TIMEZONE,
-  weekday: "long",
-  day: "numeric",
-  month: "long",
-});
-const CURRENCY_FORMATTER = new Intl.NumberFormat("id-ID", {
-  style: "currency",
-  currency: "IDR",
-  minimumFractionDigits: 0,
+  weekday: "short",
 });
 
-export interface DigestTransaction {
-  amount?: number | string | null;
-  type?: string | null;
-  date?: string | null;
-  category?: string | null;
-  category_name?: string | null;
-  merchant?: string | null | { name?: string | null };
-  merchant_name?: string | null;
-  deleted_at?: string | null;
+const WEEKDAY_INDEX: Record<string, number> = {
+  sun: 0,
+  mon: 1,
+  tue: 2,
+  wed: 3,
+  thu: 4,
+  fri: 5,
+  sat: 6,
+};
+
+const memoryCache = new Map<string, CachedDigest>();
+
+type UUID = string;
+
+type DailyRow = {
+  date: string;
+  type: string;
+  total: number;
+};
+
+type CategoryRow = {
+  category_id: string | null;
+  category?: { name?: string | null } | null;
+  total: number;
+};
+
+type TotalsByTypeRow = {
+  type: string;
+  total: number;
+};
+
+interface CachedDigest {
+  data: DailyDigestData;
+  expiresAt: number;
 }
 
-interface HighlightItem {
+interface BudgetRow {
+  id: string;
+  name: string | null;
+  planned: number;
+  category_id: string | null;
+}
+
+interface SubscriptionRow {
+  id: string;
   name: string;
-  amount: number;
+  next_due_date: string | null;
+  amount: number | null;
+}
+
+interface DebtRow {
+  id: string;
+  title: string;
+  party_name: string | null;
+  due_date: string | null;
+  amount: number | null;
+  status: string | null;
+}
+
+export interface BalanceSummary {
+  total: number;
+  diff: number;
+  direction: "up" | "down" | "flat";
+}
+
+export interface TodayExpenseSummary {
+  total: number;
+  avgDaily: number;
+  ratio: number;
+}
+
+export interface PeriodSummary {
+  total: number;
+  average: number;
+  ratio: number;
+}
+
+export interface MonthSummary {
+  total: number;
+  budgetTotal: number | null;
+  ratioToBudget: number | null;
+}
+
+export interface TopCategoryItem {
+  id: string | null;
+  name: string;
+  total: number;
+  pctOfMonth: number;
+}
+
+export interface BudgetWarningItem {
+  id: string;
+  name: string;
+  planned: number;
+  actual: number;
+  progressPct: number;
+}
+
+export interface UpcomingItems {
+  budgets: BudgetWarningItem[];
+  subscriptions: Array<{ id: string; name: string; dueDate: string; amount: number }>;
+  debts: Array<{ id: string; name: string; dueDate: string; amount: number }>;
 }
 
 export interface DailyDigestData {
-  totalSpent: number;
-  transactionCount: number;
-  average7Day: number;
-  diffPercent: number;
-  diffDirection: "up" | "down" | "flat";
-  topCategories: HighlightItem[];
-  topMerchants: HighlightItem[];
-  highlightLabel: string | null;
-  suggestion: string;
-  summary: string;
-  comparisonSentence: string;
-  yesterdayLabel: string;
-  yesterdayDate: string;
+  balance: BalanceSummary;
+  todayExpense: TodayExpenseSummary;
+  wtd: PeriodSummary;
+  mtd: MonthSummary;
+  topCategories: TopCategoryItem[];
+  upcoming: UpcomingItems;
+  insight: string;
+  hasTodayTransactions: boolean;
 }
 
 export interface UseDailyDigestResult {
-  open: boolean;
   data: DailyDigestData | null;
-  close: () => void;
-  markSeen: () => void;
-  variant: "modal" | "banner";
-  userId: string | null;
+  loading: boolean;
+  error: Error | null;
+  refresh: () => Promise<void>;
 }
 
-export interface UseDailyDigestOptions {
-  transactions?: DigestTransaction[] | null;
-}
-
-export function todayJakarta(): string {
-  return DATE_FORMATTER.format(new Date());
-}
-
-function formatDateInZone(date: Date): string {
+function formatDateLocal(date: Date): string {
   return DATE_FORMATTER.format(date);
 }
 
-function shiftLocalDateString(base: string, offset: number): string {
-  const [year, month, day] = base.split("-").map((part) => Number.parseInt(part, 10));
-  if (!year || !month || !day) return base;
-  const ref = new Date(Date.UTC(year, month - 1, day));
-  ref.setUTCDate(ref.getUTCDate() + offset);
-  const y = ref.getUTCFullYear();
-  const m = String(ref.getUTCMonth() + 1).padStart(2, "0");
-  const d = String(ref.getUTCDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
+function parseLocalDate(value: string): Date {
+  return new Date(`${value}T00:00:00+07:00`);
 }
 
-function getTransactionDate(tx: DigestTransaction): string | null {
-  if (!tx?.date) return null;
-  const parsed = new Date(tx.date);
-  if (Number.isNaN(parsed.getTime())) return null;
-  return formatDateInZone(parsed);
+function getTodayLocal(): string {
+  return formatDateLocal(new Date());
 }
 
-function toNumber(value: number | string | null | undefined): number {
-  const numeric = typeof value === "string" ? Number.parseFloat(value) : Number(value ?? 0);
-  return Number.isFinite(numeric) ? numeric : 0;
+function shiftDateString(base: string, offsetDays: number): string {
+  const ref = parseLocalDate(base);
+  ref.setUTCDate(ref.getUTCDate() + offsetDays);
+  return formatDateLocal(ref);
 }
 
-function getMerchantName(tx: DigestTransaction): string | null {
-  const candidates: Array<string | null | undefined> = [
-    tx.merchant_name,
-    typeof tx.merchant === "string" ? tx.merchant : null,
-    tx.merchant && typeof tx.merchant === "object" ? tx.merchant.name : null,
-  ];
-  for (const candidate of candidates) {
-    const trimmed = typeof candidate === "string" ? candidate.trim() : "";
-    if (trimmed) return trimmed;
+function getWeekday(date: Date): number {
+  const label = WEEKDAY_FORMATTER.format(date).toLowerCase().slice(0, 3);
+  return WEEKDAY_INDEX[label] ?? 0;
+}
+
+function getStartOfWeek(base: string): string {
+  const ref = parseLocalDate(base);
+  const weekday = getWeekday(ref);
+  const diff = (weekday - 1 + 7) % 7;
+  return shiftDateString(base, -diff);
+}
+
+function getStartOfMonth(base: string): string {
+  const [year, month] = base.split("-");
+  return `${year}-${month}-01`;
+}
+
+function shiftMonthString(base: string, offset: number): string {
+  const [yearStr, monthStr, dayStr] = base.split("-");
+  let year = Number.parseInt(yearStr, 10);
+  let month = Number.parseInt(monthStr, 10);
+  const day = Number.parseInt(dayStr, 10);
+  if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) {
+    return base;
   }
-  return null;
-}
-
-function getCategoryName(tx: DigestTransaction): string | null {
-  const candidates: Array<string | null | undefined> = [
-    tx.category,
-    tx.category_name,
-  ];
-  for (const candidate of candidates) {
-    const trimmed = typeof candidate === "string" ? candidate.trim() : "";
-    if (trimmed) return trimmed;
+  month += offset;
+  while (month > 12) {
+    month -= 12;
+    year += 1;
   }
-  return null;
+  while (month < 1) {
+    month += 12;
+    year -= 1;
+  }
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  const resolvedDay = Math.min(day, daysInMonth);
+  return `${year}-${String(month).padStart(2, "0")}-${String(resolvedDay).padStart(2, "0")}`;
 }
 
-function summarizeHighlights(entries: HighlightItem[]): string | null {
-  if (!entries.length) return null;
-  if (entries.length === 1) return entries[0].name;
-  return `${entries[0].name} & ${entries[1].name}`;
+function daysBetween(start: string, end: string): number {
+  const startDate = parseLocalDate(start);
+  const endDate = parseLocalDate(end);
+  const diff = endDate.getTime() - startDate.getTime();
+  return Math.max(Math.floor(diff / (1000 * 60 * 60 * 24)) + 1, 1);
 }
 
-function formatCurrency(value: number): string {
-  return CURRENCY_FORMATTER.format(Math.round(value));
+function parseNumber(value: unknown): number {
+  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
 }
 
-function buildSummary(
-  totalSpent: number,
-  transactionCount: number,
-  diffDirection: "up" | "down" | "flat",
-  diffPercent: number,
-  average7Day: number,
-  suggestion: string,
-): { comparison: string; summary: string } {
-  const spendSentence =
-    transactionCount === 0
-      ? "Kemarin belum ada transaksi yang terekam."
-      : `Kemarin kamu belanja ${formatCurrency(totalSpent)} di ${transactionCount} transaksi.`;
-  let comparisonSentence: string;
-  if (average7Day > 0) {
-    if (diffDirection === "flat") {
-      comparisonSentence = "Itu setara dengan rata-rata 7 hari.";
-    } else if (diffDirection === "up") {
-      comparisonSentence = `Itu lebih tinggi ${Math.abs(Math.round(diffPercent))}% dari rata-rata 7 hari.`;
-    } else {
-      comparisonSentence = `Itu lebih rendah ${Math.abs(Math.round(diffPercent))}% dari rata-rata 7 hari.`;
+function formatInList(values: string[]): string {
+  return `(${values.map((value) => `"${value}"`).join(",")})`;
+}
+
+async function fetchDailySums(
+  userId: string,
+  accountIds: string[],
+  start: string,
+  end: string,
+): Promise<DailyRow[]> {
+  const params = new URLSearchParams();
+  params.set("select", "date,type,amount.sum().as(total)");
+  params.append("user_id", `eq.${userId}`);
+  params.append("deleted_at", "is.null");
+  params.append("type", "in.(\"income\",\"expense\")");
+  params.append("date", `gte.${start}`);
+  params.append("date", `lte.${end}`);
+  if (accountIds.length) {
+    params.append("account_id", `in.${formatInList(accountIds)}`);
+  }
+  params.append("group", "date,type");
+  params.append("order", "date.asc");
+
+  const url = createRestUrl("/rest/v1/transactions", params);
+  const rows = await fetchJson<Array<{ date: string; type: string; total: number }>>(url, {
+    headers: buildSupabaseHeaders(),
+  });
+  return Array.isArray(rows)
+    ? rows.map((row) => ({
+        date: String(row.date ?? "").slice(0, 10),
+        type: String(row.type ?? ""),
+        total: parseNumber(row.total),
+      }))
+    : [];
+}
+
+async function fetchTotalsByType(
+  userId: string,
+  accountIds: string[],
+): Promise<Record<"income" | "expense", number>> {
+  const params = new URLSearchParams();
+  params.set("select", "type,amount.sum().as(total)");
+  params.append("user_id", `eq.${userId}`);
+  params.append("deleted_at", "is.null");
+  params.append("type", "in.(\"income\",\"expense\")");
+  if (accountIds.length) {
+    params.append("account_id", `in.${formatInList(accountIds)}`);
+  }
+  params.append("group", "type");
+
+  const url = createRestUrl("/rest/v1/transactions", params);
+  const rows = await fetchJson<TotalsByTypeRow[]>(url, {
+    headers: buildSupabaseHeaders(),
+  });
+  const result: Record<"income" | "expense", number> = { income: 0, expense: 0 };
+  for (const row of rows ?? []) {
+    const key = row?.type === "income" ? "income" : row?.type === "expense" ? "expense" : null;
+    if (!key) continue;
+    result[key] = parseNumber(row?.total);
+  }
+  return result;
+}
+
+async function fetchCategoryTotals(
+  userId: string,
+  accountIds: string[],
+  start: string,
+  end: string,
+): Promise<CategoryRow[]> {
+  const params = new URLSearchParams();
+  params.set("select", "category_id,category:categories(name),amount.sum().as(total)");
+  params.append("user_id", `eq.${userId}`);
+  params.append("deleted_at", "is.null");
+  params.append("type", "eq.expense");
+  params.append("date", `gte.${start}`);
+  params.append("date", `lte.${end}`);
+  if (accountIds.length) {
+    params.append("account_id", `in.${formatInList(accountIds)}`);
+  }
+  params.append("group", "category_id,category");
+  params.append("order", "total.desc.nullslast");
+
+  const url = createRestUrl("/rest/v1/transactions", params);
+  const rows = await fetchJson<CategoryRow[]>(url, {
+    headers: buildSupabaseHeaders(),
+  });
+  return Array.isArray(rows)
+    ? rows.map((row) => ({
+        category_id: row.category_id ?? null,
+        category: row.category ?? null,
+        total: parseNumber((row as { total?: number }).total),
+      }))
+    : [];
+}
+
+async function fetchBudgets(
+  userId: string,
+  periodMonth: string,
+): Promise<BudgetRow[]> {
+  const { data, error } = await supabase
+    .from("budgets")
+    .select("id,name,planned,category_id")
+    .eq("user_id", userId)
+    .eq("period_month", periodMonth);
+  if (error) throw error;
+  return Array.isArray(data)
+    ? data.map((row) => ({
+        id: String(row.id),
+        name: row.name ?? null,
+        planned: parseNumber((row as { planned?: number }).planned),
+        category_id: (row as { category_id?: string | null }).category_id ?? null,
+      }))
+    : [];
+}
+
+async function fetchUpcomingSubscriptions(
+  userId: string,
+  start: string,
+  end: string,
+): Promise<SubscriptionRow[]> {
+  const { data, error } = await supabase
+    .from("subscriptions")
+    .select("id,name,next_due_date,amount,status")
+    .eq("user_id", userId)
+    .eq("status", "active")
+    .gte("next_due_date", start)
+    .lte("next_due_date", end)
+    .order("next_due_date", { ascending: true });
+  if (error) throw error;
+  return Array.isArray(data)
+    ? data.map((row) => ({
+        id: String(row.id),
+        name: String(row.name ?? "Langganan"),
+        next_due_date: row.next_due_date ?? null,
+        amount: parseNumber((row as { amount?: number }).amount),
+      }))
+    : [];
+}
+
+async function fetchUpcomingDebts(
+  userId: string,
+  startIso: string,
+  endIso: string,
+): Promise<DebtRow[]> {
+  const { data, error } = await supabase
+    .from("debts")
+    .select("id,title,party_name,due_date,amount,status")
+    .eq("user_id", userId)
+    .neq("status", "paid")
+    .not("due_date", "is", null)
+    .gte("due_date", startIso)
+    .lte("due_date", endIso)
+    .order("due_date", { ascending: true });
+  if (error) throw error;
+  return Array.isArray(data)
+    ? data.map((row) => ({
+        id: String(row.id),
+        title: String(row.title ?? "Hutang"),
+        party_name: row.party_name ?? null,
+        due_date: row.due_date ?? null,
+        amount: parseNumber((row as { amount?: number }).amount),
+        status: row.status ?? null,
+      }))
+    : [];
+}
+
+function computeBalanceSummary(
+  totalsByType: Record<"income" | "expense", number>,
+  dailySums: Map<string, { income: number; expense: number }>,
+  today: string,
+): BalanceSummary {
+  const incomeTotal = totalsByType.income ?? 0;
+  const expenseTotal = totalsByType.expense ?? 0;
+  const total = incomeTotal - expenseTotal;
+  const todayData = dailySums.get(today);
+  const todayIncome = todayData?.income ?? 0;
+  const todayExpense = todayData?.expense ?? 0;
+  const delta = todayIncome - todayExpense;
+  const diff = delta;
+  let direction: "up" | "down" | "flat" = "flat";
+  if (Math.abs(diff) <= 0.01) direction = "flat";
+  else if (diff > 0) direction = "up";
+  else direction = "down";
+  return { total, diff, direction };
+}
+
+function computePeriodTotal(
+  dailySums: Map<string, { income: number; expense: number }>,
+  start: string,
+  end: string,
+): { income: number; expense: number } {
+  let income = 0;
+  let expense = 0;
+  let cursor = start;
+  while (cursor <= end) {
+    const entry = dailySums.get(cursor);
+    if (entry) {
+      income += entry.income;
+      expense += entry.expense;
     }
-  } else {
-    comparisonSentence = "Belum ada cukup data untuk rata-rata 7 hari.";
+    cursor = shiftDateString(cursor, 1);
   }
-  const summary = `${spendSentence} ${comparisonSentence} ${suggestion}`.trim();
-  return { comparison: comparisonSentence, summary };
+  return { income, expense };
 }
 
-function computeHighlights(map: Map<string, number>): HighlightItem[] {
-  return Array.from(map.entries())
-    .filter(([, amount]) => amount > 0)
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 2)
-    .map(([name, amount]) => ({ name, amount }));
+function buildInsight(
+  todayExpense: TodayExpenseSummary,
+  week: PeriodSummary,
+  month: MonthSummary,
+  topCategories: TopCategoryItem[],
+): string {
+  const top = topCategories[0];
+  if (todayExpense.total > 0) {
+    const direction = todayExpense.ratio > 1 ? "di atas" : "di bawah";
+    return `Hari ini pengeluaranmu ${direction} rata-rata: Rp${Math.round(todayExpense.total).toLocaleString("id-ID")}.`;
+  }
+  if (top && month.total > 0) {
+    return `${top.name} menyumbang ${Math.round(top.pctOfMonth)}% dari pengeluaran bulan ini.`;
+  }
+  if (week.total > 0 && week.ratio > 1) {
+    return `Pengeluaran minggu ini ${Math.round(week.ratio * 100)}% dari rata-rata 3 bulan terakhir.`;
+  }
+  return "Pengeluaranmu stabil. Tetap pertahankan ritme hematnya!";
 }
 
-function computeDigest(
-  transactions: DigestTransaction[] | null | undefined,
-  todayLocal: string,
-): DailyDigestData {
-  const yesterdayLocal = shiftLocalDateString(todayLocal, -1);
-  const weekStart = shiftLocalDateString(yesterdayLocal, -6);
+function mapBudgets(
+  budgets: BudgetRow[],
+  categoryTotals: Map<string | null, number>,
+): BudgetWarningItem[] {
+  const warnings: BudgetWarningItem[] = [];
+  for (const budget of budgets) {
+    if (!budget) continue;
+    const planned = budget.planned ?? 0;
+    if (planned <= 0) continue;
+    const actual = categoryTotals.get(budget.category_id ?? null) ?? 0;
+    if (actual <= 0) continue;
+    const progress = planned > 0 ? actual / planned : 0;
+    if (progress < 0.9) continue;
+    warnings.push({
+      id: budget.id,
+      name: budget.name || "Tanpa kategori",
+      planned,
+      actual,
+      progressPct: progress * 100,
+    });
+  }
+  warnings.sort((a, b) => b.progressPct - a.progressPct);
+  return warnings.slice(0, 5);
+}
 
-  const expenses = Array.isArray(transactions)
-    ? transactions.filter((tx) => tx && tx.type === "expense" && !tx.deleted_at)
+async function computeDigest(userId: string): Promise<DailyDigestData> {
+  const today = getTodayLocal();
+  const monthStart = getStartOfMonth(today);
+  const weekStart = getStartOfWeek(today);
+  const threeMonthStart = getStartOfMonth(shiftMonthString(today, -2));
+  const weekDayCount = daysBetween(threeMonthStart, today);
+
+  const { data: accountData, error: accountError } = await supabase
+    .from("accounts")
+    .select("id,type")
+    .eq("user_id", userId)
+    .in("type", ["cash", "bank", "ewallet"]);
+  if (accountError) throw accountError;
+  const accountIds = Array.isArray(accountData)
+    ? accountData.map((row) => String((row as { id: UUID }).id))
     : [];
 
-  let totalSpent = 0;
-  let transactionCount = 0;
-  const categoryTotals = new Map<string, number>();
-  const merchantTotals = new Map<string, number>();
-  let weekTotal = 0;
+  const [dailyRows, totalsByType, categoryRows, budgets, subscriptions, debts] = await Promise.all([
+    fetchDailySums(userId, accountIds, threeMonthStart, today),
+    fetchTotalsByType(userId, accountIds),
+    fetchCategoryTotals(userId, accountIds, monthStart, today),
+    fetchBudgets(userId, monthStart),
+    fetchUpcomingSubscriptions(userId, today, shiftDateString(today, 7)),
+    fetchUpcomingDebts(userId, `${today}T00:00:00+07:00`, `${shiftDateString(today, 7)}T23:59:59+07:00`),
+  ]);
 
-  for (const tx of expenses) {
-    const date = getTransactionDate(tx);
-    if (!date) continue;
-
-    const amount = toNumber(tx.amount);
-    if (amount <= 0) continue;
-
-    if (date === yesterdayLocal) {
-      totalSpent += amount;
-      transactionCount += 1;
-      const category = getCategoryName(tx);
-      if (category) {
-        categoryTotals.set(category, (categoryTotals.get(category) || 0) + amount);
-      }
-      const merchant = getMerchantName(tx);
-      if (merchant) {
-        merchantTotals.set(merchant, (merchantTotals.get(merchant) || 0) + amount);
-      }
+  const dailyMap = new Map<string, { income: number; expense: number }>();
+  for (const row of dailyRows) {
+    const existing = dailyMap.get(row.date) ?? { income: 0, expense: 0 };
+    if (row.type === "income") {
+      existing.income += row.total;
+    } else if (row.type === "expense") {
+      existing.expense += row.total;
     }
-
-    if (date >= weekStart && date <= yesterdayLocal) {
-      weekTotal += amount;
-    }
+    dailyMap.set(row.date, existing);
   }
 
-  const average7Day = weekTotal / 7;
-  const diffPercent = average7Day > 0 ? ((totalSpent - average7Day) / average7Day) * 100 : 0;
-  const diffDirection: "up" | "down" | "flat" =
-    average7Day === 0 || Math.abs(diffPercent) < 0.5
-      ? "flat"
-      : diffPercent > 0
-      ? "up"
-      : "down";
+  const todayEntry = dailyMap.get(today) ?? { income: 0, expense: 0 };
+  const todayTotalExpense = todayEntry.expense;
+  const dayOfMonth = Number.parseInt(today.slice(8, 10), 10) || 1;
+  const monthTotals = computePeriodTotal(dailyMap, monthStart, today);
+  const weekTotals = computePeriodTotal(dailyMap, weekStart, today);
+  const quarterTotals = computePeriodTotal(dailyMap, threeMonthStart, today);
 
-  const topCategories = computeHighlights(categoryTotals);
-  const topMerchants = computeHighlights(merchantTotals);
+  const avgDaily = monthTotals.expense / dayOfMonth || 0;
+  const todayRatio = avgDaily > 0 ? todayTotalExpense / avgDaily : 0;
 
-  let suggestion = "Tetap pantau pengeluaran kecil ya 😉";
-  const highlightChoices = topCategories.length ? topCategories : topMerchants;
-  const highlightLabel = summarizeHighlights(highlightChoices);
-  if (transactionCount === 0) {
-    suggestion = "Yuk catat pengeluaran biar laporan makin akurat 😉";
-  } else if (highlightLabel) {
-    suggestion = diffDirection === "down"
-      ? `Mantap! Pertahankan kontrol di ${highlightLabel} ya 😉`
-      : `Coba hemat di ${highlightLabel} ya 😉`;
+  const totalWeeks = weekDayCount / 7;
+  const avgWeekly = totalWeeks > 0 ? quarterTotals.expense / totalWeeks : 0;
+  const weekRatio = avgWeekly > 0 ? weekTotals.expense / avgWeekly : 0;
+
+  const balance = computeBalanceSummary(totalsByType, dailyMap, today);
+
+  const monthSummary: MonthSummary = {
+    total: monthTotals.expense,
+    budgetTotal: null,
+    ratioToBudget: null,
+  };
+
+  let totalBudgetPlanned = 0;
+  for (const budget of budgets) {
+    totalBudgetPlanned += budget.planned ?? 0;
+  }
+  if (totalBudgetPlanned > 0) {
+    monthSummary.budgetTotal = totalBudgetPlanned;
+    monthSummary.ratioToBudget = monthTotals.expense / totalBudgetPlanned;
   }
 
-  const { comparison, summary } = buildSummary(
-    totalSpent,
-    transactionCount,
-    diffDirection,
-    diffPercent,
-    average7Day,
-    suggestion,
-  );
+  const categoryTotals = new Map<string | null, number>();
+  for (const row of categoryRows) {
+    const key = row.category_id ?? null;
+    const current = categoryTotals.get(key) ?? 0;
+    categoryTotals.set(key, current + parseNumber((row as { total?: number }).total));
+  }
 
-  const yesterdayDate = yesterdayLocal;
-  const yesterdayLabel = HUMAN_DATE_FORMATTER.format(
-    new Date(`${yesterdayLocal}T00:00:00+07:00`),
-  );
+  const topCategories: TopCategoryItem[] = categoryRows
+    .map((row) => {
+      const total = parseNumber((row as { total?: number }).total);
+      return {
+        id: row.category_id ?? null,
+        name: row.category?.name?.trim() || "Tanpa kategori",
+        total,
+        pctOfMonth: monthTotals.expense > 0 ? (total / monthTotals.expense) * 100 : 0,
+      };
+    })
+    .filter((item) => item.total > 0)
+    .slice(0, 3);
+
+  const budgetWarnings = mapBudgets(budgets, categoryTotals);
+
+  const upcomingSubscriptions = subscriptions
+    .map((row) => ({
+      id: row.id,
+      name: row.name,
+      dueDate: row.next_due_date ? String(row.next_due_date).slice(0, 10) : today,
+      amount: row.amount ?? 0,
+    }))
+    .filter((item) => item.amount > 0)
+    .slice(0, 5);
+
+  const upcomingDebts = debts
+    .map((row) => ({
+      id: row.id,
+      name: row.party_name ? `${row.title} • ${row.party_name}` : row.title,
+      dueDate: row.due_date ? String(row.due_date).slice(0, 10) : today,
+      amount: row.amount ?? 0,
+    }))
+    .filter((item) => item.amount > 0)
+    .slice(0, 5);
+
+  const todaySummary: TodayExpenseSummary = {
+    total: todayTotalExpense,
+    avgDaily,
+    ratio: todayRatio,
+  };
+
+  const wtdSummary: PeriodSummary = {
+    total: weekTotals.expense,
+    average: avgWeekly,
+    ratio: weekRatio,
+  };
+
+  const insight = buildInsight(todaySummary, wtdSummary, monthSummary, topCategories);
 
   return {
-    totalSpent,
-    transactionCount,
-    average7Day,
-    diffPercent,
-    diffDirection,
+    balance,
+    todayExpense: todaySummary,
+    wtd: wtdSummary,
+    mtd: monthSummary,
     topCategories,
-    topMerchants,
-    highlightLabel,
-    suggestion,
-    summary,
-    comparisonSentence: comparison,
-    yesterdayLabel,
-    yesterdayDate,
+    upcoming: {
+      budgets: budgetWarnings,
+      subscriptions: upcomingSubscriptions,
+      debts: upcomingDebts,
+    },
+    insight,
+    hasTodayTransactions: todayEntry.income > 0 || todayEntry.expense > 0,
   };
 }
 
-interface DigestState {
-  open: boolean;
-  data: DailyDigestData | null;
-  today: string;
+function loadCache(userId: string): DailyDigestData | null {
+  const entry = memoryCache.get(userId);
+  const now = Date.now();
+  if (entry && entry.expiresAt > now) {
+    return entry.data;
+  }
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(`${CACHE_PREFIX}${userId}`);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as CachedDigest;
+    if (!parsed || typeof parsed !== "object") return null;
+    if (parsed.expiresAt > now && parsed.data) {
+      memoryCache.set(userId, parsed);
+      return parsed.data;
+    }
+  } catch {
+    return null;
+  }
+  return null;
 }
 
-const DEFAULT_STATE: DigestState = {
-  open: false,
-  data: null,
-  today: "",
-};
+function saveCache(userId: string, data: DailyDigestData): void {
+  const payload: CachedDigest = { data, expiresAt: Date.now() + CACHE_TTL_MS };
+  memoryCache.set(userId, payload);
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(`${CACHE_PREFIX}${userId}`, JSON.stringify(payload));
+  } catch {
+    // ignore write error
+  }
+}
 
-export default function useDailyDigest({
-  transactions,
-}: UseDailyDigestOptions): UseDailyDigestResult {
-  const [{ open, data, today }, setState] = useState<DigestState>(DEFAULT_STATE);
-  const [sessionReady, setSessionReady] = useState(false);
-  const [userId, setUserId] = useState<string | null>(null);
+function mapError(error: unknown): Error {
+  if (error instanceof Error) return error;
+  if (error && typeof error === "object" && "message" in error) {
+    const message = String((error as { message?: unknown }).message ?? "Gagal memuat data");
+    return new Error(message);
+  }
+  return new Error("Gagal memuat data");
+}
 
-  const storageKey = useMemo(
-    () => (userId ? `${STORAGE_PREFIX}${userId}` : null),
-    [userId],
-  );
+export default function useDailyDigest(): UseDailyDigestResult {
+  const { addToast } = useToast() ?? { addToast: () => undefined };
+  const [data, setData] = useState<DailyDigestData | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+  const userIdRef = useRef<string | null>(null);
+  const mountedRef = useRef<boolean>(true);
 
-  const evaluateDigest = useCallback(
-    (currentUid: string) => {
-      if (!currentUid) return;
-      if (typeof window === "undefined") return;
-
-      const todayLocal = todayJakarta();
-      let lastShown = "";
+  const fetchData = useCallback(
+    async (userId: string, silent = false) => {
+      if (!userId) return;
+      if (!silent) {
+        setLoading(true);
+        setError(null);
+      }
       try {
-        lastShown = window.localStorage.getItem(`${STORAGE_PREFIX}${currentUid}`) || "";
-      } catch {
-        lastShown = "";
+        const digest = await computeDigest(userId);
+        if (!mountedRef.current) return;
+        setData(digest);
+        saveCache(userId, digest);
+      } catch (err) {
+        if (!mountedRef.current) return;
+        const mapped = mapError(err);
+        setError(mapped);
+        if (!silent && typeof addToast === "function") {
+          addToast(mapped.message, "error");
+        }
+      } finally {
+        if (mountedRef.current) {
+          setLoading(false);
+        }
       }
-
-      if (lastShown === todayLocal) {
-        setState({ open: false, data: null, today: todayLocal });
-        return;
-      }
-
-      const digest = computeDigest(transactions ?? [], todayLocal);
-      setState({ open: true, data: digest, today: todayLocal });
     },
-    [transactions],
+    [addToast],
   );
 
-  const evaluateDigestRef = useRef(evaluateDigest);
-  useEffect(() => {
-    evaluateDigestRef.current = evaluateDigest;
-  }, [evaluateDigest]);
+  const refresh = useCallback(async () => {
+    const userId = userIdRef.current;
+    if (!userId) return;
+    await fetchData(userId);
+  }, [fetchData]);
 
   useEffect(() => {
-    let active = true;
-
-    supabase.auth
-      .getSession()
-      .then(({ data }) => {
-        if (!active) return;
-        const session = data.session ?? null;
-        const uid = session?.user?.id ?? null;
-        setUserId(uid);
-        setSessionReady(true);
-        if (uid) {
-          evaluateDigestRef.current(uid);
-        } else {
-          setState(DEFAULT_STATE);
-        }
-      })
-      .catch(() => {
-        if (!active) return;
-        setUserId(null);
-        setSessionReady(true);
-        setState(DEFAULT_STATE);
-      });
-
-    const { data: subscription } = supabase.auth.onAuthStateChange((event, session) => {
-      if (!active) return;
-
-      if (event === "SIGNED_OUT") {
-        setUserId(null);
-        setState(DEFAULT_STATE);
-        return;
-      }
-
-      if (event === "SIGNED_IN") {
-        const uid = session?.user?.id ?? null;
-        setUserId(uid);
-        if (uid) {
-          evaluateDigestRef.current(uid);
-        } else {
-          setState(DEFAULT_STATE);
-        }
-        return;
-      }
-
-      const uid = session?.user?.id ?? null;
-      setUserId(uid);
-    });
-
+    mountedRef.current = true;
     return () => {
-      active = false;
-      subscription.subscription?.unsubscribe();
+      mountedRef.current = false;
     };
   }, []);
 
   useEffect(() => {
-    if (!sessionReady) return;
-    if (!userId) return;
-    evaluateDigest(userId);
-  }, [sessionReady, userId, evaluateDigest]);
+    let cancelled = false;
+    supabase.auth
+      .getUser()
+      .then(async ({ data: authData, error: authError }) => {
+        if (cancelled) return;
+        if (authError) throw authError;
+        const userId = authData.user?.id ?? null;
+        userIdRef.current = userId;
+        if (!userId) {
+          setData(null);
+          setLoading(false);
+          return;
+        }
+        const cached = loadCache(userId);
+        if (cached) {
+          setData(cached);
+          setLoading(false);
+          fetchData(userId, true).catch(() => undefined);
+          return;
+        }
+        await fetchData(userId);
+      })
+      .catch((err: PostgrestError | Error) => {
+        if (cancelled) return;
+        const mapped = mapError(err);
+        setError(mapped);
+        setLoading(false);
+      });
 
-  const markSeen = useCallback(() => {
-    setState((prev) => ({ ...prev, open: false }));
-    if (!storageKey) return;
-    if (typeof window === "undefined") return;
-    const targetDate = today || todayJakarta();
-    try {
-      window.localStorage.setItem(storageKey, targetDate);
-    } catch {
-      /* ignore */
-    }
-  }, [storageKey, today]);
+    const { data: subscription } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!session?.user?.id) {
+        userIdRef.current = null;
+        setData(null);
+        setLoading(false);
+        return;
+      }
+      userIdRef.current = session.user.id;
+      fetchData(session.user.id).catch(() => undefined);
+    });
 
-  const close = useCallback(() => {
-    markSeen();
-  }, [markSeen]);
+    return () => {
+      cancelled = true;
+      subscription.subscription?.unsubscribe();
+    };
+  }, [fetchData]);
 
-  return {
-    open,
-    data,
-    close,
-    markSeen,
-    variant: "modal",
-    userId,
-  };
+  const result = useMemo(
+    () => ({
+      data,
+      loading,
+      error,
+      refresh,
+    }),
+    [data, loading, error, refresh],
+  );
+
+  return result;
 }
+

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -16,6 +16,8 @@ import PeriodPicker, {
   getPresetRange,
 } from "../components/dashboard/PeriodPicker";
 import useDashboardBalances from "../hooks/useDashboardBalances";
+import DailyDigestCard from "../components/DailyDigestCard";
+import useDailyDigest from "../hooks/useDailyDigest";
 
 const DEFAULT_PRESET = "month";
 
@@ -24,6 +26,7 @@ export default function Dashboard({ stats, txs, budgetStatus = [] }) {
   const [periodPreset, setPeriodPreset] = useState(DEFAULT_PRESET);
   const [periodRange, setPeriodRange] = useState(() => getPresetRange(DEFAULT_PRESET));
   const balances = useDashboardBalances(periodRange);
+  const dailyDigest = useDailyDigest();
   const {
     income: periodIncome,
     expense: periodExpense,
@@ -76,6 +79,13 @@ export default function Dashboard({ stats, txs, budgetStatus = [] }) {
           Ringkasan keuanganmu
         </p>
       </header>
+
+      <DailyDigestCard
+        data={dailyDigest.data}
+        loading={dailyDigest.loading}
+        error={dailyDigest.error}
+        onRetry={dailyDigest.refresh}
+      />
 
       <section className="space-y-4">
         <PeriodPicker


### PR DESCRIPTION
## Summary
- rebuild the daily digest hook to aggregate Supabase data with local caching and richer fields for highlights and warnings
- add a responsive DailyDigestCard component that surfaces KPIs, top categories, upcoming items, insights, skeletons, and empty states
- surface the new card on the dashboard in place of the legacy modal wiring

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d65e6450d48332afd934ae88642d43