### PR TITLE
Redesign transactions list for desktop and mobile

### DIFF
--- a/src/components/transactions/BatchToolbar.tsx
+++ b/src/components/transactions/BatchToolbar.tsx
@@ -1,0 +1,88 @@
+import clsx from "clsx";
+import { ArrowRightLeft, Tag, Trash2 } from "lucide-react";
+
+interface BatchToolbarProps {
+  count: number;
+  onClear: () => void;
+  onDelete: () => void;
+  onChangeCategory: () => void;
+  onChangeAccount?: () => void;
+  deleting?: boolean;
+  updating?: boolean;
+  className?: string;
+}
+
+export default function BatchToolbar({
+  count,
+  onClear,
+  onDelete,
+  onChangeCategory,
+  onChangeAccount,
+  deleting = false,
+  updating = false,
+  className,
+}: BatchToolbarProps) {
+  if (count <= 0) return null;
+
+  return (
+    <div
+      className={clsx(
+        "pointer-events-auto fixed inset-x-0 bottom-6 z-40 flex justify-center px-4",
+        className,
+      )}
+      role="region"
+      aria-live="polite"
+      aria-label="Aksi batch transaksi"
+    >
+      <div className="flex w-full max-w-xl items-center justify-between gap-3 rounded-3xl bg-slate-900/90 p-3 text-slate-200 shadow-2xl ring-1 ring-slate-800 backdrop-blur">
+        <div className="flex flex-1 items-center gap-2 text-sm font-medium">
+          <span className="inline-flex h-7 min-w-[2rem] items-center justify-center rounded-full bg-[var(--accent)]/20 px-2 text-[var(--accent)]">
+            {count}
+          </span>
+          <span>{count === 1 ? "1 transaksi dipilih" : `${count} transaksi dipilih`}</span>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={onClear}
+            className="inline-flex h-11 items-center rounded-2xl px-4 text-sm font-semibold text-slate-400 transition hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          >
+            Batal
+          </button>
+          <button
+            type="button"
+            onClick={onChangeCategory}
+            disabled={updating || deleting}
+            className="inline-flex h-11 items-center gap-2 rounded-2xl bg-slate-800 px-4 text-sm font-semibold text-slate-100 transition hover:bg-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60"
+            aria-label="Ubah kategori transaksi dipilih"
+          >
+            <Tag className="h-4 w-4" aria-hidden="true" />
+            Ubah Kategori
+          </button>
+          {onChangeAccount && (
+            <button
+              type="button"
+              onClick={onChangeAccount}
+              disabled={updating || deleting}
+              className="inline-flex h-11 items-center gap-2 rounded-2xl bg-slate-800 px-4 text-sm font-semibold text-slate-100 transition hover:bg-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60"
+              aria-label="Ubah akun transaksi dipilih"
+            >
+              <ArrowRightLeft className="h-4 w-4" aria-hidden="true" />
+              Ubah Akun
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onDelete}
+            disabled={deleting}
+            className="inline-flex h-11 items-center gap-2 rounded-2xl bg-rose-500/90 px-4 text-sm font-semibold text-white transition hover:bg-rose-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300 disabled:cursor-not-allowed disabled:opacity-70"
+            aria-label="Hapus transaksi dipilih"
+          >
+            <Trash2 className="h-4 w-4" aria-hidden="true" />
+            Hapus
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/transactions/CategoryDot.tsx
+++ b/src/components/transactions/CategoryDot.tsx
@@ -1,0 +1,25 @@
+import clsx from "clsx";
+
+const TYPE_COLORS: Record<string, string> = {
+  income: "bg-emerald-500/80",
+  expense: "bg-rose-500/80",
+  transfer: "bg-slate-500/80",
+};
+
+interface CategoryDotProps {
+  color?: string | null;
+  type?: string | null;
+  className?: string;
+  "aria-hidden"?: boolean;
+}
+
+export default function CategoryDot({ color, type, className, ...rest }: CategoryDotProps) {
+  const fallback = type ? TYPE_COLORS[type] : "bg-slate-500/70";
+  return (
+    <span
+      className={clsx("inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full", fallback, className)}
+      style={color ? { backgroundColor: color } : undefined}
+      {...rest}
+    />
+  );
+}

--- a/src/components/transactions/TransactionsCardList.tsx
+++ b/src/components/transactions/TransactionsCardList.tsx
@@ -1,0 +1,278 @@
+import clsx from "clsx";
+import { Pencil, Trash2 } from "lucide-react";
+import CategoryDot from "./CategoryDot";
+import {
+  formatAmount,
+  formatTransactionDate,
+  getAmountTone,
+  getTypeLabel,
+  parseTags,
+} from "./utils";
+import type { TransactionItem } from "./TransactionsTable";
+
+interface TransactionsCardListProps {
+  items: TransactionItem[];
+  loading: boolean;
+  error: Error | null;
+  onRetry: () => void;
+  selectedIds: Set<string>;
+  onToggleSelect: (id: string, event?: React.ChangeEvent<HTMLInputElement>) => void;
+  onDelete: (id: string) => void;
+  onEdit: (item: TransactionItem) => void;
+  sort: string;
+  onSortChange: (value: string) => void;
+  page: number;
+  pageSize: number;
+  total: number;
+  onPageChange: (page: number) => void;
+  deleteDisabled?: boolean;
+  onResetFilters: () => void;
+  onOpenAdd: () => void;
+}
+
+const SORT_OPTIONS = [
+  { value: "date-desc", label: "Terbaru" },
+  { value: "date-asc", label: "Terlama" },
+  { value: "amount-desc", label: "Nominal Tertinggi" },
+  { value: "amount-asc", label: "Nominal Terendah" },
+];
+
+export default function TransactionsCardList({
+  items,
+  loading,
+  error,
+  onRetry,
+  selectedIds,
+  onToggleSelect,
+  onDelete,
+  onEdit,
+  sort,
+  onSortChange,
+  page,
+  pageSize,
+  total,
+  onPageChange,
+  deleteDisabled = false,
+  onResetFilters,
+  onOpenAdd,
+}: TransactionsCardListProps) {
+  const isInitialLoading = loading && items.length === 0;
+  const hasNext = page * pageSize < total;
+  const hasPrev = page > 1;
+  const rangeStart = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const rangeEnd = total === 0 ? 0 : Math.min(rangeStart + items.length - 1, total);
+
+  if (error && !items.length) {
+    return (
+      <div className="rounded-2xl ring-1 ring-red-500/30 bg-red-500/10 p-4 text-red-200">
+        <p className="text-sm font-semibold">Gagal memuat transaksi.</p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-3 inline-flex h-10 items-center rounded-2xl bg-red-500/20 px-4 text-sm font-semibold text-red-100 transition hover:bg-red-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300"
+        >
+          Coba lagi
+        </button>
+      </div>
+    );
+  }
+
+  if (!loading && items.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-slate-800 bg-slate-900/60 p-6 text-center text-slate-300">
+        <p className="text-sm font-semibold">Belum ada transaksi</p>
+        <p className="mt-2 text-sm text-slate-400">Mulai dengan menambahkan transaksi atau reset filter.</p>
+        <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
+          <button
+            type="button"
+            onClick={onResetFilters}
+            className="inline-flex h-10 items-center rounded-2xl border border-slate-800 px-4 text-sm font-semibold text-slate-300 transition hover:bg-slate-800/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          >
+            Reset Filter
+          </button>
+          <button
+            type="button"
+            onClick={onOpenAdd}
+            className="inline-flex h-10 items-center rounded-2xl bg-[var(--accent)] px-4 text-sm font-semibold text-slate-950 transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+          >
+            Tambah Transaksi
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="md:hidden">
+      <div className="mb-3 flex items-center justify-end">
+        <label className="flex h-11 items-center gap-2 rounded-2xl bg-slate-900/70 px-3 text-xs font-semibold uppercase tracking-wide text-slate-400 ring-2 ring-slate-800 focus-within:ring-[var(--accent)]">
+          <span>Urutkan</span>
+          <select
+            value={sort}
+            onChange={(event) => onSortChange(event.target.value)}
+            className="h-full rounded-2xl bg-transparent text-sm text-slate-200 focus:outline-none"
+            aria-label="Urutkan transaksi"
+          >
+            {SORT_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value} className="bg-slate-900 text-slate-200">
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div className="space-y-2">
+        {items.map((item) => (
+          <Card
+            key={item.id}
+            item={item}
+            selected={selectedIds.has(item.id)}
+            onToggleSelect={onToggleSelect}
+            onDelete={onDelete}
+            onEdit={onEdit}
+            deleteDisabled={deleteDisabled}
+          />
+        ))}
+        {isInitialLoading &&
+          Array.from({ length: 6 }).map((_, index) => <SkeletonCard key={`skeleton-${index}`} />)}
+      </div>
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-3 text-xs text-slate-400">
+        <span>Menampilkan {rangeStart === 0 ? 0 : `${rangeStart}–${rangeEnd}`} dari {total}</span>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => onPageChange(page - 1)}
+            disabled={!hasPrev || loading}
+            className="inline-flex h-9 items-center rounded-full px-4 text-xs font-semibold text-slate-300 transition hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Prev
+          </button>
+          <span className="text-slate-500">Halaman {page}</span>
+          <button
+            type="button"
+            onClick={() => onPageChange(page + 1)}
+            disabled={!hasNext || loading}
+            className="inline-flex h-9 items-center rounded-full px-4 text-xs font-semibold text-slate-300 transition hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface CardProps {
+  item: TransactionItem;
+  selected: boolean;
+  onToggleSelect: (id: string, event?: React.ChangeEvent<HTMLInputElement>) => void;
+  onDelete: (id: string) => void;
+  onEdit: (item: TransactionItem) => void;
+  deleteDisabled: boolean;
+}
+
+function Card({ item, selected, onToggleSelect, onDelete, onEdit, deleteDisabled }: CardProps) {
+  const tags = parseTags(item.tags);
+  const note = item.note ?? item.notes ?? item.description ?? "";
+  const amountTone = getAmountTone(item.type);
+  const amount = formatAmount(item.amount, item.currency);
+  const dateLabel = formatTransactionDate(item.date);
+  const typeLabel = getTypeLabel(item.type);
+
+  return (
+    <article className={clsx("rounded-2xl bg-slate-900 ring-1 ring-slate-800 p-3", selected && "ring-[var(--accent)]")}> 
+      <div className="flex items-start gap-3">
+        <input
+          type="checkbox"
+          checked={selected}
+          onChange={(event) => onToggleSelect(item.id, event)}
+          className="mt-1 h-5 w-5 flex-shrink-0 rounded border-slate-700 bg-slate-900 text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          aria-label="Pilih transaksi"
+        />
+        <div className="min-w-0 flex-1 space-y-2">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <CategoryDot color={item.category_color || undefined} type={item.type} aria-hidden="true" />
+              <div>
+                <p className="text-sm font-semibold text-slate-200">{item.category || typeLabel}</p>
+                <p className="text-xs text-slate-400">{dateLabel}</p>
+              </div>
+            </div>
+            <span className={clsx("text-right font-mono text-base", amountTone)}>{amount}</span>
+          </div>
+          <p className="line-clamp-2 text-sm text-slate-300" title={note || item.title || undefined}>
+            {item.title || note || "(Tanpa catatan)"}
+          </p>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-slate-400">
+            {item.type === "transfer" ? (
+              <span>
+                {item.account || "—"} → {item.to_account || "—"}
+              </span>
+            ) : (
+              <span>{item.account || "—"}</span>
+            )}
+            {tags.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="inline-flex items-center rounded-full bg-slate-800/70 px-2 py-0.5 text-[11px] text-slate-300"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+          <div className="flex items-center justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={() => onEdit(item)}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full ring-1 ring-slate-700 transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+              aria-label="Edit transaksi"
+            >
+              <Pencil className="h-4 w-4" aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              onClick={() => onDelete(item.id)}
+              disabled={deleteDisabled}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full text-rose-400 ring-1 ring-rose-400/50 transition hover:bg-rose-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300 disabled:cursor-not-allowed disabled:opacity-60"
+              aria-label="Hapus transaksi"
+            >
+              <Trash2 className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function SkeletonCard() {
+  return (
+    <article className="rounded-2xl bg-slate-900/60 p-3 ring-1 ring-slate-800 animate-pulse">
+      <div className="flex items-start gap-3">
+        <div className="mt-1 h-5 w-5 rounded bg-slate-800" />
+        <div className="flex-1 space-y-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-2">
+              <div className="h-4 w-24 rounded-full bg-slate-800/80" />
+              <div className="h-3 w-20 rounded-full bg-slate-800/60" />
+            </div>
+            <div className="h-6 w-24 rounded-full bg-slate-800/80" />
+          </div>
+          <div className="h-4 w-full rounded-full bg-slate-800/70" />
+          <div className="flex gap-2">
+            <div className="h-4 w-24 rounded-full bg-slate-800/70" />
+            <div className="h-4 w-16 rounded-full bg-slate-800/60" />
+          </div>
+          <div className="flex justify-end gap-2">
+            <div className="h-9 w-9 rounded-full bg-slate-800/70" />
+            <div className="h-9 w-9 rounded-full bg-slate-800/60" />
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/components/transactions/TransactionsFilters.tsx
+++ b/src/components/transactions/TransactionsFilters.tsx
@@ -1,0 +1,144 @@
+import { ChangeEvent, Ref } from "react";
+import clsx from "clsx";
+import { Search } from "lucide-react";
+
+interface TransactionsFiltersProps {
+  searchTerm: string;
+  onSearchChange: (value: string) => void;
+  type: string;
+  onTypeChange: (value: string) => void;
+  categories: Array<{ id: string; name: string } | null> | null | undefined;
+  selectedCategories: string[];
+  onCategoriesChange: (value: string[]) => void;
+  dateRange: { start?: string; end?: string };
+  onDateRangeChange: (start: string, end: string) => void;
+  onClear: () => void;
+  className?: string;
+  searchInputRef?: Ref<HTMLInputElement>;
+}
+
+const TYPE_OPTIONS = [
+  { value: "all", label: "Semua" },
+  { value: "income", label: "Pemasukan" },
+  { value: "expense", label: "Pengeluaran" },
+  { value: "transfer", label: "Transfer" },
+];
+
+export default function TransactionsFilters({
+  searchTerm,
+  onSearchChange,
+  type,
+  onTypeChange,
+  categories,
+  selectedCategories,
+  onCategoriesChange,
+  dateRange,
+  onDateRangeChange,
+  onClear,
+  className,
+  searchInputRef,
+}: TransactionsFiltersProps) {
+  const selectedCategory = selectedCategories[0] ?? "";
+
+  const handleCategoryChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value;
+    if (!value) {
+      onCategoriesChange([]);
+    } else {
+      onCategoriesChange([value]);
+    }
+  };
+
+  return (
+    <div
+      className={clsx(
+        "rounded-2xl bg-slate-950/60 p-4 shadow-lg ring-1 ring-slate-800 backdrop-blur",
+        className,
+      )}
+    >
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,240px)_minmax(0,180px)_minmax(0,220px)_repeat(2,minmax(0,160px))]">
+        <label className="group relative flex h-11 items-center overflow-hidden rounded-2xl ring-2 ring-slate-800 transition focus-within:ring-[var(--accent)]">
+          <Search className="pointer-events-none ml-3 h-4 w-4 text-slate-500 transition group-focus-within:text-[var(--accent)]" aria-hidden="true" />
+          <input
+            type="search"
+            value={searchTerm}
+            onChange={(event) => onSearchChange(event.target.value)}
+            placeholder="Cari judul atau catatan"
+            className="h-full w-full bg-transparent px-3 text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none"
+            aria-label="Cari transaksi"
+            ref={searchInputRef}
+          />
+        </label>
+
+        <label className="flex h-11 items-center rounded-2xl ring-2 ring-slate-800 focus-within:ring-[var(--accent)]">
+          <span className="sr-only">Filter tipe transaksi</span>
+          <select
+            value={type}
+            onChange={(event) => onTypeChange(event.target.value)}
+            className="h-full w-full rounded-2xl bg-transparent px-3 text-sm text-slate-200 focus:outline-none"
+            aria-label="Filter tipe transaksi"
+          >
+            {TYPE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value} className="bg-slate-900 text-slate-200">
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex h-11 items-center rounded-2xl ring-2 ring-slate-800 focus-within:ring-[var(--accent)]">
+          <span className="sr-only">Filter kategori transaksi</span>
+          <select
+            value={selectedCategory}
+            onChange={handleCategoryChange}
+            className="h-full w-full rounded-2xl bg-transparent px-3 text-sm text-slate-200 focus:outline-none"
+            aria-label="Filter kategori transaksi"
+          >
+            <option value="" className="bg-slate-900 text-slate-200">
+              Semua kategori
+            </option>
+            {(categories || [])
+              ?.filter(Boolean)
+              .map((category) => (
+                <option key={category!.id} value={category!.id} className="bg-slate-900 text-slate-200">
+                  {category!.name || "Tanpa nama"}
+                </option>
+              ))}
+          </select>
+        </label>
+
+        <label className="flex h-11 items-center rounded-2xl ring-2 ring-slate-800 focus-within:ring-[var(--accent)]">
+          <span className="sr-only">Tanggal mulai</span>
+          <input
+            type="date"
+            value={dateRange.start ?? ""}
+            onChange={(event) => onDateRangeChange(event.target.value, dateRange.end ?? "")}
+            className="h-full w-full rounded-2xl bg-transparent px-3 text-sm text-slate-200 focus:outline-none"
+            aria-label="Tanggal mulai"
+          />
+        </label>
+
+        <label className="flex h-11 items-center rounded-2xl ring-2 ring-slate-800 focus-within:ring-[var(--accent)]">
+          <span className="sr-only">Tanggal akhir</span>
+          <input
+            type="date"
+            value={dateRange.end ?? ""}
+            min={dateRange.start ?? undefined}
+            onChange={(event) => onDateRangeChange(dateRange.start ?? "", event.target.value)}
+            className="h-full w-full rounded-2xl bg-transparent px-3 text-sm text-slate-200 focus:outline-none"
+            aria-label="Tanggal akhir"
+          />
+        </label>
+      </div>
+      <div className="mt-3 flex flex-wrap items-center justify-end gap-2">
+        <button
+          type="button"
+          onClick={onClear}
+          className="inline-flex h-11 items-center rounded-2xl px-4 text-sm font-semibold text-slate-300 transition hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+        >
+          Bersihkan
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/transactions/TransactionsTable.tsx
+++ b/src/components/transactions/TransactionsTable.tsx
@@ -1,0 +1,373 @@
+import clsx from "clsx";
+import { Pencil, Trash2 } from "lucide-react";
+import CategoryDot from "./CategoryDot";
+import {
+  formatAmount,
+  formatTransactionDate,
+  getAmountTone,
+  getTypeLabel,
+  parseTags,
+} from "./utils";
+
+export interface TransactionItem {
+  id: string;
+  type?: string;
+  category?: string;
+  category_id?: string;
+  category_color?: string | null;
+  title?: string;
+  note?: string;
+  notes?: string;
+  description?: string;
+  amount?: number | string;
+  currency?: string;
+  date?: string;
+  account?: string;
+  to_account?: string;
+  tags?: string[] | string;
+}
+
+interface TransactionsTableProps {
+  items: TransactionItem[];
+  loading: boolean;
+  error: Error | null;
+  onRetry: () => void;
+  onToggleSelectAll: () => void;
+  allSelected: boolean;
+  onToggleSelect: (id: string, event?: React.ChangeEvent<HTMLInputElement>) => void;
+  selectedIds: Set<string>;
+  onDelete: (id: string) => void;
+  onEdit: (item: TransactionItem) => void;
+  sort: string;
+  onSortChange: (sort: string) => void;
+  page: number;
+  pageSize: number;
+  total: number;
+  onPageChange: (page: number) => void;
+  deleteDisabled?: boolean;
+  tableStickyTop?: string;
+  onResetFilters: () => void;
+  onOpenAdd: () => void;
+}
+
+const SORT_ARROW: Record<string, string> = {
+  asc: "▲",
+  desc: "▼",
+};
+
+export default function TransactionsTable({
+  items,
+  loading,
+  error,
+  onRetry,
+  onToggleSelectAll,
+  allSelected,
+  onToggleSelect,
+  selectedIds,
+  onDelete,
+  onEdit,
+  sort,
+  onSortChange,
+  page,
+  pageSize,
+  total,
+  onPageChange,
+  deleteDisabled = false,
+  tableStickyTop,
+  onResetFilters,
+  onOpenAdd,
+}: TransactionsTableProps) {
+  const isInitialLoading = loading && items.length === 0;
+  const rangeStart = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const rangeEnd = total === 0 ? 0 : Math.min(rangeStart + items.length - 1, total);
+  const hasNext = page * pageSize < total;
+  const hasPrev = page > 1;
+
+  if (error && !items.length) {
+    return (
+      <div className="rounded-2xl border border-red-500/30 bg-red-500/10 p-6 text-red-200">
+        <div className="flex flex-col items-start gap-3">
+          <p className="text-sm font-semibold">Gagal memuat transaksi.</p>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="inline-flex h-11 items-center rounded-2xl bg-red-500/20 px-4 text-sm font-semibold text-red-100 transition hover:bg-red-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300"
+          >
+            Coba lagi
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!loading && items.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-slate-800 bg-slate-900/60 px-6 py-16 text-center text-slate-300">
+        <span className="rounded-full bg-[var(--accent)]/10 px-4 py-2 text-sm font-semibold text-[var(--accent)]">
+          Belum ada transaksi
+        </span>
+        <p className="max-w-sm text-sm text-slate-400">
+          Coba atur ulang filter atau tambahkan transaksi baru untuk mulai melacak keuanganmu.
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          <button
+            type="button"
+            onClick={onResetFilters}
+            className="inline-flex h-11 items-center rounded-2xl border border-slate-800 px-4 text-sm font-semibold text-slate-300 transition hover:bg-slate-800/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          >
+            Reset Filter
+          </button>
+          <button
+            type="button"
+            onClick={onOpenAdd}
+            className="inline-flex h-11 items-center rounded-2xl bg-[var(--accent)] px-5 text-sm font-semibold text-slate-950 transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+          >
+            Tambah Transaksi
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const amountSortState = sort.startsWith("amount-") ? sort.split("-")[1] : null;
+  const dateSortState = sort.startsWith("date-") ? sort.split("-")[1] : null;
+
+  return (
+    <div className="hidden md:block">
+      <div className="overflow-hidden rounded-2xl ring-1 ring-slate-800">
+        <div className="overflow-x-auto">
+          <table className="hidden w-full min-w-[960px] md:table" aria-label="Daftar transaksi">
+            <thead
+              className="bg-slate-900 text-xs uppercase tracking-wide text-slate-400"
+              style={tableStickyTop ? { position: "sticky", top: tableStickyTop, zIndex: 10 } : undefined}
+            >
+              <tr>
+                <th scope="col" className="w-12 px-4 py-3">
+                  <div className="flex items-center justify-center">
+                    <input
+                      type="checkbox"
+                      checked={allSelected}
+                      onChange={onToggleSelectAll}
+                      className="h-4 w-4 rounded border-slate-700 bg-slate-900 text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+                      aria-label="Pilih semua transaksi di halaman ini"
+                    />
+                  </div>
+                </th>
+                <th scope="col" className="px-4 py-3 text-left text-xs uppercase tracking-wide text-slate-400">
+                  Kategori &amp; Judul
+                </th>
+                <SortableHeader
+                  label="Tanggal"
+                  alignment="left"
+                  active={Boolean(dateSortState)}
+                  onClick={() => onSortChange(dateSortState === "desc" ? "date-asc" : "date-desc")}
+                  indicator={dateSortState ? SORT_ARROW[dateSortState as "asc" | "desc"] : undefined}
+                />
+                <th scope="col" className="px-4 py-3 text-left text-xs uppercase tracking-wide text-slate-400">
+                  Akun
+                </th>
+                <th scope="col" className="px-4 py-3 text-left text-xs uppercase tracking-wide text-slate-400">
+                  Tags
+                </th>
+                <SortableHeader
+                  label="Jumlah"
+                  alignment="right"
+                  active={Boolean(amountSortState)}
+                  onClick={() => onSortChange(amountSortState === "desc" ? "amount-asc" : "amount-desc")}
+                  indicator={amountSortState ? SORT_ARROW[amountSortState as "asc" | "desc"] : undefined}
+                />
+                <th scope="col" className="px-4 py-3 text-right text-xs uppercase tracking-wide text-slate-400">
+                  Aksi
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800">
+              {items.map((item) => (
+                <TableRow
+                  key={item.id}
+                  item={item}
+                  onToggleSelect={onToggleSelect}
+                  selected={selectedIds.has(item.id)}
+                  onDelete={onDelete}
+                  onEdit={onEdit}
+                  deleteDisabled={deleteDisabled}
+                />
+              ))}
+              {isInitialLoading &&
+                Array.from({ length: 6 }).map((_, index) => <SkeletonRow key={`skeleton-${index}`} />)}
+            </tbody>
+          </table>
+        </div>
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-slate-800 bg-slate-900/80 px-4 py-3 text-sm text-slate-400">
+          <p>
+            Menampilkan {rangeStart === 0 ? 0 : `${rangeStart}–${rangeEnd}`} dari {total} transaksi
+          </p>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => onPageChange(page - 1)}
+              disabled={!hasPrev || loading}
+              className="inline-flex h-9 items-center rounded-full px-4 text-xs font-semibold text-slate-300 transition hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Prev
+            </button>
+            <span className="text-xs text-slate-500">Halaman {page}</span>
+            <button
+              type="button"
+              onClick={() => onPageChange(page + 1)}
+              disabled={!hasNext || loading}
+              className="inline-flex h-9 items-center rounded-full px-4 text-xs font-semibold text-slate-300 transition hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface SortableHeaderProps {
+  label: string;
+  onClick: () => void;
+  active: boolean;
+  indicator?: string;
+  alignment?: "left" | "right";
+}
+
+function SortableHeader({ label, onClick, active, indicator, alignment = "left" }: SortableHeaderProps) {
+  return (
+    <th
+      scope="col"
+      className={clsx(
+        "px-4 py-3 text-xs uppercase tracking-wide text-slate-400",
+        alignment === "right" ? "text-right" : "text-left",
+      )}
+    >
+      <button
+        type="button"
+        onClick={onClick}
+        className={clsx(
+          "group inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400",
+          active ? "text-[var(--accent)]" : "hover:text-slate-200",
+        )}
+      >
+        {label}
+        {active && indicator && <span aria-hidden="true">{indicator}</span>}
+      </button>
+    </th>
+  );
+}
+
+interface TableRowProps {
+  item: TransactionItem;
+  selected: boolean;
+  onToggleSelect: (id: string, event?: React.ChangeEvent<HTMLInputElement>) => void;
+  onDelete: (id: string) => void;
+  onEdit: (item: TransactionItem) => void;
+  deleteDisabled: boolean;
+}
+
+function TableRow({ item, selected, onToggleSelect, onDelete, onEdit, deleteDisabled }: TableRowProps) {
+  const tags = parseTags(item.tags);
+  const note = item.note ?? item.notes ?? item.description ?? item.title ?? "";
+  const amountTone = getAmountTone(item.type);
+  const amount = formatAmount(item.amount, item.currency);
+  const dateLabel = formatTransactionDate(item.date);
+  const typeLabel = getTypeLabel(item.type);
+
+  return (
+    <tr className="transition hover:bg-slate-800/50">
+      <td className="px-4 py-3 align-middle">
+        <div className="flex items-center justify-center">
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={(event) => onToggleSelect(item.id, event)}
+            className="h-4 w-4 rounded border-slate-700 bg-slate-900 text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+            aria-label="Pilih transaksi"
+          />
+        </div>
+      </td>
+      <td className="px-4 py-3 align-middle">
+        <div className="flex items-center gap-3">
+          <CategoryDot color={item.category_color || undefined} type={item.type} aria-hidden="true" />
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold text-slate-200" title={item.category || typeLabel}>
+              {item.category || typeLabel}
+            </p>
+            <p className="truncate text-xs text-slate-400" title={note}>
+              {item.title || note || "(Tanpa judul)"}
+            </p>
+          </div>
+        </div>
+      </td>
+      <td className="px-4 py-3 align-middle text-sm text-slate-300">
+        <time dateTime={item.date || undefined}>{dateLabel}</time>
+      </td>
+      <td className="px-4 py-3 align-middle text-sm text-slate-300">
+        {item.type === "transfer" ? (
+          <div className="flex flex-wrap items-center gap-2 text-slate-300">
+            <span className="truncate max-w-[140px]">{item.account || "—"}</span>
+            <span className="text-slate-500">→</span>
+            <span className="truncate max-w-[140px]">{item.to_account || "—"}</span>
+          </div>
+        ) : (
+          <span className="truncate max-w-[160px]">{item.account || "—"}</span>
+        )}
+      </td>
+      <td className="px-4 py-3 align-middle">
+        {tags.length ? (
+          <div className="flex flex-wrap gap-2">
+            {tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center rounded-full bg-slate-800/70 px-2.5 py-0.5 text-xs text-slate-300"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <span className="text-sm text-slate-500">—</span>
+        )}
+      </td>
+      <td className="px-4 py-3 align-middle">
+        <span className={clsx("block text-right font-mono text-sm", amountTone)}>{amount}</span>
+      </td>
+      <td className="px-4 py-3 align-middle">
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => onEdit(item)}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full ring-1 ring-slate-700 transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+            aria-label="Edit transaksi"
+          >
+            <Pencil className="h-4 w-4" aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            onClick={() => onDelete(item.id)}
+            disabled={deleteDisabled}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full text-rose-400 ring-1 ring-rose-400/50 transition hover:bg-rose-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300 disabled:cursor-not-allowed disabled:opacity-60"
+            aria-label="Hapus transaksi"
+          >
+            <Trash2 className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+function SkeletonRow() {
+  return (
+    <tr className="animate-pulse">
+      {Array.from({ length: 7 }).map((_, index) => (
+        <td key={index} className="px-4 py-3 align-middle">
+          <div className="h-5 rounded-full bg-slate-800/60" />
+        </td>
+      ))}
+    </tr>
+  );
+}

--- a/src/components/transactions/utils.ts
+++ b/src/components/transactions/utils.ts
@@ -1,0 +1,55 @@
+import { formatCurrency } from "../../lib/format";
+
+const TRANSACTION_DATE_FORMATTER =
+  typeof Intl !== "undefined"
+    ? new Intl.DateTimeFormat("id-ID", {
+        weekday: "short",
+        day: "2-digit",
+        month: "short",
+        year: "numeric",
+      })
+    : null;
+
+export function formatTransactionDate(value?: string | number | Date | null) {
+  if (!value) return "";
+  try {
+    const date = value instanceof Date ? value : new Date(value);
+    if (!Number.isFinite(date.getTime())) return String(value);
+    return TRANSACTION_DATE_FORMATTER ? TRANSACTION_DATE_FORMATTER.format(date) : String(value);
+  } catch (error) {
+    return String(value);
+  }
+}
+
+export function parseTags(value: unknown): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value
+      .map((tag) => String(tag).trim())
+      .filter(Boolean);
+  }
+  return String(value)
+    .split(",")
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+}
+
+export function formatAmount(value: unknown, currency: string | undefined, locale = "IDR") {
+  const amountNumber = Number(value ?? 0);
+  const currencyCode = currency || locale;
+  return formatCurrency(amountNumber, currencyCode);
+}
+
+export function getAmountTone(type?: string) {
+  if (type === "income") return "text-emerald-400";
+  if (type === "expense") return "text-rose-400";
+  if (type === "transfer") return "text-slate-300";
+  return "text-slate-200";
+}
+
+export function getTypeLabel(type?: string) {
+  if (type === "income") return "Pemasukan";
+  if (type === "expense") return "Pengeluaran";
+  if (type === "transfer") return "Transfer";
+  return type || "Transaksi";
+}

--- a/src/hooks/useTransactionsQuery.js
+++ b/src/hooks/useTransactionsQuery.js
@@ -3,7 +3,7 @@ import { useSearchParams } from "react-router-dom";
 import { getTransactionsSummary, listCategories } from "../lib/api";
 import { listTransactions } from "../lib/api-transactions";
 
-const PAGE_SIZE = 50;
+const PAGE_SIZE = 20;
 
 const DEFAULT_FILTER = {
   period: { preset: "all", month: "", start: "", end: "" },
@@ -204,9 +204,17 @@ export default function useTransactionsQuery() {
     [updateParams],
   );
 
+  const setPage = useCallback(
+    (nextPage) => {
+      const target = Number.isFinite(nextPage) ? Math.max(1, Math.floor(nextPage)) : 1;
+      updateParams({}, target);
+    },
+    [updateParams],
+  );
+
   const loadMore = useCallback(() => {
-    updateParams({}, page + 1);
-  }, [page, updateParams]);
+    setPage(page + 1);
+  }, [page, setPage]);
 
   const refresh = useCallback(
     ({ keepPage = false } = {}) => {
@@ -232,6 +240,7 @@ export default function useTransactionsQuery() {
     filter,
     setFilter,
     loadMore,
+    setPage,
     refresh,
     categories,
     summary,


### PR DESCRIPTION
## Summary
- replace the transactions page layout with a modern table on desktop and card list on mobile
- extract responsive filter controls, batch toolbar, and shared utilities into new transactions components
- add pagination support with prev/next controls and update the transactions query hook to expose setPage

## Testing
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d663dfd8848332bbc1a72d36bc419b