### PR TITLE
Redesign transactions history UI

### DIFF
--- a/src/components/transactions/BatchToolbar.tsx
+++ b/src/components/transactions/BatchToolbar.tsx
@@ -1,0 +1,74 @@
+import { Loader2, Sparkles, Tags, Trash2, X } from "lucide-react";
+import clsx from "clsx";
+
+interface BatchToolbarProps {
+  selectedCount: number;
+  onClear: () => void;
+  onDelete: () => void;
+  onChangeCategory: () => void;
+  deleting?: boolean;
+  updating?: boolean;
+}
+
+export default function BatchToolbar({
+  selectedCount,
+  onClear,
+  onDelete,
+  onChangeCategory,
+  deleting = false,
+  updating = false,
+}: BatchToolbarProps) {
+  const busy = deleting || updating;
+
+  return (
+    <div
+      className={clsx(
+        "pointer-events-auto fixed inset-x-4 bottom-6 z-30 flex justify-center md:inset-x-auto",
+        "md:left-1/2 md:w-auto md:-translate-x-1/2",
+      )}
+      role="region"
+      aria-label="Aksi batch transaksi"
+    >
+      <div
+        className="flex w-full max-w-xl items-center gap-3 rounded-2xl bg-slate-900/95 p-3 text-slate-200 shadow-2xl ring-1 ring-slate-800 backdrop-blur"
+      >
+        <div className="flex flex-1 items-center gap-2 text-sm">
+          <Sparkles className="h-4 w-4 text-[var(--accent)]" aria-hidden="true" />
+          <span className="font-medium">
+            {selectedCount} transaksi dipilih
+          </span>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={onClear}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-slate-800/70 text-slate-300 ring-1 ring-slate-700 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+            aria-label="Batal pilih"
+            disabled={busy}
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            onClick={onChangeCategory}
+            className="inline-flex h-10 items-center justify-center gap-2 rounded-full bg-slate-800/70 px-4 text-sm font-semibold text-slate-200 ring-1 ring-slate-700 transition hover:bg-slate-800 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={busy}
+          >
+            <Tags className="h-4 w-4" aria-hidden="true" />
+            Ubah Kategori
+          </button>
+          <button
+            type="button"
+            onClick={onDelete}
+            className="inline-flex h-10 items-center justify-center gap-2 rounded-full bg-rose-500/20 px-4 text-sm font-semibold text-rose-200 ring-1 ring-rose-500/40 transition hover:bg-rose-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={deleting}
+            aria-label="Hapus transaksi terpilih"
+          >
+            {deleting ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Trash2 className="h-4 w-4" aria-hidden="true" />}
+            {!deleting && "Hapus"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/transactions/CategoryDot.tsx
+++ b/src/components/transactions/CategoryDot.tsx
@@ -1,0 +1,19 @@
+import clsx from "clsx";
+import type { CSSProperties } from "react";
+
+type CategoryDotProps = {
+  color?: string | null;
+  className?: string;
+};
+
+export default function CategoryDot({ color, className }: CategoryDotProps) {
+  const style: CSSProperties | undefined = color ? { backgroundColor: color } : undefined;
+
+  return (
+    <span
+      className={clsx("inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-slate-500", className)}
+      style={style}
+      aria-hidden="true"
+    />
+  );
+}

--- a/src/components/transactions/TransactionsCardList.tsx
+++ b/src/components/transactions/TransactionsCardList.tsx
@@ -1,0 +1,343 @@
+import clsx from "clsx";
+import type { ChangeEvent } from "react";
+import { Pencil, Trash2 } from "lucide-react";
+import { formatCurrency } from "../../lib/format";
+import CategoryDot from "./CategoryDot";
+import type { TransactionRecord } from "./TransactionsTable";
+
+const TYPE_LABELS: Record<string, string> = {
+  income: "Pemasukan",
+  expense: "Pengeluaran",
+  transfer: "Transfer",
+};
+
+const SORT_OPTIONS = [
+  { value: "date-desc", label: "Terbaru" },
+  { value: "date-asc", label: "Terlama" },
+  { value: "amount-desc", label: "Nominal Tertinggi" },
+  { value: "amount-asc", label: "Nominal Terendah" },
+];
+
+interface TransactionsCardListProps {
+  items: TransactionRecord[];
+  loading: boolean;
+  error: unknown;
+  onRetry: () => void;
+  selectedIds: Set<string>;
+  onToggleSelect: (id: string, event: ChangeEvent<HTMLInputElement>) => void;
+  onDelete: (id: string) => void;
+  onEdit: (item: TransactionRecord) => void;
+  sort: string;
+  onSortChange: (sort: string) => void;
+  page: number;
+  pageSize: number;
+  total: number;
+  onPageChange: (page: number) => void;
+  onOpenAdd: () => void;
+  onResetFilters: () => void;
+  deleteDisabled?: boolean;
+}
+
+const DATE_FORMATTER =
+  typeof Intl !== "undefined"
+    ? new Intl.DateTimeFormat("id-ID", {
+        weekday: "short",
+        day: "2-digit",
+        month: "short",
+        year: "numeric",
+      })
+    : null;
+
+function formatDate(value?: string | null) {
+  if (!value) return "";
+  try {
+    const date = new Date(value);
+    if (!Number.isFinite(date.getTime())) return "";
+    return DATE_FORMATTER ? DATE_FORMATTER.format(date) : value;
+  } catch {
+    return "";
+  }
+}
+
+function parseTags(tags?: string[] | string | null) {
+  if (!tags) return [] as string[];
+  if (Array.isArray(tags)) return tags;
+  return tags
+    .split(",")
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+}
+
+function getNote(item: TransactionRecord) {
+  return (
+    item.notes ??
+    item.note ??
+    item.title ??
+    item.description ??
+    ""
+  );
+}
+
+function getAmountClass(type?: string) {
+  if (type === "income") return "text-emerald-400";
+  if (type === "expense") return "text-rose-400";
+  return "text-slate-300";
+}
+
+export default function TransactionsCardList({
+  items,
+  loading,
+  error,
+  onRetry,
+  selectedIds,
+  onToggleSelect,
+  onDelete,
+  onEdit,
+  sort,
+  onSortChange,
+  page,
+  pageSize,
+  total,
+  onPageChange,
+  onOpenAdd,
+  onResetFilters,
+  deleteDisabled = false,
+}: TransactionsCardListProps) {
+  const isInitialLoading = loading && items.length === 0;
+  const skeletonCount = 6;
+  const totalPages = total === 0 ? 1 : Math.max(1, Math.ceil(total / pageSize));
+  const clampedPage = Math.min(page, totalPages);
+  const displayStart = total === 0 ? 0 : (clampedPage - 1) * pageSize + (items.length > 0 ? 1 : 0);
+  const displayEnd = total === 0 ? 0 : (clampedPage - 1) * pageSize + items.length;
+  const showEmpty = !loading && items.length === 0 && !error;
+
+  return (
+    <section className="flex flex-col gap-4 md:hidden">
+      {error && (
+        <div className="rounded-2xl bg-red-500/10 p-4 text-sm text-red-200 ring-1 ring-red-500/30">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <span>Gagal memuat transaksi.</span>
+            <button
+              type="button"
+              onClick={onRetry}
+              className="rounded-full bg-red-500/20 px-3 py-1 text-xs font-semibold text-red-100 transition hover:bg-red-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
+            >
+              Coba lagi
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="flex items-center gap-3">
+        <label className="flex-1">
+          <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-400">
+            Urutkan
+          </span>
+          <select
+            value={sort}
+            onChange={(event) => onSortChange(event.target.value)}
+            className="h-11 w-full rounded-2xl bg-slate-900 px-3 text-sm font-medium text-slate-200 ring-2 ring-slate-800 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+            aria-label="Urutkan transaksi"
+          >
+            {SORT_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {showEmpty ? (
+        <div className="flex flex-col items-center justify-center gap-4 rounded-2xl bg-slate-900/80 px-6 py-16 text-center text-slate-300 ring-1 ring-slate-800">
+          <p className="text-lg font-semibold text-slate-200">Belum ada transaksi</p>
+          <p className="max-w-md text-sm text-slate-400">
+            Coba tambahkan transaksi baru atau reset filter untuk melihat semua histori.
+          </p>
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            <button
+              type="button"
+              onClick={onOpenAdd}
+              className="rounded-full bg-[var(--accent)] px-4 py-2 text-sm font-semibold text-white shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+            >
+              Tambah Transaksi
+            </button>
+            <button
+              type="button"
+              onClick={onResetFilters}
+              className="rounded-full border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-200 hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+            >
+              Reset Filter
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {items.map((item) => {
+            const tags = parseTags(item.tags);
+            const note = getNote(item).trim();
+            const categoryName = item.category || "(Tanpa kategori)";
+            const formattedDate = formatDate(item.date);
+            const amountClass = getAmountClass(item.type);
+            return (
+              <article
+                key={item.id}
+                className={clsx(
+                  "rounded-2xl bg-slate-900 p-3 ring-1 ring-slate-800 transition", 
+                  selectedIds.has(item.id) && "ring-2 ring-[var(--accent)]"
+                )}
+              >
+                <div className="flex items-start gap-3">
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.has(item.id)}
+                    onChange={(event) => onToggleSelect(item.id, event)}
+                    className="mt-1 h-5 w-5 rounded border-slate-700 bg-slate-900 text-[var(--accent)] focus:ring-[var(--accent)]"
+                    aria-label="Pilih transaksi"
+                  />
+                  <div className="min-w-0 flex-1 space-y-3">
+                    <header className="flex items-start justify-between gap-2">
+                      <div className="flex items-center gap-2">
+                        <CategoryDot color={item.category_color} />
+                        <p className="text-sm font-semibold text-slate-200" title={categoryName}>
+                          {categoryName}
+                        </p>
+                        <span className="rounded-full bg-slate-800 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+                          {TYPE_LABELS[item.type ?? ""] ?? item.type ?? ""}
+                        </span>
+                      </div>
+                      <span className="text-xs font-medium uppercase tracking-wide text-slate-400">
+                        {formattedDate || ""}
+                      </span>
+                    </header>
+                    <p className="line-clamp-2 text-sm text-slate-400" title={note}>
+                      {note || "Tidak ada catatan"}
+                    </p>
+                    <div className="text-sm text-slate-300">
+                      {item.type === "transfer" ? (
+                        <span className="inline-flex flex-wrap items-center gap-1">
+                          <span className="truncate">{item.account || "—"}</span>
+                          <span aria-hidden="true" className="text-slate-500">
+                            ➜
+                          </span>
+                          <span className="truncate">{item.to_account || "—"}</span>
+                        </span>
+                      ) : (
+                        <span className="truncate">{item.account || "—"}</span>
+                      )}
+                    </div>
+                    {tags.length > 0 && (
+                      <div className="flex flex-wrap gap-2">
+                        {tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="inline-flex items-center rounded-full bg-slate-800/80 px-3 py-1 text-xs font-medium text-slate-200"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                    <footer className="flex items-center justify-between gap-3 pt-1">
+                      <span className={clsx("font-mono text-lg font-semibold", amountClass)}>
+                        {formatCurrency(Number(item.amount ?? 0), "IDR")}
+                      </span>
+                      <div className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => onEdit(item)}
+                          className="flex h-9 w-9 items-center justify-center rounded-full bg-slate-900 text-slate-300 ring-1 ring-slate-700 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+                          aria-label="Edit transaksi"
+                        >
+                          <Pencil className="h-4 w-4" aria-hidden="true" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => onDelete(item.id)}
+                          className="flex h-9 w-9 items-center justify-center rounded-full bg-slate-900 text-rose-300 ring-1 ring-rose-500/40 transition hover:text-rose-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-60"
+                          aria-label="Hapus transaksi"
+                          disabled={deleteDisabled}
+                        >
+                          <Trash2 className="h-4 w-4" aria-hidden="true" />
+                        </button>
+                      </div>
+                    </footer>
+                  </div>
+                </div>
+              </article>
+            );
+          })}
+
+          {isInitialLoading &&
+            Array.from({ length: skeletonCount }).map((_, index) => (
+              <article
+                key={`skeleton-${index}`}
+                className="rounded-2xl bg-slate-900 p-3 ring-1 ring-slate-800"
+              >
+                <div className="flex items-start gap-3">
+                  <div className="h-5 w-5 rounded bg-slate-800" />
+                  <div className="flex-1 space-y-3">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <div className="h-2.5 w-2.5 rounded-full bg-slate-800" />
+                        <div className="h-4 w-28 rounded-full bg-slate-800" />
+                      </div>
+                      <div className="h-3 w-20 rounded-full bg-slate-800" />
+                    </div>
+                    <div className="h-4 w-full rounded-full bg-slate-800" />
+                    <div className="h-4 w-32 rounded-full bg-slate-800" />
+                    <div className="flex gap-2">
+                      <div className="h-5 w-16 rounded-full bg-slate-800" />
+                      <div className="h-5 w-12 rounded-full bg-slate-800" />
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <div className="h-6 w-24 rounded-full bg-slate-800" />
+                      <div className="flex gap-2">
+                        <div className="h-9 w-9 rounded-full bg-slate-800" />
+                        <div className="h-9 w-9 rounded-full bg-slate-800" />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </article>
+            ))}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl bg-slate-900/80 px-4 py-3 text-sm text-slate-300 ring-1 ring-slate-800">
+        <div>
+          {total > 0 ? (
+            <span>
+              Menampilkan {displayStart.toLocaleString("id-ID")}-{displayEnd.toLocaleString("id-ID")} dari {total.toLocaleString("id-ID")} ({pageSize} per halaman)
+            </span>
+          ) : (
+            <span>Tidak ada transaksi</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => onPageChange(Math.max(1, clampedPage - 1))}
+            disabled={clampedPage <= 1}
+            className="rounded-full bg-slate-900 px-3 py-1 text-xs font-semibold text-slate-300 ring-1 ring-slate-700 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60"
+            aria-label="Halaman sebelumnya"
+          >
+            Prev
+          </button>
+          <span className="text-xs font-semibold text-slate-400">
+            Halaman {clampedPage} / {totalPages}
+          </span>
+          <button
+            type="button"
+            onClick={() => onPageChange(Math.min(totalPages, clampedPage + 1))}
+            disabled={clampedPage >= totalPages}
+            className="rounded-full bg-slate-900 px-3 py-1 text-xs font-semibold text-slate-300 ring-1 ring-slate-700 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60"
+            aria-label="Halaman berikutnya"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/transactions/TransactionsFilters.tsx
+++ b/src/components/transactions/TransactionsFilters.tsx
@@ -1,0 +1,126 @@
+import { forwardRef } from "react";
+import { CalendarDays, FilterX, Search } from "lucide-react";
+
+interface TransactionsFiltersProps {
+  categories: Array<{ id: string; name: string; color?: string | null }>;
+  filter: {
+    type: string;
+    categories: string[];
+    period: { start?: string; end?: string; preset?: string };
+  };
+  searchTerm: string;
+  onSearchChange: (value: string) => void;
+  onTypeChange: (value: string) => void;
+  onCategoryChange: (value: string | null) => void;
+  onDateChange: (range: { start: string; end: string }) => void;
+  onClear: () => void;
+}
+
+const TransactionsFilters = forwardRef<HTMLInputElement, TransactionsFiltersProps>(
+  (
+    {
+      categories,
+      filter,
+      searchTerm,
+      onSearchChange,
+      onTypeChange,
+      onCategoryChange,
+      onDateChange,
+      onClear,
+    },
+    searchInputRef,
+  ) => {
+    const selectedCategory = filter.categories[0] ?? "";
+    const startValue = filter.period.start ? filter.period.start.slice(0, 10) : "";
+    const endValue = filter.period.end ? filter.period.end.slice(0, 10) : "";
+
+    return (
+      <div className="rounded-2xl bg-slate-900/80 p-4 ring-1 ring-slate-800 shadow-sm">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-5">
+          <label className="relative flex h-11 items-center rounded-2xl ring-2 ring-slate-800 focus-within:ring-[var(--accent)]">
+            <span className="sr-only">Cari transaksi</span>
+            <Search className="pointer-events-none absolute left-3 h-4 w-4 text-slate-500" aria-hidden="true" />
+            <input
+              ref={searchInputRef}
+              type="search"
+              value={searchTerm}
+              onChange={(event) => onSearchChange(event.target.value)}
+              placeholder="Cari judul atau catatan"
+              className="h-full w-full rounded-2xl bg-transparent pl-10 pr-3 text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none"
+              aria-label="Cari transaksi"
+            />
+          </label>
+          <label className="flex h-11 items-center rounded-2xl ring-2 ring-slate-800 focus-within:ring-[var(--accent)]">
+            <span className="sr-only">Filter tipe transaksi</span>
+            <select
+              value={filter.type}
+              onChange={(event) => onTypeChange(event.target.value)}
+              className="h-full w-full rounded-2xl bg-transparent px-3 text-sm font-medium text-slate-200 focus:outline-none"
+              aria-label="Filter tipe transaksi"
+            >
+              <option value="all">Semua tipe</option>
+              <option value="income">Pemasukan</option>
+              <option value="expense">Pengeluaran</option>
+              <option value="transfer">Transfer</option>
+            </select>
+          </label>
+          <label className="flex h-11 items-center rounded-2xl ring-2 ring-slate-800 focus-within:ring-[var(--accent)]">
+            <span className="sr-only">Filter kategori transaksi</span>
+            <select
+              value={selectedCategory}
+              onChange={(event) => {
+                const value = event.target.value;
+                onCategoryChange(value ? value : null);
+              }}
+              className="h-full w-full rounded-2xl bg-transparent px-3 text-sm font-medium text-slate-200 focus:outline-none"
+              aria-label="Filter kategori transaksi"
+            >
+              <option value="">Semua kategori</option>
+              {categories.map((category) => (
+                <option key={category.id} value={category.id}>
+                  {category.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="flex h-11 items-center gap-2 rounded-2xl bg-slate-900/40 px-3 ring-2 ring-slate-800 focus-within:ring-[var(--accent)]">
+            <CalendarDays className="h-4 w-4 text-slate-500" aria-hidden="true" />
+            <label className="flex-1 text-xs uppercase tracking-wide text-slate-500">
+              <span className="sr-only">Tanggal mulai</span>
+              <input
+                type="date"
+                value={startValue}
+                onChange={(event) => onDateChange({ start: event.target.value, end: endValue })}
+                className="h-6 w-full bg-transparent text-sm font-medium text-slate-200 focus:outline-none"
+                aria-label="Tanggal mulai"
+              />
+            </label>
+            <span className="text-slate-600">—</span>
+            <label className="flex-1 text-xs uppercase tracking-wide text-slate-500">
+              <span className="sr-only">Tanggal akhir</span>
+              <input
+                type="date"
+                value={endValue}
+                onChange={(event) => onDateChange({ start: startValue, end: event.target.value })}
+                className="h-6 w-full bg-transparent text-sm font-medium text-slate-200 focus:outline-none"
+                aria-label="Tanggal akhir"
+              />
+            </label>
+          </div>
+          <button
+            type="button"
+            onClick={onClear}
+            className="flex h-11 items-center justify-center gap-2 rounded-2xl bg-slate-900/40 text-sm font-semibold text-slate-300 ring-2 ring-slate-800 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          >
+            <FilterX className="h-4 w-4" aria-hidden="true" />
+            Reset
+          </button>
+        </div>
+      </div>
+    );
+  },
+);
+
+TransactionsFilters.displayName = "TransactionsFilters";
+
+export default TransactionsFilters;

--- a/src/components/transactions/TransactionsTable.tsx
+++ b/src/components/transactions/TransactionsTable.tsx
@@ -1,0 +1,454 @@
+import clsx from "clsx";
+import type { ChangeEvent } from "react";
+import { Pencil, Trash2 } from "lucide-react";
+import { formatCurrency } from "../../lib/format";
+import CategoryDot from "./CategoryDot";
+
+const TYPE_LABELS: Record<string, string> = {
+  income: "Pemasukan",
+  expense: "Pengeluaran",
+  transfer: "Transfer",
+};
+
+export interface TransactionRecord {
+  id: string;
+  type?: string;
+  date?: string;
+  amount?: number | string;
+  category?: string | null;
+  category_color?: string | null;
+  account?: string | null;
+  to_account?: string | null;
+  tags?: string[] | string | null;
+  note?: string | null;
+  notes?: string | null;
+  title?: string | null;
+  description?: string | null;
+}
+
+interface TransactionsTableProps {
+  items: TransactionRecord[];
+  loading: boolean;
+  error: unknown;
+  onRetry: () => void;
+  onToggleSelect: (id: string, event: ChangeEvent<HTMLInputElement>) => void;
+  onToggleSelectAll: () => void;
+  allSelected: boolean;
+  selectedIds: Set<string>;
+  onDelete: (id: string) => void;
+  onEdit: (item: TransactionRecord) => void;
+  sort: string;
+  onSortChange: (sort: string) => void;
+  stickyOffset?: string;
+  page: number;
+  pageSize: number;
+  total: number;
+  onPageChange: (page: number) => void;
+  onOpenAdd: () => void;
+  onResetFilters: () => void;
+  deleteDisabled?: boolean;
+}
+
+const DATE_FORMATTER =
+  typeof Intl !== "undefined"
+    ? new Intl.DateTimeFormat("id-ID", {
+        weekday: "short",
+        day: "2-digit",
+        month: "short",
+        year: "numeric",
+      })
+    : null;
+
+function formatDate(value?: string | null) {
+  if (!value) return "—";
+  try {
+    const date = new Date(value);
+    if (!Number.isFinite(date.getTime())) return "—";
+    return DATE_FORMATTER ? DATE_FORMATTER.format(date) : date.toISOString().slice(0, 10);
+  } catch {
+    return "—";
+  }
+}
+
+function parseTags(tags?: string[] | string | null) {
+  if (!tags) return [] as string[];
+  if (Array.isArray(tags)) return tags;
+  return tags
+    .split(",")
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+}
+
+function getNote(item: TransactionRecord) {
+  return (
+    item.notes ??
+    item.note ??
+    item.title ??
+    item.description ??
+    ""
+  );
+}
+
+function getAmountClass(type?: string) {
+  if (type === "income") return "text-emerald-400";
+  if (type === "expense") return "text-rose-400";
+  return "text-slate-300";
+}
+
+function computeSort(column: "date" | "amount", currentSort: string) {
+  if (column === "date") {
+    return currentSort === "date-desc" ? "date-asc" : "date-desc";
+  }
+  if (column === "amount") {
+    return currentSort === "amount-desc" ? "amount-asc" : "amount-desc";
+  }
+  return currentSort;
+}
+
+function SortButton({
+  label,
+  active,
+  direction,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  direction: "asc" | "desc";
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={clsx(
+        "flex w-full items-center gap-1 text-left text-xs uppercase tracking-wide transition",
+        active ? "text-slate-200" : "text-slate-400 hover:text-slate-200",
+      )}
+    >
+      <span>{label}</span>
+      <span aria-hidden="true" className="text-[10px] leading-none">
+        {active ? (direction === "asc" ? "▲" : "▼") : ""}
+      </span>
+    </button>
+  );
+}
+
+export default function TransactionsTable({
+  items,
+  loading,
+  error,
+  onRetry,
+  onToggleSelect,
+  onToggleSelectAll,
+  allSelected,
+  selectedIds,
+  onDelete,
+  onEdit,
+  sort,
+  onSortChange,
+  stickyOffset,
+  page,
+  pageSize,
+  total,
+  onPageChange,
+  onOpenAdd,
+  onResetFilters,
+  deleteDisabled = false,
+}: TransactionsTableProps) {
+  const isInitialLoading = loading && items.length === 0;
+  const skeletonCount = 6;
+  const totalPages = total === 0 ? 1 : Math.max(1, Math.ceil(total / pageSize));
+  const clampedPage = Math.min(page, totalPages);
+  const displayStart = total === 0 ? 0 : (clampedPage - 1) * pageSize + (items.length > 0 ? 1 : 0);
+  const displayEnd = total === 0 ? 0 : (clampedPage - 1) * pageSize + items.length;
+
+  const showEmpty = !loading && items.length === 0 && !error;
+
+  return (
+    <section className="hidden flex-col gap-4 md:flex">
+      {error && (
+        <div className="rounded-2xl bg-red-500/10 p-4 text-sm text-red-200 ring-1 ring-red-500/30">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <span>Gagal memuat transaksi.</span>
+            <button
+              type="button"
+              onClick={onRetry}
+              className="rounded-full bg-red-500/20 px-3 py-1 text-xs font-semibold text-red-100 transition hover:bg-red-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
+            >
+              Coba lagi
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="overflow-hidden rounded-2xl bg-slate-900 ring-1 ring-slate-800">
+        {showEmpty ? (
+          <div className="flex flex-col items-center justify-center gap-4 px-6 py-16 text-center text-slate-300">
+            <p className="text-lg font-semibold text-slate-200">Belum ada transaksi</p>
+            <p className="max-w-md text-sm text-slate-400">
+              Coba tambahkan transaksi baru atau reset filter untuk melihat semua histori.
+            </p>
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <button
+                type="button"
+                onClick={onOpenAdd}
+                className="rounded-full bg-[var(--accent)] px-4 py-2 text-sm font-semibold text-white shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+              >
+                Tambah Transaksi
+              </button>
+              <button
+                type="button"
+                onClick={onResetFilters}
+                className="rounded-full border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-200 hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+              >
+                Reset Filter
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="hidden min-w-full table-fixed text-sm md:table" aria-label="Daftar transaksi">
+              <thead
+                className="sticky top-0 z-10 bg-slate-900 text-xs uppercase tracking-wide text-slate-400 backdrop-blur"
+                style={stickyOffset ? { top: stickyOffset } : undefined}
+              >
+                <tr>
+                  <th scope="col" className="w-14 px-4 py-3">
+                    <input
+                      type="checkbox"
+                      checked={allSelected}
+                      onChange={onToggleSelectAll}
+                      className="h-4 w-4 rounded border-slate-700 bg-slate-900 text-[var(--accent)] focus:ring-[var(--accent)]"
+                      aria-label="Pilih semua transaksi"
+                    />
+                  </th>
+                  <th scope="col" className="min-w-[240px] px-4 py-3 text-left">
+                    <span className="text-xs uppercase tracking-wide text-slate-400">Kategori &amp; Catatan</span>
+                  </th>
+                  <th
+                    scope="col"
+                    className="min-w-[160px] px-4 py-3"
+                    aria-sort={sort === "date-asc" ? "ascending" : sort === "date-desc" ? "descending" : undefined}
+                  >
+                    <SortButton
+                      label="Tanggal"
+                      active={sort === "date-desc" || sort === "date-asc"}
+                      direction={sort === "date-asc" ? "asc" : "desc"}
+                      onClick={() => onSortChange(computeSort("date", sort))}
+                    />
+                  </th>
+                  <th scope="col" className="min-w-[180px] px-4 py-3 text-left">
+                    <span className="text-xs uppercase tracking-wide text-slate-400">Akun</span>
+                  </th>
+                  <th scope="col" className="min-w-[200px] px-4 py-3 text-left">
+                    <span className="text-xs uppercase tracking-wide text-slate-400">Tags</span>
+                  </th>
+                  <th
+                    scope="col"
+                    className="min-w-[140px] px-4 py-3 text-right"
+                    aria-sort={sort === "amount-asc" ? "ascending" : sort === "amount-desc" ? "descending" : undefined}
+                  >
+                    <SortButton
+                      label="Jumlah"
+                      active={sort === "amount-desc" || sort === "amount-asc"}
+                      direction={sort === "amount-asc" ? "asc" : "desc"}
+                      onClick={() => onSortChange(computeSort("amount", sort))}
+                    />
+                  </th>
+                  <th scope="col" className="w-[96px] px-4 py-3 text-right">
+                    <span className="text-xs uppercase tracking-wide text-slate-400">Aksi</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-800">
+                {items.map((item) => {
+                  const tags = parseTags(item.tags);
+                  const note = getNote(item).trim();
+                  const categoryName = item.category || "(Tanpa kategori)";
+                  const formattedDate = formatDate(item.date);
+                  const dateValue = item.date ? new Date(item.date).toISOString() : undefined;
+                  return (
+                    <tr
+                      key={item.id}
+                      className={clsx(
+                        "transition-colors",
+                        selectedIds.has(item.id)
+                          ? "bg-slate-800/80"
+                          : "hover:bg-slate-800/50",
+                      )}
+                    >
+                      <td className="px-4 py-3 align-middle">
+                        <div className="flex justify-center">
+                          <input
+                            type="checkbox"
+                            checked={selectedIds.has(item.id)}
+                            onChange={(event) => onToggleSelect(item.id, event)}
+                            className="h-4 w-4 rounded border-slate-700 bg-slate-900 text-[var(--accent)] focus:ring-[var(--accent)]"
+                            aria-label="Pilih transaksi"
+                          />
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 align-middle">
+                        <div className="flex gap-3">
+                          <CategoryDot color={item.category_color} className="mt-1" />
+                          <div className="min-w-0 space-y-1">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <p className="text-sm font-semibold text-slate-200" title={categoryName}>
+                                {categoryName}
+                              </p>
+                              <span className="rounded-full bg-slate-800 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+                                {TYPE_LABELS[item.type ?? ""] ?? item.type ?? ""}
+                              </span>
+                            </div>
+                            <p className="line-clamp-2 text-sm text-slate-400" title={note}>
+                              {note || "Tidak ada catatan"}
+                            </p>
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 align-middle text-sm text-slate-300">
+                        {formattedDate !== "—" ? (
+                          <time dateTime={dateValue}>{formattedDate}</time>
+                        ) : (
+                          "—"
+                        )}
+                      </td>
+                      <td className="px-4 py-3 align-middle text-sm text-slate-300">
+                        {item.type === "transfer" ? (
+                          <span className="inline-flex flex-wrap items-center gap-1 text-slate-200">
+                            <span className="truncate">{item.account || "—"}</span>
+                            <span aria-hidden="true" className="text-slate-500">
+                              ➜
+                            </span>
+                            <span className="truncate">{item.to_account || "—"}</span>
+                          </span>
+                        ) : (
+                          <span className="truncate text-slate-200">{item.account || "—"}</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 align-middle">
+                        {tags.length > 0 ? (
+                          <div className="flex flex-wrap gap-2">
+                            {tags.map((tag) => (
+                              <span
+                                key={tag}
+                                className="inline-flex items-center rounded-full bg-slate-800/80 px-3 py-1 text-xs font-medium text-slate-200"
+                              >
+                                {tag}
+                              </span>
+                            ))}
+                          </div>
+                        ) : (
+                          <span className="text-sm text-slate-500">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 align-middle text-right">
+                        <span className={clsx("font-mono text-sm font-semibold", getAmountClass(item.type))}>
+                          {formatCurrency(Number(item.amount ?? 0), "IDR")}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 align-middle">
+                        <div className="flex justify-end gap-2">
+                          <button
+                            type="button"
+                            onClick={() => onEdit(item)}
+                            className="flex h-9 w-9 items-center justify-center rounded-full bg-slate-900 text-slate-300 ring-1 ring-slate-700 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+                            aria-label="Edit transaksi"
+                          >
+                            <Pencil className="h-4 w-4" aria-hidden="true" />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => onDelete(item.id)}
+                            className="flex h-9 w-9 items-center justify-center rounded-full bg-slate-900 text-rose-300 ring-1 ring-rose-500/40 transition hover:text-rose-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-60"
+                            aria-label="Hapus transaksi"
+                            disabled={deleteDisabled}
+                          >
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+                {isInitialLoading &&
+                  Array.from({ length: skeletonCount }).map((_, index) => (
+                    <tr key={`skeleton-${index}`} className="animate-pulse">
+                      <td className="px-4 py-3">
+                        <div className="h-4 w-4 rounded bg-slate-800" />
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex gap-3">
+                          <div className="h-2.5 w-2.5 rounded-full bg-slate-800" />
+                          <div className="flex-1 space-y-2">
+                            <div className="h-4 w-40 rounded-full bg-slate-800" />
+                            <div className="h-4 w-56 rounded-full bg-slate-800" />
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="h-4 w-24 rounded-full bg-slate-800" />
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="h-4 w-28 rounded-full bg-slate-800" />
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex gap-2">
+                          <div className="h-5 w-16 rounded-full bg-slate-800" />
+                          <div className="h-5 w-12 rounded-full bg-slate-800" />
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <div className="ml-auto h-4 w-20 rounded-full bg-slate-800" />
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="ml-auto flex gap-2">
+                          <div className="h-9 w-9 rounded-full bg-slate-800" />
+                          <div className="h-9 w-9 rounded-full bg-slate-800" />
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl bg-slate-900/70 px-4 py-3 text-sm text-slate-300 ring-1 ring-slate-800">
+        <div>
+          {total > 0 ? (
+            <span>
+              Menampilkan {displayStart.toLocaleString("id-ID")}-{displayEnd.toLocaleString("id-ID")} dari {total.toLocaleString("id-ID")} ({pageSize} per halaman)
+            </span>
+          ) : (
+            <span>Tidak ada transaksi</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => onPageChange(Math.max(1, clampedPage - 1))}
+            disabled={clampedPage <= 1}
+            className="rounded-full bg-slate-900 px-3 py-1 text-xs font-semibold text-slate-300 ring-1 ring-slate-700 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60"
+            aria-label="Halaman sebelumnya"
+          >
+            Prev
+          </button>
+          <span className="text-xs font-semibold text-slate-400">
+            Halaman {clampedPage} / {totalPages}
+          </span>
+          <button
+            type="button"
+            onClick={() => onPageChange(Math.min(totalPages, clampedPage + 1))}
+            disabled={clampedPage >= totalPages}
+            className="rounded-full bg-slate-900 px-3 py-1 text-xs font-semibold text-slate-300 ring-1 ring-slate-700 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60"
+            aria-label="Halaman berikutnya"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -1,20 +1,12 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 import { useNavigate } from "react-router-dom";
 import clsx from "clsx";
 import {
   AlertTriangle,
-  ArrowRight,
-  ArrowRightLeft,
   ChevronDown,
-  Check,
   Download,
-  Inbox,
   Loader2,
-  Paperclip,
-  Pencil,
   Plus,
-  Search,
   Trash2,
   Upload,
   X,
@@ -23,6 +15,10 @@ import useTransactionsQuery from "../hooks/useTransactionsQuery";
 import useNetworkStatus from "../hooks/useNetworkStatus";
 import { useToast } from "../context/ToastContext";
 import PageHeader from "../layout/PageHeader";
+import TransactionsFilters from "../components/transactions/TransactionsFilters";
+import TransactionsTable from "../components/transactions/TransactionsTable";
+import TransactionsCardList from "../components/transactions/TransactionsCardList";
+import BatchToolbar from "../components/transactions/BatchToolbar";
 import { addTransaction, listAccounts, listMerchants, updateTransaction } from "../lib/api";
 import {
   listTransactions,
@@ -59,46 +55,14 @@ const PAGE_DESCRIPTION = "Kelola catatan keuangan";
 
 const FILTER_PANEL_BREAKPOINT = 768;
 const FILTER_PANEL_STORAGE_KEY = "transactions-filter-open";
-const MOBILE_BREAKPOINT = 992;
-
-function detectTableVariant() {
-  if (typeof window === "undefined") return "table";
-  return window.innerWidth < MOBILE_BREAKPOINT ? "card" : "table";
-}
 
 function toDateInput(value) {
   if (!value) return "";
   return String(value).slice(0, 10);
 }
 
-function currentMonthValue() {
-  const now = new Date();
-  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
-}
-
 function formatIDR(value) {
   return formatCurrency(Number(value ?? 0), "IDR");
-}
-
-const TRANSACTION_DATE_FORMATTER =
-  typeof Intl !== "undefined"
-    ? new Intl.DateTimeFormat("id-ID", {
-        weekday: "short",
-        day: "2-digit",
-        month: "short",
-        year: "numeric",
-      })
-    : null;
-
-function formatTransactionDate(value) {
-  if (!value) return "";
-  try {
-    const date = new Date(value);
-    if (!Number.isFinite(date.getTime())) return String(value);
-    return TRANSACTION_DATE_FORMATTER ? TRANSACTION_DATE_FORMATTER.format(date) : String(value);
-  } catch {
-    return String(value);
-  }
 }
 
 function chunk(arr, size) {
@@ -113,16 +77,16 @@ export default function Transactions() {
   const {
     items: queryItems,
     total,
-    hasMore,
     loading,
     error,
     filter,
     setFilter,
-    loadMore,
     refresh,
     categories,
     summary,
     pageSize,
+    page,
+    setPage,
   } = useTransactionsQuery();
   const { addToast } = useToast();
   const online = useNetworkStatus();
@@ -142,7 +106,6 @@ export default function Transactions() {
   const lastSelectedIdRef = useRef(null);
   const [searchTerm, setSearchTerm] = useState(filter.search);
   const [filterBarStuck, setFilterBarStuck] = useState(false);
-  const [tableVariant, setTableVariant] = useState(() => detectTableVariant());
   const [deleteInProgress, setDeleteInProgress] = useState(false);
   const [confirmState, setConfirmState] = useState(null);
   const undoTimerRef = useRef(null);
@@ -173,15 +136,6 @@ export default function Transactions() {
   useEffect(() => {
     setSearchTerm(filter.search);
   }, [filter.search]);
-
-  useEffect(() => {
-    const handleResize = () => {
-      setTableVariant(detectTableVariant());
-    };
-    handleResize();
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
@@ -465,6 +419,52 @@ export default function Transactions() {
     });
   }, [setFilter, setSearchTerm]);
 
+  const handleTypeFilterChange = useCallback(
+    (value) => {
+      setFilter({ type: value });
+    },
+    [setFilter],
+  );
+
+  const handleCategoryFilterChange = useCallback(
+    (value) => {
+      setFilter({ categories: value ? [value] : [] });
+    },
+    [setFilter],
+  );
+
+  const handleDateRangeChange = useCallback(
+    ({ start, end }) => {
+      const cleanStart = start ? start.slice(0, 10) : "";
+      const cleanEnd = end ? end.slice(0, 10) : "";
+      setFilter({
+        period: {
+          preset: cleanStart || cleanEnd ? "custom" : "all",
+          month: "",
+          start: cleanStart,
+          end: cleanEnd,
+        },
+      });
+    },
+    [setFilter],
+  );
+
+  const handleSortChange = useCallback(
+    (value) => {
+      setFilter({ sort: value });
+    },
+    [setFilter],
+  );
+
+  const handlePageChange = useCallback(
+    (nextPage) => {
+      setPage(nextPage);
+      setSelectedIds(new Set());
+      lastSelectedIdRef.current = null;
+    },
+    [setPage],
+  );
+
   const showUndoSnackbar = useCallback((payload) => {
     if (!payload || !payload.ids?.length) return;
     if (undoTimerRef.current) {
@@ -709,7 +709,6 @@ export default function Transactions() {
   }, [navigate]);
 
   const tableStickyTop = `calc(var(--app-header-height, var(--app-topbar-h, 64px)) + ${filterBarHeight}px + 16px)`;
-  const selectionToolbarOffset = tableStickyTop ? `calc(${tableStickyTop} + 12px)` : "16px";
   const isFilterPanelVisible = isDesktopFilterView || filterPanelOpen;
   const activeFilterCount = activeChips.length;
 
@@ -805,14 +804,16 @@ export default function Transactions() {
               WebkitBackdropFilter: "blur(6px)",
             }}
           >
-            <TransactionsFilterBar
+            <TransactionsFilters
+              ref={searchInputRef}
               filter={filter}
-              categories={categories}
+              categories={categories || []}
               searchTerm={searchTerm}
               onSearchChange={setSearchTerm}
-              onFilterChange={setFilter}
-              searchInputRef={searchInputRef}
-              onOpenAdd={handleNavigateToAdd}
+              onTypeChange={handleTypeFilterChange}
+              onCategoryChange={handleCategoryFilterChange}
+              onDateChange={handleDateRangeChange}
+              onClear={handleResetFilters}
             />
           </div>
         </div>
@@ -846,39 +847,59 @@ export default function Transactions() {
         )}
 
         {selectedIds.size > 0 && (
-          <SelectionToolbar
-            count={selectedIds.size}
+          <BatchToolbar
+            selectedCount={selectedIds.size}
             onClear={() => {
               setSelectedIds(new Set());
               lastSelectedIdRef.current = null;
             }}
             onDelete={handleRequestBulkDelete}
-            onEditCategory={() => setBulkEditMode("category")}
-            onEditAccount={() => setBulkEditMode("account")}
+            onChangeCategory={() => setBulkEditMode("category")}
             deleting={deleteInProgress}
             updating={bulkUpdating}
-            topOffset={selectionToolbarOffset}
           />
         )}
+
+        <TransactionsCardList
+          items={items}
+          loading={loading}
+          error={error}
+          onRetry={() => refresh({ keepPage: true })}
+          selectedIds={selectedIds}
+          onToggleSelect={toggleSelect}
+          onDelete={handleRequestDelete}
+          onEdit={handleEditTransaction}
+          sort={filter.sort}
+          onSortChange={handleSortChange}
+          page={page}
+          pageSize={pageSize}
+          total={total}
+          onPageChange={handlePageChange}
+          onOpenAdd={handleNavigateToAdd}
+          onResetFilters={handleResetFilters}
+          deleteDisabled={deleteInProgress}
+        />
 
         <TransactionsTable
           items={items}
           loading={loading}
           error={error}
           onRetry={() => refresh({ keepPage: true })}
-          onLoadMore={loadMore}
-          hasMore={hasMore}
           onToggleSelect={toggleSelect}
           onToggleSelectAll={toggleSelectAll}
           allSelected={allSelected}
           selectedIds={selectedIds}
           onDelete={handleRequestDelete}
           onEdit={handleEditTransaction}
-          tableStickyTop={tableStickyTop}
-          variant={tableVariant}
-          onResetFilters={handleResetFilters}
+          sort={filter.sort}
+          onSortChange={handleSortChange}
+          stickyOffset={tableStickyTop}
+          page={page}
+          pageSize={pageSize}
           total={total}
+          onPageChange={handlePageChange}
           onOpenAdd={handleNavigateToAdd}
+          onResetFilters={handleResetFilters}
           deleteDisabled={deleteInProgress}
         />
 
@@ -971,490 +992,6 @@ export default function Transactions() {
   );
 }
 
-function TransactionsFilterBar({
-  filter,
-  categories,
-  searchTerm,
-  onSearchChange,
-  onFilterChange,
-  searchInputRef,
-  onOpenAdd = () => {},
-}) {
-  const currentMonth = currentMonthValue();
-  const customButtonRef = useRef(null);
-  const actualSearchInputRef = useRef(null);
-  const [customOpen, setCustomOpen] = useState(false);
-  const typeSelectId = useId();
-  const sortSelectId = useId();
-  const searchInputId = useId();
-
-  useEffect(() => {
-    if (!searchInputRef) return;
-    searchInputRef.current = {
-      focus: () => {
-        actualSearchInputRef.current?.focus();
-        actualSearchInputRef.current?.select();
-      },
-    };
-  }, [searchInputRef]);
-
-  useEffect(() => {
-    if (filter.period.preset !== "custom") {
-      setCustomOpen(false);
-    }
-  }, [filter.period.preset]);
-
-  const handlePresetChange = (preset) => {
-    if (preset === "custom" && filter.period.preset === "custom") {
-      setCustomOpen((prev) => !prev);
-      return;
-    }
-    if (preset === "all") {
-      onFilterChange({ period: { preset: "all", month: "", start: "", end: "" } });
-      setCustomOpen(false);
-      return;
-    }
-    if (preset === "month") {
-      onFilterChange({ period: { preset: "month", month: filter.period.month || currentMonth, start: "", end: "" } });
-      setCustomOpen(false);
-      return;
-    }
-    if (preset === "week") {
-      onFilterChange({ period: { preset: "week", month: "", start: "", end: "" } });
-      setCustomOpen(false);
-      return;
-    }
-    if (preset === "custom") {
-      const today = new Date().toISOString().slice(0, 10);
-      onFilterChange({ period: { preset: "custom", month: "", start: filter.period.start || today, end: filter.period.end || today } });
-      setCustomOpen(true);
-    }
-  };
-
-  const handleCategoryChange = (selected) => {
-    onFilterChange({ categories: selected });
-  };
-
-  const handleReset = () => {
-    onFilterChange({
-      period: { preset: "all", month: "", start: "", end: "" },
-      categories: [],
-      type: "all",
-      sort: "date-desc",
-      search: "",
-    });
-    onSearchChange("");
-  };
-
-  const handleSearchChange = (value) => {
-    onSearchChange(value);
-  };
-
-  const handleTypeChange = (value) => {
-    onFilterChange({ type: value });
-  };
-
-  const handleSortChange = (value) => {
-    onFilterChange({ sort: value });
-  };
-
-  return (
-    <div className="space-y-4 rounded-2xl border border-white/10 bg-slate-900/70 p-4 text-white shadow">
-      <div
-        role="toolbar"
-        aria-label="Filter transaksi"
-        className="grid grid-cols-2 items-center gap-3 md:grid-cols-6"
-      >
-        <div className="col-span-2 min-w-0 md:col-span-2">
-          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-white/60">
-            Rentang Waktu
-          </p>
-          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 md:grid-cols-2 lg:grid-cols-4">
-            {Object.entries(PERIOD_LABELS).map(([value, label]) => (
-              <button
-                key={value}
-                type="button"
-                onClick={() => handlePresetChange(value)}
-                ref={value === "custom" ? customButtonRef : undefined}
-                className={clsx(
-                  "inline-flex h-[40px] items-center justify-center rounded-xl border border-white/10 bg-white/5 px-3 text-sm font-semibold text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60",
-                  filter.period.preset === value
-                    ? "bg-brand text-white shadow"
-                    : "text-white/70 hover:bg-white/10",
-                )}
-                aria-pressed={filter.period.preset === value}
-              >
-                {label}
-              </button>
-            ))}
-          </div>
-        </div>
-        <div className="col-span-2 min-w-0 md:col-span-1">
-          <CategoryMultiSelect
-            categories={categories}
-            selected={filter.categories}
-            onChange={handleCategoryChange}
-            ariaLabel="Filter kategori transaksi"
-          />
-        </div>
-        <div className="col-span-2 min-w-0 md:col-span-1">
-          <label htmlFor={typeSelectId} className="sr-only">
-            Filter jenis transaksi
-          </label>
-          <select
-            id={typeSelectId}
-            value={filter.type}
-            onChange={(event) => handleTypeChange(event.target.value)}
-            aria-label="Filter jenis transaksi"
-            className="h-[40px] w-full rounded-xl border border-white/10 bg-white/5 px-3 text-sm font-medium text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-          >
-            <option value="all">Semua</option>
-            <option value="expense">Pengeluaran</option>
-            <option value="income">Pemasukan</option>
-            <option value="transfer">Transfer</option>
-          </select>
-        </div>
-        <div className="col-span-2 min-w-0 md:col-span-1">
-          <label htmlFor={sortSelectId} className="sr-only">
-            Urutkan transaksi
-          </label>
-          <select
-            id={sortSelectId}
-            value={filter.sort}
-            onChange={(event) => handleSortChange(event.target.value)}
-            aria-label="Urutkan transaksi"
-            className="h-[40px] w-full rounded-xl border border-white/10 bg-white/5 px-3 text-sm font-medium text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-          >
-            <option value="date-desc">Terbaru</option>
-            <option value="date-asc">Terlama</option>
-            <option value="amount-desc">Terbesar</option>
-            <option value="amount-asc">Terkecil</option>
-          </select>
-        </div>
-        <div className="col-span-2 min-w-0 md:col-span-1">
-          <div className="relative min-w-0">
-            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-white/40" aria-hidden="true" />
-            <input
-              id={searchInputId}
-              ref={actualSearchInputRef}
-              type="search"
-              value={searchTerm}
-              onChange={(event) => handleSearchChange(event.target.value)}
-              placeholder="Cari judul/catatan…"
-              aria-label="Cari transaksi"
-              className="h-[40px] w-full rounded-xl border border-white/10 bg-white/5 pl-9 pr-3 text-sm text-white placeholder:text-white/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-            />
-          </div>
-        </div>
-        <div className="col-span-2 flex min-w-0 flex-wrap items-center justify-end gap-2 md:col-span-6 md:flex-nowrap md:gap-3">
-          <button
-            type="button"
-            onClick={handleReset}
-            className="inline-flex h-[40px] items-center rounded-xl border border-white/10 bg-white/5 px-3 text-sm font-medium text-white/80 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-            aria-label="Reset semua filter"
-          >
-            Reset
-          </button>
-          <button
-            type="button"
-            onClick={onOpenAdd}
-            className="inline-flex h-[40px] items-center gap-2 rounded-xl bg-brand px-4 text-sm font-semibold text-white shadow transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-            aria-label="Tambah transaksi"
-          >
-            <Plus className="h-4 w-4" /> Tambah Transaksi
-          </button>
-        </div>
-      </div>
-      {customOpen && filter.period.preset === "custom" && (
-        <CustomRangePopover
-          anchorRef={customButtonRef}
-          period={filter.period}
-          onChange={(next) => onFilterChange({ period: next })}
-          onClose={() => setCustomOpen(false)}
-        />
-      )}
-    </div>
-  );
-}
-
-
-function CategoryMultiSelect({ categories = [], selected = [], onChange, ariaLabel }) {
-  const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState("");
-  const triggerRef = useRef(null);
-  const panelRef = useRef(null);
-  const [position, setPosition] = useState({ top: 0, left: 0, width: 0 });
-
-  useEffect(() => {
-    if (!open) return;
-    const updatePosition = () => {
-      const anchor = triggerRef.current;
-      if (!anchor) return;
-      const rect = anchor.getBoundingClientRect();
-      const preferredWidth = Math.min(320, Math.max(260, rect.width || 260));
-      const left = Math.min(
-        Math.max(16, rect.left),
-        window.innerWidth - preferredWidth - 16,
-      );
-      setPosition({
-        top: rect.bottom + 8,
-        left,
-        width: preferredWidth,
-      });
-    };
-    updatePosition();
-    window.addEventListener("resize", updatePosition);
-    window.addEventListener("scroll", updatePosition, true);
-    return () => {
-      window.removeEventListener("resize", updatePosition);
-      window.removeEventListener("scroll", updatePosition, true);
-    };
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const handleClick = (event) => {
-      if (triggerRef.current?.contains(event.target)) return;
-      if (panelRef.current?.contains(event.target)) return;
-      setOpen(false);
-    };
-    const handleKey = (event) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        setOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClick);
-    document.addEventListener("keydown", handleKey);
-    return () => {
-      document.removeEventListener("mousedown", handleClick);
-      document.removeEventListener("keydown", handleKey);
-    };
-  }, [open]);
-
-  useEffect(() => {
-    if (open) {
-      setQuery("");
-    }
-  }, [open]);
-
-  const toggle = (id) => {
-    const set = new Set(selected);
-    if (set.has(id)) set.delete(id);
-    else set.add(id);
-    onChange(Array.from(set));
-  };
-
-  const clearAll = () => {
-    onChange([]);
-  };
-
-  const filteredCategories = useMemo(() => {
-    const term = query.trim().toLowerCase();
-    if (!term) return categories;
-    return categories.filter((cat) => {
-      return (
-        cat.name?.toLowerCase().includes(term) ||
-        (TYPE_LABELS[cat.type] || "").toLowerCase().includes(term)
-      );
-    });
-  }, [categories, query]);
-
-  const summaryLabel = useMemo(() => {
-    if (!selected.length) return "Semua kategori";
-    if (selected.length === 1) {
-      const match = categories.find((cat) => cat.id === selected[0]);
-      return match?.name || "1 dipilih";
-    }
-    return `${selected.length} dipilih`;
-  }, [categories, selected]);
-
-  const label = ariaLabel || "Pilih kategori transaksi";
-
-  return (
-    <>
-      <button
-        type="button"
-        ref={triggerRef}
-        onClick={() => setOpen((prev) => !prev)}
-        className="inline-flex h-[40px] w-full min-w-0 flex-shrink-0 items-center justify-between rounded-xl border border-white/10 bg-white/5 px-3 text-sm font-medium text-white transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        aria-label={label}
-      >
-        <span className="truncate">{summaryLabel}</span>
-        <ChevronDown className="h-4 w-4 text-white/60" aria-hidden="true" />
-      </button>
-      {open &&
-        createPortal(
-          <div className="fixed inset-0 z-40" role="presentation">
-            <div
-              ref={panelRef}
-              role="listbox"
-              aria-multiselectable="true"
-              className="absolute max-h-[320px] w-[min(320px,calc(100%-32px))] overflow-hidden rounded-2xl border border-white/10 bg-slate-900/95 shadow-2xl backdrop-blur"
-              style={{ top: position.top, left: position.left, width: position.width || undefined }}
-              data-role="category-panel"
-            >
-              <div className="flex items-center justify-between px-3 pt-3">
-                <span className="text-xs font-semibold uppercase tracking-wide text-white/60">Kategori</span>
-                <button
-                  type="button"
-                  onClick={clearAll}
-                  className="rounded-full px-2 py-1 text-xs text-white/60 transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-                >
-                  Reset
-                </button>
-              </div>
-              <div className="px-3 pb-2">
-                <div className="flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-3">
-                  <Search className="h-4 w-4 text-white/40" aria-hidden="true" />
-                  <input
-                    type="search"
-                    value={query}
-                    onChange={(event) => setQuery(event.target.value)}
-                    placeholder="Cari kategori"
-                    className="h-9 w-full bg-transparent text-sm text-white placeholder:text-white/40 focus-visible:outline-none"
-                    aria-label="Cari kategori"
-                  />
-                </div>
-              </div>
-              <div className="max-h-[220px] overflow-y-auto px-1 pb-3">
-                {filteredCategories.length ? (
-                  filteredCategories.map((cat) => {
-                    const checked = selected.includes(cat.id);
-                    return (
-                      <button
-                        key={cat.id}
-                        type="button"
-                        onClick={() => toggle(cat.id)}
-                        className={clsx(
-                          "flex w-full items-center justify-between rounded-xl px-3 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60",
-                          checked ? "bg-white/10 text-white" : "text-white/80 hover:bg-white/5",
-                        )}
-                        role="option"
-                        aria-selected={checked}
-                      >
-                      <div className="flex flex-col text-left">
-                        <span className="font-medium text-white">{cat.name}</span>
-                      </div>
-                        {checked ? (
-                          <Check className="h-4 w-4 text-brand" aria-hidden="true" />
-                        ) : (
-                          <span className="h-4 w-4 rounded-full border border-white/30" aria-hidden="true" />
-                        )}
-                      </button>
-                    );
-                  })
-                ) : (
-                  <p className="px-3 py-6 text-center text-sm text-white/50">Tidak ada kategori ditemukan.</p>
-                )}
-              </div>
-            </div>
-          </div>,
-          document.body,
-        )}
-    </>
-  );
-}
-
-function CustomRangePopover({ anchorRef, period, onChange, onClose }) {
-  const popoverRef = useRef(null);
-  const [position, setPosition] = useState({ top: 0, left: 0 });
-
-  const updatePosition = useCallback(() => {
-    const anchor = anchorRef?.current;
-    if (!anchor) return;
-    const rect = anchor.getBoundingClientRect();
-    const width = Math.min(360, Math.max(280, rect.width + 120));
-    const left = Math.min(
-      Math.max(16, rect.left - (width - rect.width) / 2),
-      window.innerWidth - width - 16,
-    );
-    setPosition({
-      top: rect.bottom + 8,
-      left,
-      width,
-    });
-  }, [anchorRef]);
-
-  useEffect(() => {
-    updatePosition();
-    window.addEventListener("resize", updatePosition);
-    window.addEventListener("scroll", updatePosition, true);
-    return () => {
-      window.removeEventListener("resize", updatePosition);
-      window.removeEventListener("scroll", updatePosition, true);
-    };
-  }, [updatePosition]);
-
-  useEffect(() => {
-    const handleClick = (event) => {
-      if (anchorRef?.current?.contains(event.target)) return;
-      if (popoverRef.current?.contains(event.target)) return;
-      onClose();
-    };
-    const handleKey = (event) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onClose();
-      }
-    };
-    document.addEventListener("mousedown", handleClick);
-    document.addEventListener("keydown", handleKey);
-    return () => {
-      document.removeEventListener("mousedown", handleClick);
-      document.removeEventListener("keydown", handleKey);
-    };
-  }, [anchorRef, onClose]);
-
-  const content = (
-    <div className="fixed inset-0 z-40" role="presentation">
-      <div
-        ref={popoverRef}
-        className="absolute w-[min(360px,calc(100%-32px))] rounded-2xl border border-white/10 bg-slate-900/95 p-4 shadow-2xl backdrop-blur"
-        style={{ top: position.top, left: position.left, width: position.width || undefined }}
-        data-role="custom-range"
-      >
-        <p className="text-xs font-semibold uppercase tracking-wide text-white/60">Rentang custom</p>
-        <div className="mt-3 grid gap-3 sm:grid-cols-2">
-          <label className="flex flex-col gap-2 text-xs text-white/60">
-            <span className="font-medium text-white/70">Mulai</span>
-            <input
-              type="date"
-              value={period.start || ""}
-              onChange={(event) => onChange({ ...period, start: event.target.value })}
-              className="h-11 rounded-xl border border-white/10 bg-white/5 px-3 text-sm text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-            />
-          </label>
-          <label className="flex flex-col gap-2 text-xs text-white/60">
-            <span className="font-medium text-white/70">Selesai</span>
-            <input
-              type="date"
-              value={period.end || ""}
-              min={period.start || undefined}
-              onChange={(event) => onChange({ ...period, end: event.target.value })}
-              className="h-11 rounded-xl border border-white/10 bg-white/5 px-3 text-sm text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-            />
-          </label>
-        </div>
-        <div className="mt-3 flex items-center justify-between text-xs text-white/50">
-          <span>Pilih rentang tanggal sesuai kebutuhan.</span>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-full px-3 py-1 text-xs font-semibold text-white/80 transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-          >
-            Selesai
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-
-  return createPortal(content, document.body);
-}
-
 function ActiveFilterChips({ chips, onRemove }) {
   if (!chips?.length) return null;
   return (
@@ -1514,524 +1051,6 @@ function SummaryCards({ summary, loading }) {
       ))}
     </div>
   );
-}
-
-function SelectionToolbar({
-  count,
-  onClear,
-  onDelete,
-  onEditCategory,
-  onEditAccount,
-  deleting,
-  updating,
-  topOffset,
-}) {
-  return (
-    <div
-      className="pointer-events-none sticky bottom-4 z-30 md:bottom-auto md:top-0 md:sticky"
-      style={topOffset ? { top: topOffset } : undefined}
-      aria-live="polite"
-    >
-      <div className="pointer-events-auto mx-auto flex w-full max-w-[720px] flex-col gap-3 rounded-2xl border border-border bg-surface/95 p-4 shadow-lg shadow-black/5 md:flex-row md:items-center md:justify-between md:px-6">
-        <div className="flex flex-1 flex-wrap items-center gap-3">
-          <span className="inline-flex items-center gap-2 rounded-full bg-brand/10 px-3 py-1 text-sm font-semibold text-brand">
-            {count} dipilih
-          </span>
-          <button
-            type="button"
-            onClick={onClear}
-            className="text-sm font-medium text-muted transition hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-          >
-            Batal
-          </button>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <button
-            type="button"
-            onClick={onEditCategory}
-            disabled={updating}
-            className="inline-flex h-11 items-center justify-center gap-2 rounded-2xl border border-border px-4 text-sm font-medium text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {updating ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Pencil className="h-4 w-4" aria-hidden="true" />}
-            Ubah kategori
-          </button>
-          <button
-            type="button"
-            onClick={onEditAccount}
-            disabled={updating}
-            className="inline-flex h-11 items-center justify-center gap-2 rounded-2xl border border-border px-4 text-sm font-medium text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {updating ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <ArrowRightLeft className="h-4 w-4" aria-hidden="true" />}
-            Ubah akun
-          </button>
-          <button
-            type="button"
-            onClick={onDelete}
-            disabled={deleting}
-            className="inline-flex h-11 items-center justify-center gap-2 rounded-2xl bg-danger px-4 text-sm font-semibold text-white shadow transition hover:bg-[color:var(--color-danger-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-ring-danger)] disabled:cursor-not-allowed disabled:opacity-70"
-          >
-            {deleting ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Trash2 className="h-4 w-4" aria-hidden="true" />}
-            Hapus
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function TransactionsTable({
-  items,
-  loading,
-  error,
-  onRetry,
-  onLoadMore,
-  hasMore,
-  onToggleSelect,
-  onToggleSelectAll,
-  allSelected,
-  selectedIds,
-  onDelete,
-  onEdit,
-  tableStickyTop,
-  total,
-  variant = "table",
-  onResetFilters = () => {},
-  onOpenAdd = () => {},
-  deleteDisabled = false,
-}) {
-  const isCardVariant = variant === "card";
-  const isInitialLoading = loading && items.length === 0;
-  const isFetchingMore = loading && items.length > 0;
-  const displayStart = items.length > 0 ? 1 : 0;
-  const displayEnd = items.length;
-  const stickyHeaderStyle = tableStickyTop ? { top: tableStickyTop } : undefined;
-
-  if (error && !items.length) {
-    return (
-      <div className="rounded-2xl border border-danger/30 bg-danger/10 p-6 text-center">
-        <p className="mb-3 text-sm font-medium text-danger">Gagal memuat data transaksi.</p>
-        <button
-          type="button"
-          onClick={onRetry}
-          className="inline-flex h-11 items-center justify-center rounded-2xl border border-danger/40 bg-white/80 px-4 text-sm font-semibold text-danger transition hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-ring-danger)]"
-        >
-          Coba lagi
-        </button>
-      </div>
-    );
-  }
-
-  if (!loading && !items.length) {
-    return <EmptyTransactionsState onResetFilters={onResetFilters} onOpenAdd={onOpenAdd} />;
-  }
-
-  return (
-    <section className="space-y-4">
-      <div className={clsx("rounded-2xl border border-border bg-surface shadow-sm", isCardVariant ? "p-3" : "") }>
-        {isCardVariant ? (
-          <div className="flex flex-col gap-3">
-            {items.map((item) => (
-              <TransactionItem
-                key={item.id}
-                item={item}
-                variant="card"
-                isSelected={selectedIds.has(item.id)}
-                onToggleSelect={(event) => onToggleSelect(item.id, event)}
-                onDelete={() => onDelete(item.id)}
-                onEdit={() => onEdit(item)}
-                deleteDisabled={deleteDisabled}
-              />
-            ))}
-            {isInitialLoading &&
-              Array.from({ length: 6 }).map((_, index) => <TransactionSkeletonCard key={`card-skeleton-${index}`} />)}
-            {isFetchingMore &&
-              !isInitialLoading &&
-              Array.from({ length: 2 }).map((_, index) => <TransactionSkeletonCard key={`card-fetch-${index}`} />)}
-          </div>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full table-fixed border-separate border-spacing-0" aria-label="Daftar transaksi">
-              <thead
-                className="sticky top-0 z-10 border-b border-border/70 bg-surface-1/95 text-xs font-semibold uppercase tracking-wide text-muted backdrop-blur"
-                style={stickyHeaderStyle}
-              >
-                <tr>
-                  <th scope="col" className="w-12 px-3 py-3 text-center">
-                    <input
-                      type="checkbox"
-                      checked={allSelected}
-                      onChange={onToggleSelectAll}
-                      className="h-4 w-4 rounded border-border/70 text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-                      aria-label="Pilih semua transaksi"
-                    />
-                  </th>
-                  <th scope="col" className="min-w-[200px] px-3 py-3 text-left">Kategori</th>
-                  <th scope="col" className="min-w-[160px] px-3 py-3 text-left">Tanggal</th>
-                  <th scope="col" className="min-w-[240px] px-3 py-3 text-left">Catatan</th>
-                  <th scope="col" className="min-w-[180px] px-3 py-3 text-left">Akun</th>
-                  <th scope="col" className="min-w-[200px] px-3 py-3 text-left">Tags</th>
-                  <th scope="col" className="min-w-[140px] px-3 py-3 text-right">Jumlah</th>
-                  <th scope="col" className="w-[120px] px-3 py-3 text-right">Aksi</th>
-                </tr>
-              </thead>
-              <tbody>
-                {items.map((item) => (
-                  <TransactionItem
-                    key={item.id}
-                    item={item}
-                    variant="table"
-                    isSelected={selectedIds.has(item.id)}
-                    onToggleSelect={(event) => onToggleSelect(item.id, event)}
-                    onDelete={() => onDelete(item.id)}
-                    onEdit={() => onEdit(item)}
-                    deleteDisabled={deleteDisabled}
-                  />
-                ))}
-                {isInitialLoading &&
-                  Array.from({ length: 6 }).map((_, index) => <TransactionSkeletonRow key={`row-skeleton-${index}`} />)}
-                {isFetchingMore &&
-                  !isInitialLoading &&
-                  Array.from({ length: 2 }).map((_, index) => <TransactionSkeletonRow key={`row-fetch-${index}`} />)}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
-      <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted">
-        <span>
-          {total
-            ? `Menampilkan ${displayStart || 0}–${displayEnd} dari ${total}`
-            : `Menampilkan ${displayEnd} transaksi`}
-        </span>
-        {hasMore ? (
-          <button
-            type="button"
-            onClick={onLoadMore}
-            disabled={isFetchingMore}
-            className="inline-flex h-11 items-center gap-2 rounded-2xl border border-border px-4 text-sm font-medium text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {isFetchingMore && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
-            {isFetchingMore ? "Memuat…" : "Muat lagi"}
-          </button>
-        ) : null}
-      </div>
-    </section>
-  );
-}
-
-function UndoSnackbar({ open, message, onUndo, loading }) {
-  if (!open) return null;
-  return createPortal(
-    <div
-      className="fixed inset-x-0 bottom-4 z-40 flex justify-center px-4 sm:bottom-6"
-      role="status"
-      aria-live="polite"
-    >
-      <div className="flex w-full max-w-sm items-center gap-3 rounded-2xl border border-border bg-surface/95 px-4 py-3 text-sm text-text shadow-lg shadow-black/20">
-        <span className="flex-1">{message}</span>
-        <button
-          type="button"
-          onClick={onUndo}
-          disabled={loading}
-          className="inline-flex h-11 items-center justify-center rounded-xl border border-brand/50 px-4 text-sm font-semibold text-brand transition hover:bg-brand/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {loading ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : 'Urungkan'}
-        </button>
-      </div>
-    </div>,
-    document.body,
-  );
-}
-
-function TransactionSkeletonRow() {
-  return (
-    <tr className="border-b border-border/60 last:border-b-0">
-      {Array.from({ length: 8 }).map((_, index) => (
-        <td key={index} className="px-3 py-3 align-middle">
-          <div className="h-4 w-full animate-pulse rounded-full bg-border/60" />
-        </td>
-      ))}
-    </tr>
-  );
-}
-
-function TransactionSkeletonCard() {
-  return (
-    <div className="rounded-2xl border border-border bg-surface/80 p-4 shadow-sm">
-      <div className="mb-3 flex items-center justify-between">
-        <div className="h-4 w-32 animate-pulse rounded-full bg-border/60" />
-        <div className="h-5 w-20 animate-pulse rounded-full bg-border/60" />
-      </div>
-      <div className="grid grid-cols-2 gap-3">
-        <div className="h-4 w-full animate-pulse rounded-full bg-border/60" />
-        <div className="h-4 w-full animate-pulse rounded-full bg-border/60" />
-      </div>
-      <div className="mt-4 h-12 w-full animate-pulse rounded-2xl bg-border/60" />
-    </div>
-  );
-}
-
-function TransactionItem({
-  item,
-  variant = "table",
-  isSelected,
-  onToggleSelect,
-  onDelete,
-  onEdit,
-  deleteDisabled = false,
-}) {
-  const amountTone =
-    item.type === "income"
-      ? "text-success"
-      : item.type === "transfer"
-        ? "text-info"
-        : "text-danger";
-  const amountClass = clsx("text-right text-sm font-semibold tabular-nums", amountTone);
-  const amountCardClass = clsx("text-lg font-semibold tabular-nums", amountTone);
-  const note = item.notes ?? item.note ?? item.title ?? "";
-  const noteDisplay = note.trim() ? note.trim() : "—";
-  const formattedDate = formatTransactionDate(item.date);
-  const dateValue = toDateInput(item.date);
-  const categoryName = item.category || "(Tanpa kategori)";
-  const tags = useMemo(() => parseTags(item.tags), [item.tags]);
-  const hasAttachments = Boolean(item.receipt_url) || (Array.isArray(item.receipts) && item.receipts.length > 0);
-
-  const selectionCheckbox = (
-    <input
-      type="checkbox"
-      checked={isSelected}
-      onChange={onToggleSelect}
-      className="h-4 w-4 rounded border-border/70 text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-      aria-label="Pilih transaksi"
-    />
-  );
-
-  if (variant === "card") {
-    return (
-      <article
-        className={clsx(
-          "rounded-2xl border border-border bg-surface/90 p-4 shadow-sm transition-colors",
-          isSelected && "border-brand/40 bg-brand/5 ring-2 ring-brand/40",
-        )}
-        onDoubleClick={onEdit}
-      >
-        <div className="flex items-start gap-3">
-          <div className="pt-1">{selectionCheckbox}</div>
-          <div className="min-w-0 flex-1 space-y-3">
-            <div className="flex items-start justify-between gap-3">
-              <div className="flex items-center gap-2">
-                <span
-                  className="h-2.5 w-2.5 rounded-full"
-                  style={item.category_color ? { backgroundColor: item.category_color } : undefined}
-                  aria-hidden="true"
-                />
-                <p className="text-sm font-semibold text-text" title={categoryName}>
-                  {categoryName}
-                </p>
-                {hasAttachments && <Paperclip className="h-4 w-4 text-muted" aria-hidden="true" />}
-              </div>
-              <span className={clsx("text-right", amountCardClass)}>{formatIDR(item.amount)}</span>
-            </div>
-            <div className="grid grid-cols-1 gap-3 text-sm text-muted sm:grid-cols-2">
-              <div>
-                <p className="text-xs uppercase tracking-wide">Tanggal</p>
-                <p className="font-medium text-text">
-                  <time dateTime={dateValue}>{formattedDate}</time>
-                </p>
-              </div>
-              <div>
-                <p className="text-xs uppercase tracking-wide">Akun</p>
-                <p className="font-medium text-text">
-                  {item.type === "transfer" ? (
-                    <span className="flex items-center gap-1">
-                      <span className="truncate">{item.account || "—"}</span>
-                      <ArrowRight className="h-4 w-4 text-muted" aria-hidden="true" />
-                      <span className="truncate">{item.to_account || "—"}</span>
-                    </span>
-                  ) : (
-                    <span className="truncate">{item.account || "—"}</span>
-                  )}
-                </p>
-              </div>
-            </div>
-            <p className="line-clamp-2 text-sm text-muted" title={noteDisplay}>
-              {noteDisplay}
-            </p>
-            {tags.length > 0 && (
-              <div className="flex gap-2 overflow-x-auto pb-1">
-                {tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className="inline-flex items-center rounded-full bg-surface-2 px-3 py-1 text-xs font-medium text-text"
-                  >
-                    {tag}
-                  </span>
-                ))}
-              </div>
-            )}
-          </div>
-        </div>
-        <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
-          <button
-            type="button"
-            onClick={onEdit}
-            className="inline-flex h-11 items-center gap-2 rounded-2xl border border-border px-4 text-sm font-medium text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-            aria-label="Edit transaksi"
-          >
-            <Pencil className="h-4 w-4" aria-hidden="true" />
-            Edit
-          </button>
-          <button
-            type="button"
-            onClick={onDelete}
-            disabled={deleteDisabled}
-            className="inline-flex h-11 items-center gap-2 rounded-2xl border border-danger/40 bg-danger/10 px-4 text-sm font-medium text-danger transition hover:bg-danger/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-ring-danger)] disabled:cursor-not-allowed disabled:opacity-60"
-            aria-label="Hapus transaksi"
-          >
-            <Trash2 className="h-4 w-4" aria-hidden="true" />
-            Hapus
-          </button>
-        </div>
-      </article>
-    );
-  }
-
-  return (
-    <tr
-      className={clsx(
-        "border-b border-border/60 last:border-b-0 transition-colors",
-        isSelected
-          ? "bg-brand/10 shadow-[inset_0_0_0_1px_hsl(var(--color-primary)/0.35)]"
-          : "hover:bg-surface-2/60",
-      )}
-      onDoubleClick={onEdit}
-    >
-      <td className="px-3 py-3 align-middle">
-        <div className="flex items-center justify-center">{selectionCheckbox}</div>
-      </td>
-      <td className="px-3 py-3 align-middle">
-        <div className="flex items-center gap-3">
-          <span
-            className="h-2.5 w-2.5 rounded-full"
-            style={item.category_color ? { backgroundColor: item.category_color } : undefined}
-            aria-hidden="true"
-          />
-          <div className="min-w-0">
-            <p className="truncate text-sm font-medium text-text" title={categoryName}>
-              {categoryName}
-            </p>
-            <p className="text-xs uppercase tracking-wide text-muted">{TYPE_LABELS[item.type] || item.type}</p>
-          </div>
-        </div>
-      </td>
-      <td className="px-3 py-3 align-middle text-sm text-muted">
-        <time dateTime={dateValue}>{formattedDate}</time>
-      </td>
-      <td className="px-3 py-3 align-middle">
-        <div className="flex items-start gap-2">
-          <p className="line-clamp-2 text-sm text-text" title={noteDisplay}>
-            {noteDisplay}
-          </p>
-          {hasAttachments && <Paperclip className="mt-0.5 h-4 w-4 text-muted" aria-hidden="true" />}
-        </div>
-      </td>
-      <td className="px-3 py-3 align-middle text-sm text-text">
-        {item.type === "transfer" ? (
-          <div className="flex flex-wrap items-center gap-1">
-            <span className="truncate">{item.account || "—"}</span>
-            <ArrowRight className="h-4 w-4 text-muted" aria-hidden="true" />
-            <span className="truncate">{item.to_account || "—"}</span>
-          </div>
-        ) : (
-          <span className="truncate">{item.account || "—"}</span>
-        )}
-      </td>
-      <td className="px-3 py-3 align-middle">
-        {tags.length > 0 ? (
-          <div className="flex flex-wrap gap-2">
-            {tags.map((tag) => (
-              <span
-                key={tag}
-                className="inline-flex items-center rounded-full bg-surface-2 px-3 py-1 text-xs font-medium text-text"
-              >
-                {tag}
-              </span>
-            ))}
-          </div>
-        ) : (
-          <span className="text-sm text-muted">—</span>
-        )}
-      </td>
-      <td className="px-3 py-3 align-middle">
-        <span className={clsx("block", amountClass)}>{formatIDR(item.amount)}</span>
-      </td>
-      <td className="px-3 py-3 align-middle">
-        <div className="flex items-center justify-end gap-2">
-          <button
-            type="button"
-            onClick={onEdit}
-            className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-border bg-surface text-muted transition hover:border-brand/40 hover:bg-brand/5 hover:text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-            aria-label="Edit transaksi"
-          >
-            <Pencil className="h-4 w-4" aria-hidden="true" />
-          </button>
-          <button
-            type="button"
-            onClick={onDelete}
-            disabled={deleteDisabled}
-            className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-danger/40 bg-danger/10 text-danger transition hover:bg-danger/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-ring-danger)] disabled:cursor-not-allowed disabled:opacity-60"
-            aria-label="Hapus transaksi"
-          >
-            <Trash2 className="h-4 w-4" aria-hidden="true" />
-          </button>
-        </div>
-      </td>
-    </tr>
-  );
-}
-
-function EmptyTransactionsState({ onResetFilters, onOpenAdd }) {
-  return (
-    <div className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-border bg-surface/80 px-6 py-16 text-center">
-      <span className="rounded-full bg-brand/10 p-3 text-brand">
-        <Inbox className="h-6 w-6" aria-hidden="true" />
-      </span>
-      <div className="space-y-1">
-        <h2 className="text-lg font-semibold text-text">Belum ada transaksi sesuai filter</h2>
-        <p className="text-sm text-muted">Coba atur ulang filter atau tambahkan transaksi baru.</p>
-      </div>
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={onResetFilters}
-          className="inline-flex h-11 items-center justify-center rounded-2xl border border-border px-4 text-sm font-medium text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-        >
-          Reset filter
-        </button>
-        <button
-          type="button"
-          onClick={onOpenAdd}
-          className="inline-flex h-11 items-center gap-2 rounded-2xl bg-brand px-4 text-sm font-semibold text-brand-foreground shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-        >
-          <Plus className="h-4 w-4" aria-hidden="true" />
-          Tambah Transaksi
-        </button>
-      </div>
-    </div>
-  );
-}
-
-function parseTags(value) {
-  if (!value) return [];
-  if (Array.isArray(value)) {
-    return value
-      .map((tag) => String(tag).trim())
-      .filter(Boolean);
-  }
-  return String(value)
-    .split(",")
-    .map((tag) => tag.trim())
-    .filter(Boolean);
 }
 
 function BulkEditDialog({


### PR DESCRIPTION
## Summary
- replace the Transactions page list with the new responsive filters, table, and card components
- add a floating batch toolbar and polished loading/empty/error states for the history view
- update the transactions query hook to support 20 item pages and explicit page navigation

## Testing
- pnpm lint


------
https://chatgpt.com/codex/tasks/task_e_68d663dfd8848332bbc1a72d36bc419b