### PR TITLE
Redesign transactions listing UI

### DIFF
--- a/src/components/transactions/BatchToolbar.tsx
+++ b/src/components/transactions/BatchToolbar.tsx
@@ -1,0 +1,68 @@
+import { Tag, Trash2, X } from "lucide-react";
+
+interface BatchToolbarProps {
+  count: number;
+  onClear: () => void;
+  onDelete: () => void;
+  onChangeCategory: () => void;
+  deleteDisabled?: boolean;
+  changeDisabled?: boolean;
+}
+
+export default function BatchToolbar({
+  count,
+  onClear,
+  onDelete,
+  onChangeCategory,
+  deleteDisabled = false,
+  changeDisabled = false,
+}: BatchToolbarProps) {
+  if (count <= 0) return null;
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-6 z-40 flex justify-center px-4">
+      <div
+        className="pointer-events-auto flex w-full max-w-xl items-center justify-between gap-4 rounded-3xl bg-slate-900/90 px-5 py-3 text-sm text-slate-200 shadow-2xl ring-1 ring-slate-800"
+        aria-live="polite"
+      >
+        <div className="flex items-center gap-3">
+          <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-[var(--accent)]/20 text-sm font-semibold text-[var(--accent)]">
+            {count}
+          </span>
+          <div className="leading-tight">
+            <p className="text-sm font-semibold text-slate-100">{count} transaksi dipilih</p>
+            <button
+              type="button"
+              onClick={onClear}
+              className="mt-0.5 inline-flex items-center gap-1 text-xs text-slate-400 underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+              aria-label="Batalkan pilihan"
+            >
+              <X className="h-3 w-3" aria-hidden="true" />
+              Bersihkan
+            </button>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onDelete}
+            disabled={deleteDisabled}
+            className="inline-flex h-11 items-center gap-2 rounded-2xl bg-rose-500/20 px-4 text-sm font-semibold text-rose-100 ring-1 ring-rose-500/40 transition hover:bg-rose-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-60"
+            aria-label="Hapus transaksi terpilih"
+          >
+            <Trash2 className="h-4 w-4" aria-hidden="true" /> Hapus
+          </button>
+          <button
+            type="button"
+            onClick={onChangeCategory}
+            disabled={changeDisabled}
+            className="inline-flex h-11 items-center gap-2 rounded-2xl bg-[var(--accent)]/20 px-4 text-sm font-semibold text-[var(--accent)] ring-1 ring-[var(--accent)]/50 transition hover:bg-[var(--accent)]/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60 disabled:cursor-not-allowed disabled:opacity-60"
+            aria-label="Ubah kategori transaksi terpilih"
+          >
+            <Tag className="h-4 w-4" aria-hidden="true" /> Ubah Kategori
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/transactions/CategoryDot.tsx
+++ b/src/components/transactions/CategoryDot.tsx
@@ -1,0 +1,20 @@
+import clsx from "clsx";
+import type { HTMLAttributes } from "react";
+
+interface CategoryDotProps extends HTMLAttributes<HTMLSpanElement> {
+  color?: string | null;
+}
+
+export default function CategoryDot({ color, className, style, ...props }: CategoryDotProps) {
+  return (
+    <span
+      aria-hidden="true"
+      {...props}
+      className={clsx("inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full", className)}
+      style={{
+        backgroundColor: color || "var(--accent, #38bdf8)",
+        ...style,
+      }}
+    />
+  );
+}

--- a/src/components/transactions/TransactionsCardList.tsx
+++ b/src/components/transactions/TransactionsCardList.tsx
@@ -1,0 +1,372 @@
+import clsx from "clsx";
+import { Pencil, Trash2 } from "lucide-react";
+import type { ChangeEvent } from "react";
+import CategoryDot from "./CategoryDot";
+import type { TransactionRecord } from "./TransactionsTable";
+import { formatCurrency } from "../../lib/format";
+
+const TYPE_LABELS: Record<string, string> = {
+  income: "Pemasukan",
+  expense: "Pengeluaran",
+  transfer: "Transfer",
+};
+
+const DATE_FORMATTER =
+  typeof Intl !== "undefined"
+    ? new Intl.DateTimeFormat("id-ID", {
+        weekday: "short",
+        day: "2-digit",
+        month: "short",
+        year: "numeric",
+      })
+    : null;
+
+function formatDate(value?: string | null) {
+  if (!value) return "";
+  try {
+    const date = new Date(value);
+    if (!Number.isFinite(date.getTime())) return String(value);
+    return DATE_FORMATTER ? DATE_FORMATTER.format(date) : String(value);
+  } catch (err) {
+    return String(value);
+  }
+}
+
+function parseTags(value: unknown): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value.map((tag) => String(tag).trim()).filter(Boolean);
+  }
+  return String(value)
+    .split(",")
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+}
+
+function getAmountClass(type?: string | null) {
+  if (type === "income") return "text-emerald-400";
+  if (type === "expense") return "text-rose-400";
+  return "text-slate-300";
+}
+
+interface SortOption {
+  value: string;
+  label: string;
+}
+
+interface TransactionsCardListProps {
+  items: TransactionRecord[];
+  loading: boolean;
+  error: Error | null;
+  onRetry: () => void;
+  selectedIds: Set<string>;
+  onToggleSelect: (id: string, event?: ChangeEvent<HTMLInputElement>) => void;
+  onEdit: (item: TransactionRecord) => void;
+  onDelete: (id: string) => void;
+  deleteDisabled?: boolean;
+  sort: string;
+  onSortChange: (sort: string) => void;
+  sortOptions: SortOption[];
+  page: number;
+  pageSize: number;
+  total: number;
+  onPageChange: (page: number) => void;
+  onOpenAdd: () => void;
+  onResetFilters: () => void;
+}
+
+export default function TransactionsCardList({
+  items,
+  loading,
+  error,
+  onRetry,
+  selectedIds,
+  onToggleSelect,
+  onEdit,
+  onDelete,
+  deleteDisabled = false,
+  sort,
+  onSortChange,
+  sortOptions,
+  page,
+  pageSize,
+  total,
+  onPageChange,
+  onOpenAdd,
+  onResetFilters,
+}: TransactionsCardListProps) {
+  const isInitialLoading = loading && items.length === 0;
+  const hasErrorBanner = Boolean(error) && items.length > 0;
+  const pageCount = Math.max(1, Math.ceil(total / pageSize));
+  const start = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const end = Math.min(total, page * pageSize);
+
+  if (error && !items.length && !loading) {
+    return (
+      <div className="md:hidden">
+        <div className="rounded-3xl ring-1 ring-red-500/40 bg-red-500/10 p-6 text-center text-sm text-red-200">
+          <p className="mb-3 font-semibold">Gagal memuat transaksi.</p>
+          <div className="flex flex-wrap justify-center gap-3">
+            <button
+              type="button"
+              onClick={onRetry}
+              className="h-11 rounded-2xl bg-red-500/20 px-4 font-semibold text-red-100 ring-1 ring-red-500/40 transition hover:bg-red-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/60"
+            >
+              Coba lagi
+            </button>
+            <button
+              type="button"
+              onClick={onOpenAdd}
+              className="h-11 rounded-2xl bg-[var(--accent)]/20 px-4 font-semibold text-[var(--accent)] ring-1 ring-[var(--accent)]/50 transition hover:bg-[var(--accent)]/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+            >
+              Tambah Transaksi
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!loading && !items.length) {
+    return (
+      <div className="md:hidden">
+        <div className="flex flex-col items-center justify-center gap-4 rounded-3xl bg-slate-900/60 p-12 text-center ring-1 ring-slate-800">
+          <div className="rounded-full bg-slate-800/60 p-3 text-[var(--accent)]">📄</div>
+          <div className="space-y-1 text-slate-300">
+            <p className="text-lg font-semibold">Belum ada transaksi</p>
+            <p className="text-sm text-slate-400">Mulai catat arus kas untuk melihat ringkasan di sini.</p>
+          </div>
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            <button
+              type="button"
+              onClick={onOpenAdd}
+              className="h-11 rounded-2xl bg-[var(--accent)] px-4 text-sm font-semibold text-slate-950 shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/70"
+            >
+              Tambah Transaksi
+            </button>
+            <button
+              type="button"
+              onClick={onResetFilters}
+              className="h-11 rounded-2xl px-4 text-sm font-medium text-slate-300 ring-1 ring-slate-700 transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+            >
+              Reset Filter
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3 md:hidden">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="transactions-sort-mobile">
+          Urutkan
+        </label>
+        <select
+          id="transactions-sort-mobile"
+          value={sort}
+          onChange={(event) => onSortChange(event.target.value)}
+          className="h-11 flex-1 min-w-[160px] rounded-2xl bg-slate-900/60 px-3 text-sm text-slate-200 ring-2 ring-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          aria-label="Urutkan daftar transaksi"
+        >
+          {sortOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {hasErrorBanner && (
+        <div className="rounded-2xl bg-red-500/10 px-4 py-3 text-sm text-red-200 ring-1 ring-red-500/30">
+          Gagal memperbarui daftar transaksi. <button type="button" onClick={onRetry} className="underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/60">Coba lagi</button>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {items.map((item) => (
+          <TransactionCard
+            key={item.id}
+            item={item}
+            isSelected={selectedIds.has(item.id)}
+            onToggleSelect={onToggleSelect}
+            onEdit={onEdit}
+            onDelete={onDelete}
+            deleteDisabled={deleteDisabled}
+          />
+        ))}
+        {isInitialLoading &&
+          Array.from({ length: 6 }).map((_, index) => <SkeletonCard key={`card-skeleton-${index}`} />)}
+      </div>
+
+      <Pagination
+        page={page}
+        pageCount={pageCount}
+        start={start}
+        end={end}
+        total={total}
+        onPageChange={onPageChange}
+        disabled={loading}
+      />
+    </div>
+  );
+}
+
+interface TransactionCardProps {
+  item: TransactionRecord;
+  isSelected: boolean;
+  onToggleSelect: (id: string, event?: ChangeEvent<HTMLInputElement>) => void;
+  onEdit: (item: TransactionRecord) => void;
+  onDelete: (id: string) => void;
+  deleteDisabled: boolean;
+}
+
+function TransactionCard({ item, isSelected, onToggleSelect, onEdit, onDelete, deleteDisabled }: TransactionCardProps) {
+  const note = (item.title || item.note || item.notes || item.description || "").toString().trim();
+  const displayNote = note.length > 0 ? note : "(Tanpa catatan)";
+  const tags = parseTags(item.tags);
+  const amount = formatCurrency(Number(item.amount ?? 0), "IDR");
+  const amountClass = clsx("text-right text-lg font-semibold", getAmountClass(item.type));
+
+  return (
+    <article className="rounded-2xl bg-slate-900 ring-1 ring-slate-800 p-3">
+      <div className="flex items-start gap-3">
+        <input
+          type="checkbox"
+          checked={isSelected}
+          onChange={(event) => onToggleSelect(item.id, event)}
+          className="mt-1 h-5 w-5 flex-shrink-0 rounded border-slate-700 bg-slate-900 text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+          aria-label="Pilih transaksi"
+        />
+        <div className="min-w-0 flex-1 space-y-2">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="flex items-center gap-2 text-sm font-semibold text-slate-200">
+                <CategoryDot color={item.category_color} />
+                <span className="truncate">{item.category || "(Tanpa kategori)"}</span>
+                <span className="text-[0.7rem] uppercase tracking-wide text-slate-500">
+                  {TYPE_LABELS[item.type || ""] || "—"}
+                </span>
+              </div>
+              <time className="text-xs text-slate-400" dateTime={item.date ? String(item.date) : undefined}>
+                {formatDate(item.date)}
+              </time>
+            </div>
+            <span className={amountClass}>{amount}</span>
+          </div>
+          <p className="line-clamp-2 text-sm text-slate-300">{displayNote}</p>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-slate-400">
+            {item.type === "transfer" ? (
+              <span className="inline-flex items-center gap-1 rounded-full bg-slate-800 px-3 py-1 text-xs text-slate-200">
+                <span>{item.account || "—"}</span>
+                <span aria-hidden="true">→</span>
+                <span>{item.to_account || "—"}</span>
+              </span>
+            ) : (
+              <span className="inline-flex items-center rounded-full bg-slate-800 px-3 py-1 text-xs text-slate-200">
+                {item.account || "—"}
+              </span>
+            )}
+          </div>
+          {tags.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="inline-flex items-center rounded-full bg-slate-800 px-3 py-1 text-xs font-medium text-slate-200"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="mt-3 flex items-center justify-end gap-2">
+        <button
+          type="button"
+          onClick={() => onEdit(item)}
+          className="h-9 w-9 rounded-full ring-1 ring-slate-700 text-slate-200 transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+          aria-label="Edit transaksi"
+        >
+          <Pencil className="h-4 w-4" aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          onClick={() => onDelete(item.id)}
+          disabled={deleteDisabled}
+          className="h-9 w-9 rounded-full ring-1 ring-slate-700 text-slate-200 transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-60"
+          aria-label="Hapus transaksi"
+        >
+          <Trash2 className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function SkeletonCard() {
+  return (
+    <article className="animate-pulse rounded-2xl bg-slate-900 ring-1 ring-slate-800 p-3">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="h-4 w-32 rounded-full bg-slate-800/60" />
+        <div className="h-6 w-20 rounded-full bg-slate-800/60" />
+      </div>
+      <div className="mb-3 h-4 w-full rounded-full bg-slate-800/60" />
+      <div className="mb-2 h-4 w-3/4 rounded-full bg-slate-800/60" />
+      <div className="flex gap-2">
+        <div className="h-5 w-16 rounded-full bg-slate-800/60" />
+        <div className="h-5 w-16 rounded-full bg-slate-800/60" />
+      </div>
+    </article>
+  );
+}
+
+interface PaginationProps {
+  page: number;
+  pageCount: number;
+  start: number;
+  end: number;
+  total: number;
+  onPageChange: (page: number) => void;
+  disabled?: boolean;
+}
+
+function Pagination({ page, pageCount, start, end, total, onPageChange, disabled = false }: PaginationProps) {
+  const handlePrev = () => {
+    if (page > 1) onPageChange(page - 1);
+  };
+  const handleNext = () => {
+    if (page < pageCount) onPageChange(page + 1);
+  };
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl bg-slate-900/50 px-4 py-3 text-sm text-slate-300 ring-1 ring-slate-800">
+      <p>
+        Menampilkan <span className="font-semibold text-slate-100">{start}</span>–
+        <span className="font-semibold text-slate-100">{end}</span> dari {total}. Halaman {page} / {pageCount}
+      </p>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handlePrev}
+          disabled={page <= 1 || disabled}
+          className="h-9 rounded-full px-3 text-sm font-semibold text-slate-200 ring-1 ring-slate-700 transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60 disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label="Halaman sebelumnya"
+        >
+          Prev
+        </button>
+        <button
+          type="button"
+          onClick={handleNext}
+          disabled={page >= pageCount || disabled}
+          className="h-9 rounded-full px-3 text-sm font-semibold text-slate-200 ring-1 ring-slate-700 transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60 disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label="Halaman selanjutnya"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/transactions/TransactionsFilters.tsx
+++ b/src/components/transactions/TransactionsFilters.tsx
@@ -1,0 +1,247 @@
+import clsx from "clsx";
+import { Calendar, ChevronDown, Search, X } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { MutableRefObject } from "react";
+
+interface PeriodFilter {
+  preset: string;
+  start: string;
+  end: string;
+}
+
+interface TransactionsFilterValue {
+  search: string;
+  type: string;
+  categories: string[];
+  period: PeriodFilter;
+}
+
+interface CategoryOption {
+  id: string;
+  name?: string | null;
+}
+
+interface TransactionsFiltersProps {
+  filter: TransactionsFilterValue;
+  categories: CategoryOption[];
+  searchTerm: string;
+  onSearchChange: (value: string) => void;
+  onFilterChange: (patch: Partial<TransactionsFilterValue>) => void;
+  onReset: () => void;
+  searchInputRef?: MutableRefObject<{ focus: () => void } | null>;
+}
+
+const controlClass =
+  "h-11 w-full rounded-2xl bg-slate-900/60 px-4 text-sm text-slate-200 ring-2 ring-slate-800 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]";
+
+export default function TransactionsFilters({
+  filter,
+  categories,
+  searchTerm,
+  onSearchChange,
+  onFilterChange,
+  onReset,
+  searchInputRef,
+}: TransactionsFiltersProps) {
+  const [categoryOpen, setCategoryOpen] = useState(false);
+  const categoryButtonRef = useRef<HTMLButtonElement | null>(null);
+  const categoryPanelRef = useRef<HTMLDivElement | null>(null);
+  const searchFieldRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (!searchInputRef) return;
+    searchInputRef.current = {
+      focus: () => {
+        searchFieldRef.current?.focus();
+        searchFieldRef.current?.select();
+      },
+    };
+  }, [searchInputRef]);
+
+  useEffect(() => {
+    if (!categoryOpen) return;
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (categoryButtonRef.current?.contains(target)) return;
+      if (categoryPanelRef.current?.contains(target)) return;
+      setCategoryOpen(false);
+    };
+    window.addEventListener("mousedown", handleClick);
+    return () => window.removeEventListener("mousedown", handleClick);
+  }, [categoryOpen]);
+
+  const selectedCategoryNames = useMemo(() => {
+    if (!filter.categories?.length) return [] as string[];
+    const index = new Map(categories.map((cat) => [cat.id, cat.name || "(Tanpa kategori)"]));
+    return filter.categories.map((id) => index.get(id) || "Kategori");
+  }, [categories, filter.categories]);
+
+  const categoryLabel = selectedCategoryNames.length
+    ? selectedCategoryNames.slice(0, 2).join(", ") + (selectedCategoryNames.length > 2 ? ` +${selectedCategoryNames.length - 2}` : "")
+    : "Semua kategori";
+
+  const handleToggleCategory = (categoryId: string) => {
+    const next = new Set(filter.categories);
+    if (next.has(categoryId)) {
+      next.delete(categoryId);
+    } else {
+      next.add(categoryId);
+    }
+    onFilterChange({ categories: Array.from(next) });
+  };
+
+  const handleStartDateChange = (value: string) => {
+    const trimmed = value;
+    const nextPeriod: PeriodFilter = {
+      ...filter.period,
+      start: trimmed,
+      preset: trimmed || filter.period.end ? "custom" : "all",
+    };
+    if (!nextPeriod.preset) nextPeriod.preset = "all";
+    onFilterChange({ period: nextPeriod });
+  };
+
+  const handleEndDateChange = (value: string) => {
+    const trimmed = value;
+    const nextPeriod: PeriodFilter = {
+      ...filter.period,
+      end: trimmed,
+      preset: filter.period.start || trimmed ? "custom" : "all",
+    };
+    if (!nextPeriod.preset) nextPeriod.preset = "all";
+    onFilterChange({ period: nextPeriod });
+  };
+
+  const startValue = filter.period.preset === "custom" ? filter.period.start : "";
+  const endValue = filter.period.preset === "custom" ? filter.period.end : "";
+
+  return (
+    <div className="flex flex-col gap-3 rounded-3xl bg-slate-900/60 p-4 ring-1 ring-slate-800 backdrop-blur">
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-5">
+        <div className="md:col-span-2">
+          <label htmlFor="transactions-search" className="sr-only">
+            Cari transaksi
+          </label>
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+            <input
+              id="transactions-search"
+              type="search"
+              value={searchTerm}
+              onChange={(event) => onSearchChange(event.target.value)}
+              placeholder="Cari judul atau catatan"
+              ref={searchFieldRef}
+              className={clsx(controlClass, "pl-10")}
+              aria-label="Cari transaksi"
+            />
+          </div>
+        </div>
+        <div>
+          <label htmlFor="transactions-type" className="sr-only">
+            Filter jenis transaksi
+          </label>
+          <select
+            id="transactions-type"
+            value={filter.type}
+            onChange={(event) => onFilterChange({ type: event.target.value })}
+            className={controlClass}
+            aria-label="Filter jenis transaksi"
+          >
+            <option value="all">Semua tipe</option>
+            <option value="income">Pemasukan</option>
+            <option value="expense">Pengeluaran</option>
+            <option value="transfer">Transfer</option>
+          </select>
+        </div>
+        <div className="relative">
+          <button
+            type="button"
+            ref={categoryButtonRef}
+            onClick={() => setCategoryOpen((open) => !open)}
+            className={clsx(controlClass, "flex items-center justify-between gap-2 px-4 text-left")}
+            aria-haspopup="listbox"
+            aria-expanded={categoryOpen}
+          >
+            <span className="truncate text-sm font-medium text-slate-200">{categoryLabel}</span>
+            <ChevronDown className={clsx("h-4 w-4 transition-transform", categoryOpen ? "rotate-180" : "rotate-0")} aria-hidden="true" />
+          </button>
+          {categoryOpen && (
+            <div
+              ref={categoryPanelRef}
+              role="listbox"
+              aria-multiselectable="true"
+              className="absolute z-20 mt-2 max-h-64 w-full overflow-y-auto rounded-2xl bg-slate-900/95 p-2 text-sm text-slate-200 shadow-xl ring-1 ring-slate-800"
+            >
+              <button
+                type="button"
+                onClick={() => onFilterChange({ categories: [] })}
+                className="flex w-full items-center justify-between rounded-xl px-3 py-2 text-left text-sm text-slate-200 hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+              >
+                <span>Semua kategori</span>
+                {!filter.categories.length && <span className="text-[var(--accent)]">Aktif</span>}
+              </button>
+              <div className="my-2 h-px bg-slate-800" aria-hidden="true" />
+              {categories.map((category) => {
+                const checked = filter.categories.includes(category.id);
+                return (
+                  <label
+                    key={category.id}
+                    className="flex cursor-pointer items-center gap-2 rounded-xl px-3 py-2 text-sm hover:bg-slate-800 focus-within:outline-none focus-within:ring-2 focus-within:ring-[var(--accent)]/60"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => handleToggleCategory(category.id)}
+                      className="h-4 w-4 rounded border-slate-700 bg-slate-900 text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+                    />
+                    <span className="truncate">{category.name || "(Tanpa kategori)"}</span>
+                  </label>
+                );
+              })}
+            </div>
+          )}
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <label htmlFor="transactions-start-date" className="sr-only">
+            Tanggal mulai
+          </label>
+          <div className="relative flex-1">
+            <Calendar className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+            <input
+              id="transactions-start-date"
+              type="date"
+              value={startValue}
+              onChange={(event) => handleStartDateChange(event.target.value)}
+              className={clsx(controlClass, "pl-10")}
+              aria-label="Tanggal mulai"
+            />
+          </div>
+          <label htmlFor="transactions-end-date" className="sr-only">
+            Tanggal selesai
+          </label>
+          <div className="relative flex-1">
+            <Calendar className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+            <input
+              id="transactions-end-date"
+              type="date"
+              value={endValue}
+              onChange={(event) => handleEndDateChange(event.target.value)}
+              className={clsx(controlClass, "pl-10")}
+              aria-label="Tanggal selesai"
+            />
+          </div>
+        </div>
+        <div className="flex items-center justify-end gap-2 md:justify-start">
+          <button
+            type="button"
+            onClick={onReset}
+            className="inline-flex h-11 items-center gap-2 rounded-2xl px-4 text-sm font-medium text-slate-300 ring-2 ring-slate-800 transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+            Bersihkan
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/transactions/TransactionsTable.tsx
+++ b/src/components/transactions/TransactionsTable.tsx
@@ -1,0 +1,470 @@
+import clsx from "clsx";
+import { Pencil, Trash2 } from "lucide-react";
+import type { ChangeEvent, CSSProperties } from "react";
+import { formatCurrency } from "../../lib/format";
+import CategoryDot from "./CategoryDot";
+
+const TYPE_LABELS: Record<string, string> = {
+  income: "Pemasukan",
+  expense: "Pengeluaran",
+  transfer: "Transfer",
+};
+
+const DATE_FORMATTER =
+  typeof Intl !== "undefined"
+    ? new Intl.DateTimeFormat("id-ID", {
+        weekday: "short",
+        day: "2-digit",
+        month: "short",
+        year: "numeric",
+      })
+    : null;
+
+function formatDate(value?: string | null) {
+  if (!value) return "";
+  try {
+    const date = new Date(value);
+    if (!Number.isFinite(date.getTime())) return String(value);
+    return DATE_FORMATTER ? DATE_FORMATTER.format(date) : String(value);
+  } catch (err) {
+    return String(value);
+  }
+}
+
+function parseTags(value: unknown): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value.map((tag) => String(tag).trim()).filter(Boolean);
+  }
+  return String(value)
+    .split(",")
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+}
+
+function formatAmount(value: unknown): string {
+  return formatCurrency(Number(value ?? 0), "IDR");
+}
+
+function getAmountClass(type?: string | null) {
+  if (type === "income") return "text-emerald-400";
+  if (type === "expense") return "text-rose-400";
+  return "text-slate-300";
+}
+
+export interface TransactionRecord {
+  id: string;
+  type?: string;
+  category?: string;
+  category_color?: string | null;
+  title?: string | null;
+  note?: string | null;
+  notes?: string | null;
+  description?: string | null;
+  date?: string | null;
+  account?: string | null;
+  to_account?: string | null;
+  tags?: string[] | string | null;
+  amount?: number | string | null;
+  receipt_url?: string | null;
+  receipts?: unknown;
+}
+
+interface TransactionsTableProps {
+  items: TransactionRecord[];
+  loading: boolean;
+  error: Error | null;
+  onRetry: () => void;
+  selectedIds: Set<string>;
+  allSelected: boolean;
+  onToggleSelect: (id: string, event?: ChangeEvent<HTMLInputElement>) => void;
+  onToggleSelectAll: () => void;
+  onEdit: (item: TransactionRecord) => void;
+  onDelete: (id: string) => void;
+  sort: string;
+  onSortChange: (sort: string) => void;
+  tableStickyTop?: string;
+  page: number;
+  pageSize: number;
+  total: number;
+  onPageChange: (page: number) => void;
+  deleteDisabled?: boolean;
+  onOpenAdd: () => void;
+  onResetFilters: () => void;
+}
+
+export default function TransactionsTable({
+  items,
+  loading,
+  error,
+  onRetry,
+  selectedIds,
+  allSelected,
+  onToggleSelect,
+  onToggleSelectAll,
+  onEdit,
+  onDelete,
+  sort,
+  onSortChange,
+  tableStickyTop,
+  page,
+  pageSize,
+  total,
+  onPageChange,
+  deleteDisabled = false,
+  onOpenAdd,
+  onResetFilters,
+}: TransactionsTableProps) {
+  const isInitialLoading = loading && items.length === 0;
+  const hasErrorBanner = Boolean(error) && items.length > 0;
+  const pageCount = Math.max(1, Math.ceil(total / pageSize));
+  const start = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const end = Math.min(total, page * pageSize);
+  const headerStyle: CSSProperties | undefined = tableStickyTop
+    ? { position: "sticky", top: tableStickyTop, zIndex: 10 }
+    : undefined;
+
+  const handleDateSort = () => {
+    if (sort === "date-desc") {
+      onSortChange("date-asc");
+    } else {
+      onSortChange("date-desc");
+    }
+  };
+
+  const handleAmountSort = () => {
+    if (sort === "amount-desc") {
+      onSortChange("amount-asc");
+    } else {
+      onSortChange("amount-desc");
+    }
+  };
+
+  if (error && !items.length && !loading) {
+    return (
+      <div className="rounded-3xl ring-1 ring-red-500/40 bg-red-500/10 p-6 text-center text-sm text-red-200">
+        <p className="mb-3 font-semibold">Gagal memuat transaksi.</p>
+        <div className="flex justify-center gap-3">
+          <button
+            type="button"
+            onClick={onRetry}
+            className="h-11 rounded-2xl bg-red-500/20 px-4 font-semibold text-red-100 ring-1 ring-red-500/40 transition hover:bg-red-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/60"
+          >
+            Coba lagi
+          </button>
+          <button
+            type="button"
+            onClick={onOpenAdd}
+            className="h-11 rounded-2xl bg-[var(--accent)]/20 px-4 font-semibold text-[var(--accent)] ring-1 ring-[var(--accent)]/50 transition hover:bg-[var(--accent)]/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+          >
+            Tambah Transaksi
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!loading && !items.length) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 rounded-3xl bg-slate-900/60 p-12 text-center ring-1 ring-slate-800">
+        <div className="rounded-full bg-slate-800/60 p-3 text-[var(--accent)]">📄</div>
+        <div className="space-y-1 text-slate-300">
+          <p className="text-lg font-semibold">Belum ada transaksi</p>
+          <p className="text-sm text-slate-400">Mulai catat arus kas untuk melihat ringkasan di sini.</p>
+        </div>
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <button
+            type="button"
+            onClick={onOpenAdd}
+            className="h-11 rounded-2xl bg-[var(--accent)] px-4 text-sm font-semibold text-slate-950 shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/70"
+          >
+            Tambah Transaksi
+          </button>
+          <button
+            type="button"
+            onClick={onResetFilters}
+            className="h-11 rounded-2xl px-4 text-sm font-medium text-slate-300 ring-1 ring-slate-700 transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+          >
+            Reset Filter
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {hasErrorBanner && (
+        <div className="rounded-2xl bg-red-500/10 px-4 py-3 text-sm text-red-200 ring-1 ring-red-500/30">
+          Gagal memperbarui daftar transaksi. <button type="button" onClick={onRetry} className="underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/60">Coba lagi</button>
+        </div>
+      )}
+      <div className="overflow-hidden rounded-3xl bg-slate-900/60 ring-1 ring-slate-800">
+        <div className="overflow-x-auto">
+          <table className="hidden min-w-full table-fixed md:table" aria-label="Daftar transaksi">
+            <thead className="bg-slate-900 text-slate-400" style={headerStyle}>
+              <tr className="text-left text-xs uppercase tracking-wide">
+                <th scope="col" className="px-4 py-3">
+                  <div className="flex justify-center">
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4 rounded border-slate-700 bg-slate-900 text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+                      checked={allSelected}
+                      onChange={onToggleSelectAll}
+                      aria-label="Pilih semua transaksi"
+                    />
+                  </div>
+                </th>
+                <th scope="col" className="px-4 py-3 text-slate-300">Tipe &amp; Kategori</th>
+                <th scope="col" className="px-4 py-3">
+                  <button
+                    type="button"
+                    onClick={handleDateSort}
+                    className="flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+                    aria-label="Urutkan berdasarkan tanggal"
+                  >
+                    Tanggal
+                    <SortIndicator active={sort.startsWith("date")} direction={sort === "date-asc" ? "asc" : "desc"} />
+                  </button>
+                </th>
+                <th scope="col" className="px-4 py-3 text-slate-300">Akun</th>
+                <th scope="col" className="px-4 py-3 text-slate-300">Tags</th>
+                <th scope="col" className="px-4 py-3 text-right">
+                  <button
+                    type="button"
+                    onClick={handleAmountSort}
+                    className="ml-auto flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+                    aria-label="Urutkan berdasarkan jumlah"
+                  >
+                    Jumlah
+                    <SortIndicator active={sort.startsWith("amount")} direction={sort === "amount-asc" ? "asc" : "desc"} />
+                  </button>
+                </th>
+                <th scope="col" className="px-4 py-3 text-right text-slate-300">Aksi</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800 text-sm text-slate-200">
+              {items.map((item) => (
+                <TransactionRow
+                  key={item.id}
+                  item={item}
+                  isSelected={selectedIds.has(item.id)}
+                  onToggleSelect={onToggleSelect}
+                  onEdit={onEdit}
+                  onDelete={onDelete}
+                  deleteDisabled={deleteDisabled}
+                />
+              ))}
+              {isInitialLoading &&
+                Array.from({ length: 6 }).map((_, index) => <SkeletonRow key={`skeleton-${index}`} />)}
+            </tbody>
+          </table>
+        </div>
+        {loading && items.length > 0 && (
+          <div className="hidden items-center justify-center gap-2 border-t border-slate-800 px-4 py-3 text-sm text-slate-400 md:flex">
+            Memuat...
+          </div>
+        )}
+      </div>
+      <Pagination
+        page={page}
+        pageCount={pageCount}
+        start={start}
+        end={end}
+        total={total}
+        onPageChange={onPageChange}
+        disabled={loading}
+      />
+    </div>
+  );
+}
+
+interface SortIndicatorProps {
+  active: boolean;
+  direction: "asc" | "desc";
+}
+
+function SortIndicator({ active, direction }: SortIndicatorProps) {
+  if (!active) {
+    return <span aria-hidden="true" className="text-slate-600">◂▸</span>;
+  }
+  return <span aria-hidden="true">{direction === "asc" ? "▲" : "▼"}</span>;
+}
+
+interface TransactionRowProps {
+  item: TransactionRecord;
+  isSelected: boolean;
+  onToggleSelect: (id: string, event?: ChangeEvent<HTMLInputElement>) => void;
+  onEdit: (item: TransactionRecord) => void;
+  onDelete: (id: string) => void;
+  deleteDisabled: boolean;
+}
+
+function TransactionRow({ item, isSelected, onToggleSelect, onEdit, onDelete, deleteDisabled }: TransactionRowProps) {
+  const note = (item.title || item.note || item.notes || item.description || "").toString().trim();
+  const displayNote = note.length > 0 ? note : "—";
+  const dateValue = item.date ? String(item.date) : undefined;
+  const tags = parseTags(item.tags);
+
+  const amountClass = clsx("font-mono text-right", getAmountClass(item.type));
+
+  return (
+    <tr className="transition-colors hover:bg-slate-800/50">
+      <td className="px-4 py-3">
+        <div className="flex justify-center">
+          <input
+            type="checkbox"
+            checked={isSelected}
+            onChange={(event) => onToggleSelect(item.id, event)}
+            className="h-4 w-4 rounded border-slate-700 bg-slate-900 text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+            aria-label="Pilih transaksi"
+          />
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-3">
+          <CategoryDot color={item.category_color} />
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold text-slate-200" title={item.category || "(Tanpa kategori)"}>
+              {item.category || "(Tanpa kategori)"}
+            </p>
+            <p className="text-xs uppercase tracking-wide text-slate-400">{TYPE_LABELS[item.type || ""] || "—"}</p>
+          </div>
+        </div>
+      </td>
+      <td className="px-4 py-3 text-sm text-slate-300">
+        <time dateTime={dateValue}>{formatDate(item.date)}</time>
+      </td>
+      <td className="px-4 py-3 text-sm text-slate-200">
+        {item.type === "transfer" ? (
+          <div className="flex flex-wrap items-center gap-1 text-slate-300">
+            <span className="truncate">{item.account || "—"}</span>
+            <span aria-hidden="true">→</span>
+            <span className="truncate">{item.to_account || "—"}</span>
+          </div>
+        ) : (
+          <span className="truncate">{item.account || "—"}</span>
+        )}
+      </td>
+      <td className="px-4 py-3 text-sm text-slate-200">
+        {tags.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center rounded-full bg-slate-800 px-2.5 py-1 text-xs font-medium text-slate-200"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <span className="text-slate-500">—</span>
+        )}
+      </td>
+      <td className="px-4 py-3">
+        <span className={amountClass}>{formatAmount(item.amount)}</span>
+      </td>
+      <td className="px-4 py-3">
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => onEdit(item)}
+            className="h-9 w-9 rounded-full ring-1 ring-slate-700 text-slate-200 transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+            aria-label="Edit transaksi"
+          >
+            <Pencil className="h-4 w-4" aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            onClick={() => onDelete(item.id)}
+            disabled={deleteDisabled}
+            className="h-9 w-9 rounded-full ring-1 ring-slate-700 text-slate-200 transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-60"
+            aria-label="Hapus transaksi"
+          >
+            <Trash2 className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+function SkeletonRow() {
+  return (
+    <tr className="animate-pulse">
+      <td className="px-4 py-4">
+        <div className="mx-auto h-4 w-4 rounded bg-slate-800/60" />
+      </td>
+      <td className="px-4 py-4">
+        <div className="h-4 w-40 rounded-full bg-slate-800/60" />
+      </td>
+      <td className="px-4 py-4">
+        <div className="h-4 w-32 rounded-full bg-slate-800/60" />
+      </td>
+      <td className="px-4 py-4">
+        <div className="h-4 w-36 rounded-full bg-slate-800/60" />
+      </td>
+      <td className="px-4 py-4">
+        <div className="h-4 w-48 rounded-full bg-slate-800/60" />
+      </td>
+      <td className="px-4 py-4">
+        <div className="ml-auto h-4 w-24 rounded-full bg-slate-800/60" />
+      </td>
+      <td className="px-4 py-4">
+        <div className="ml-auto flex gap-2">
+          <span className="inline-flex h-9 w-9 rounded-full bg-slate-800/60" />
+          <span className="inline-flex h-9 w-9 rounded-full bg-slate-800/60" />
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+interface PaginationProps {
+  page: number;
+  pageCount: number;
+  start: number;
+  end: number;
+  total: number;
+  onPageChange: (page: number) => void;
+  disabled?: boolean;
+}
+
+function Pagination({ page, pageCount, start, end, total, onPageChange, disabled = false }: PaginationProps) {
+  const handlePrev = () => {
+    if (page > 1) onPageChange(page - 1);
+  };
+  const handleNext = () => {
+    if (page < pageCount) onPageChange(page + 1);
+  };
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl bg-slate-900/50 px-4 py-3 text-sm text-slate-300 ring-1 ring-slate-800">
+      <p>
+        Menampilkan <span className="font-semibold text-slate-100">{start}</span>–
+        <span className="font-semibold text-slate-100">{end}</span> dari {total}. Halaman {page} / {pageCount}
+      </p>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handlePrev}
+          disabled={page <= 1 || disabled}
+          className="h-9 rounded-full px-3 text-sm font-semibold text-slate-200 ring-1 ring-slate-700 transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60 disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label="Halaman sebelumnya"
+        >
+          Prev
+        </button>
+        <button
+          type="button"
+          onClick={handleNext}
+          disabled={page >= pageCount || disabled}
+          className="h-9 rounded-full px-3 text-sm font-semibold text-slate-200 ring-1 ring-slate-700 transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60 disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label="Halaman selanjutnya"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useTransactionsQuery.js
+++ b/src/hooks/useTransactionsQuery.js
@@ -3,7 +3,7 @@ import { useSearchParams } from "react-router-dom";
 import { getTransactionsSummary, listCategories } from "../lib/api";
 import { listTransactions } from "../lib/api-transactions";
 
-const PAGE_SIZE = 50;
+const PAGE_SIZE = 20;
 
 const DEFAULT_FILTER = {
   period: { preset: "all", month: "", start: "", end: "" },
@@ -204,6 +204,14 @@ export default function useTransactionsQuery() {
     [updateParams],
   );
 
+  const setPage = useCallback(
+    (nextPage) => {
+      const safePage = Number.isFinite(nextPage) ? Math.max(1, Math.floor(nextPage)) : 1;
+      updateParams({}, safePage);
+    },
+    [updateParams],
+  );
+
   const loadMore = useCallback(() => {
     updateParams({}, page + 1);
   }, [page, updateParams]);
@@ -231,6 +239,7 @@ export default function useTransactionsQuery() {
     error,
     filter,
     setFilter,
+    setPage,
     loadMore,
     refresh,
     categories,

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -1,24 +1,20 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 import { useNavigate } from "react-router-dom";
 import clsx from "clsx";
 import {
   AlertTriangle,
-  ArrowRight,
-  ArrowRightLeft,
   ChevronDown,
   Check,
   Download,
-  Inbox,
   Loader2,
-  Paperclip,
-  Pencil,
   Plus,
-  Search,
-  Trash2,
   Upload,
   X,
 } from "lucide-react";
+import TransactionsTable from "../components/transactions/TransactionsTable";
+import TransactionsCardList from "../components/transactions/TransactionsCardList";
+import TransactionsFilters from "../components/transactions/TransactionsFilters";
+import BatchToolbar from "../components/transactions/BatchToolbar";
 import useTransactionsQuery from "../hooks/useTransactionsQuery";
 import useNetworkStatus from "../hooks/useNetworkStatus";
 import { useToast } from "../context/ToastContext";
@@ -59,46 +55,13 @@ const PAGE_DESCRIPTION = "Kelola catatan keuangan";
 
 const FILTER_PANEL_BREAKPOINT = 768;
 const FILTER_PANEL_STORAGE_KEY = "transactions-filter-open";
-const MOBILE_BREAKPOINT = 992;
-
-function detectTableVariant() {
-  if (typeof window === "undefined") return "table";
-  return window.innerWidth < MOBILE_BREAKPOINT ? "card" : "table";
-}
-
 function toDateInput(value) {
   if (!value) return "";
   return String(value).slice(0, 10);
 }
 
-function currentMonthValue() {
-  const now = new Date();
-  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
-}
-
 function formatIDR(value) {
   return formatCurrency(Number(value ?? 0), "IDR");
-}
-
-const TRANSACTION_DATE_FORMATTER =
-  typeof Intl !== "undefined"
-    ? new Intl.DateTimeFormat("id-ID", {
-        weekday: "short",
-        day: "2-digit",
-        month: "short",
-        year: "numeric",
-      })
-    : null;
-
-function formatTransactionDate(value) {
-  if (!value) return "";
-  try {
-    const date = new Date(value);
-    if (!Number.isFinite(date.getTime())) return String(value);
-    return TRANSACTION_DATE_FORMATTER ? TRANSACTION_DATE_FORMATTER.format(date) : String(value);
-  } catch {
-    return String(value);
-  }
 }
 
 function chunk(arr, size) {
@@ -113,12 +76,12 @@ export default function Transactions() {
   const {
     items: queryItems,
     total,
-    hasMore,
+    page,
     loading,
     error,
     filter,
     setFilter,
-    loadMore,
+    setPage,
     refresh,
     categories,
     summary,
@@ -142,7 +105,6 @@ export default function Transactions() {
   const lastSelectedIdRef = useRef(null);
   const [searchTerm, setSearchTerm] = useState(filter.search);
   const [filterBarStuck, setFilterBarStuck] = useState(false);
-  const [tableVariant, setTableVariant] = useState(() => detectTableVariant());
   const [deleteInProgress, setDeleteInProgress] = useState(false);
   const [confirmState, setConfirmState] = useState(null);
   const undoTimerRef = useRef(null);
@@ -173,15 +135,6 @@ export default function Transactions() {
   useEffect(() => {
     setSearchTerm(filter.search);
   }, [filter.search]);
-
-  useEffect(() => {
-    const handleResize = () => {
-      setTableVariant(detectTableVariant());
-    };
-    handleResize();
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
@@ -373,6 +326,11 @@ export default function Transactions() {
     }
     return chips;
   }, [filter, categoriesById]);
+
+  const sortOptions = useMemo(
+    () => Object.entries(SORT_LABELS).map(([value, label]) => ({ value, label })),
+    [],
+  );
 
   const toggleSelect = useCallback(
     (id, event) => {
@@ -709,7 +667,6 @@ export default function Transactions() {
   }, [navigate]);
 
   const tableStickyTop = `calc(var(--app-header-height, var(--app-topbar-h, 64px)) + ${filterBarHeight}px + 16px)`;
-  const selectionToolbarOffset = tableStickyTop ? `calc(${tableStickyTop} + 12px)` : "16px";
   const isFilterPanelVisible = isDesktopFilterView || filterPanelOpen;
   const activeFilterCount = activeChips.length;
 
@@ -805,14 +762,14 @@ export default function Transactions() {
               WebkitBackdropFilter: "blur(6px)",
             }}
           >
-            <TransactionsFilterBar
+            <TransactionsFilters
               filter={filter}
               categories={categories}
               searchTerm={searchTerm}
               onSearchChange={setSearchTerm}
               onFilterChange={setFilter}
+              onReset={handleResetFilters}
               searchInputRef={searchInputRef}
-              onOpenAdd={handleNavigateToAdd}
             />
           </div>
         </div>
@@ -845,41 +802,61 @@ export default function Transactions() {
           <ActiveFilterChips chips={activeChips} onRemove={handleRemoveChip} />
         )}
 
-        {selectedIds.size > 0 && (
-          <SelectionToolbar
-            count={selectedIds.size}
-            onClear={() => {
-              setSelectedIds(new Set());
-              lastSelectedIdRef.current = null;
-            }}
-            onDelete={handleRequestBulkDelete}
-            onEditCategory={() => setBulkEditMode("category")}
-            onEditAccount={() => setBulkEditMode("account")}
-            deleting={deleteInProgress}
-            updating={bulkUpdating}
-            topOffset={selectionToolbarOffset}
-          />
-        )}
+        <BatchToolbar
+          count={selectedIds.size}
+          onClear={() => {
+            setSelectedIds(new Set());
+            lastSelectedIdRef.current = null;
+          }}
+          onDelete={handleRequestBulkDelete}
+          onChangeCategory={() => setBulkEditMode("category")}
+          deleteDisabled={deleteInProgress}
+          changeDisabled={bulkUpdating}
+        />
 
-        <TransactionsTable
+        <div className="hidden md:block">
+          <TransactionsTable
+            items={items}
+            loading={loading}
+            error={error}
+            onRetry={() => refresh({ keepPage: true })}
+            selectedIds={selectedIds}
+            allSelected={allSelected}
+            onToggleSelect={toggleSelect}
+            onToggleSelectAll={toggleSelectAll}
+            onEdit={handleEditTransaction}
+            onDelete={handleRequestDelete}
+            sort={filter.sort}
+            onSortChange={(nextSort) => setFilter({ sort: nextSort })}
+            tableStickyTop={tableStickyTop}
+            page={page}
+            pageSize={pageSize}
+            total={total}
+            onPageChange={setPage}
+            deleteDisabled={deleteInProgress}
+            onOpenAdd={handleNavigateToAdd}
+            onResetFilters={handleResetFilters}
+          />
+        </div>
+        <TransactionsCardList
           items={items}
           loading={loading}
           error={error}
           onRetry={() => refresh({ keepPage: true })}
-          onLoadMore={loadMore}
-          hasMore={hasMore}
-          onToggleSelect={toggleSelect}
-          onToggleSelectAll={toggleSelectAll}
-          allSelected={allSelected}
           selectedIds={selectedIds}
-          onDelete={handleRequestDelete}
+          onToggleSelect={toggleSelect}
           onEdit={handleEditTransaction}
-          tableStickyTop={tableStickyTop}
-          variant={tableVariant}
-          onResetFilters={handleResetFilters}
-          total={total}
-          onOpenAdd={handleNavigateToAdd}
+          onDelete={handleRequestDelete}
           deleteDisabled={deleteInProgress}
+          sort={filter.sort}
+          onSortChange={(nextSort) => setFilter({ sort: nextSort })}
+          sortOptions={sortOptions}
+          page={page}
+          pageSize={pageSize}
+          total={total}
+          onPageChange={setPage}
+          onOpenAdd={handleNavigateToAdd}
+          onResetFilters={handleResetFilters}
         />
 
         {confirmState && (
@@ -969,1069 +946,6 @@ export default function Transactions() {
       </div>
     </main>
   );
-}
-
-function TransactionsFilterBar({
-  filter,
-  categories,
-  searchTerm,
-  onSearchChange,
-  onFilterChange,
-  searchInputRef,
-  onOpenAdd = () => {},
-}) {
-  const currentMonth = currentMonthValue();
-  const customButtonRef = useRef(null);
-  const actualSearchInputRef = useRef(null);
-  const [customOpen, setCustomOpen] = useState(false);
-  const typeSelectId = useId();
-  const sortSelectId = useId();
-  const searchInputId = useId();
-
-  useEffect(() => {
-    if (!searchInputRef) return;
-    searchInputRef.current = {
-      focus: () => {
-        actualSearchInputRef.current?.focus();
-        actualSearchInputRef.current?.select();
-      },
-    };
-  }, [searchInputRef]);
-
-  useEffect(() => {
-    if (filter.period.preset !== "custom") {
-      setCustomOpen(false);
-    }
-  }, [filter.period.preset]);
-
-  const handlePresetChange = (preset) => {
-    if (preset === "custom" && filter.period.preset === "custom") {
-      setCustomOpen((prev) => !prev);
-      return;
-    }
-    if (preset === "all") {
-      onFilterChange({ period: { preset: "all", month: "", start: "", end: "" } });
-      setCustomOpen(false);
-      return;
-    }
-    if (preset === "month") {
-      onFilterChange({ period: { preset: "month", month: filter.period.month || currentMonth, start: "", end: "" } });
-      setCustomOpen(false);
-      return;
-    }
-    if (preset === "week") {
-      onFilterChange({ period: { preset: "week", month: "", start: "", end: "" } });
-      setCustomOpen(false);
-      return;
-    }
-    if (preset === "custom") {
-      const today = new Date().toISOString().slice(0, 10);
-      onFilterChange({ period: { preset: "custom", month: "", start: filter.period.start || today, end: filter.period.end || today } });
-      setCustomOpen(true);
-    }
-  };
-
-  const handleCategoryChange = (selected) => {
-    onFilterChange({ categories: selected });
-  };
-
-  const handleReset = () => {
-    onFilterChange({
-      period: { preset: "all", month: "", start: "", end: "" },
-      categories: [],
-      type: "all",
-      sort: "date-desc",
-      search: "",
-    });
-    onSearchChange("");
-  };
-
-  const handleSearchChange = (value) => {
-    onSearchChange(value);
-  };
-
-  const handleTypeChange = (value) => {
-    onFilterChange({ type: value });
-  };
-
-  const handleSortChange = (value) => {
-    onFilterChange({ sort: value });
-  };
-
-  return (
-    <div className="space-y-4 rounded-2xl border border-white/10 bg-slate-900/70 p-4 text-white shadow">
-      <div
-        role="toolbar"
-        aria-label="Filter transaksi"
-        className="grid grid-cols-2 items-center gap-3 md:grid-cols-6"
-      >
-        <div className="col-span-2 min-w-0 md:col-span-2">
-          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-white/60">
-            Rentang Waktu
-          </p>
-          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 md:grid-cols-2 lg:grid-cols-4">
-            {Object.entries(PERIOD_LABELS).map(([value, label]) => (
-              <button
-                key={value}
-                type="button"
-                onClick={() => handlePresetChange(value)}
-                ref={value === "custom" ? customButtonRef : undefined}
-                className={clsx(
-                  "inline-flex h-[40px] items-center justify-center rounded-xl border border-white/10 bg-white/5 px-3 text-sm font-semibold text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60",
-                  filter.period.preset === value
-                    ? "bg-brand text-white shadow"
-                    : "text-white/70 hover:bg-white/10",
-                )}
-                aria-pressed={filter.period.preset === value}
-              >
-                {label}
-              </button>
-            ))}
-          </div>
-        </div>
-        <div className="col-span-2 min-w-0 md:col-span-1">
-          <CategoryMultiSelect
-            categories={categories}
-            selected={filter.categories}
-            onChange={handleCategoryChange}
-            ariaLabel="Filter kategori transaksi"
-          />
-        </div>
-        <div className="col-span-2 min-w-0 md:col-span-1">
-          <label htmlFor={typeSelectId} className="sr-only">
-            Filter jenis transaksi
-          </label>
-          <select
-            id={typeSelectId}
-            value={filter.type}
-            onChange={(event) => handleTypeChange(event.target.value)}
-            aria-label="Filter jenis transaksi"
-            className="h-[40px] w-full rounded-xl border border-white/10 bg-white/5 px-3 text-sm font-medium text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-          >
-            <option value="all">Semua</option>
-            <option value="expense">Pengeluaran</option>
-            <option value="income">Pemasukan</option>
-            <option value="transfer">Transfer</option>
-          </select>
-        </div>
-        <div className="col-span-2 min-w-0 md:col-span-1">
-          <label htmlFor={sortSelectId} className="sr-only">
-            Urutkan transaksi
-          </label>
-          <select
-            id={sortSelectId}
-            value={filter.sort}
-            onChange={(event) => handleSortChange(event.target.value)}
-            aria-label="Urutkan transaksi"
-            className="h-[40px] w-full rounded-xl border border-white/10 bg-white/5 px-3 text-sm font-medium text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-          >
-            <option value="date-desc">Terbaru</option>
-            <option value="date-asc">Terlama</option>
-            <option value="amount-desc">Terbesar</option>
-            <option value="amount-asc">Terkecil</option>
-          </select>
-        </div>
-        <div className="col-span-2 min-w-0 md:col-span-1">
-          <div className="relative min-w-0">
-            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-white/40" aria-hidden="true" />
-            <input
-              id={searchInputId}
-              ref={actualSearchInputRef}
-              type="search"
-              value={searchTerm}
-              onChange={(event) => handleSearchChange(event.target.value)}
-              placeholder="Cari judul/catatan…"
-              aria-label="Cari transaksi"
-              className="h-[40px] w-full rounded-xl border border-white/10 bg-white/5 pl-9 pr-3 text-sm text-white placeholder:text-white/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-            />
-          </div>
-        </div>
-        <div className="col-span-2 flex min-w-0 flex-wrap items-center justify-end gap-2 md:col-span-6 md:flex-nowrap md:gap-3">
-          <button
-            type="button"
-            onClick={handleReset}
-            className="inline-flex h-[40px] items-center rounded-xl border border-white/10 bg-white/5 px-3 text-sm font-medium text-white/80 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-            aria-label="Reset semua filter"
-          >
-            Reset
-          </button>
-          <button
-            type="button"
-            onClick={onOpenAdd}
-            className="inline-flex h-[40px] items-center gap-2 rounded-xl bg-brand px-4 text-sm font-semibold text-white shadow transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-            aria-label="Tambah transaksi"
-          >
-            <Plus className="h-4 w-4" /> Tambah Transaksi
-          </button>
-        </div>
-      </div>
-      {customOpen && filter.period.preset === "custom" && (
-        <CustomRangePopover
-          anchorRef={customButtonRef}
-          period={filter.period}
-          onChange={(next) => onFilterChange({ period: next })}
-          onClose={() => setCustomOpen(false)}
-        />
-      )}
-    </div>
-  );
-}
-
-
-function CategoryMultiSelect({ categories = [], selected = [], onChange, ariaLabel }) {
-  const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState("");
-  const triggerRef = useRef(null);
-  const panelRef = useRef(null);
-  const [position, setPosition] = useState({ top: 0, left: 0, width: 0 });
-
-  useEffect(() => {
-    if (!open) return;
-    const updatePosition = () => {
-      const anchor = triggerRef.current;
-      if (!anchor) return;
-      const rect = anchor.getBoundingClientRect();
-      const preferredWidth = Math.min(320, Math.max(260, rect.width || 260));
-      const left = Math.min(
-        Math.max(16, rect.left),
-        window.innerWidth - preferredWidth - 16,
-      );
-      setPosition({
-        top: rect.bottom + 8,
-        left,
-        width: preferredWidth,
-      });
-    };
-    updatePosition();
-    window.addEventListener("resize", updatePosition);
-    window.addEventListener("scroll", updatePosition, true);
-    return () => {
-      window.removeEventListener("resize", updatePosition);
-      window.removeEventListener("scroll", updatePosition, true);
-    };
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const handleClick = (event) => {
-      if (triggerRef.current?.contains(event.target)) return;
-      if (panelRef.current?.contains(event.target)) return;
-      setOpen(false);
-    };
-    const handleKey = (event) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        setOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClick);
-    document.addEventListener("keydown", handleKey);
-    return () => {
-      document.removeEventListener("mousedown", handleClick);
-      document.removeEventListener("keydown", handleKey);
-    };
-  }, [open]);
-
-  useEffect(() => {
-    if (open) {
-      setQuery("");
-    }
-  }, [open]);
-
-  const toggle = (id) => {
-    const set = new Set(selected);
-    if (set.has(id)) set.delete(id);
-    else set.add(id);
-    onChange(Array.from(set));
-  };
-
-  const clearAll = () => {
-    onChange([]);
-  };
-
-  const filteredCategories = useMemo(() => {
-    const term = query.trim().toLowerCase();
-    if (!term) return categories;
-    return categories.filter((cat) => {
-      return (
-        cat.name?.toLowerCase().includes(term) ||
-        (TYPE_LABELS[cat.type] || "").toLowerCase().includes(term)
-      );
-    });
-  }, [categories, query]);
-
-  const summaryLabel = useMemo(() => {
-    if (!selected.length) return "Semua kategori";
-    if (selected.length === 1) {
-      const match = categories.find((cat) => cat.id === selected[0]);
-      return match?.name || "1 dipilih";
-    }
-    return `${selected.length} dipilih`;
-  }, [categories, selected]);
-
-  const label = ariaLabel || "Pilih kategori transaksi";
-
-  return (
-    <>
-      <button
-        type="button"
-        ref={triggerRef}
-        onClick={() => setOpen((prev) => !prev)}
-        className="inline-flex h-[40px] w-full min-w-0 flex-shrink-0 items-center justify-between rounded-xl border border-white/10 bg-white/5 px-3 text-sm font-medium text-white transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        aria-label={label}
-      >
-        <span className="truncate">{summaryLabel}</span>
-        <ChevronDown className="h-4 w-4 text-white/60" aria-hidden="true" />
-      </button>
-      {open &&
-        createPortal(
-          <div className="fixed inset-0 z-40" role="presentation">
-            <div
-              ref={panelRef}
-              role="listbox"
-              aria-multiselectable="true"
-              className="absolute max-h-[320px] w-[min(320px,calc(100%-32px))] overflow-hidden rounded-2xl border border-white/10 bg-slate-900/95 shadow-2xl backdrop-blur"
-              style={{ top: position.top, left: position.left, width: position.width || undefined }}
-              data-role="category-panel"
-            >
-              <div className="flex items-center justify-between px-3 pt-3">
-                <span className="text-xs font-semibold uppercase tracking-wide text-white/60">Kategori</span>
-                <button
-                  type="button"
-                  onClick={clearAll}
-                  className="rounded-full px-2 py-1 text-xs text-white/60 transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-                >
-                  Reset
-                </button>
-              </div>
-              <div className="px-3 pb-2">
-                <div className="flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-3">
-                  <Search className="h-4 w-4 text-white/40" aria-hidden="true" />
-                  <input
-                    type="search"
-                    value={query}
-                    onChange={(event) => setQuery(event.target.value)}
-                    placeholder="Cari kategori"
-                    className="h-9 w-full bg-transparent text-sm text-white placeholder:text-white/40 focus-visible:outline-none"
-                    aria-label="Cari kategori"
-                  />
-                </div>
-              </div>
-              <div className="max-h-[220px] overflow-y-auto px-1 pb-3">
-                {filteredCategories.length ? (
-                  filteredCategories.map((cat) => {
-                    const checked = selected.includes(cat.id);
-                    return (
-                      <button
-                        key={cat.id}
-                        type="button"
-                        onClick={() => toggle(cat.id)}
-                        className={clsx(
-                          "flex w-full items-center justify-between rounded-xl px-3 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60",
-                          checked ? "bg-white/10 text-white" : "text-white/80 hover:bg-white/5",
-                        )}
-                        role="option"
-                        aria-selected={checked}
-                      >
-                      <div className="flex flex-col text-left">
-                        <span className="font-medium text-white">{cat.name}</span>
-                      </div>
-                        {checked ? (
-                          <Check className="h-4 w-4 text-brand" aria-hidden="true" />
-                        ) : (
-                          <span className="h-4 w-4 rounded-full border border-white/30" aria-hidden="true" />
-                        )}
-                      </button>
-                    );
-                  })
-                ) : (
-                  <p className="px-3 py-6 text-center text-sm text-white/50">Tidak ada kategori ditemukan.</p>
-                )}
-              </div>
-            </div>
-          </div>,
-          document.body,
-        )}
-    </>
-  );
-}
-
-function CustomRangePopover({ anchorRef, period, onChange, onClose }) {
-  const popoverRef = useRef(null);
-  const [position, setPosition] = useState({ top: 0, left: 0 });
-
-  const updatePosition = useCallback(() => {
-    const anchor = anchorRef?.current;
-    if (!anchor) return;
-    const rect = anchor.getBoundingClientRect();
-    const width = Math.min(360, Math.max(280, rect.width + 120));
-    const left = Math.min(
-      Math.max(16, rect.left - (width - rect.width) / 2),
-      window.innerWidth - width - 16,
-    );
-    setPosition({
-      top: rect.bottom + 8,
-      left,
-      width,
-    });
-  }, [anchorRef]);
-
-  useEffect(() => {
-    updatePosition();
-    window.addEventListener("resize", updatePosition);
-    window.addEventListener("scroll", updatePosition, true);
-    return () => {
-      window.removeEventListener("resize", updatePosition);
-      window.removeEventListener("scroll", updatePosition, true);
-    };
-  }, [updatePosition]);
-
-  useEffect(() => {
-    const handleClick = (event) => {
-      if (anchorRef?.current?.contains(event.target)) return;
-      if (popoverRef.current?.contains(event.target)) return;
-      onClose();
-    };
-    const handleKey = (event) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onClose();
-      }
-    };
-    document.addEventListener("mousedown", handleClick);
-    document.addEventListener("keydown", handleKey);
-    return () => {
-      document.removeEventListener("mousedown", handleClick);
-      document.removeEventListener("keydown", handleKey);
-    };
-  }, [anchorRef, onClose]);
-
-  const content = (
-    <div className="fixed inset-0 z-40" role="presentation">
-      <div
-        ref={popoverRef}
-        className="absolute w-[min(360px,calc(100%-32px))] rounded-2xl border border-white/10 bg-slate-900/95 p-4 shadow-2xl backdrop-blur"
-        style={{ top: position.top, left: position.left, width: position.width || undefined }}
-        data-role="custom-range"
-      >
-        <p className="text-xs font-semibold uppercase tracking-wide text-white/60">Rentang custom</p>
-        <div className="mt-3 grid gap-3 sm:grid-cols-2">
-          <label className="flex flex-col gap-2 text-xs text-white/60">
-            <span className="font-medium text-white/70">Mulai</span>
-            <input
-              type="date"
-              value={period.start || ""}
-              onChange={(event) => onChange({ ...period, start: event.target.value })}
-              className="h-11 rounded-xl border border-white/10 bg-white/5 px-3 text-sm text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-            />
-          </label>
-          <label className="flex flex-col gap-2 text-xs text-white/60">
-            <span className="font-medium text-white/70">Selesai</span>
-            <input
-              type="date"
-              value={period.end || ""}
-              min={period.start || undefined}
-              onChange={(event) => onChange({ ...period, end: event.target.value })}
-              className="h-11 rounded-xl border border-white/10 bg-white/5 px-3 text-sm text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-            />
-          </label>
-        </div>
-        <div className="mt-3 flex items-center justify-between text-xs text-white/50">
-          <span>Pilih rentang tanggal sesuai kebutuhan.</span>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-full px-3 py-1 text-xs font-semibold text-white/80 transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-          >
-            Selesai
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-
-  return createPortal(content, document.body);
-}
-
-function ActiveFilterChips({ chips, onRemove }) {
-  if (!chips?.length) return null;
-  return (
-    <div className="flex flex-wrap items-center gap-2">
-      {chips.map((chip) => (
-        <button
-          key={chip.key}
-          type="button"
-          onClick={() => onRemove(chip)}
-          className="group inline-flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1.5 text-xs font-medium text-muted transition hover:border-brand/40 hover:bg-brand/5 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-          aria-label={`Hapus filter ${chip.label}`}
-        >
-          <span className="truncate">{chip.label}</span>
-          <X className="h-3.5 w-3.5 transition group-hover:text-brand" aria-hidden="true" />
-        </button>
-      ))}
-    </div>
-  );
-}
-
-function SummaryCards({ summary, loading }) {
-  const cards = [
-    {
-      key: "income",
-      title: "Pemasukan",
-      value: summary?.income ?? 0,
-      accent: "text-success",
-    },
-    {
-      key: "expense",
-      title: "Pengeluaran",
-      value: summary?.expense ?? 0,
-      accent: "text-danger",
-    },
-    {
-      key: "net",
-      title: "Net",
-      value: summary?.net ?? 0,
-      accent: "text-info",
-    },
-  ];
-
-  return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-      {cards.map((card) => (
-        <div
-          key={card.key}
-          className="rounded-2xl border border-border bg-surface-1/90 p-5 shadow-sm"
-        >
-          <p className="text-xs font-semibold uppercase tracking-wide text-muted">{card.title}</p>
-          {loading ? (
-            <div className="mt-3 h-6 w-32 animate-pulse rounded-full bg-border/60" />
-          ) : (
-            <p className={clsx("mt-2 text-2xl font-semibold", card.accent)}>{formatIDR(card.value)}</p>
-          )}
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function SelectionToolbar({
-  count,
-  onClear,
-  onDelete,
-  onEditCategory,
-  onEditAccount,
-  deleting,
-  updating,
-  topOffset,
-}) {
-  return (
-    <div
-      className="pointer-events-none sticky bottom-4 z-30 md:bottom-auto md:top-0 md:sticky"
-      style={topOffset ? { top: topOffset } : undefined}
-      aria-live="polite"
-    >
-      <div className="pointer-events-auto mx-auto flex w-full max-w-[720px] flex-col gap-3 rounded-2xl border border-border bg-surface/95 p-4 shadow-lg shadow-black/5 md:flex-row md:items-center md:justify-between md:px-6">
-        <div className="flex flex-1 flex-wrap items-center gap-3">
-          <span className="inline-flex items-center gap-2 rounded-full bg-brand/10 px-3 py-1 text-sm font-semibold text-brand">
-            {count} dipilih
-          </span>
-          <button
-            type="button"
-            onClick={onClear}
-            className="text-sm font-medium text-muted transition hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-          >
-            Batal
-          </button>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <button
-            type="button"
-            onClick={onEditCategory}
-            disabled={updating}
-            className="inline-flex h-11 items-center justify-center gap-2 rounded-2xl border border-border px-4 text-sm font-medium text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {updating ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Pencil className="h-4 w-4" aria-hidden="true" />}
-            Ubah kategori
-          </button>
-          <button
-            type="button"
-            onClick={onEditAccount}
-            disabled={updating}
-            className="inline-flex h-11 items-center justify-center gap-2 rounded-2xl border border-border px-4 text-sm font-medium text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {updating ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <ArrowRightLeft className="h-4 w-4" aria-hidden="true" />}
-            Ubah akun
-          </button>
-          <button
-            type="button"
-            onClick={onDelete}
-            disabled={deleting}
-            className="inline-flex h-11 items-center justify-center gap-2 rounded-2xl bg-danger px-4 text-sm font-semibold text-white shadow transition hover:bg-[color:var(--color-danger-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-ring-danger)] disabled:cursor-not-allowed disabled:opacity-70"
-          >
-            {deleting ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Trash2 className="h-4 w-4" aria-hidden="true" />}
-            Hapus
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function TransactionsTable({
-  items,
-  loading,
-  error,
-  onRetry,
-  onLoadMore,
-  hasMore,
-  onToggleSelect,
-  onToggleSelectAll,
-  allSelected,
-  selectedIds,
-  onDelete,
-  onEdit,
-  tableStickyTop,
-  total,
-  variant = "table",
-  onResetFilters = () => {},
-  onOpenAdd = () => {},
-  deleteDisabled = false,
-}) {
-  const isCardVariant = variant === "card";
-  const isInitialLoading = loading && items.length === 0;
-  const isFetchingMore = loading && items.length > 0;
-  const displayStart = items.length > 0 ? 1 : 0;
-  const displayEnd = items.length;
-  const stickyHeaderStyle = tableStickyTop ? { top: tableStickyTop } : undefined;
-
-  if (error && !items.length) {
-    return (
-      <div className="rounded-2xl border border-danger/30 bg-danger/10 p-6 text-center">
-        <p className="mb-3 text-sm font-medium text-danger">Gagal memuat data transaksi.</p>
-        <button
-          type="button"
-          onClick={onRetry}
-          className="inline-flex h-11 items-center justify-center rounded-2xl border border-danger/40 bg-white/80 px-4 text-sm font-semibold text-danger transition hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-ring-danger)]"
-        >
-          Coba lagi
-        </button>
-      </div>
-    );
-  }
-
-  if (!loading && !items.length) {
-    return <EmptyTransactionsState onResetFilters={onResetFilters} onOpenAdd={onOpenAdd} />;
-  }
-
-  return (
-    <section className="space-y-4">
-      <div className={clsx("rounded-2xl border border-border bg-surface shadow-sm", isCardVariant ? "p-3" : "") }>
-        {isCardVariant ? (
-          <div className="flex flex-col gap-3">
-            {items.map((item) => (
-              <TransactionItem
-                key={item.id}
-                item={item}
-                variant="card"
-                isSelected={selectedIds.has(item.id)}
-                onToggleSelect={(event) => onToggleSelect(item.id, event)}
-                onDelete={() => onDelete(item.id)}
-                onEdit={() => onEdit(item)}
-                deleteDisabled={deleteDisabled}
-              />
-            ))}
-            {isInitialLoading &&
-              Array.from({ length: 6 }).map((_, index) => <TransactionSkeletonCard key={`card-skeleton-${index}`} />)}
-            {isFetchingMore &&
-              !isInitialLoading &&
-              Array.from({ length: 2 }).map((_, index) => <TransactionSkeletonCard key={`card-fetch-${index}`} />)}
-          </div>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full table-fixed border-separate border-spacing-0" aria-label="Daftar transaksi">
-              <thead
-                className="sticky top-0 z-10 border-b border-border/70 bg-surface-1/95 text-xs font-semibold uppercase tracking-wide text-muted backdrop-blur"
-                style={stickyHeaderStyle}
-              >
-                <tr>
-                  <th scope="col" className="w-12 px-3 py-3 text-center">
-                    <input
-                      type="checkbox"
-                      checked={allSelected}
-                      onChange={onToggleSelectAll}
-                      className="h-4 w-4 rounded border-border/70 text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-                      aria-label="Pilih semua transaksi"
-                    />
-                  </th>
-                  <th scope="col" className="min-w-[200px] px-3 py-3 text-left">Kategori</th>
-                  <th scope="col" className="min-w-[160px] px-3 py-3 text-left">Tanggal</th>
-                  <th scope="col" className="min-w-[240px] px-3 py-3 text-left">Catatan</th>
-                  <th scope="col" className="min-w-[180px] px-3 py-3 text-left">Akun</th>
-                  <th scope="col" className="min-w-[200px] px-3 py-3 text-left">Tags</th>
-                  <th scope="col" className="min-w-[140px] px-3 py-3 text-right">Jumlah</th>
-                  <th scope="col" className="w-[120px] px-3 py-3 text-right">Aksi</th>
-                </tr>
-              </thead>
-              <tbody>
-                {items.map((item) => (
-                  <TransactionItem
-                    key={item.id}
-                    item={item}
-                    variant="table"
-                    isSelected={selectedIds.has(item.id)}
-                    onToggleSelect={(event) => onToggleSelect(item.id, event)}
-                    onDelete={() => onDelete(item.id)}
-                    onEdit={() => onEdit(item)}
-                    deleteDisabled={deleteDisabled}
-                  />
-                ))}
-                {isInitialLoading &&
-                  Array.from({ length: 6 }).map((_, index) => <TransactionSkeletonRow key={`row-skeleton-${index}`} />)}
-                {isFetchingMore &&
-                  !isInitialLoading &&
-                  Array.from({ length: 2 }).map((_, index) => <TransactionSkeletonRow key={`row-fetch-${index}`} />)}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
-      <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted">
-        <span>
-          {total
-            ? `Menampilkan ${displayStart || 0}–${displayEnd} dari ${total}`
-            : `Menampilkan ${displayEnd} transaksi`}
-        </span>
-        {hasMore ? (
-          <button
-            type="button"
-            onClick={onLoadMore}
-            disabled={isFetchingMore}
-            className="inline-flex h-11 items-center gap-2 rounded-2xl border border-border px-4 text-sm font-medium text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {isFetchingMore && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
-            {isFetchingMore ? "Memuat…" : "Muat lagi"}
-          </button>
-        ) : null}
-      </div>
-    </section>
-  );
-}
-
-function UndoSnackbar({ open, message, onUndo, loading }) {
-  if (!open) return null;
-  return createPortal(
-    <div
-      className="fixed inset-x-0 bottom-4 z-40 flex justify-center px-4 sm:bottom-6"
-      role="status"
-      aria-live="polite"
-    >
-      <div className="flex w-full max-w-sm items-center gap-3 rounded-2xl border border-border bg-surface/95 px-4 py-3 text-sm text-text shadow-lg shadow-black/20">
-        <span className="flex-1">{message}</span>
-        <button
-          type="button"
-          onClick={onUndo}
-          disabled={loading}
-          className="inline-flex h-11 items-center justify-center rounded-xl border border-brand/50 px-4 text-sm font-semibold text-brand transition hover:bg-brand/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {loading ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : 'Urungkan'}
-        </button>
-      </div>
-    </div>,
-    document.body,
-  );
-}
-
-function TransactionSkeletonRow() {
-  return (
-    <tr className="border-b border-border/60 last:border-b-0">
-      {Array.from({ length: 8 }).map((_, index) => (
-        <td key={index} className="px-3 py-3 align-middle">
-          <div className="h-4 w-full animate-pulse rounded-full bg-border/60" />
-        </td>
-      ))}
-    </tr>
-  );
-}
-
-function TransactionSkeletonCard() {
-  return (
-    <div className="rounded-2xl border border-border bg-surface/80 p-4 shadow-sm">
-      <div className="mb-3 flex items-center justify-between">
-        <div className="h-4 w-32 animate-pulse rounded-full bg-border/60" />
-        <div className="h-5 w-20 animate-pulse rounded-full bg-border/60" />
-      </div>
-      <div className="grid grid-cols-2 gap-3">
-        <div className="h-4 w-full animate-pulse rounded-full bg-border/60" />
-        <div className="h-4 w-full animate-pulse rounded-full bg-border/60" />
-      </div>
-      <div className="mt-4 h-12 w-full animate-pulse rounded-2xl bg-border/60" />
-    </div>
-  );
-}
-
-function TransactionItem({
-  item,
-  variant = "table",
-  isSelected,
-  onToggleSelect,
-  onDelete,
-  onEdit,
-  deleteDisabled = false,
-}) {
-  const amountTone =
-    item.type === "income"
-      ? "text-success"
-      : item.type === "transfer"
-        ? "text-info"
-        : "text-danger";
-  const amountClass = clsx("text-right text-sm font-semibold tabular-nums", amountTone);
-  const amountCardClass = clsx("text-lg font-semibold tabular-nums", amountTone);
-  const note = item.notes ?? item.note ?? item.title ?? "";
-  const noteDisplay = note.trim() ? note.trim() : "—";
-  const formattedDate = formatTransactionDate(item.date);
-  const dateValue = toDateInput(item.date);
-  const categoryName = item.category || "(Tanpa kategori)";
-  const tags = useMemo(() => parseTags(item.tags), [item.tags]);
-  const hasAttachments = Boolean(item.receipt_url) || (Array.isArray(item.receipts) && item.receipts.length > 0);
-
-  const selectionCheckbox = (
-    <input
-      type="checkbox"
-      checked={isSelected}
-      onChange={onToggleSelect}
-      className="h-4 w-4 rounded border-border/70 text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-      aria-label="Pilih transaksi"
-    />
-  );
-
-  if (variant === "card") {
-    return (
-      <article
-        className={clsx(
-          "rounded-2xl border border-border bg-surface/90 p-4 shadow-sm transition-colors",
-          isSelected && "border-brand/40 bg-brand/5 ring-2 ring-brand/40",
-        )}
-        onDoubleClick={onEdit}
-      >
-        <div className="flex items-start gap-3">
-          <div className="pt-1">{selectionCheckbox}</div>
-          <div className="min-w-0 flex-1 space-y-3">
-            <div className="flex items-start justify-between gap-3">
-              <div className="flex items-center gap-2">
-                <span
-                  className="h-2.5 w-2.5 rounded-full"
-                  style={item.category_color ? { backgroundColor: item.category_color } : undefined}
-                  aria-hidden="true"
-                />
-                <p className="text-sm font-semibold text-text" title={categoryName}>
-                  {categoryName}
-                </p>
-                {hasAttachments && <Paperclip className="h-4 w-4 text-muted" aria-hidden="true" />}
-              </div>
-              <span className={clsx("text-right", amountCardClass)}>{formatIDR(item.amount)}</span>
-            </div>
-            <div className="grid grid-cols-1 gap-3 text-sm text-muted sm:grid-cols-2">
-              <div>
-                <p className="text-xs uppercase tracking-wide">Tanggal</p>
-                <p className="font-medium text-text">
-                  <time dateTime={dateValue}>{formattedDate}</time>
-                </p>
-              </div>
-              <div>
-                <p className="text-xs uppercase tracking-wide">Akun</p>
-                <p className="font-medium text-text">
-                  {item.type === "transfer" ? (
-                    <span className="flex items-center gap-1">
-                      <span className="truncate">{item.account || "—"}</span>
-                      <ArrowRight className="h-4 w-4 text-muted" aria-hidden="true" />
-                      <span className="truncate">{item.to_account || "—"}</span>
-                    </span>
-                  ) : (
-                    <span className="truncate">{item.account || "—"}</span>
-                  )}
-                </p>
-              </div>
-            </div>
-            <p className="line-clamp-2 text-sm text-muted" title={noteDisplay}>
-              {noteDisplay}
-            </p>
-            {tags.length > 0 && (
-              <div className="flex gap-2 overflow-x-auto pb-1">
-                {tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className="inline-flex items-center rounded-full bg-surface-2 px-3 py-1 text-xs font-medium text-text"
-                  >
-                    {tag}
-                  </span>
-                ))}
-              </div>
-            )}
-          </div>
-        </div>
-        <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
-          <button
-            type="button"
-            onClick={onEdit}
-            className="inline-flex h-11 items-center gap-2 rounded-2xl border border-border px-4 text-sm font-medium text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-            aria-label="Edit transaksi"
-          >
-            <Pencil className="h-4 w-4" aria-hidden="true" />
-            Edit
-          </button>
-          <button
-            type="button"
-            onClick={onDelete}
-            disabled={deleteDisabled}
-            className="inline-flex h-11 items-center gap-2 rounded-2xl border border-danger/40 bg-danger/10 px-4 text-sm font-medium text-danger transition hover:bg-danger/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-ring-danger)] disabled:cursor-not-allowed disabled:opacity-60"
-            aria-label="Hapus transaksi"
-          >
-            <Trash2 className="h-4 w-4" aria-hidden="true" />
-            Hapus
-          </button>
-        </div>
-      </article>
-    );
-  }
-
-  return (
-    <tr
-      className={clsx(
-        "border-b border-border/60 last:border-b-0 transition-colors",
-        isSelected
-          ? "bg-brand/10 shadow-[inset_0_0_0_1px_hsl(var(--color-primary)/0.35)]"
-          : "hover:bg-surface-2/60",
-      )}
-      onDoubleClick={onEdit}
-    >
-      <td className="px-3 py-3 align-middle">
-        <div className="flex items-center justify-center">{selectionCheckbox}</div>
-      </td>
-      <td className="px-3 py-3 align-middle">
-        <div className="flex items-center gap-3">
-          <span
-            className="h-2.5 w-2.5 rounded-full"
-            style={item.category_color ? { backgroundColor: item.category_color } : undefined}
-            aria-hidden="true"
-          />
-          <div className="min-w-0">
-            <p className="truncate text-sm font-medium text-text" title={categoryName}>
-              {categoryName}
-            </p>
-            <p className="text-xs uppercase tracking-wide text-muted">{TYPE_LABELS[item.type] || item.type}</p>
-          </div>
-        </div>
-      </td>
-      <td className="px-3 py-3 align-middle text-sm text-muted">
-        <time dateTime={dateValue}>{formattedDate}</time>
-      </td>
-      <td className="px-3 py-3 align-middle">
-        <div className="flex items-start gap-2">
-          <p className="line-clamp-2 text-sm text-text" title={noteDisplay}>
-            {noteDisplay}
-          </p>
-          {hasAttachments && <Paperclip className="mt-0.5 h-4 w-4 text-muted" aria-hidden="true" />}
-        </div>
-      </td>
-      <td className="px-3 py-3 align-middle text-sm text-text">
-        {item.type === "transfer" ? (
-          <div className="flex flex-wrap items-center gap-1">
-            <span className="truncate">{item.account || "—"}</span>
-            <ArrowRight className="h-4 w-4 text-muted" aria-hidden="true" />
-            <span className="truncate">{item.to_account || "—"}</span>
-          </div>
-        ) : (
-          <span className="truncate">{item.account || "—"}</span>
-        )}
-      </td>
-      <td className="px-3 py-3 align-middle">
-        {tags.length > 0 ? (
-          <div className="flex flex-wrap gap-2">
-            {tags.map((tag) => (
-              <span
-                key={tag}
-                className="inline-flex items-center rounded-full bg-surface-2 px-3 py-1 text-xs font-medium text-text"
-              >
-                {tag}
-              </span>
-            ))}
-          </div>
-        ) : (
-          <span className="text-sm text-muted">—</span>
-        )}
-      </td>
-      <td className="px-3 py-3 align-middle">
-        <span className={clsx("block", amountClass)}>{formatIDR(item.amount)}</span>
-      </td>
-      <td className="px-3 py-3 align-middle">
-        <div className="flex items-center justify-end gap-2">
-          <button
-            type="button"
-            onClick={onEdit}
-            className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-border bg-surface text-muted transition hover:border-brand/40 hover:bg-brand/5 hover:text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-            aria-label="Edit transaksi"
-          >
-            <Pencil className="h-4 w-4" aria-hidden="true" />
-          </button>
-          <button
-            type="button"
-            onClick={onDelete}
-            disabled={deleteDisabled}
-            className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-danger/40 bg-danger/10 text-danger transition hover:bg-danger/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-ring-danger)] disabled:cursor-not-allowed disabled:opacity-60"
-            aria-label="Hapus transaksi"
-          >
-            <Trash2 className="h-4 w-4" aria-hidden="true" />
-          </button>
-        </div>
-      </td>
-    </tr>
-  );
-}
-
-function EmptyTransactionsState({ onResetFilters, onOpenAdd }) {
-  return (
-    <div className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-border bg-surface/80 px-6 py-16 text-center">
-      <span className="rounded-full bg-brand/10 p-3 text-brand">
-        <Inbox className="h-6 w-6" aria-hidden="true" />
-      </span>
-      <div className="space-y-1">
-        <h2 className="text-lg font-semibold text-text">Belum ada transaksi sesuai filter</h2>
-        <p className="text-sm text-muted">Coba atur ulang filter atau tambahkan transaksi baru.</p>
-      </div>
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={onResetFilters}
-          className="inline-flex h-11 items-center justify-center rounded-2xl border border-border px-4 text-sm font-medium text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-        >
-          Reset filter
-        </button>
-        <button
-          type="button"
-          onClick={onOpenAdd}
-          className="inline-flex h-11 items-center gap-2 rounded-2xl bg-brand px-4 text-sm font-semibold text-brand-foreground shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-        >
-          <Plus className="h-4 w-4" aria-hidden="true" />
-          Tambah Transaksi
-        </button>
-      </div>
-    </div>
-  );
-}
-
-function parseTags(value) {
-  if (!value) return [];
-  if (Array.isArray(value)) {
-    return value
-      .map((tag) => String(tag).trim())
-      .filter(Boolean);
-  }
-  return String(value)
-    .split(",")
-    .map((tag) => tag.trim())
-    .filter(Boolean);
 }
 
 function BulkEditDialog({


### PR DESCRIPTION
## Summary
- implement a modern transactions table for desktop with sticky headers, sorting, pagination, and skeleton/error/empty states
- add a mobile card list experience plus reusable filter controls, category dot, and floating batch toolbar
- adjust the transactions query to expose page controls and use 20-row pages to match the new pagination UX

## Testing
- pnpm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d663dfd8848332bbc1a72d36bc419b