### PR TITLE
Redesign transactions list UI

### DIFF
--- a/src/components/transactions/BatchToolbar.tsx
+++ b/src/components/transactions/BatchToolbar.tsx
@@ -1,0 +1,73 @@
+import clsx from "clsx";
+import { Loader2, Trash2, Wand2 } from "lucide-react";
+import { ReactNode } from "react";
+
+interface BatchToolbarProps {
+  count: number;
+  onClear: () => void;
+  onDelete: () => void;
+  onChangeCategory: () => void;
+  deleting?: boolean;
+  updating?: boolean;
+  className?: string;
+  secondaryAction?: ReactNode;
+}
+
+export default function BatchToolbar({
+  count,
+  onClear,
+  onDelete,
+  onChangeCategory,
+  deleting = false,
+  updating = false,
+  className,
+  secondaryAction,
+}: BatchToolbarProps) {
+  if (count <= 0) return null;
+
+  return (
+    <div
+      className={clsx(
+        "pointer-events-none fixed inset-x-0 bottom-6 z-40 flex justify-center px-4",
+        className,
+      )}
+      aria-live="polite"
+    >
+      <div className="pointer-events-auto flex w-full max-w-xl flex-col gap-3 rounded-3xl bg-slate-900/95 p-4 text-slate-200 shadow-2xl ring-1 ring-slate-800 backdrop-blur">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <span className="inline-flex items-center gap-2 rounded-full bg-[var(--accent)]/10 px-3 py-1 text-sm font-semibold text-[var(--accent)]">
+            {count} dipilih
+          </span>
+          <button
+            type="button"
+            onClick={onClear}
+            className="text-sm font-medium text-slate-400 transition-colors hover:text-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          >
+            Batal
+          </button>
+        </div>
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {secondaryAction}
+          <button
+            type="button"
+            onClick={onChangeCategory}
+            disabled={updating}
+            className="inline-flex h-11 flex-1 items-center justify-center gap-2 rounded-2xl bg-slate-800 px-4 text-sm font-semibold text-slate-200 transition hover:bg-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60 sm:flex-initial"
+          >
+            {updating ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Wand2 className="h-4 w-4" aria-hidden="true" />}
+            Ubah Kategori
+          </button>
+          <button
+            type="button"
+            onClick={onDelete}
+            disabled={deleting}
+            className="inline-flex h-11 flex-1 items-center justify-center gap-2 rounded-2xl bg-rose-500/20 px-4 text-sm font-semibold text-rose-200 transition hover:bg-rose-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-60 sm:flex-initial"
+          >
+            {deleting ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Trash2 className="h-4 w-4" aria-hidden="true" />}
+            Hapus
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/transactions/CategoryDot.tsx
+++ b/src/components/transactions/CategoryDot.tsx
@@ -1,0 +1,23 @@
+import clsx from "clsx";
+
+interface CategoryDotProps {
+  color?: string | null;
+  className?: string;
+  size?: "sm" | "md" | "lg";
+}
+
+const SIZE_MAP: Record<CategoryDotProps["size"], string> = {
+  sm: "h-2 w-2",
+  md: "h-2.5 w-2.5",
+  lg: "h-3 w-3",
+};
+
+export default function CategoryDot({ color, className, size = "md" }: CategoryDotProps) {
+  return (
+    <span
+      aria-hidden="true"
+      className={clsx("inline-flex flex-shrink-0 rounded-full bg-slate-600", SIZE_MAP[size], className)}
+      style={color ? { backgroundColor: color } : undefined}
+    />
+  );
+}

--- a/src/components/transactions/TransactionsCardList.tsx
+++ b/src/components/transactions/TransactionsCardList.tsx
@@ -1,0 +1,243 @@
+import clsx from "clsx";
+import { Pencil, Trash2 } from "lucide-react";
+import { ChangeEvent, ReactNode } from "react";
+import CategoryDot from "./CategoryDot";
+
+interface TransactionRowData {
+  id: string;
+  type: string;
+  category?: string | null;
+  category_color?: string | null;
+  amount: number;
+  date?: string;
+  account?: string | null;
+  to_account?: string | null;
+  notes?: string | null;
+  note?: string | null;
+  title?: string | null;
+  description?: string | null;
+  tags?: string[] | string | null;
+}
+
+interface TransactionsCardListProps {
+  items: TransactionRowData[];
+  loading: boolean;
+  error: Error | null;
+  onRetry: () => void;
+  selectedIds: Set<string>;
+  onToggleSelect: (id: string, event?: ChangeEvent<HTMLInputElement>) => void;
+  onEdit: (item: TransactionRowData) => void;
+  onDelete: (item: TransactionRowData) => void;
+  formatAmount: (value: number) => string;
+  formatDate: (value?: string | null) => string;
+  toDateValue: (value?: string | null) => string;
+  parseTags: (value: TransactionRowData["tags"]) => string[];
+  typeLabels: Record<string, string>;
+  page: number;
+  pageSize: number;
+  total: number;
+  onPageChange: (page: number) => void;
+  deleteDisabled?: boolean;
+  emptyState: ReactNode;
+}
+
+const AMOUNT_CLASS: Record<string, string> = {
+  income: "text-emerald-400",
+  expense: "text-rose-400",
+  transfer: "text-slate-300",
+};
+
+export default function TransactionsCardList({
+  items,
+  loading,
+  error,
+  onRetry,
+  selectedIds,
+  onToggleSelect,
+  onEdit,
+  onDelete,
+  formatAmount,
+  formatDate,
+  toDateValue,
+  parseTags,
+  typeLabels,
+  page,
+  pageSize,
+  total,
+  onPageChange,
+  deleteDisabled = false,
+  emptyState,
+}: TransactionsCardListProps) {
+  const isInitialLoading = loading && items.length === 0;
+  const displayStart = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const displayEnd = total === 0 ? 0 : Math.min((page - 1) * pageSize + items.length, total);
+  const hasNext = page * pageSize < total;
+  const hasPrev = page > 1;
+
+  if (error && !items.length) {
+    return (
+      <div className="rounded-3xl bg-red-500/10 p-4 text-red-200 ring-1 ring-red-500/30">
+        <div className="flex flex-col gap-3">
+          <p className="text-sm font-medium">Gagal memuat transaksi. Coba lagi?</p>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="inline-flex h-11 items-center justify-center rounded-2xl bg-red-500/20 px-4 text-sm font-semibold text-red-100 transition hover:bg-red-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300"
+          >
+            Muat ulang
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!loading && items.length === 0) {
+    return <div className="md:hidden">{emptyState}</div>;
+  }
+
+  return (
+    <div className="space-y-4 md:hidden">
+      {error && (
+        <div className="rounded-2xl bg-red-500/10 px-4 py-3 text-sm text-red-200 ring-1 ring-red-500/30">
+          Gagal memuat transaksi. <button type="button" onClick={onRetry} className="font-semibold underline-offset-4 hover:underline">Coba lagi</button>
+        </div>
+      )}
+      <div className="space-y-2">
+        {isInitialLoading
+          ? Array.from({ length: 6 }).map((_, index) => <SkeletonCard key={index} />)
+          : items.map((item) => {
+              const selected = selectedIds.has(item.id);
+              const tags = parseTags(item.tags);
+              const note = item.title || item.description || item.notes || item.note || "";
+              const description = note.trim() || "(Tanpa judul)";
+              const formattedDate = formatDate(item.date);
+              const amountTone = AMOUNT_CLASS[item.type] || AMOUNT_CLASS.transfer;
+
+              return (
+                <article
+                  key={item.id}
+                  className={clsx(
+                    "rounded-2xl bg-slate-900 ring-1 ring-slate-800 p-3",
+                    selected && "ring-[var(--accent)]/60",
+                  )}
+                >
+                  <header className="flex items-start gap-3">
+                    <div className="pt-1">
+                      <input
+                        type="checkbox"
+                        checked={selected}
+                        onChange={(event) => onToggleSelect(item.id, event)}
+                        className="h-4 w-4 rounded border-slate-700 bg-slate-900 text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+                        aria-label="Pilih transaksi"
+                      />
+                    </div>
+                    <div className="flex flex-1 items-start justify-between gap-3">
+                      <div className="space-y-1">
+                        <div className="flex items-center gap-2">
+                          <CategoryDot color={item.category_color} />
+                          <p className="text-sm font-semibold text-slate-200">{item.category || "(Tanpa kategori)"}</p>
+                        </div>
+                        <p className="text-xs uppercase tracking-wide text-slate-400">{typeLabels[item.type] || item.type}</p>
+                      </div>
+                      <time dateTime={toDateValue(item.date)} className="text-xs text-slate-400">
+                        {formattedDate}
+                      </time>
+                    </div>
+                  </header>
+                  <div className="mt-3 space-y-2">
+                    <p className="text-sm font-medium text-slate-200 line-clamp-2" title={description}>
+                      {description}
+                    </p>
+                    <div className="flex flex-wrap items-center gap-2 text-xs text-slate-400">
+                      <span className="rounded-full bg-slate-800/80 px-2 py-1">{item.account || "—"}</span>
+                      {item.type === "transfer" && (
+                        <span className="rounded-full bg-slate-800/80 px-2 py-1">→ {item.to_account || "—"}</span>
+                      )}
+                      {tags.map((tag) => (
+                        <span
+                          key={tag}
+                          className="rounded-full bg-slate-800/80 px-2 py-1 text-slate-300"
+                        >
+                          #{tag}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                  <footer className="mt-4 flex items-center justify-between gap-3">
+                    <span className={clsx("text-lg font-semibold", amountTone)}>{formatAmount(item.amount)}</span>
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => onEdit(item)}
+                        className="flex h-9 w-9 items-center justify-center rounded-full bg-slate-900 text-slate-300 ring-1 ring-slate-700 transition hover:bg-slate-800 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+                        aria-label="Edit transaksi"
+                      >
+                        <Pencil className="h-4 w-4" aria-hidden="true" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => onDelete(item)}
+                        disabled={deleteDisabled}
+                        className="flex h-9 w-9 items-center justify-center rounded-full bg-rose-500/10 text-rose-300 ring-1 ring-rose-400/40 transition hover:bg-rose-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-60"
+                        aria-label="Hapus transaksi"
+                      >
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
+                      </button>
+                    </div>
+                  </footer>
+                </article>
+              );
+            })}
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl bg-slate-900/60 px-4 py-3 text-sm text-slate-400 ring-1 ring-slate-800">
+        <span>
+          Menampilkan {displayStart}&ndash;{displayEnd} dari {total} transaksi
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => onPageChange(page - 1)}
+            disabled={!hasPrev || loading}
+            className="inline-flex h-9 items-center justify-center rounded-2xl bg-slate-900 px-4 text-sm font-medium text-slate-200 ring-1 ring-slate-800 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Sebelumnya
+          </button>
+          <button
+            type="button"
+            onClick={() => onPageChange(page + 1)}
+            disabled={!hasNext || loading}
+            className="inline-flex h-9 items-center justify-center rounded-2xl bg-slate-900 px-4 text-sm font-medium text-slate-200 ring-1 ring-slate-800 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Selanjutnya
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SkeletonCard() {
+  return (
+    <div className="space-y-3 rounded-2xl bg-slate-900/80 p-3 ring-1 ring-slate-800 animate-pulse">
+      <div className="flex items-center gap-3">
+        <div className="h-4 w-4 rounded bg-slate-800" />
+        <div className="flex-1 space-y-2">
+          <div className="h-3 w-32 rounded-full bg-slate-800" />
+          <div className="h-3 w-24 rounded-full bg-slate-800/70" />
+        </div>
+      </div>
+      <div className="h-3 w-full rounded-full bg-slate-800" />
+      <div className="flex gap-2">
+        <span className="h-5 w-16 rounded-full bg-slate-800" />
+        <span className="h-5 w-16 rounded-full bg-slate-800/80" />
+      </div>
+      <div className="flex items-center justify-between">
+        <span className="h-4 w-24 rounded-full bg-slate-800" />
+        <div className="flex gap-2">
+          <span className="h-9 w-9 rounded-full bg-slate-800" />
+          <span className="h-9 w-9 rounded-full bg-slate-800/80" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/transactions/TransactionsFilters.tsx
+++ b/src/components/transactions/TransactionsFilters.tsx
@@ -1,0 +1,420 @@
+import { createPortal } from "react-dom";
+import { ChangeEvent, MutableRefObject, useEffect, useId, useMemo, useRef, useState } from "react";
+import clsx from "clsx";
+import { Calendar, ChevronDown, Search } from "lucide-react";
+import CategoryDot from "./CategoryDot";
+
+const TYPE_LABELS: Record<string, string> = {
+  income: "Pemasukan",
+  expense: "Pengeluaran",
+  transfer: "Transfer",
+};
+
+const SORT_OPTIONS: Record<string, string> = {
+  "date-desc": "Terbaru",
+  "date-asc": "Terlama",
+  "amount-desc": "Nominal Tertinggi",
+  "amount-asc": "Nominal Terendah",
+};
+
+const PRESET_OPTIONS: Record<string, string> = {
+  all: "Semua waktu",
+  month: "Bulan ini",
+  week: "Minggu ini",
+  custom: "Rentang tanggal",
+};
+
+function currentMonthValue() {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function toDateInput(value?: string | null) {
+  if (!value) return "";
+  return String(value).slice(0, 10);
+}
+
+interface TransactionsFiltersProps {
+  filter: any;
+  categories: Array<any>;
+  searchTerm: string;
+  onSearchChange: (value: string) => void;
+  onFilterChange: (next: any) => void;
+  searchInputRef?: MutableRefObject<{ focus: () => void } | null> | null;
+  onClear: () => void;
+  sort: string;
+  onSortChange: (value: string) => void;
+}
+
+export default function TransactionsFilters({
+  filter,
+  categories,
+  searchTerm,
+  onSearchChange,
+  onFilterChange,
+  searchInputRef,
+  onClear,
+  sort,
+  onSortChange,
+}: TransactionsFiltersProps) {
+  const searchId = useId();
+  const typeId = useId();
+  const sortId = useId();
+  const rangeId = useId();
+  const startId = useId();
+  const endId = useId();
+  const internalSearchRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (!searchInputRef) return;
+    searchInputRef.current = {
+      focus: () => {
+        internalSearchRef.current?.focus();
+        internalSearchRef.current?.select();
+      },
+    };
+  }, [searchInputRef]);
+
+  const handleTypeChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    onFilterChange({ type: event.target.value });
+  };
+
+  const handleSearchInput = (event: ChangeEvent<HTMLInputElement>) => {
+    onSearchChange(event.target.value);
+  };
+
+  const handlePresetChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value;
+    if (value === "all") {
+      onFilterChange({
+        period: { preset: "all", month: "", start: "", end: "" },
+      });
+      return;
+    }
+    if (value === "month") {
+      onFilterChange({
+        period: { preset: "month", month: filter.period.month || currentMonthValue(), start: "", end: "" },
+      });
+      return;
+    }
+    if (value === "week") {
+      onFilterChange({
+        period: { preset: "week", month: "", start: "", end: "" },
+      });
+      return;
+    }
+    onFilterChange({
+      period: {
+        preset: "custom",
+        month: "",
+        start: filter.period.start || new Date().toISOString().slice(0, 10),
+        end: filter.period.end || new Date().toISOString().slice(0, 10),
+      },
+    });
+  };
+
+  const handleStartChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onFilterChange({
+      period: {
+        ...filter.period,
+        preset: "custom",
+        start: event.target.value,
+      },
+    });
+  };
+
+  const handleEndChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onFilterChange({
+      period: {
+        ...filter.period,
+        preset: "custom",
+        end: event.target.value,
+      },
+    });
+  };
+
+  const presetValue = filter.period?.preset ?? "all";
+
+  return (
+    <section
+      className="flex flex-col gap-3 rounded-3xl bg-slate-950/70 p-4 text-slate-200 shadow-lg ring-1 ring-slate-800 backdrop-blur"
+      role="search"
+      aria-label="Filter transaksi"
+    >
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative flex min-w-[240px] flex-1 items-center">
+          <Search className="pointer-events-none absolute left-4 h-4 w-4 text-slate-500" aria-hidden="true" />
+          <input
+            id={searchId}
+            ref={internalSearchRef}
+            type="search"
+            value={searchTerm}
+            onChange={handleSearchInput}
+            placeholder="Cari judul atau catatan"
+            className="h-11 w-full rounded-2xl bg-slate-900/60 pl-11 pr-4 text-sm text-slate-200 placeholder:text-slate-500 ring-2 ring-slate-800 focus:outline-none focus:ring-[var(--accent)]"
+            aria-label="Cari transaksi"
+          />
+        </div>
+        <div className="flex flex-1 gap-3">
+          <label className="flex flex-1 items-center">
+            <span className="sr-only">Filter tipe transaksi</span>
+            <select
+              id={typeId}
+              value={filter.type}
+              onChange={handleTypeChange}
+              className="h-11 w-full rounded-2xl bg-slate-900/60 px-4 text-sm font-medium text-slate-200 ring-2 ring-slate-800 focus:outline-none focus:ring-[var(--accent)]"
+            >
+              <option value="all">Semua tipe</option>
+              <option value="income">Pemasukan</option>
+              <option value="expense">Pengeluaran</option>
+              <option value="transfer">Transfer</option>
+            </select>
+          </label>
+          <CategoryMultiSelect
+            categories={categories}
+            selected={filter.categories}
+            onChange={(next) => onFilterChange({ categories: next })}
+          />
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        <label className="flex w-full min-w-[160px] flex-1 items-center md:w-auto">
+          <span className="sr-only">Preset rentang waktu</span>
+          <div className="relative w-full">
+            <select
+              id={rangeId}
+              value={presetValue}
+              onChange={handlePresetChange}
+              className="h-11 w-full appearance-none rounded-2xl bg-slate-900/60 px-4 text-sm font-medium text-slate-200 ring-2 ring-slate-800 focus:outline-none focus:ring-[var(--accent)]"
+            >
+              {Object.entries(PRESET_OPTIONS).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+            <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" aria-hidden="true" />
+          </div>
+        </label>
+        <div className="flex flex-1 flex-wrap gap-3 md:flex-nowrap">
+          <label className="flex min-w-[160px] flex-1 items-center gap-2 rounded-2xl bg-slate-900/60 px-3 ring-2 ring-slate-800 focus-within:ring-[var(--accent)]">
+            <Calendar className="h-4 w-4 text-slate-500" aria-hidden="true" />
+            <input
+              id={startId}
+              type="date"
+              value={toDateInput(filter.period?.start)}
+              onChange={handleStartChange}
+              className="h-10 flex-1 bg-transparent text-sm text-slate-200 focus:outline-none"
+              aria-label="Tanggal mulai"
+            />
+          </label>
+          <label className="flex min-w-[160px] flex-1 items-center gap-2 rounded-2xl bg-slate-900/60 px-3 ring-2 ring-slate-800 focus-within:ring-[var(--accent)]">
+            <Calendar className="h-4 w-4 text-slate-500" aria-hidden="true" />
+            <input
+              id={endId}
+              type="date"
+              value={toDateInput(filter.period?.end)}
+              onChange={handleEndChange}
+              className="h-10 flex-1 bg-transparent text-sm text-slate-200 focus:outline-none"
+              aria-label="Tanggal akhir"
+            />
+          </label>
+        </div>
+        <div className="flex flex-1 items-center justify-end gap-3">
+          <label className="md:hidden inline-flex min-w-[160px] flex-1 items-center">
+            <span className="sr-only">Urutkan transaksi</span>
+            <select
+              id={sortId}
+              value={sort}
+              onChange={(event) => onSortChange(event.target.value)}
+              className="h-11 w-full rounded-2xl bg-slate-900/60 px-4 text-sm font-medium text-slate-200 ring-2 ring-slate-800 focus:outline-none focus:ring-[var(--accent)]"
+            >
+              {Object.entries(SORT_OPTIONS).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            onClick={onClear}
+            className="inline-flex h-11 items-center justify-center rounded-2xl bg-slate-900/60 px-4 text-sm font-semibold text-slate-200 ring-2 ring-slate-800 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          >
+            Bersihkan
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+interface CategoryMultiSelectProps {
+  categories: Array<any>;
+  selected: string[];
+  onChange: (next: string[]) => void;
+}
+
+function CategoryMultiSelect({ categories, selected, onChange }: CategoryMultiSelectProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const [position, setPosition] = useState({ top: 0, left: 0, width: 0 });
+
+  useEffect(() => {
+    if (!open) return;
+    const updatePosition = () => {
+      const anchor = triggerRef.current;
+      if (!anchor) return;
+      const rect = anchor.getBoundingClientRect();
+      const width = Math.min(360, Math.max(260, rect.width));
+      const left = Math.min(Math.max(16, rect.left), window.innerWidth - width - 16);
+      setPosition({ top: rect.bottom + 8, left, width });
+    };
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, { passive: true });
+    return () => {
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (event: MouseEvent) => {
+      if (!panelRef.current || !triggerRef.current) return;
+      if (panelRef.current.contains(event.target as Node)) return;
+      if (triggerRef.current.contains(event.target as Node)) return;
+      setOpen(false);
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (open) setQuery("");
+  }, [open]);
+
+  const filteredCategories = useMemo(() => {
+    const term = query.trim().toLowerCase();
+    if (!term) return categories;
+    return categories.filter((cat) =>
+      [cat.name, TYPE_LABELS[cat.type] ?? ""].some((value) =>
+        String(value || "").toLowerCase().includes(term),
+      ),
+    );
+  }, [categories, query]);
+
+  const summaryLabel = useMemo(() => {
+    if (!selected.length) return "Semua kategori";
+    if (selected.length === 1) {
+      const match = categories.find((cat) => cat.id === selected[0]);
+      return match?.name || "1 kategori";
+    }
+    return `${selected.length} kategori`;
+  }, [categories, selected]);
+
+  const toggle = (id: string) => {
+    const next = new Set(selected);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    onChange(Array.from(next));
+  };
+
+  const clear = () => {
+    onChange([]);
+  };
+
+  return (
+    <div className="flex flex-1 min-w-[200px]">
+      <button
+        type="button"
+        ref={triggerRef}
+        onClick={() => setOpen((prev) => !prev)}
+        className="inline-flex h-11 w-full items-center justify-between rounded-2xl bg-slate-900/60 px-4 text-sm font-medium text-slate-200 ring-2 ring-slate-800 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <span className="truncate">{summaryLabel}</span>
+        <ChevronDown className="ml-3 h-4 w-4 text-slate-500" aria-hidden="true" />
+      </button>
+      {open &&
+        createPortal(
+          <div className="fixed inset-0 z-50" role="presentation">
+            <div
+              ref={panelRef}
+              role="listbox"
+              aria-multiselectable="true"
+              className="absolute max-h-[360px] w-[min(360px,calc(100%-32px))] overflow-hidden rounded-3xl bg-slate-900/95 text-slate-200 shadow-2xl ring-1 ring-slate-800 backdrop-blur"
+              style={{ top: position.top, left: position.left, width: position.width || undefined }}
+            >
+              <div className="flex items-center justify-between px-4 pb-3 pt-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Kategori</p>
+                <button
+                  type="button"
+                  onClick={clear}
+                  className="rounded-full px-2 py-1 text-xs text-slate-400 transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+                >
+                  Reset
+                </button>
+              </div>
+              <div className="px-4 pb-3">
+                <div className="flex items-center gap-2 rounded-2xl bg-slate-800/80 px-3">
+                  <Search className="h-4 w-4 flex-shrink-0 text-slate-500" aria-hidden="true" />
+                  <input
+                    type="search"
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                    placeholder="Cari kategori"
+                    className="h-9 w-full bg-transparent text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none"
+                  />
+                </div>
+              </div>
+              <div className="max-h-[240px] overflow-y-auto px-2 pb-4">
+                {filteredCategories.length === 0 && (
+                  <p className="px-4 py-3 text-sm text-slate-400">Kategori tidak ditemukan</p>
+                )}
+                {filteredCategories.map((cat) => {
+                  const checked = selected.includes(cat.id);
+                  return (
+                    <button
+                      key={cat.id}
+                      type="button"
+                      onClick={() => toggle(cat.id)}
+                      className={clsx(
+                        "flex w-full items-center justify-between rounded-2xl px-3 py-2 text-left text-sm transition",
+                        checked ? "bg-[var(--accent)]/15 text-slate-50" : "text-slate-300 hover:bg-slate-800/80",
+                      )}
+                      role="option"
+                      aria-selected={checked}
+                    >
+                      <span className="flex items-center gap-3">
+                        <CategoryDot color={cat.color} />
+                        <span className="font-medium">{cat.name || "(Tanpa kategori)"}</span>
+                      </span>
+                      {checked && <span className="text-xs uppercase text-[var(--accent)]">Dipilih</span>}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </div>,
+        )}
+    </div>
+  );
+}

--- a/src/components/transactions/TransactionsTable.tsx
+++ b/src/components/transactions/TransactionsTable.tsx
@@ -1,0 +1,361 @@
+import clsx from "clsx";
+import { Pencil, Trash2 } from "lucide-react";
+import { ChangeEvent, ReactNode } from "react";
+import CategoryDot from "./CategoryDot";
+
+interface TransactionRowData {
+  id: string;
+  type: string;
+  category?: string | null;
+  category_color?: string | null;
+  amount: number;
+  date?: string;
+  account?: string | null;
+  to_account?: string | null;
+  notes?: string | null;
+  note?: string | null;
+  title?: string | null;
+  description?: string | null;
+  tags?: string[] | string | null;
+}
+
+interface TransactionsTableProps {
+  items: TransactionRowData[];
+  loading: boolean;
+  error: Error | null;
+  onRetry: () => void;
+  selectedIds: Set<string>;
+  onToggleSelect: (id: string, event?: ChangeEvent<HTMLInputElement>) => void;
+  onToggleSelectAll: () => void;
+  allSelected: boolean;
+  onEdit: (item: TransactionRowData) => void;
+  onDelete: (item: TransactionRowData) => void;
+  formatAmount: (value: number) => string;
+  formatDate: (value?: string | null) => string;
+  toDateValue: (value?: string | null) => string;
+  parseTags: (value: TransactionRowData["tags"]) => string[];
+  typeLabels: Record<string, string>;
+  sort: string;
+  onSortChange: (next: string) => void;
+  tableStickyTop?: string;
+  page: number;
+  pageSize: number;
+  total: number;
+  onPageChange: (page: number) => void;
+  deleteDisabled?: boolean;
+  emptyState: ReactNode;
+}
+
+const AMOUNT_CLASS: Record<string, string> = {
+  income: "text-emerald-400",
+  expense: "text-rose-400",
+  transfer: "text-slate-300",
+};
+
+export default function TransactionsTable({
+  items,
+  loading,
+  error,
+  onRetry,
+  selectedIds,
+  onToggleSelect,
+  onToggleSelectAll,
+  allSelected,
+  onEdit,
+  onDelete,
+  formatAmount,
+  formatDate,
+  toDateValue,
+  parseTags,
+  typeLabels,
+  sort,
+  onSortChange,
+  tableStickyTop,
+  page,
+  pageSize,
+  total,
+  onPageChange,
+  deleteDisabled = false,
+  emptyState,
+}: TransactionsTableProps) {
+  const isInitialLoading = loading && items.length === 0;
+
+  const displayStart = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const displayEnd = total === 0 ? 0 : Math.min((page - 1) * pageSize + items.length, total);
+  const hasNext = page * pageSize < total;
+  const hasPrev = page > 1;
+
+  const handleDateSort = () => {
+    const next = sort === "date-desc" ? "date-asc" : "date-desc";
+    onSortChange(next);
+  };
+
+  const handleAmountSort = () => {
+    const next = sort === "amount-desc" ? "amount-asc" : "amount-desc";
+    onSortChange(next);
+  };
+
+  if (error && !items.length) {
+    return (
+      <div className="rounded-3xl bg-red-500/10 p-4 text-red-200 ring-1 ring-red-500/30">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <p className="text-sm font-medium">Gagal memuat transaksi. Coba lagi?</p>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="inline-flex h-10 items-center justify-center rounded-2xl bg-red-500/20 px-4 text-sm font-semibold text-red-100 transition hover:bg-red-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300"
+          >
+            Muat ulang
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!loading && items.length === 0) {
+    return <>{emptyState}</>;
+  }
+
+  return (
+    <div className="hidden md:block">
+      {error && (
+        <div className="mb-4 rounded-2xl bg-red-500/10 px-4 py-3 text-sm text-red-200 ring-1 ring-red-500/30">
+          Terjadi kesalahan memuat data. <button type="button" onClick={onRetry} className="font-semibold underline-offset-4 hover:underline">Coba lagi</button>
+        </div>
+      )}
+      <div className="overflow-hidden rounded-3xl bg-slate-950/50 ring-1 ring-slate-800">
+        <div className="max-h-[min(70vh,640px)] overflow-y-auto">
+          <table className="min-w-full divide-y divide-slate-800">
+            <thead className="bg-slate-900" style={tableStickyTop ? { top: tableStickyTop } : undefined}>
+              <tr className="sticky top-0 z-10">
+                <th scope="col" className="w-12 px-4 py-3 text-left text-xs uppercase tracking-wide text-slate-400">
+                  <div className="flex justify-center">
+                    <input
+                      type="checkbox"
+                      checked={allSelected}
+                      onChange={onToggleSelectAll}
+                      aria-label="Pilih semua transaksi"
+                      className="h-4 w-4 rounded border-slate-700 bg-slate-900 text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+                    />
+                  </div>
+                </th>
+                <th scope="col" className="px-4 py-3 text-left text-xs uppercase tracking-wide text-slate-400">
+                  Kategori &amp; Judul
+                </th>
+                <th scope="col" className="px-4 py-3 text-left text-xs uppercase tracking-wide text-slate-400">
+                  <button
+                    type="button"
+                    onClick={handleDateSort}
+                    className="inline-flex items-center gap-2 font-semibold text-slate-300 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+                  >
+                    Tanggal
+                    <SortIndicator active={sort.startsWith("date")} direction={sort === "date-asc" ? "asc" : "desc"} />
+                  </button>
+                </th>
+                <th scope="col" className="px-4 py-3 text-left text-xs uppercase tracking-wide text-slate-400">
+                  Akun
+                </th>
+                <th scope="col" className="px-4 py-3 text-left text-xs uppercase tracking-wide text-slate-400">
+                  Tag
+                </th>
+                <th scope="col" className="px-4 py-3 text-right text-xs uppercase tracking-wide text-slate-400">
+                  <button
+                    type="button"
+                    onClick={handleAmountSort}
+                    className="inline-flex items-center gap-2 font-semibold text-slate-300 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+                  >
+                    Jumlah
+                    <SortIndicator active={sort.startsWith("amount")} direction={sort === "amount-asc" ? "asc" : "desc"} />
+                  </button>
+                </th>
+                <th scope="col" className="w-24 px-4 py-3 text-right text-xs uppercase tracking-wide text-slate-400">
+                  Aksi
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800">
+              {isInitialLoading
+                ? Array.from({ length: 6 }).map((_, index) => <SkeletonRow key={index} />)
+                : items.map((item) => {
+                    const selected = selectedIds.has(item.id);
+                    const tags = parseTags(item.tags);
+                    const note = item.title || item.description || item.notes || item.note || "";
+                    const description = note.trim() || "(Tanpa judul)";
+                    const formattedDate = formatDate(item.date);
+                    const amountTone = AMOUNT_CLASS[item.type] || AMOUNT_CLASS.transfer;
+
+                    return (
+                      <tr
+                        key={item.id}
+                        className={clsx(
+                          "transition-colors hover:bg-slate-900/40",
+                          selected && "bg-[var(--accent)]/5",
+                        )}
+                      >
+                        <td className="px-4 py-4 align-middle">
+                          <div className="flex justify-center">
+                            <input
+                              type="checkbox"
+                              checked={selected}
+                              onChange={(event) => onToggleSelect(item.id, event)}
+                              className="h-4 w-4 rounded border-slate-700 bg-slate-900 text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+                              aria-label="Pilih transaksi"
+                            />
+                          </div>
+                        </td>
+                        <td className="px-4 py-4 align-middle">
+                          <div className="flex items-start gap-3">
+                            <CategoryDot color={item.category_color} className="mt-1" />
+                            <div className="min-w-0 space-y-1">
+                              <p className="truncate text-sm font-semibold text-slate-200" title={item.category || "(Tanpa kategori)"}>
+                                {item.category || "(Tanpa kategori)"}
+                              </p>
+                              <p className="truncate text-xs uppercase tracking-wide text-slate-400">
+                                {typeLabels[item.type] || item.type}
+                              </p>
+                              <p className="truncate text-sm text-slate-400" title={description}>
+                                {description}
+                              </p>
+                            </div>
+                          </div>
+                        </td>
+                        <td className="px-4 py-4 align-middle text-sm text-slate-300">
+                          <time dateTime={toDateValue(item.date)}>{formattedDate}</time>
+                        </td>
+                        <td className="px-4 py-4 align-middle text-sm text-slate-200">
+                          {item.type === "transfer" ? (
+                            <span className="flex items-center gap-1">
+                              <span className="truncate">{item.account || "—"}</span>
+                              <span aria-hidden="true" className="text-slate-500">
+                                →
+                              </span>
+                              <span className="truncate">{item.to_account || "—"}</span>
+                            </span>
+                          ) : (
+                            <span className="truncate">{item.account || "—"}</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-4 align-middle text-sm text-slate-200">
+                          {tags.length ? (
+                            <div className="flex flex-wrap gap-2">
+                              {tags.map((tag) => (
+                                <span
+                                  key={tag}
+                                  className="inline-flex items-center rounded-full bg-slate-900 px-3 py-1 text-xs text-slate-300 ring-1 ring-slate-800"
+                                >
+                                  {tag}
+                                </span>
+                              ))}
+                            </div>
+                          ) : (
+                            <span className="text-slate-500">—</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-4 align-middle">
+                          <span className={clsx("font-mono text-sm font-semibold", amountTone, "block text-right")}>{formatAmount(item.amount)}</span>
+                        </td>
+                        <td className="px-4 py-4 align-middle">
+                          <div className="flex justify-end gap-2">
+                            <button
+                              type="button"
+                              onClick={() => onEdit(item)}
+                              className="flex h-9 w-9 items-center justify-center rounded-full bg-slate-900 text-slate-300 ring-1 ring-slate-700 transition hover:bg-slate-800 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+                              aria-label="Edit transaksi"
+                            >
+                              <Pencil className="h-4 w-4" aria-hidden="true" />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => onDelete(item)}
+                              disabled={deleteDisabled}
+                              className="flex h-9 w-9 items-center justify-center rounded-full bg-rose-500/10 text-rose-300 ring-1 ring-rose-400/40 transition hover:bg-rose-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-60"
+                              aria-label="Hapus transaksi"
+                            >
+                              <Trash2 className="h-4 w-4" aria-hidden="true" />
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+            </tbody>
+          </table>
+        </div>
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-slate-800 px-4 py-3 text-sm text-slate-400">
+          <span>
+            Menampilkan {displayStart}&ndash;{displayEnd} dari {total} transaksi
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => onPageChange(page - 1)}
+              disabled={!hasPrev || loading}
+              className="inline-flex h-9 items-center justify-center rounded-2xl bg-slate-900/60 px-4 text-sm font-medium text-slate-200 ring-1 ring-slate-800 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Sebelumnya
+            </button>
+            <button
+              type="button"
+              onClick={() => onPageChange(page + 1)}
+              disabled={!hasNext || loading}
+              className="inline-flex h-9 items-center justify-center rounded-2xl bg-slate-900/60 px-4 text-sm font-medium text-slate-200 ring-1 ring-slate-800 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Selanjutnya
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SkeletonRow() {
+  return (
+    <tr className="animate-pulse">
+      <td className="px-4 py-4">
+        <div className="mx-auto h-4 w-4 rounded bg-slate-800" />
+      </td>
+      <td className="px-4 py-4">
+        <div className="flex items-center gap-3">
+          <span className="h-3 w-3 rounded-full bg-slate-800" />
+          <div className="flex-1 space-y-2">
+            <div className="h-3 w-32 rounded-full bg-slate-800" />
+            <div className="h-3 w-48 rounded-full bg-slate-800/70" />
+          </div>
+        </div>
+      </td>
+      <td className="px-4 py-4">
+        <div className="h-3 w-24 rounded-full bg-slate-800" />
+      </td>
+      <td className="px-4 py-4">
+        <div className="h-3 w-24 rounded-full bg-slate-800" />
+      </td>
+      <td className="px-4 py-4">
+        <div className="flex gap-2">
+          <span className="h-5 w-16 rounded-full bg-slate-800" />
+          <span className="h-5 w-16 rounded-full bg-slate-800/80" />
+        </div>
+      </td>
+      <td className="px-4 py-4">
+        <div className="ml-auto h-3 w-20 rounded-full bg-slate-800" />
+      </td>
+      <td className="px-4 py-4">
+        <div className="ml-auto flex w-20 justify-end gap-2">
+          <span className="h-9 w-9 rounded-full bg-slate-800" />
+          <span className="h-9 w-9 rounded-full bg-slate-800/80" />
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+function SortIndicator({ active, direction }: { active: boolean; direction: "asc" | "desc" }) {
+  if (!active) {
+    return <span aria-hidden="true" className="text-slate-600">⇅</span>;
+  }
+  return (
+    <span aria-hidden="true" className="text-[var(--accent)]">
+      {direction === "asc" ? "▲" : "▼"}
+    </span>
+  );
+}

--- a/src/hooks/useTransactionsQuery.js
+++ b/src/hooks/useTransactionsQuery.js
@@ -204,9 +204,18 @@ export default function useTransactionsQuery() {
     [updateParams],
   );
 
+  const goToPage = useCallback(
+    (nextPage) => {
+      const value = Number.isFinite(nextPage) ? nextPage : page;
+      const safePage = value > 0 ? Math.floor(value) : 1;
+      updateParams({}, safePage);
+    },
+    [page, updateParams],
+  );
+
   const loadMore = useCallback(() => {
-    updateParams({}, page + 1);
-  }, [page, updateParams]);
+    goToPage(page + 1);
+  }, [goToPage, page]);
 
   const refresh = useCallback(
     ({ keepPage = false } = {}) => {
@@ -232,6 +241,7 @@ export default function useTransactionsQuery() {
     filter,
     setFilter,
     loadMore,
+    goToPage,
     refresh,
     categories,
     summary,

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -1,24 +1,24 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 import { useNavigate } from "react-router-dom";
 import clsx from "clsx";
 import {
   AlertTriangle,
-  ArrowRight,
   ArrowRightLeft,
-  ChevronDown,
   Check,
+  ChevronDown,
   Download,
   Inbox,
   Loader2,
-  Paperclip,
   Pencil,
   Plus,
-  Search,
   Trash2,
   Upload,
   X,
 } from "lucide-react";
+import TransactionsFilters from "../components/transactions/TransactionsFilters";
+import TransactionsTable from "../components/transactions/TransactionsTable";
+import TransactionsCardList from "../components/transactions/TransactionsCardList";
+import BatchToolbar from "../components/transactions/BatchToolbar";
 import useTransactionsQuery from "../hooks/useTransactionsQuery";
 import useNetworkStatus from "../hooks/useNetworkStatus";
 import { useToast } from "../context/ToastContext";
@@ -59,21 +59,10 @@ const PAGE_DESCRIPTION = "Kelola catatan keuangan";
 
 const FILTER_PANEL_BREAKPOINT = 768;
 const FILTER_PANEL_STORAGE_KEY = "transactions-filter-open";
-const MOBILE_BREAKPOINT = 992;
-
-function detectTableVariant() {
-  if (typeof window === "undefined") return "table";
-  return window.innerWidth < MOBILE_BREAKPOINT ? "card" : "table";
-}
 
 function toDateInput(value) {
   if (!value) return "";
   return String(value).slice(0, 10);
-}
-
-function currentMonthValue() {
-  const now = new Date();
-  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
 }
 
 function formatIDR(value) {
@@ -113,12 +102,12 @@ export default function Transactions() {
   const {
     items: queryItems,
     total,
-    hasMore,
+    page,
     loading,
     error,
     filter,
     setFilter,
-    loadMore,
+    goToPage,
     refresh,
     categories,
     summary,
@@ -142,7 +131,6 @@ export default function Transactions() {
   const lastSelectedIdRef = useRef(null);
   const [searchTerm, setSearchTerm] = useState(filter.search);
   const [filterBarStuck, setFilterBarStuck] = useState(false);
-  const [tableVariant, setTableVariant] = useState(() => detectTableVariant());
   const [deleteInProgress, setDeleteInProgress] = useState(false);
   const [confirmState, setConfirmState] = useState(null);
   const undoTimerRef = useRef(null);
@@ -173,15 +161,6 @@ export default function Transactions() {
   useEffect(() => {
     setSearchTerm(filter.search);
   }, [filter.search]);
-
-  useEffect(() => {
-    const handleResize = () => {
-      setTableVariant(detectTableVariant());
-    };
-    handleResize();
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
@@ -340,12 +319,18 @@ export default function Transactions() {
     return map;
   }, [categories]);
 
+  const visibleItems = useMemo(() => {
+    if (!Array.isArray(items) || items.length === 0) return [];
+    const start = Math.max(0, (page - 1) * pageSize);
+    return items.slice(start, start + pageSize);
+  }, [items, page, pageSize]);
+
   const selectedItems = useMemo(
     () => items.filter((item) => selectedIds.has(item.id)),
     [items, selectedIds],
   );
 
-  const allSelected = items.length > 0 && items.every((item) => selectedIds.has(item.id));
+  const allSelected = visibleItems.length > 0 && visibleItems.every((item) => selectedIds.has(item.id));
 
   const activeChips = useMemo(() => {
     const chips = [];
@@ -382,13 +367,13 @@ export default function Transactions() {
         const next = new Set(prev);
         const currentlySelected = next.has(id);
         desiredState = event?.target?.checked ?? !currentlySelected;
-        if (!items.length) {
+        if (!visibleItems.length) {
           if (desiredState) next.add(id);
           else next.delete(id);
           return next;
         }
         if (isShiftKey && lastSelectedIdRef.current) {
-          const ids = items.map((item) => item.id);
+          const ids = visibleItems.map((item) => item.id);
           const currentIndex = ids.indexOf(id);
           const lastIndex = ids.indexOf(lastSelectedIdRef.current);
           if (currentIndex !== -1 && lastIndex !== -1) {
@@ -410,20 +395,24 @@ export default function Transactions() {
         lastSelectedIdRef.current = id;
       }
     },
-    [items],
+    [visibleItems],
   );
 
   const toggleSelectAll = useCallback(() => {
-    setSelectedIds(() => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (!visibleItems.length) return next;
+      const ids = visibleItems.map((item) => item.id);
       if (allSelected) {
+        ids.forEach((itemId) => next.delete(itemId));
         lastSelectedIdRef.current = null;
-        return new Set();
+        return next;
       }
-      const ids = items.map((item) => item.id);
+      ids.forEach((itemId) => next.add(itemId));
       lastSelectedIdRef.current = ids[ids.length - 1] ?? null;
-      return new Set(ids);
+      return next;
     });
-  }, [allSelected, items]);
+  }, [allSelected, visibleItems]);
 
   const handleRemoveChip = useCallback(
     (chip) => {
@@ -709,7 +698,6 @@ export default function Transactions() {
   }, [navigate]);
 
   const tableStickyTop = `calc(var(--app-header-height, var(--app-topbar-h, 64px)) + ${filterBarHeight}px + 16px)`;
-  const selectionToolbarOffset = tableStickyTop ? `calc(${tableStickyTop} + 12px)` : "16px";
   const isFilterPanelVisible = isDesktopFilterView || filterPanelOpen;
   const activeFilterCount = activeChips.length;
 
@@ -792,27 +780,24 @@ export default function Transactions() {
             aria-hidden={!isDesktopFilterView && !isFilterPanelVisible}
             inert={!isDesktopFilterView && !isFilterPanelVisible ? "" : undefined}
             className={clsx(
-              "rounded-2xl border border-white/10 bg-slate-900/60 transition-[max-height,opacity] duration-200 ease-in-out",
+              "transition-[max-height,opacity] duration-200 ease-in-out",
               "md:max-h-none md:opacity-100 md:transition-none md:overflow-visible md:pointer-events-auto",
               !isDesktopFilterView && "overflow-hidden",
               !isDesktopFilterView && isFilterPanelVisible && "mt-3",
               !isDesktopFilterView && !isFilterPanelVisible && "pointer-events-none",
               isFilterPanelVisible ? "max-h-[1200px] opacity-100" : "max-h-0 opacity-0",
-              filterBarStuck && isFilterPanelVisible && "border-white/15 shadow-[0_12px_30px_-16px_rgba(15,23,42,0.85)]",
             )}
-            style={{
-              backdropFilter: "blur(6px)",
-              WebkitBackdropFilter: "blur(6px)",
-            }}
           >
-            <TransactionsFilterBar
+            <TransactionsFilters
               filter={filter}
               categories={categories}
               searchTerm={searchTerm}
               onSearchChange={setSearchTerm}
               onFilterChange={setFilter}
               searchInputRef={searchInputRef}
-              onOpenAdd={handleNavigateToAdd}
+              onClear={handleResetFilters}
+              sort={filter.sort}
+              onSortChange={(value) => setFilter({ sort: value })}
             />
           </div>
         </div>
@@ -846,40 +831,90 @@ export default function Transactions() {
         )}
 
         {selectedIds.size > 0 && (
-          <SelectionToolbar
+          <BatchToolbar
             count={selectedIds.size}
             onClear={() => {
               setSelectedIds(new Set());
               lastSelectedIdRef.current = null;
             }}
             onDelete={handleRequestBulkDelete}
-            onEditCategory={() => setBulkEditMode("category")}
-            onEditAccount={() => setBulkEditMode("account")}
+            onChangeCategory={() => setBulkEditMode("category")}
             deleting={deleteInProgress}
             updating={bulkUpdating}
-            topOffset={selectionToolbarOffset}
+            secondaryAction={
+              <button
+                type="button"
+                onClick={() => setBulkEditMode("account")}
+                disabled={bulkUpdating}
+                className="inline-flex h-11 flex-1 items-center justify-center gap-2 rounded-2xl bg-slate-900/70 px-4 text-sm font-semibold text-slate-200 ring-1 ring-slate-800 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60 sm:flex-initial"
+              >
+                {bulkUpdating ? (
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                ) : (
+                  <ArrowRightLeft className="h-4 w-4" aria-hidden="true" />
+                )}
+                Ubah Akun
+              </button>
+            }
           />
         )}
 
         <TransactionsTable
-          items={items}
+          items={visibleItems}
           loading={loading}
           error={error}
           onRetry={() => refresh({ keepPage: true })}
-          onLoadMore={loadMore}
-          hasMore={hasMore}
+          selectedIds={selectedIds}
           onToggleSelect={toggleSelect}
           onToggleSelectAll={toggleSelectAll}
           allSelected={allSelected}
-          selectedIds={selectedIds}
           onDelete={handleRequestDelete}
           onEdit={handleEditTransaction}
+          formatAmount={formatIDR}
+          formatDate={formatTransactionDate}
+          toDateValue={toDateInput}
+          parseTags={parseTags}
+          typeLabels={TYPE_LABELS}
+          sort={filter.sort}
+          onSortChange={(value) => setFilter({ sort: value })}
           tableStickyTop={tableStickyTop}
-          variant={tableVariant}
-          onResetFilters={handleResetFilters}
+          page={page}
+          pageSize={pageSize}
           total={total}
-          onOpenAdd={handleNavigateToAdd}
+          onPageChange={goToPage}
           deleteDisabled={deleteInProgress}
+          emptyState={
+            <EmptyTransactionsState
+              onResetFilters={handleResetFilters}
+              onOpenAdd={handleNavigateToAdd}
+            />
+          }
+        />
+        <TransactionsCardList
+          items={visibleItems}
+          loading={loading}
+          error={error}
+          onRetry={() => refresh({ keepPage: true })}
+          selectedIds={selectedIds}
+          onToggleSelect={toggleSelect}
+          onDelete={handleRequestDelete}
+          onEdit={handleEditTransaction}
+          formatAmount={formatIDR}
+          formatDate={formatTransactionDate}
+          toDateValue={toDateInput}
+          parseTags={parseTags}
+          typeLabels={TYPE_LABELS}
+          page={page}
+          pageSize={pageSize}
+          total={total}
+          onPageChange={goToPage}
+          deleteDisabled={deleteInProgress}
+          emptyState={
+            <EmptyTransactionsState
+              onResetFilters={handleResetFilters}
+              onOpenAdd={handleNavigateToAdd}
+            />
+          }
         />
 
         {confirmState && (
@@ -971,490 +1006,6 @@ export default function Transactions() {
   );
 }
 
-function TransactionsFilterBar({
-  filter,
-  categories,
-  searchTerm,
-  onSearchChange,
-  onFilterChange,
-  searchInputRef,
-  onOpenAdd = () => {},
-}) {
-  const currentMonth = currentMonthValue();
-  const customButtonRef = useRef(null);
-  const actualSearchInputRef = useRef(null);
-  const [customOpen, setCustomOpen] = useState(false);
-  const typeSelectId = useId();
-  const sortSelectId = useId();
-  const searchInputId = useId();
-
-  useEffect(() => {
-    if (!searchInputRef) return;
-    searchInputRef.current = {
-      focus: () => {
-        actualSearchInputRef.current?.focus();
-        actualSearchInputRef.current?.select();
-      },
-    };
-  }, [searchInputRef]);
-
-  useEffect(() => {
-    if (filter.period.preset !== "custom") {
-      setCustomOpen(false);
-    }
-  }, [filter.period.preset]);
-
-  const handlePresetChange = (preset) => {
-    if (preset === "custom" && filter.period.preset === "custom") {
-      setCustomOpen((prev) => !prev);
-      return;
-    }
-    if (preset === "all") {
-      onFilterChange({ period: { preset: "all", month: "", start: "", end: "" } });
-      setCustomOpen(false);
-      return;
-    }
-    if (preset === "month") {
-      onFilterChange({ period: { preset: "month", month: filter.period.month || currentMonth, start: "", end: "" } });
-      setCustomOpen(false);
-      return;
-    }
-    if (preset === "week") {
-      onFilterChange({ period: { preset: "week", month: "", start: "", end: "" } });
-      setCustomOpen(false);
-      return;
-    }
-    if (preset === "custom") {
-      const today = new Date().toISOString().slice(0, 10);
-      onFilterChange({ period: { preset: "custom", month: "", start: filter.period.start || today, end: filter.period.end || today } });
-      setCustomOpen(true);
-    }
-  };
-
-  const handleCategoryChange = (selected) => {
-    onFilterChange({ categories: selected });
-  };
-
-  const handleReset = () => {
-    onFilterChange({
-      period: { preset: "all", month: "", start: "", end: "" },
-      categories: [],
-      type: "all",
-      sort: "date-desc",
-      search: "",
-    });
-    onSearchChange("");
-  };
-
-  const handleSearchChange = (value) => {
-    onSearchChange(value);
-  };
-
-  const handleTypeChange = (value) => {
-    onFilterChange({ type: value });
-  };
-
-  const handleSortChange = (value) => {
-    onFilterChange({ sort: value });
-  };
-
-  return (
-    <div className="space-y-4 rounded-2xl border border-white/10 bg-slate-900/70 p-4 text-white shadow">
-      <div
-        role="toolbar"
-        aria-label="Filter transaksi"
-        className="grid grid-cols-2 items-center gap-3 md:grid-cols-6"
-      >
-        <div className="col-span-2 min-w-0 md:col-span-2">
-          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-white/60">
-            Rentang Waktu
-          </p>
-          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 md:grid-cols-2 lg:grid-cols-4">
-            {Object.entries(PERIOD_LABELS).map(([value, label]) => (
-              <button
-                key={value}
-                type="button"
-                onClick={() => handlePresetChange(value)}
-                ref={value === "custom" ? customButtonRef : undefined}
-                className={clsx(
-                  "inline-flex h-[40px] items-center justify-center rounded-xl border border-white/10 bg-white/5 px-3 text-sm font-semibold text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60",
-                  filter.period.preset === value
-                    ? "bg-brand text-white shadow"
-                    : "text-white/70 hover:bg-white/10",
-                )}
-                aria-pressed={filter.period.preset === value}
-              >
-                {label}
-              </button>
-            ))}
-          </div>
-        </div>
-        <div className="col-span-2 min-w-0 md:col-span-1">
-          <CategoryMultiSelect
-            categories={categories}
-            selected={filter.categories}
-            onChange={handleCategoryChange}
-            ariaLabel="Filter kategori transaksi"
-          />
-        </div>
-        <div className="col-span-2 min-w-0 md:col-span-1">
-          <label htmlFor={typeSelectId} className="sr-only">
-            Filter jenis transaksi
-          </label>
-          <select
-            id={typeSelectId}
-            value={filter.type}
-            onChange={(event) => handleTypeChange(event.target.value)}
-            aria-label="Filter jenis transaksi"
-            className="h-[40px] w-full rounded-xl border border-white/10 bg-white/5 px-3 text-sm font-medium text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-          >
-            <option value="all">Semua</option>
-            <option value="expense">Pengeluaran</option>
-            <option value="income">Pemasukan</option>
-            <option value="transfer">Transfer</option>
-          </select>
-        </div>
-        <div className="col-span-2 min-w-0 md:col-span-1">
-          <label htmlFor={sortSelectId} className="sr-only">
-            Urutkan transaksi
-          </label>
-          <select
-            id={sortSelectId}
-            value={filter.sort}
-            onChange={(event) => handleSortChange(event.target.value)}
-            aria-label="Urutkan transaksi"
-            className="h-[40px] w-full rounded-xl border border-white/10 bg-white/5 px-3 text-sm font-medium text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-          >
-            <option value="date-desc">Terbaru</option>
-            <option value="date-asc">Terlama</option>
-            <option value="amount-desc">Terbesar</option>
-            <option value="amount-asc">Terkecil</option>
-          </select>
-        </div>
-        <div className="col-span-2 min-w-0 md:col-span-1">
-          <div className="relative min-w-0">
-            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-white/40" aria-hidden="true" />
-            <input
-              id={searchInputId}
-              ref={actualSearchInputRef}
-              type="search"
-              value={searchTerm}
-              onChange={(event) => handleSearchChange(event.target.value)}
-              placeholder="Cari judul/catatan…"
-              aria-label="Cari transaksi"
-              className="h-[40px] w-full rounded-xl border border-white/10 bg-white/5 pl-9 pr-3 text-sm text-white placeholder:text-white/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-            />
-          </div>
-        </div>
-        <div className="col-span-2 flex min-w-0 flex-wrap items-center justify-end gap-2 md:col-span-6 md:flex-nowrap md:gap-3">
-          <button
-            type="button"
-            onClick={handleReset}
-            className="inline-flex h-[40px] items-center rounded-xl border border-white/10 bg-white/5 px-3 text-sm font-medium text-white/80 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-            aria-label="Reset semua filter"
-          >
-            Reset
-          </button>
-          <button
-            type="button"
-            onClick={onOpenAdd}
-            className="inline-flex h-[40px] items-center gap-2 rounded-xl bg-brand px-4 text-sm font-semibold text-white shadow transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-            aria-label="Tambah transaksi"
-          >
-            <Plus className="h-4 w-4" /> Tambah Transaksi
-          </button>
-        </div>
-      </div>
-      {customOpen && filter.period.preset === "custom" && (
-        <CustomRangePopover
-          anchorRef={customButtonRef}
-          period={filter.period}
-          onChange={(next) => onFilterChange({ period: next })}
-          onClose={() => setCustomOpen(false)}
-        />
-      )}
-    </div>
-  );
-}
-
-
-function CategoryMultiSelect({ categories = [], selected = [], onChange, ariaLabel }) {
-  const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState("");
-  const triggerRef = useRef(null);
-  const panelRef = useRef(null);
-  const [position, setPosition] = useState({ top: 0, left: 0, width: 0 });
-
-  useEffect(() => {
-    if (!open) return;
-    const updatePosition = () => {
-      const anchor = triggerRef.current;
-      if (!anchor) return;
-      const rect = anchor.getBoundingClientRect();
-      const preferredWidth = Math.min(320, Math.max(260, rect.width || 260));
-      const left = Math.min(
-        Math.max(16, rect.left),
-        window.innerWidth - preferredWidth - 16,
-      );
-      setPosition({
-        top: rect.bottom + 8,
-        left,
-        width: preferredWidth,
-      });
-    };
-    updatePosition();
-    window.addEventListener("resize", updatePosition);
-    window.addEventListener("scroll", updatePosition, true);
-    return () => {
-      window.removeEventListener("resize", updatePosition);
-      window.removeEventListener("scroll", updatePosition, true);
-    };
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const handleClick = (event) => {
-      if (triggerRef.current?.contains(event.target)) return;
-      if (panelRef.current?.contains(event.target)) return;
-      setOpen(false);
-    };
-    const handleKey = (event) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        setOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClick);
-    document.addEventListener("keydown", handleKey);
-    return () => {
-      document.removeEventListener("mousedown", handleClick);
-      document.removeEventListener("keydown", handleKey);
-    };
-  }, [open]);
-
-  useEffect(() => {
-    if (open) {
-      setQuery("");
-    }
-  }, [open]);
-
-  const toggle = (id) => {
-    const set = new Set(selected);
-    if (set.has(id)) set.delete(id);
-    else set.add(id);
-    onChange(Array.from(set));
-  };
-
-  const clearAll = () => {
-    onChange([]);
-  };
-
-  const filteredCategories = useMemo(() => {
-    const term = query.trim().toLowerCase();
-    if (!term) return categories;
-    return categories.filter((cat) => {
-      return (
-        cat.name?.toLowerCase().includes(term) ||
-        (TYPE_LABELS[cat.type] || "").toLowerCase().includes(term)
-      );
-    });
-  }, [categories, query]);
-
-  const summaryLabel = useMemo(() => {
-    if (!selected.length) return "Semua kategori";
-    if (selected.length === 1) {
-      const match = categories.find((cat) => cat.id === selected[0]);
-      return match?.name || "1 dipilih";
-    }
-    return `${selected.length} dipilih`;
-  }, [categories, selected]);
-
-  const label = ariaLabel || "Pilih kategori transaksi";
-
-  return (
-    <>
-      <button
-        type="button"
-        ref={triggerRef}
-        onClick={() => setOpen((prev) => !prev)}
-        className="inline-flex h-[40px] w-full min-w-0 flex-shrink-0 items-center justify-between rounded-xl border border-white/10 bg-white/5 px-3 text-sm font-medium text-white transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        aria-label={label}
-      >
-        <span className="truncate">{summaryLabel}</span>
-        <ChevronDown className="h-4 w-4 text-white/60" aria-hidden="true" />
-      </button>
-      {open &&
-        createPortal(
-          <div className="fixed inset-0 z-40" role="presentation">
-            <div
-              ref={panelRef}
-              role="listbox"
-              aria-multiselectable="true"
-              className="absolute max-h-[320px] w-[min(320px,calc(100%-32px))] overflow-hidden rounded-2xl border border-white/10 bg-slate-900/95 shadow-2xl backdrop-blur"
-              style={{ top: position.top, left: position.left, width: position.width || undefined }}
-              data-role="category-panel"
-            >
-              <div className="flex items-center justify-between px-3 pt-3">
-                <span className="text-xs font-semibold uppercase tracking-wide text-white/60">Kategori</span>
-                <button
-                  type="button"
-                  onClick={clearAll}
-                  className="rounded-full px-2 py-1 text-xs text-white/60 transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-                >
-                  Reset
-                </button>
-              </div>
-              <div className="px-3 pb-2">
-                <div className="flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-3">
-                  <Search className="h-4 w-4 text-white/40" aria-hidden="true" />
-                  <input
-                    type="search"
-                    value={query}
-                    onChange={(event) => setQuery(event.target.value)}
-                    placeholder="Cari kategori"
-                    className="h-9 w-full bg-transparent text-sm text-white placeholder:text-white/40 focus-visible:outline-none"
-                    aria-label="Cari kategori"
-                  />
-                </div>
-              </div>
-              <div className="max-h-[220px] overflow-y-auto px-1 pb-3">
-                {filteredCategories.length ? (
-                  filteredCategories.map((cat) => {
-                    const checked = selected.includes(cat.id);
-                    return (
-                      <button
-                        key={cat.id}
-                        type="button"
-                        onClick={() => toggle(cat.id)}
-                        className={clsx(
-                          "flex w-full items-center justify-between rounded-xl px-3 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60",
-                          checked ? "bg-white/10 text-white" : "text-white/80 hover:bg-white/5",
-                        )}
-                        role="option"
-                        aria-selected={checked}
-                      >
-                      <div className="flex flex-col text-left">
-                        <span className="font-medium text-white">{cat.name}</span>
-                      </div>
-                        {checked ? (
-                          <Check className="h-4 w-4 text-brand" aria-hidden="true" />
-                        ) : (
-                          <span className="h-4 w-4 rounded-full border border-white/30" aria-hidden="true" />
-                        )}
-                      </button>
-                    );
-                  })
-                ) : (
-                  <p className="px-3 py-6 text-center text-sm text-white/50">Tidak ada kategori ditemukan.</p>
-                )}
-              </div>
-            </div>
-          </div>,
-          document.body,
-        )}
-    </>
-  );
-}
-
-function CustomRangePopover({ anchorRef, period, onChange, onClose }) {
-  const popoverRef = useRef(null);
-  const [position, setPosition] = useState({ top: 0, left: 0 });
-
-  const updatePosition = useCallback(() => {
-    const anchor = anchorRef?.current;
-    if (!anchor) return;
-    const rect = anchor.getBoundingClientRect();
-    const width = Math.min(360, Math.max(280, rect.width + 120));
-    const left = Math.min(
-      Math.max(16, rect.left - (width - rect.width) / 2),
-      window.innerWidth - width - 16,
-    );
-    setPosition({
-      top: rect.bottom + 8,
-      left,
-      width,
-    });
-  }, [anchorRef]);
-
-  useEffect(() => {
-    updatePosition();
-    window.addEventListener("resize", updatePosition);
-    window.addEventListener("scroll", updatePosition, true);
-    return () => {
-      window.removeEventListener("resize", updatePosition);
-      window.removeEventListener("scroll", updatePosition, true);
-    };
-  }, [updatePosition]);
-
-  useEffect(() => {
-    const handleClick = (event) => {
-      if (anchorRef?.current?.contains(event.target)) return;
-      if (popoverRef.current?.contains(event.target)) return;
-      onClose();
-    };
-    const handleKey = (event) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onClose();
-      }
-    };
-    document.addEventListener("mousedown", handleClick);
-    document.addEventListener("keydown", handleKey);
-    return () => {
-      document.removeEventListener("mousedown", handleClick);
-      document.removeEventListener("keydown", handleKey);
-    };
-  }, [anchorRef, onClose]);
-
-  const content = (
-    <div className="fixed inset-0 z-40" role="presentation">
-      <div
-        ref={popoverRef}
-        className="absolute w-[min(360px,calc(100%-32px))] rounded-2xl border border-white/10 bg-slate-900/95 p-4 shadow-2xl backdrop-blur"
-        style={{ top: position.top, left: position.left, width: position.width || undefined }}
-        data-role="custom-range"
-      >
-        <p className="text-xs font-semibold uppercase tracking-wide text-white/60">Rentang custom</p>
-        <div className="mt-3 grid gap-3 sm:grid-cols-2">
-          <label className="flex flex-col gap-2 text-xs text-white/60">
-            <span className="font-medium text-white/70">Mulai</span>
-            <input
-              type="date"
-              value={period.start || ""}
-              onChange={(event) => onChange({ ...period, start: event.target.value })}
-              className="h-11 rounded-xl border border-white/10 bg-white/5 px-3 text-sm text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-            />
-          </label>
-          <label className="flex flex-col gap-2 text-xs text-white/60">
-            <span className="font-medium text-white/70">Selesai</span>
-            <input
-              type="date"
-              value={period.end || ""}
-              min={period.start || undefined}
-              onChange={(event) => onChange({ ...period, end: event.target.value })}
-              className="h-11 rounded-xl border border-white/10 bg-white/5 px-3 text-sm text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-            />
-          </label>
-        </div>
-        <div className="mt-3 flex items-center justify-between text-xs text-white/50">
-          <span>Pilih rentang tanggal sesuai kebutuhan.</span>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-full px-3 py-1 text-xs font-semibold text-white/80 transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-          >
-            Selesai
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-
-  return createPortal(content, document.body);
-}
-
 function ActiveFilterChips({ chips, onRemove }) {
   if (!chips?.length) return null;
   return (
@@ -1516,502 +1067,28 @@ function SummaryCards({ summary, loading }) {
   );
 }
 
-function SelectionToolbar({
-  count,
-  onClear,
-  onDelete,
-  onEditCategory,
-  onEditAccount,
-  deleting,
-  updating,
-  topOffset,
-}) {
-  return (
-    <div
-      className="pointer-events-none sticky bottom-4 z-30 md:bottom-auto md:top-0 md:sticky"
-      style={topOffset ? { top: topOffset } : undefined}
-      aria-live="polite"
-    >
-      <div className="pointer-events-auto mx-auto flex w-full max-w-[720px] flex-col gap-3 rounded-2xl border border-border bg-surface/95 p-4 shadow-lg shadow-black/5 md:flex-row md:items-center md:justify-between md:px-6">
-        <div className="flex flex-1 flex-wrap items-center gap-3">
-          <span className="inline-flex items-center gap-2 rounded-full bg-brand/10 px-3 py-1 text-sm font-semibold text-brand">
-            {count} dipilih
-          </span>
-          <button
-            type="button"
-            onClick={onClear}
-            className="text-sm font-medium text-muted transition hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-          >
-            Batal
-          </button>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <button
-            type="button"
-            onClick={onEditCategory}
-            disabled={updating}
-            className="inline-flex h-11 items-center justify-center gap-2 rounded-2xl border border-border px-4 text-sm font-medium text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {updating ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Pencil className="h-4 w-4" aria-hidden="true" />}
-            Ubah kategori
-          </button>
-          <button
-            type="button"
-            onClick={onEditAccount}
-            disabled={updating}
-            className="inline-flex h-11 items-center justify-center gap-2 rounded-2xl border border-border px-4 text-sm font-medium text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {updating ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <ArrowRightLeft className="h-4 w-4" aria-hidden="true" />}
-            Ubah akun
-          </button>
-          <button
-            type="button"
-            onClick={onDelete}
-            disabled={deleting}
-            className="inline-flex h-11 items-center justify-center gap-2 rounded-2xl bg-danger px-4 text-sm font-semibold text-white shadow transition hover:bg-[color:var(--color-danger-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-ring-danger)] disabled:cursor-not-allowed disabled:opacity-70"
-          >
-            {deleting ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Trash2 className="h-4 w-4" aria-hidden="true" />}
-            Hapus
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function TransactionsTable({
-  items,
-  loading,
-  error,
-  onRetry,
-  onLoadMore,
-  hasMore,
-  onToggleSelect,
-  onToggleSelectAll,
-  allSelected,
-  selectedIds,
-  onDelete,
-  onEdit,
-  tableStickyTop,
-  total,
-  variant = "table",
-  onResetFilters = () => {},
-  onOpenAdd = () => {},
-  deleteDisabled = false,
-}) {
-  const isCardVariant = variant === "card";
-  const isInitialLoading = loading && items.length === 0;
-  const isFetchingMore = loading && items.length > 0;
-  const displayStart = items.length > 0 ? 1 : 0;
-  const displayEnd = items.length;
-  const stickyHeaderStyle = tableStickyTop ? { top: tableStickyTop } : undefined;
-
-  if (error && !items.length) {
-    return (
-      <div className="rounded-2xl border border-danger/30 bg-danger/10 p-6 text-center">
-        <p className="mb-3 text-sm font-medium text-danger">Gagal memuat data transaksi.</p>
-        <button
-          type="button"
-          onClick={onRetry}
-          className="inline-flex h-11 items-center justify-center rounded-2xl border border-danger/40 bg-white/80 px-4 text-sm font-semibold text-danger transition hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-ring-danger)]"
-        >
-          Coba lagi
-        </button>
-      </div>
-    );
-  }
-
-  if (!loading && !items.length) {
-    return <EmptyTransactionsState onResetFilters={onResetFilters} onOpenAdd={onOpenAdd} />;
-  }
-
-  return (
-    <section className="space-y-4">
-      <div className={clsx("rounded-2xl border border-border bg-surface shadow-sm", isCardVariant ? "p-3" : "") }>
-        {isCardVariant ? (
-          <div className="flex flex-col gap-3">
-            {items.map((item) => (
-              <TransactionItem
-                key={item.id}
-                item={item}
-                variant="card"
-                isSelected={selectedIds.has(item.id)}
-                onToggleSelect={(event) => onToggleSelect(item.id, event)}
-                onDelete={() => onDelete(item.id)}
-                onEdit={() => onEdit(item)}
-                deleteDisabled={deleteDisabled}
-              />
-            ))}
-            {isInitialLoading &&
-              Array.from({ length: 6 }).map((_, index) => <TransactionSkeletonCard key={`card-skeleton-${index}`} />)}
-            {isFetchingMore &&
-              !isInitialLoading &&
-              Array.from({ length: 2 }).map((_, index) => <TransactionSkeletonCard key={`card-fetch-${index}`} />)}
-          </div>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full table-fixed border-separate border-spacing-0" aria-label="Daftar transaksi">
-              <thead
-                className="sticky top-0 z-10 border-b border-border/70 bg-surface-1/95 text-xs font-semibold uppercase tracking-wide text-muted backdrop-blur"
-                style={stickyHeaderStyle}
-              >
-                <tr>
-                  <th scope="col" className="w-12 px-3 py-3 text-center">
-                    <input
-                      type="checkbox"
-                      checked={allSelected}
-                      onChange={onToggleSelectAll}
-                      className="h-4 w-4 rounded border-border/70 text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-                      aria-label="Pilih semua transaksi"
-                    />
-                  </th>
-                  <th scope="col" className="min-w-[200px] px-3 py-3 text-left">Kategori</th>
-                  <th scope="col" className="min-w-[160px] px-3 py-3 text-left">Tanggal</th>
-                  <th scope="col" className="min-w-[240px] px-3 py-3 text-left">Catatan</th>
-                  <th scope="col" className="min-w-[180px] px-3 py-3 text-left">Akun</th>
-                  <th scope="col" className="min-w-[200px] px-3 py-3 text-left">Tags</th>
-                  <th scope="col" className="min-w-[140px] px-3 py-3 text-right">Jumlah</th>
-                  <th scope="col" className="w-[120px] px-3 py-3 text-right">Aksi</th>
-                </tr>
-              </thead>
-              <tbody>
-                {items.map((item) => (
-                  <TransactionItem
-                    key={item.id}
-                    item={item}
-                    variant="table"
-                    isSelected={selectedIds.has(item.id)}
-                    onToggleSelect={(event) => onToggleSelect(item.id, event)}
-                    onDelete={() => onDelete(item.id)}
-                    onEdit={() => onEdit(item)}
-                    deleteDisabled={deleteDisabled}
-                  />
-                ))}
-                {isInitialLoading &&
-                  Array.from({ length: 6 }).map((_, index) => <TransactionSkeletonRow key={`row-skeleton-${index}`} />)}
-                {isFetchingMore &&
-                  !isInitialLoading &&
-                  Array.from({ length: 2 }).map((_, index) => <TransactionSkeletonRow key={`row-fetch-${index}`} />)}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
-      <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted">
-        <span>
-          {total
-            ? `Menampilkan ${displayStart || 0}–${displayEnd} dari ${total}`
-            : `Menampilkan ${displayEnd} transaksi`}
-        </span>
-        {hasMore ? (
-          <button
-            type="button"
-            onClick={onLoadMore}
-            disabled={isFetchingMore}
-            className="inline-flex h-11 items-center gap-2 rounded-2xl border border-border px-4 text-sm font-medium text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {isFetchingMore && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
-            {isFetchingMore ? "Memuat…" : "Muat lagi"}
-          </button>
-        ) : null}
-      </div>
-    </section>
-  );
-}
-
-function UndoSnackbar({ open, message, onUndo, loading }) {
-  if (!open) return null;
-  return createPortal(
-    <div
-      className="fixed inset-x-0 bottom-4 z-40 flex justify-center px-4 sm:bottom-6"
-      role="status"
-      aria-live="polite"
-    >
-      <div className="flex w-full max-w-sm items-center gap-3 rounded-2xl border border-border bg-surface/95 px-4 py-3 text-sm text-text shadow-lg shadow-black/20">
-        <span className="flex-1">{message}</span>
-        <button
-          type="button"
-          onClick={onUndo}
-          disabled={loading}
-          className="inline-flex h-11 items-center justify-center rounded-xl border border-brand/50 px-4 text-sm font-semibold text-brand transition hover:bg-brand/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {loading ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : 'Urungkan'}
-        </button>
-      </div>
-    </div>,
-    document.body,
-  );
-}
-
-function TransactionSkeletonRow() {
-  return (
-    <tr className="border-b border-border/60 last:border-b-0">
-      {Array.from({ length: 8 }).map((_, index) => (
-        <td key={index} className="px-3 py-3 align-middle">
-          <div className="h-4 w-full animate-pulse rounded-full bg-border/60" />
-        </td>
-      ))}
-    </tr>
-  );
-}
-
-function TransactionSkeletonCard() {
-  return (
-    <div className="rounded-2xl border border-border bg-surface/80 p-4 shadow-sm">
-      <div className="mb-3 flex items-center justify-between">
-        <div className="h-4 w-32 animate-pulse rounded-full bg-border/60" />
-        <div className="h-5 w-20 animate-pulse rounded-full bg-border/60" />
-      </div>
-      <div className="grid grid-cols-2 gap-3">
-        <div className="h-4 w-full animate-pulse rounded-full bg-border/60" />
-        <div className="h-4 w-full animate-pulse rounded-full bg-border/60" />
-      </div>
-      <div className="mt-4 h-12 w-full animate-pulse rounded-2xl bg-border/60" />
-    </div>
-  );
-}
-
-function TransactionItem({
-  item,
-  variant = "table",
-  isSelected,
-  onToggleSelect,
-  onDelete,
-  onEdit,
-  deleteDisabled = false,
-}) {
-  const amountTone =
-    item.type === "income"
-      ? "text-success"
-      : item.type === "transfer"
-        ? "text-info"
-        : "text-danger";
-  const amountClass = clsx("text-right text-sm font-semibold tabular-nums", amountTone);
-  const amountCardClass = clsx("text-lg font-semibold tabular-nums", amountTone);
-  const note = item.notes ?? item.note ?? item.title ?? "";
-  const noteDisplay = note.trim() ? note.trim() : "—";
-  const formattedDate = formatTransactionDate(item.date);
-  const dateValue = toDateInput(item.date);
-  const categoryName = item.category || "(Tanpa kategori)";
-  const tags = useMemo(() => parseTags(item.tags), [item.tags]);
-  const hasAttachments = Boolean(item.receipt_url) || (Array.isArray(item.receipts) && item.receipts.length > 0);
-
-  const selectionCheckbox = (
-    <input
-      type="checkbox"
-      checked={isSelected}
-      onChange={onToggleSelect}
-      className="h-4 w-4 rounded border-border/70 text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-      aria-label="Pilih transaksi"
-    />
-  );
-
-  if (variant === "card") {
-    return (
-      <article
-        className={clsx(
-          "rounded-2xl border border-border bg-surface/90 p-4 shadow-sm transition-colors",
-          isSelected && "border-brand/40 bg-brand/5 ring-2 ring-brand/40",
-        )}
-        onDoubleClick={onEdit}
-      >
-        <div className="flex items-start gap-3">
-          <div className="pt-1">{selectionCheckbox}</div>
-          <div className="min-w-0 flex-1 space-y-3">
-            <div className="flex items-start justify-between gap-3">
-              <div className="flex items-center gap-2">
-                <span
-                  className="h-2.5 w-2.5 rounded-full"
-                  style={item.category_color ? { backgroundColor: item.category_color } : undefined}
-                  aria-hidden="true"
-                />
-                <p className="text-sm font-semibold text-text" title={categoryName}>
-                  {categoryName}
-                </p>
-                {hasAttachments && <Paperclip className="h-4 w-4 text-muted" aria-hidden="true" />}
-              </div>
-              <span className={clsx("text-right", amountCardClass)}>{formatIDR(item.amount)}</span>
-            </div>
-            <div className="grid grid-cols-1 gap-3 text-sm text-muted sm:grid-cols-2">
-              <div>
-                <p className="text-xs uppercase tracking-wide">Tanggal</p>
-                <p className="font-medium text-text">
-                  <time dateTime={dateValue}>{formattedDate}</time>
-                </p>
-              </div>
-              <div>
-                <p className="text-xs uppercase tracking-wide">Akun</p>
-                <p className="font-medium text-text">
-                  {item.type === "transfer" ? (
-                    <span className="flex items-center gap-1">
-                      <span className="truncate">{item.account || "—"}</span>
-                      <ArrowRight className="h-4 w-4 text-muted" aria-hidden="true" />
-                      <span className="truncate">{item.to_account || "—"}</span>
-                    </span>
-                  ) : (
-                    <span className="truncate">{item.account || "—"}</span>
-                  )}
-                </p>
-              </div>
-            </div>
-            <p className="line-clamp-2 text-sm text-muted" title={noteDisplay}>
-              {noteDisplay}
-            </p>
-            {tags.length > 0 && (
-              <div className="flex gap-2 overflow-x-auto pb-1">
-                {tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className="inline-flex items-center rounded-full bg-surface-2 px-3 py-1 text-xs font-medium text-text"
-                  >
-                    {tag}
-                  </span>
-                ))}
-              </div>
-            )}
-          </div>
-        </div>
-        <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
-          <button
-            type="button"
-            onClick={onEdit}
-            className="inline-flex h-11 items-center gap-2 rounded-2xl border border-border px-4 text-sm font-medium text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-            aria-label="Edit transaksi"
-          >
-            <Pencil className="h-4 w-4" aria-hidden="true" />
-            Edit
-          </button>
-          <button
-            type="button"
-            onClick={onDelete}
-            disabled={deleteDisabled}
-            className="inline-flex h-11 items-center gap-2 rounded-2xl border border-danger/40 bg-danger/10 px-4 text-sm font-medium text-danger transition hover:bg-danger/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-ring-danger)] disabled:cursor-not-allowed disabled:opacity-60"
-            aria-label="Hapus transaksi"
-          >
-            <Trash2 className="h-4 w-4" aria-hidden="true" />
-            Hapus
-          </button>
-        </div>
-      </article>
-    );
-  }
-
-  return (
-    <tr
-      className={clsx(
-        "border-b border-border/60 last:border-b-0 transition-colors",
-        isSelected
-          ? "bg-brand/10 shadow-[inset_0_0_0_1px_hsl(var(--color-primary)/0.35)]"
-          : "hover:bg-surface-2/60",
-      )}
-      onDoubleClick={onEdit}
-    >
-      <td className="px-3 py-3 align-middle">
-        <div className="flex items-center justify-center">{selectionCheckbox}</div>
-      </td>
-      <td className="px-3 py-3 align-middle">
-        <div className="flex items-center gap-3">
-          <span
-            className="h-2.5 w-2.5 rounded-full"
-            style={item.category_color ? { backgroundColor: item.category_color } : undefined}
-            aria-hidden="true"
-          />
-          <div className="min-w-0">
-            <p className="truncate text-sm font-medium text-text" title={categoryName}>
-              {categoryName}
-            </p>
-            <p className="text-xs uppercase tracking-wide text-muted">{TYPE_LABELS[item.type] || item.type}</p>
-          </div>
-        </div>
-      </td>
-      <td className="px-3 py-3 align-middle text-sm text-muted">
-        <time dateTime={dateValue}>{formattedDate}</time>
-      </td>
-      <td className="px-3 py-3 align-middle">
-        <div className="flex items-start gap-2">
-          <p className="line-clamp-2 text-sm text-text" title={noteDisplay}>
-            {noteDisplay}
-          </p>
-          {hasAttachments && <Paperclip className="mt-0.5 h-4 w-4 text-muted" aria-hidden="true" />}
-        </div>
-      </td>
-      <td className="px-3 py-3 align-middle text-sm text-text">
-        {item.type === "transfer" ? (
-          <div className="flex flex-wrap items-center gap-1">
-            <span className="truncate">{item.account || "—"}</span>
-            <ArrowRight className="h-4 w-4 text-muted" aria-hidden="true" />
-            <span className="truncate">{item.to_account || "—"}</span>
-          </div>
-        ) : (
-          <span className="truncate">{item.account || "—"}</span>
-        )}
-      </td>
-      <td className="px-3 py-3 align-middle">
-        {tags.length > 0 ? (
-          <div className="flex flex-wrap gap-2">
-            {tags.map((tag) => (
-              <span
-                key={tag}
-                className="inline-flex items-center rounded-full bg-surface-2 px-3 py-1 text-xs font-medium text-text"
-              >
-                {tag}
-              </span>
-            ))}
-          </div>
-        ) : (
-          <span className="text-sm text-muted">—</span>
-        )}
-      </td>
-      <td className="px-3 py-3 align-middle">
-        <span className={clsx("block", amountClass)}>{formatIDR(item.amount)}</span>
-      </td>
-      <td className="px-3 py-3 align-middle">
-        <div className="flex items-center justify-end gap-2">
-          <button
-            type="button"
-            onClick={onEdit}
-            className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-border bg-surface text-muted transition hover:border-brand/40 hover:bg-brand/5 hover:text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-            aria-label="Edit transaksi"
-          >
-            <Pencil className="h-4 w-4" aria-hidden="true" />
-          </button>
-          <button
-            type="button"
-            onClick={onDelete}
-            disabled={deleteDisabled}
-            className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-danger/40 bg-danger/10 text-danger transition hover:bg-danger/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-ring-danger)] disabled:cursor-not-allowed disabled:opacity-60"
-            aria-label="Hapus transaksi"
-          >
-            <Trash2 className="h-4 w-4" aria-hidden="true" />
-          </button>
-        </div>
-      </td>
-    </tr>
-  );
-}
-
 function EmptyTransactionsState({ onResetFilters, onOpenAdd }) {
   return (
-    <div className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-border bg-surface/80 px-6 py-16 text-center">
-      <span className="rounded-full bg-brand/10 p-3 text-brand">
-        <Inbox className="h-6 w-6" aria-hidden="true" />
+    <div className="flex flex-col items-center justify-center gap-5 rounded-3xl bg-slate-950/70 px-8 py-16 text-center text-slate-200 ring-1 ring-slate-800">
+      <span className="rounded-full bg-[var(--accent)]/10 p-3 text-[var(--accent)]">
+        <Inbox className="h-7 w-7" aria-hidden="true" />
       </span>
-      <div className="space-y-1">
-        <h2 className="text-lg font-semibold text-text">Belum ada transaksi sesuai filter</h2>
-        <p className="text-sm text-muted">Coba atur ulang filter atau tambahkan transaksi baru.</p>
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">Belum ada transaksi</h2>
+        <p className="text-sm text-slate-400">Coba bersihkan filter atau mulai catat transaksi pertama Anda.</p>
       </div>
-      <div className="flex flex-wrap items-center justify-center gap-2">
+      <div className="flex flex-wrap items-center justify-center gap-3">
         <button
           type="button"
           onClick={onResetFilters}
-          className="inline-flex h-11 items-center justify-center rounded-2xl border border-border px-4 text-sm font-medium text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+          className="inline-flex h-11 items-center justify-center rounded-2xl bg-slate-900 px-4 text-sm font-semibold text-slate-200 ring-1 ring-slate-800 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
         >
-          Reset filter
+          Bersihkan Filter
         </button>
         <button
           type="button"
           onClick={onOpenAdd}
-          className="inline-flex h-11 items-center gap-2 rounded-2xl bg-brand px-4 text-sm font-semibold text-brand-foreground shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+          className="inline-flex h-11 items-center gap-2 rounded-2xl bg-[var(--accent)] px-4 text-sm font-semibold text-white shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
         >
           <Plus className="h-4 w-4" aria-hidden="true" />
           Tambah Transaksi


### PR DESCRIPTION
## Summary
- add responsive transactions table, mobile card list, and shared category dot components
- introduce refreshed filter bar and floating batch action toolbar for multi-select
- wire new UI into Transactions page with pagination support and updated hook navigation

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d663dfd8848332bbc1a72d36bc419b