### PR TITLE
Fix category filter portal target

### DIFF
--- a/src/components/transactions/TransactionsFilters.tsx
+++ b/src/components/transactions/TransactionsFilters.tsx
@@ -354,6 +354,7 @@ function CategoryMultiSelect({ categories, selected, onChange }: CategoryMultiSe
         <ChevronDown className="ml-3 h-4 w-4 text-slate-500" aria-hidden="true" />
       </button>
       {open &&
+        typeof document !== "undefined" &&
         createPortal(
           <div className="fixed inset-0 z-50" role="presentation">
             <div
@@ -414,6 +415,7 @@ function CategoryMultiSelect({ categories, selected, onChange }: CategoryMultiSe
               </div>
             </div>
           </div>,
+          document.body,
         )}
     </div>
   );


### PR DESCRIPTION
## Summary
- ensure the transactions category multi-select renders its portal into document.body to avoid runtime errors when opening the filter

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d66d015d388332afde5e5f43351695