### PR TITLE
Add Anggaran widget to dashboard

### DIFF
--- a/src/components/dashboard/BudgetOverviewCard.tsx
+++ b/src/components/dashboard/BudgetOverviewCard.tsx
@@ -1,0 +1,185 @@
+import { Link } from 'react-router-dom'
+import { PieChart, Wallet, TrendingDown } from 'lucide-react'
+import clsx from 'clsx'
+import { formatCurrency } from '../../lib/format.js'
+import useBudgetOverview from '../../hooks/useBudgetOverview'
+
+function formatPeriodLabel(isoDate: string): string {
+  if (!isoDate) return '—'
+  const date = new Date(`${isoDate}T00:00:00`)
+  return date.toLocaleDateString('id-ID', { month: 'long', year: 'numeric' })
+}
+
+function getProgressTone(percent: number): {
+  bar: string
+  badge: string
+  text: string
+} {
+  if (percent >= 90) {
+    return {
+      bar: 'bg-rose-500',
+      badge: 'bg-rose-500/10 text-rose-600 dark:text-rose-400',
+      text: 'text-rose-600 dark:text-rose-400',
+    }
+  }
+  if (percent >= 70) {
+    return {
+      bar: 'bg-amber-500',
+      badge: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+      text: 'text-amber-600 dark:text-amber-400',
+    }
+  }
+  return {
+    bar: 'bg-emerald-500',
+    badge: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+    text: 'text-emerald-600 dark:text-emerald-400',
+  }
+}
+
+function formatPercent(value: number): string {
+  if (!Number.isFinite(value)) return '0%'
+  return `${Math.min(999, Math.max(0, Math.round(value)))}%`
+}
+
+function BudgetOverviewCard(): JSX.Element {
+  const { summary, categories, loading, error, hasBudgets, refresh } = useBudgetOverview()
+  const tone = getProgressTone(summary.usagePercent)
+  const progressWidth = summary.totalAvailable > 0 ? Math.min(100, Math.max(0, (summary.totalActual / summary.totalAvailable) * 100)) : 0
+  const topCategories = categories.slice(0, 3)
+  const usageDisplay = formatPercent(summary.usagePercent)
+  const periodLabel = formatPeriodLabel(summary.period)
+  const remainingPositive = summary.remaining >= 0
+
+  return (
+    <section className="relative flex h-full flex-col rounded-3xl border border-white/20 bg-gradient-to-br from-white/95 via-white/80 to-sky-50/80 p-6 shadow-[0_12px_40px_-24px_rgba(56,152,248,0.6)] backdrop-blur dark:border-slate-700/60 dark:from-slate-900/80 dark:via-slate-900/70 dark:to-slate-900/40">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-wide text-sky-600/80 dark:text-sky-400/90">Performa Bulan Ini</p>
+          <h2 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">Anggaran</h2>
+          <p className="text-xs text-muted-foreground">Periode {periodLabel}</p>
+        </div>
+        <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-sky-500/10 text-sky-600 dark:bg-sky-400/15 dark:text-sky-300" aria-hidden="true">
+          <PieChart className="h-6 w-6" />
+        </span>
+      </div>
+
+      <div className="mt-6 flex flex-col gap-6">
+        {loading ? (
+          <div className="space-y-4">
+            <div className="h-8 w-32 animate-pulse rounded-xl bg-slate-200/70 dark:bg-slate-700/60" />
+            <div className="h-3 w-full animate-pulse rounded-full bg-slate-200/60 dark:bg-slate-700/50" />
+            <div className="space-y-2">
+              <div className="h-4 w-40 animate-pulse rounded-lg bg-slate-200/50 dark:bg-slate-700/50" />
+              <div className="h-4 w-28 animate-pulse rounded-lg bg-slate-200/50 dark:bg-slate-700/50" />
+            </div>
+          </div>
+        ) : error ? (
+          <div className="rounded-2xl border border-rose-200/70 bg-rose-50/70 p-4 text-sm text-rose-600 dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-300">
+            <p className="font-medium">Gagal memuat data anggaran.</p>
+            <p className="mt-1 text-xs opacity-80">{error}</p>
+            <button
+              type="button"
+              onClick={refresh}
+              className="mt-3 inline-flex items-center gap-2 rounded-xl bg-rose-500 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-rose-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-rose-500"
+            >
+              Coba lagi
+            </button>
+          </div>
+        ) : !hasBudgets ? (
+          <div className="flex flex-col items-start gap-4 rounded-2xl border border-dashed border-sky-300/70 bg-sky-50/60 p-5 text-slate-600 dark:border-sky-500/50 dark:bg-slate-800/40 dark:text-slate-200">
+            <div className="flex items-center gap-3">
+              <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-sky-500/20 text-sky-600 dark:bg-sky-500/15 dark:text-sky-300">
+                <Wallet className="h-5 w-5" />
+              </span>
+              <div>
+                <p className="text-sm font-semibold">Belum ada anggaran</p>
+                <p className="text-xs text-slate-500 dark:text-slate-300/80">Buat anggaran pertama agar pengeluaranmu lebih terarah.</p>
+              </div>
+            </div>
+            <Link
+              to="/budgets"
+              className="inline-flex items-center gap-2 rounded-xl bg-sky-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-sky-500"
+            >
+              Buat Anggaran
+            </Link>
+          </div>
+        ) : (
+          <>
+            <div className="flex flex-wrap items-end justify-between gap-4">
+              <div>
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Total Anggaran</p>
+                <p className="mt-1 text-3xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
+                  {formatCurrency(summary.totalAvailable, 'IDR')}
+                </p>
+              </div>
+              <div className="text-right">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Sisa</p>
+                <p className={clsx('mt-1 text-lg font-semibold', remainingPositive ? 'text-emerald-600 dark:text-emerald-400' : 'text-rose-600 dark:text-rose-400')}>
+                  {formatCurrency(summary.remaining, 'IDR')}
+                </p>
+                <p className="mt-1 inline-flex items-center gap-2 text-xs font-semibold text-muted-foreground">
+                  <TrendingDown className="h-4 w-4 text-slate-400" />
+                  {formatCurrency(summary.totalActual, 'IDR')} terpakai
+                </p>
+              </div>
+            </div>
+
+            <div>
+              <div className="flex items-center justify-between text-xs font-medium text-muted-foreground">
+                <span>Persentase penggunaan</span>
+                <span className={clsx('rounded-full px-2 py-0.5 font-semibold', tone.badge)}>{usageDisplay}</span>
+              </div>
+              <div className="mt-2 h-2 rounded-full bg-slate-200/80 dark:bg-slate-700/70">
+                <div
+                  className={clsx('h-full rounded-full transition-all duration-500 ease-out', tone.bar)}
+                  style={{ width: `${progressWidth}%` }}
+                />
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-white/40 bg-white/70 p-4 shadow-sm backdrop-blur dark:border-slate-700/60 dark:bg-slate-900/40">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">Top kategori</p>
+                <span className="hidden text-xs text-muted-foreground lg:inline">3 terbesar berdasarkan realisasi</span>
+              </div>
+              <ul className="mt-4 space-y-3">
+                {topCategories.map((category) => {
+                  const categoryTone = getProgressTone(category.usagePercent)
+                  const width = category.planned > 0 ? Math.min(100, Math.max(0, (category.actual / category.planned) * 100)) : 0
+                  return (
+                    <li key={category.id} className="space-y-2">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <p className="text-sm font-medium text-slate-800 dark:text-slate-100">{category.name}</p>
+                        <span className={clsx('rounded-full px-2 py-0.5 text-xs font-semibold', categoryTone.badge)}>
+                          {formatPercent(category.usagePercent)}
+                        </span>
+                      </div>
+                      <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
+                        <span>{formatCurrency(category.actual, 'IDR')} terpakai</span>
+                        <span className="hidden sm:inline">dari {formatCurrency(category.planned, 'IDR')}</span>
+                        <span className={clsx('font-semibold', category.remaining >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-rose-600 dark:text-rose-400')}>
+                          {formatCurrency(category.remaining, 'IDR')} sisa
+                        </span>
+                      </div>
+                      <div className="h-2 rounded-full bg-slate-200/80 dark:bg-slate-700/70">
+                        <div
+                          className={clsx('h-full rounded-full transition-all duration-500 ease-out', categoryTone.bar)}
+                          style={{ width: `${width}%` }}
+                        />
+                      </div>
+                    </li>
+                  )
+                })}
+                {topCategories.length === 0 && (
+                  <li className="text-xs text-muted-foreground">Belum ada realisasi pengeluaran.</li>
+                )}
+              </ul>
+            </div>
+          </>
+        )}
+      </div>
+    </section>
+  )
+}
+
+export default BudgetOverviewCard

--- a/src/hooks/useBudgetOverview.ts
+++ b/src/hooks/useBudgetOverview.ts
@@ -1,0 +1,259 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { supabase } from '../lib/supabase.js'
+import { getCurrentUserId } from '../lib/session.js'
+
+interface BudgetOverviewSummary {
+  totalPlanned: number
+  totalRollover: number
+  totalAvailable: number
+  totalActual: number
+  remaining: number
+  usagePercent: number
+  period: string
+}
+
+export interface BudgetCategoryUsage {
+  id: string
+  name: string
+  planned: number
+  actual: number
+  remaining: number
+  usagePercent: number
+}
+
+interface UseBudgetOverviewResult {
+  summary: BudgetOverviewSummary
+  categories: BudgetCategoryUsage[]
+  loading: boolean
+  error: string | null
+  hasBudgets: boolean
+  refresh: () => Promise<void>
+}
+
+const EMPTY_SUMMARY: BudgetOverviewSummary = {
+  totalPlanned: 0,
+  totalRollover: 0,
+  totalAvailable: 0,
+  totalActual: 0,
+  remaining: 0,
+  usagePercent: 0,
+  period: currentPeriodIso(),
+}
+
+function currentPeriodIso(): string {
+  const today = new Date()
+  const year = today.getFullYear()
+  const month = (today.getMonth() + 1).toString().padStart(2, '0')
+  return `${year}-${month}-01`
+}
+
+function normalizePeriod(period?: string): string {
+  if (!period || period.trim() === '') return currentPeriodIso()
+  const trimmed = period.trim()
+  if (trimmed.length === 7) {
+    return `${trimmed}-01`
+  }
+  if (trimmed.length >= 10) {
+    return trimmed.slice(0, 10)
+  }
+  return currentPeriodIso()
+}
+
+function parseNumber(value: unknown): number {
+  if (value == null) return 0
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : 0
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number.parseFloat(value)
+    return Number.isFinite(parsed) ? parsed : 0
+  }
+  return 0
+}
+
+const ACTUAL_FIELD_CANDIDATES = [
+  'actual',
+  'spent',
+  'amount',
+  'realized',
+  'realised',
+  'realisasi',
+  'total_spent',
+  'total',
+  'value',
+]
+
+async function fetchActualsMap(userId: string, periodIso: string): Promise<Record<string, number>> {
+  const extractActual = (row: Record<string, any>): number => {
+    for (const key of ACTUAL_FIELD_CANDIDATES) {
+      if (key in row) {
+        const parsed = parseNumber(row[key])
+        if (row[key] != null || parsed !== 0) {
+          return parsed
+        }
+      }
+    }
+    return 0
+  }
+
+  const map: Record<string, number> = {}
+
+  try {
+    const { data, error } = await supabase
+      .from('budget_actuals_v')
+      .select('*')
+      .eq('user_id', userId)
+      .eq('period_month', periodIso)
+
+    if (error) throw error
+
+    for (const row of data ?? []) {
+      const categoryId = (row as any)?.category_id ?? null
+      const budgetId = (row as any)?.budget_id ?? null
+      const key = categoryId ?? budgetId
+      if (!key) continue
+      map[key as string] = extractActual(row as Record<string, any>)
+    }
+    return map
+  } catch (error) {
+    const message = (error as Error)?.message ?? ''
+    const missingView = message.toLowerCase().includes('budget_actuals_v') || message.includes('42P01')
+    if (!missingView) {
+      throw error
+    }
+    // Fallback to legacy budget_activity view when budget_actuals_v is unavailable
+    const { data, error: activityError } = await supabase
+      .from('budget_activity')
+      .select('*')
+      .eq('period_month', periodIso)
+
+    if (activityError) throw activityError
+
+    for (const row of data ?? []) {
+      const categoryId = (row as any)?.category_id
+      if (!categoryId) continue
+      map[categoryId as string] = extractActual(row as Record<string, any>)
+    }
+    return map
+  }
+}
+
+interface HookOptions {
+  period?: string
+}
+
+export function useBudgetOverview(options?: HookOptions): UseBudgetOverviewResult {
+  const periodIso = useMemo(() => normalizePeriod(options?.period), [options?.period])
+  const [summary, setSummary] = useState<BudgetOverviewSummary>(EMPTY_SUMMARY)
+  const [categories, setCategories] = useState<BudgetCategoryUsage[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+  const [hasBudgets, setHasBudgets] = useState<boolean>(false)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const userId = await getCurrentUserId()
+      if (!userId) {
+        throw new Error('Kamu perlu login untuk melihat anggaran')
+      }
+
+      const [{ data: budgetRows, error: budgetError }, actuals] = await Promise.all([
+        supabase
+          .from('budgets')
+          .select('id, planned, rollover_in, category_id, name, period_month, category:categories(id, name)')
+          .eq('user_id', userId)
+          .eq('period_month', periodIso),
+        fetchActualsMap(userId, periodIso),
+      ])
+
+      if (budgetError) throw budgetError
+
+      const mappedBudgets = (budgetRows ?? []).map((row: any) => {
+        const planned = parseNumber(row.planned)
+        const rolloverIn = parseNumber(row.rollover_in)
+        const categoryId = row.category_id ?? null
+        const key: string = categoryId ?? (row.id as string)
+        const name: string = row.category?.name ?? row.name ?? 'Tanpa Kategori'
+        const categoryActualKey = categoryId ? String(categoryId) : null
+        const actualSource = actuals[key] ?? (categoryActualKey ? actuals[categoryActualKey] : undefined)
+        const actual = parseNumber(actualSource)
+        const available = planned + rolloverIn
+        const remaining = available - actual
+        const usagePercent = available > 0 ? (actual / available) * 100 : 0
+
+        return {
+          id: row.id as string,
+          key,
+          name,
+          planned,
+          rolloverIn,
+          available,
+          actual,
+          remaining,
+          usagePercent,
+        }
+      })
+
+      const totalPlanned = mappedBudgets.reduce((sum, item) => sum + item.planned, 0)
+      const totalRollover = mappedBudgets.reduce((sum, item) => sum + item.rolloverIn, 0)
+      const totalActual = mappedBudgets.reduce((sum, item) => sum + item.actual, 0)
+      const totalAvailable = totalPlanned + totalRollover
+      const remaining = totalAvailable - totalActual
+      const usagePercent = totalAvailable > 0 ? (totalActual / totalAvailable) * 100 : 0
+
+      const breakdown = mappedBudgets
+        .map((item) => ({
+          id: item.key,
+          name: item.name,
+          planned: item.available,
+          actual: item.actual,
+          remaining: item.remaining,
+          usagePercent: item.usagePercent,
+        }))
+        .sort((a, b) => b.actual - a.actual)
+
+      setSummary({
+        totalPlanned,
+        totalRollover,
+        totalAvailable,
+        totalActual,
+        remaining,
+        usagePercent,
+        period: periodIso,
+      })
+      setCategories(breakdown)
+      setHasBudgets(mappedBudgets.length > 0)
+    } catch (err: unknown) {
+      setSummary({ ...EMPTY_SUMMARY, period: periodIso })
+      setCategories([])
+      setHasBudgets(false)
+      setError(err instanceof Error ? err.message : 'Gagal memuat anggaran')
+    } finally {
+      setLoading(false)
+    }
+  }, [periodIso])
+
+  useEffect(() => {
+    load().catch(() => {
+      /* handled in state */
+    })
+  }, [load])
+
+  const refresh = useCallback(async () => {
+    await load()
+  }, [load])
+
+  return {
+    summary,
+    categories,
+    loading,
+    error,
+    hasBudgets,
+    refresh,
+  }
+}
+
+export default useBudgetOverview

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -12,6 +12,7 @@ import RecentTransactions from "../components/RecentTransactions";
 import useInsights from "../hooks/useInsights";
 import EventBus from "../lib/eventBus";
 import DashboardSummary from "../components/dashboard/DashboardSummary";
+import BudgetOverviewCard from "../components/dashboard/BudgetOverviewCard";
 import PeriodPicker, {
   getPresetRange,
 } from "../components/dashboard/PeriodPicker";
@@ -121,13 +122,14 @@ export default function Dashboard({ stats, txs, budgets = [], budgetStatus = [] 
 
         <QuoteBoard />
 
-        <div className="grid gap-6 sm:gap-7 lg:gap-8 lg:grid-cols-2">
+        <div className="grid gap-6 sm:gap-7 lg:gap-8 lg:grid-cols-3">
           <SavingsProgress current={stats?.balance || 0} target={savingsTarget} />
           <AchievementBadges
             stats={stats}
             streak={streak}
             target={savingsTarget}
           />
+          <BudgetOverviewCard />
         </div>
 
         <QuickActions />


### PR DESCRIPTION
## Summary
- add a modern Anggaran card to the dashboard that shows monthly totals, remaining budget, and responsive progress visuals
- implement a reusable hook that aggregates budgets with live actuals from Supabase tables/views and surfaces top category usage
- slot the new widget alongside existing dashboard tiles without breaking the responsive layout

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d6a758d4fc8332a5fd8c86e50300c6