### PR TITLE
Add Anggaran budget overview widget to dashboard

### DIFF
--- a/src/components/dashboard/BudgetOverviewWidget.tsx
+++ b/src/components/dashboard/BudgetOverviewWidget.tsx
@@ -1,0 +1,230 @@
+import { Link } from "react-router-dom"
+import { PieChart, TrendingDown, Wallet } from "lucide-react"
+import { formatCurrency } from "../../lib/format.js"
+import { useBudgetOverview } from "../../hooks/useBudgetOverview"
+
+function formatPeriodLabel(period: string): string {
+  const [year, month] = period.split("-")
+  const yearNum = Number.parseInt(year ?? "", 10)
+  const monthNum = Number.parseInt(month ?? "", 10)
+  if (!Number.isFinite(yearNum) || !Number.isFinite(monthNum)) return "Periode ini"
+  const formatter = new Intl.DateTimeFormat("id-ID", { month: "long", year: "numeric" })
+  return formatter.format(new Date(yearNum, monthNum - 1, 1))
+}
+
+function getProgressClass(progress: number): string {
+  if (progress >= 0.9) {
+    return "bg-gradient-to-r from-rose-500 via-rose-500 to-rose-600"
+  }
+  if (progress >= 0.7) {
+    return "bg-gradient-to-r from-amber-400 via-amber-400 to-amber-500"
+  }
+  return "bg-gradient-to-r from-emerald-400 via-emerald-400 to-emerald-500"
+}
+
+function clampPercent(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(value, 1))
+}
+
+function WidgetSkeleton() {
+  return (
+    <section className="h-full rounded-3xl border border-border/60 bg-card/70 p-6 shadow-sm backdrop-blur">
+      <div className="flex h-full flex-col gap-6">
+        <div className="flex items-start justify-between">
+          <div className="space-y-2">
+            <div className="h-4 w-24 animate-pulse rounded-full bg-muted/60" />
+            <div className="h-7 w-40 animate-pulse rounded-full bg-muted/60" />
+            <div className="h-3 w-28 animate-pulse rounded-full bg-muted/40" />
+          </div>
+          <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[#3898f8]/10">
+            <PieChart className="h-6 w-6 text-[#3898f8]" />
+          </span>
+        </div>
+        <div className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-3">
+              <div className="h-10 w-32 animate-pulse rounded-xl bg-muted/60" />
+              <div className="h-4 w-24 animate-pulse rounded-full bg-muted/40" />
+            </div>
+            <div className="space-y-3">
+              <div className="h-10 w-32 animate-pulse rounded-xl bg-muted/60" />
+              <div className="h-4 w-24 animate-pulse rounded-full bg-muted/40" />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>0%</span>
+              <span className="h-4 w-10 animate-pulse rounded bg-muted/50" />
+            </div>
+            <div className="h-3 w-full rounded-full bg-muted/40">
+              <div className="h-full w-1/2 animate-pulse rounded-full bg-muted/70" />
+            </div>
+          </div>
+        </div>
+        <div className="hidden gap-4 rounded-2xl bg-muted/10 p-4 md:grid md:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="space-y-3">
+              <div className="h-4 w-24 animate-pulse rounded-full bg-muted/40" />
+              <div className="h-3 w-full animate-pulse rounded-full bg-muted/30" />
+              <div className="h-2 w-full animate-pulse rounded-full bg-muted/20" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default function BudgetOverviewWidget() {
+  const { summary, categories, loading, error, empty, period, refresh } = useBudgetOverview()
+  const utilization = clampPercent(summary.utilization)
+  const percentLabel = `${Math.round(utilization * 100)}%`
+  const monthLabel = formatPeriodLabel(period)
+  const remainingClass = summary.remaining < 0 ? "text-rose-500" : "text-emerald-600"
+
+  const topCategories = categories
+    .filter((item) => item.planned > 0 || item.actual > 0)
+    .sort((a, b) => b.actual - a.actual)
+    .slice(0, 3)
+
+  if (loading) {
+    return <WidgetSkeleton />
+  }
+
+  if (error) {
+    return (
+      <section className="h-full rounded-3xl border border-rose-200/60 bg-rose-50/70 p-6 text-rose-600 shadow-sm">
+        <div className="flex h-full flex-col justify-between gap-4">
+          <div className="space-y-2">
+            <div className="flex items-center gap-3">
+              <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-rose-500/10">
+                <TrendingDown className="h-5 w-5" />
+              </span>
+              <div>
+                <h2 className="text-lg font-semibold">Anggaran tidak dapat dimuat</h2>
+                <p className="text-sm text-rose-500/80">{error}</p>
+              </div>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => refresh().catch(() => undefined)}
+            className="inline-flex items-center justify-center rounded-2xl bg-rose-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-rose-600"
+          >
+            Coba Lagi
+          </button>
+        </div>
+      </section>
+    )
+  }
+
+  if (empty) {
+    return (
+      <section className="h-full rounded-3xl border border-dashed border-border/70 bg-card/60 p-6 shadow-sm">
+        <div className="flex h-full flex-col items-start justify-between gap-6">
+          <div className="space-y-2">
+            <span className="inline-flex items-center gap-2 rounded-full bg-[#3898f8]/10 px-3 py-1 text-xs font-semibold text-[#3898f8]">
+              <Wallet className="h-4 w-4" /> Mulai rencanakan
+            </span>
+            <h2 className="text-xl font-semibold">Belum ada anggaran bulan ini</h2>
+            <p className="max-w-xs text-sm text-muted-foreground">
+              Buat anggaran untuk memantau penggunaan uang dan hindari overspending.
+            </p>
+          </div>
+          <Link
+            to="/budgets"
+            className="inline-flex items-center justify-center rounded-2xl bg-[#3898f8] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#2f7dd0]"
+          >
+            Buat Anggaran
+          </Link>
+        </div>
+      </section>
+    )
+  }
+
+  return (
+    <section className="h-full rounded-3xl border border-border/60 bg-card/70 p-6 shadow-sm backdrop-blur">
+      <div className="flex h-full flex-col gap-6">
+        <header className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/70">Anggaran</p>
+            <h2 className="text-xl font-semibold text-foreground">Ringkasan Bulan Ini</h2>
+            <p className="text-xs text-muted-foreground">Periode {monthLabel}</p>
+          </div>
+          <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[#3898f8]/10 text-[#3898f8]">
+            <PieChart className="h-6 w-6" />
+          </span>
+        </header>
+
+        <div className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="rounded-2xl bg-surface/60 p-4 shadow-sm">
+              <p className="text-xs font-medium text-muted-foreground">Total Anggaran</p>
+              <p className="mt-2 text-2xl font-semibold text-foreground">
+                {formatCurrency(summary.totalPlanned, "IDR")}
+              </p>
+              <p className="mt-2 text-xs text-muted-foreground">Terpakai {formatCurrency(summary.totalActual, "IDR")}</p>
+            </div>
+            <div className="rounded-2xl bg-surface/60 p-4 shadow-sm">
+              <p className="text-xs font-medium text-muted-foreground">Sisa Anggaran</p>
+              <p className={`mt-2 text-2xl font-semibold ${remainingClass}`}>
+                {formatCurrency(summary.remaining, "IDR")}
+              </p>
+              <p className="mt-2 text-xs text-muted-foreground">Persentase {percentLabel}</p>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between text-xs font-medium text-muted-foreground">
+              <span>Penggunaan Anggaran</span>
+              <span>{percentLabel}</span>
+            </div>
+            <div className="h-3 w-full rounded-full bg-muted/40">
+              <div
+                className={`h-full rounded-full ${getProgressClass(utilization)}`}
+                style={{ width: `${clampPercent(utilization) * 100}%` }}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-2xl bg-surface/60 p-4 shadow-sm md:p-5">
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-semibold text-foreground">Top Kategori</p>
+            <Link to="/budgets" className="text-xs font-medium text-[#3898f8] hover:underline">
+              Kelola
+            </Link>
+          </div>
+          {topCategories.length === 0 ? (
+            <p className="mt-4 text-sm text-muted-foreground">
+              Belum ada kategori dengan pengeluaran tercatat.
+            </p>
+          ) : (
+            <ul className="mt-4 space-y-4 md:grid md:grid-cols-3 md:gap-4 md:space-y-0">
+              {topCategories.map((item) => {
+                const categoryProgress = clampPercent(item.utilization)
+                return (
+                  <li key={item.id} className="flex flex-col gap-3 rounded-xl bg-card/50 p-3 shadow-sm">
+                    <div>
+                      <p className="text-sm font-semibold text-foreground">{item.label}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {formatCurrency(item.actual, "IDR")} / {formatCurrency(item.planned, "IDR")}
+                      </p>
+                    </div>
+                    <div className="h-2 rounded-full bg-muted/40">
+                      <div
+                        className={`h-full rounded-full ${getProgressClass(categoryProgress)}`}
+                        style={{ width: `${categoryProgress * 100}%` }}
+                      />
+                    </div>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/hooks/useBudgetOverview.ts
+++ b/src/hooks/useBudgetOverview.ts
@@ -1,0 +1,283 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+import type { PostgrestError } from "@supabase/supabase-js"
+import { supabase } from "../lib/supabase.js"
+
+export interface BudgetCategoryOverview {
+  id: string
+  label: string
+  planned: number
+  actual: number
+  remaining: number
+  utilization: number
+}
+
+export interface BudgetOverviewSummary {
+  totalPlanned: number
+  totalActual: number
+  remaining: number
+  utilization: number
+}
+
+export interface BudgetOverviewState {
+  summary: BudgetOverviewSummary
+  categories: BudgetCategoryOverview[]
+  loading: boolean
+  error: string | null
+  empty: boolean
+  period: string
+  refresh: () => Promise<void>
+}
+
+const INITIAL_SUMMARY: BudgetOverviewSummary = {
+  totalPlanned: 0,
+  totalActual: 0,
+  remaining: 0,
+  utilization: 0,
+}
+
+type BudgetRecord = {
+  id: string
+  category_id?: string | null
+  category_key?: string | null
+  name?: string | null
+  label?: string | null
+  planned?: number | string | null
+  amount_planned?: number | string | null
+  rollover_in?: number | string | null
+  category?: { name?: string | null } | null
+}
+
+type BudgetActualRecord = {
+  category_id?: string | null
+  category_key?: string | null
+  actual?: number | string | null
+  period_month?: string | null
+}
+
+interface LoadResult {
+  summary: BudgetOverviewSummary
+  categories: BudgetCategoryOverview[]
+  empty: boolean
+}
+
+function toMonthStart(period: string): string {
+  const safe = period?.trim()
+  if (!safe) return ""
+  const [yearStr, monthStr] = safe.split("-")
+  const year = Number.parseInt(yearStr ?? "", 10)
+  const month = Number.parseInt(monthStr ?? "", 10)
+  if (!Number.isFinite(year) || !Number.isFinite(month)) return ""
+  const normalizedMonth = Math.min(Math.max(month, 1), 12)
+  return `${year.toString().padStart(4, "0")}-${normalizedMonth
+    .toString()
+    .padStart(2, "0")}-01`
+}
+
+function getCurrentPeriod(): string {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = now.getMonth() + 1
+  return `${year.toString().padStart(4, "0")}-${month.toString().padStart(2, "0")}`
+}
+
+function toNumber(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value)
+    return Number.isFinite(parsed) ? parsed : 0
+  }
+  return 0
+}
+
+function clamp(value: number, min = 0, max = 1): number {
+  if (!Number.isFinite(value)) return min
+  if (value < min) return min
+  if (value > max) return max
+  return value
+}
+
+function extractLabel(record: BudgetRecord): string {
+  const categoryName = record.category?.name
+  if (typeof categoryName === "string" && categoryName.trim()) {
+    return categoryName.trim()
+  }
+  const providedLabel = record.label ?? record.name
+  if (typeof providedLabel === "string" && providedLabel.trim()) {
+    return providedLabel.trim()
+  }
+  return "Tanpa kategori"
+}
+
+function deriveOverview(
+  budgets: BudgetRecord[],
+  actuals: BudgetActualRecord[]
+): LoadResult {
+  const actualByKey = new Map<string, number>()
+  const actualByCategory = new Map<string, number>()
+
+  for (const row of actuals) {
+    const actual = toNumber(row.actual)
+    if (!actual) continue
+    const categoryKey = typeof row.category_key === "string" ? row.category_key : null
+    const categoryId = typeof row.category_id === "string" ? row.category_id : null
+    if (categoryKey) {
+      actualByKey.set(categoryKey, (actualByKey.get(categoryKey) ?? 0) + actual)
+    }
+    if (categoryId) {
+      actualByCategory.set(categoryId, (actualByCategory.get(categoryId) ?? 0) + actual)
+    }
+  }
+
+  const categories: BudgetCategoryOverview[] = budgets.map((budget) => {
+    const categoryId = typeof budget.category_id === "string" ? budget.category_id : null
+    const categoryKey = typeof budget.category_key === "string" ? budget.category_key : null
+    const plannedBase =
+      toNumber(budget.amount_planned ?? budget.planned) + toNumber(budget.rollover_in)
+    const actual = categoryKey && actualByKey.has(categoryKey)
+      ? actualByKey.get(categoryKey) ?? 0
+      : categoryId && actualByCategory.has(categoryId)
+        ? actualByCategory.get(categoryId) ?? 0
+        : 0
+    const remaining = plannedBase - actual
+    const utilization = plannedBase > 0 ? actual / plannedBase : 0
+    return {
+      id: budget.id,
+      label: extractLabel(budget),
+      planned: plannedBase,
+      actual,
+      remaining,
+      utilization: clamp(utilization, 0, 2),
+    }
+  })
+
+  const totalPlanned = categories.reduce((acc, item) => acc + item.planned, 0)
+  const totalActual = categories.reduce((acc, item) => acc + item.actual, 0)
+  const remaining = totalPlanned - totalActual
+  const utilization = totalPlanned > 0 ? totalActual / totalPlanned : 0
+
+  return {
+    summary: {
+      totalPlanned,
+      totalActual,
+      remaining,
+      utilization: clamp(utilization, 0, 2),
+    },
+    categories,
+    empty: budgets.length === 0,
+  }
+}
+
+function mapError(error: PostgrestError | Error): string {
+  if (error instanceof Error) return error.message
+  return error?.message ?? "Terjadi kesalahan saat memuat anggaran"
+}
+
+export function useBudgetOverview(period?: string): BudgetOverviewState {
+  const resolvedPeriod = useMemo(() => period ?? getCurrentPeriod(), [period])
+  const [summary, setSummary] = useState<BudgetOverviewSummary>(INITIAL_SUMMARY)
+  const [categories, setCategories] = useState<BudgetCategoryOverview[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+  const [empty, setEmpty] = useState<boolean>(false)
+
+  const load = useCallback(async () => {
+    const { data: authData, error: authError } = await supabase.auth.getUser()
+    if (authError) {
+      throw authError
+    }
+    const userId = authData.user?.id
+    if (!userId) {
+      return { summary: INITIAL_SUMMARY, categories: [], empty: true }
+    }
+
+    const monthStart = toMonthStart(resolvedPeriod)
+    if (!monthStart) {
+      return { summary: INITIAL_SUMMARY, categories: [], empty: true }
+    }
+
+    const [budgetsResponse, actualsResponse] = await Promise.all([
+      supabase
+        .from("budgets")
+        .select(
+          "id,category_id,category_key,name,label,planned,amount_planned,rollover_in,category:categories(name)"
+        )
+        .eq("user_id", userId)
+        .eq("period_month", monthStart),
+      supabase
+        .from("budget_actuals_v")
+        .select("category_id,category_key,actual,period_month")
+        .eq("user_id", userId)
+        .eq("period_month", monthStart),
+    ])
+
+    if (budgetsResponse.error) {
+      throw budgetsResponse.error
+    }
+    if (actualsResponse.error) {
+      throw actualsResponse.error
+    }
+
+    const budgets = (budgetsResponse.data ?? []) as BudgetRecord[]
+    const actuals = (actualsResponse.data ?? []) as BudgetActualRecord[]
+
+    return deriveOverview(budgets, actuals)
+  }, [resolvedPeriod])
+
+  useEffect(() => {
+    let active = true
+    setLoading(true)
+    setError(null)
+    load()
+      .then((result) => {
+        if (!active) return
+        setSummary(result.summary)
+        setCategories(result.categories)
+        setEmpty(result.empty)
+      })
+      .catch((err: unknown) => {
+        if (!active) return
+        setSummary(INITIAL_SUMMARY)
+        setCategories([])
+        setEmpty(true)
+        setError(mapError(err as PostgrestError | Error))
+      })
+      .finally(() => {
+        if (!active) return
+        setLoading(false)
+      })
+    return () => {
+      active = false
+    }
+  }, [load])
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await load()
+      setSummary(result.summary)
+      setCategories(result.categories)
+      setEmpty(result.empty)
+    } catch (err) {
+      setSummary(INITIAL_SUMMARY)
+      setCategories([])
+      setEmpty(true)
+      setError(mapError(err as PostgrestError | Error))
+      throw err
+    } finally {
+      setLoading(false)
+    }
+  }, [load])
+
+  return {
+    summary,
+    categories,
+    loading,
+    error,
+    empty,
+    period: resolvedPeriod,
+    refresh,
+  }
+}
+
+export { getCurrentPeriod as getBudgetCurrentPeriod }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -18,6 +18,7 @@ import PeriodPicker, {
 import useDashboardBalances from "../hooks/useDashboardBalances";
 import DailyDigestModal from "../components/DailyDigestModal";
 import useShowDigestOnLogin from "../hooks/useShowDigestOnLogin";
+import BudgetOverviewWidget from "../components/dashboard/BudgetOverviewWidget";
 
 const DEFAULT_PRESET = "month";
 
@@ -132,7 +133,12 @@ export default function Dashboard({ stats, txs, budgets = [], budgetStatus = [] 
 
         <QuickActions />
 
-        <BudgetStatusHighlights items={budgetStatus} />
+        <div className="grid gap-6 lg:grid-cols-2">
+          <BudgetOverviewWidget />
+          <div className="h-full">
+            <BudgetStatusHighlights items={budgetStatus} />
+          </div>
+        </div>
 
         <section className="space-y-6 sm:space-y-8 lg:space-y-10">
           <SectionHeader title="Analisis Bulanan" />


### PR DESCRIPTION
## Summary
- add a responsive BudgetOverviewWidget with progress and empty/error states for Anggaran
- implement useBudgetOverview hook that aggregates Supabase budgets with budget_actuals_v data
- surface the new widget on the dashboard alongside existing budget highlights

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d6a758d4fc8332a5fd8c86e50300c6