### PR TITLE
Improve responsiveness of debt modals

### DIFF
--- a/src/components/debts/DebtForm.tsx
+++ b/src/components/debts/DebtForm.tsx
@@ -220,156 +220,161 @@ export default function DebtForm({ open, mode, initialData, submitting, onSubmit
   if (!open) return null;
 
   return createPortal(
-    <div className="fixed inset-0 z-[80] flex items-center justify-center bg-black/40 px-4 py-6" role="dialog" aria-modal="true">
-      <div
-        ref={dialogRef}
-        className="w-full max-w-2xl rounded-3xl border border-border/60 bg-surface-1/95 p-6 shadow-2xl backdrop-blur"
-      >
-        <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0">
-            <h2 className="text-lg font-semibold text-text">
-              {mode === 'create' ? 'Tambah Hutang / Piutang' : 'Edit Hutang / Piutang'}
-            </h2>
-            <p className="text-sm text-muted">Catat detail hutang dan atur pengingat jatuh tempo.</p>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-surface-1 text-text hover:bg-border/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-            aria-label="Tutup formulir hutang"
-          >
-            <X className="h-5 w-5" aria-hidden="true" />
-          </button>
-        </div>
-
-        <form onSubmit={handleSubmit} className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="debt-type">
-            Tipe
-            <select
-              id="debt-type"
-              name="type"
-              value={values.type}
-              onChange={handleChange('type')}
-              className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-            >
-              <option value="debt">Hutang (kita berhutang)</option>
-              <option value="receivable">Piutang (orang berhutang)</option>
-            </select>
-          </label>
-
-          <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="party-name">
-            Pihak
-            <input
-              ref={firstFieldRef}
-              id="party-name"
-              name="party_name"
-              value={values.party_name}
-              onChange={handleChange('party_name')}
-              className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-              placeholder="Nama pihak"
-              required
-            />
-            {errors.party_name ? <span className="text-xs text-danger">{errors.party_name}</span> : null}
-          </label>
-
-          <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="title">
-            Judul
-            <input
-              id="title"
-              name="title"
-              value={values.title}
-              onChange={handleChange('title')}
-              className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-              placeholder="Contoh: Pinjaman motor"
-              required
-            />
-            {errors.title ? <span className="text-xs text-danger">{errors.title}</span> : null}
-          </label>
-
-          <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="date">
-            Tanggal
-            <input
-              id="date"
-              name="date"
-              type="date"
-              value={values.date}
-              onChange={handleChange('date')}
-              className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-            />
-          </label>
-
-          <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="due-date">
-            Jatuh tempo
-            <input
-              id="due-date"
-              name="due_date"
-              type="date"
-              value={values.due_date}
-              onChange={handleChange('due_date')}
-              className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-            />
-            {dateWarning ? <span className="text-xs text-warning">{dateWarning}</span> : null}
-          </label>
-
-          <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="amount">
-            Jumlah
-            <input
-              id="amount"
-              name="amount"
-              value={values.amount}
-              onChange={handleChange('amount')}
-              inputMode="decimal"
-              placeholder="Masukkan nominal"
-              className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-              required
-            />
-            {errors.amount ? <span className="text-xs text-danger">{errors.amount}</span> : null}
-          </label>
-
-          <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="rate">
-            Bunga / Rate (%)
-            <input
-              id="rate"
-              name="rate_percent"
-              value={values.rate_percent}
-              onChange={handleChange('rate_percent')}
-              inputMode="decimal"
-              placeholder="Opsional"
-              className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-            />
-            {errors.rate_percent ? <span className="text-xs text-danger">{errors.rate_percent}</span> : null}
-          </label>
-
-          <label className="sm:col-span-2 flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="notes">
-            Catatan
-            <textarea
-              id="notes"
-              name="notes"
-              value={values.notes}
-              onChange={handleChange('notes')}
-              rows={3}
-              className="rounded-xl border border-border bg-surface-1 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-              placeholder="Catatan tambahan (opsional)"
-            />
-          </label>
-
-          <div className="sm:col-span-2 flex flex-col gap-3 pt-2 sm:flex-row sm:justify-end">
+    <div
+      className="fixed inset-0 z-[80] overflow-y-auto bg-black/40 px-4 py-6 sm:px-6 sm:py-10"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className="mx-auto flex min-h-full w-full max-w-2xl items-start justify-center">
+        <div
+          ref={dialogRef}
+          className="w-full max-h-[calc(100vh-3rem)] overflow-y-auto rounded-3xl border border-border/60 bg-surface-1/95 p-6 shadow-2xl backdrop-blur sm:max-h-[calc(100vh-5rem)] sm:p-8"
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <h2 className="text-lg font-semibold text-text">
+                {mode === 'create' ? 'Tambah Hutang / Piutang' : 'Edit Hutang / Piutang'}
+              </h2>
+              <p className="text-sm text-muted">Catat detail hutang dan atur pengingat jatuh tempo.</p>
+            </div>
             <button
               type="button"
               onClick={onClose}
-              className="inline-flex h-[42px] items-center justify-center rounded-xl border border-border bg-surface-1 px-5 text-sm font-medium text-text transition hover:bg-border/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-surface-1 text-text hover:bg-border/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+              aria-label="Tutup formulir hutang"
             >
-              Batal
-            </button>
-            <button
-              type="submit"
-              disabled={Boolean(submitting)}
-              className="inline-flex h-[42px] items-center justify-center rounded-xl bg-brand text-sm font-semibold text-brand-foreground px-6 transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)] disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {submitting ? 'Menyimpan…' : mode === 'create' ? 'Tambah' : 'Simpan perubahan'}
+              <X className="h-5 w-5" aria-hidden="true" />
             </button>
           </div>
-        </form>
+          <form onSubmit={handleSubmit} className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="debt-type">
+              Tipe
+              <select
+                id="debt-type"
+                name="type"
+                value={values.type}
+                onChange={handleChange('type')}
+                className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+              >
+                <option value="debt">Hutang (kita berhutang)</option>
+                <option value="receivable">Piutang (orang berhutang)</option>
+              </select>
+            </label>
+
+            <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="party-name">
+              Pihak
+              <input
+                ref={firstFieldRef}
+                id="party-name"
+                name="party_name"
+                value={values.party_name}
+                onChange={handleChange('party_name')}
+                className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+                placeholder="Nama pihak"
+                required
+              />
+              {errors.party_name ? <span className="text-xs text-danger">{errors.party_name}</span> : null}
+            </label>
+
+            <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="title">
+              Judul
+              <input
+                id="title"
+                name="title"
+                value={values.title}
+                onChange={handleChange('title')}
+                className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+                placeholder="Contoh: Pinjaman motor"
+                required
+              />
+              {errors.title ? <span className="text-xs text-danger">{errors.title}</span> : null}
+            </label>
+
+            <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="date">
+              Tanggal
+              <input
+                id="date"
+                name="date"
+                type="date"
+                value={values.date}
+                onChange={handleChange('date')}
+                className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+              />
+            </label>
+
+            <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="due-date">
+              Jatuh tempo
+              <input
+                id="due-date"
+                name="due_date"
+                type="date"
+                value={values.due_date}
+                onChange={handleChange('due_date')}
+                className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+              />
+              {dateWarning ? <span className="text-xs text-warning">{dateWarning}</span> : null}
+            </label>
+
+            <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="amount">
+              Jumlah
+              <input
+                id="amount"
+                name="amount"
+                value={values.amount}
+                onChange={handleChange('amount')}
+                inputMode="decimal"
+                placeholder="Masukkan nominal"
+                className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+                required
+              />
+              {errors.amount ? <span className="text-xs text-danger">{errors.amount}</span> : null}
+            </label>
+
+            <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="rate">
+              Bunga / Rate (%)
+              <input
+                id="rate"
+                name="rate_percent"
+                value={values.rate_percent}
+                onChange={handleChange('rate_percent')}
+                inputMode="decimal"
+                placeholder="Opsional"
+                className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+              />
+              {errors.rate_percent ? <span className="text-xs text-danger">{errors.rate_percent}</span> : null}
+            </label>
+
+            <label className="sm:col-span-2 flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="notes">
+              Catatan
+              <textarea
+                id="notes"
+                name="notes"
+                value={values.notes}
+                onChange={handleChange('notes')}
+                rows={3}
+                className="rounded-xl border border-border bg-surface-1 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+                placeholder="Catatan tambahan (opsional)"
+              />
+            </label>
+
+            <div className="sm:col-span-2 flex flex-col gap-3 pt-2 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                className="inline-flex h-[42px] items-center justify-center rounded-xl border border-border bg-surface-1 px-5 text-sm font-medium text-text transition hover:bg-border/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+              >
+                Batal
+              </button>
+              <button
+                type="submit"
+                disabled={Boolean(submitting)}
+                className="inline-flex h-[42px] items-center justify-center rounded-xl bg-brand text-sm font-semibold text-brand-foreground px-6 transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)] disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {submitting ? 'Menyimpan…' : mode === 'create' ? 'Tambah' : 'Simpan perubahan'}
+              </button>
+            </div>
+          </form>
+        </div>
       </div>
     </div>,
     document.body,

--- a/src/components/debts/PaymentDrawer.tsx
+++ b/src/components/debts/PaymentDrawer.tsx
@@ -169,11 +169,11 @@ export default function PaymentDrawer({
       <div className="drawer-overlay" onClick={onClose} aria-hidden="true" />
       <div
         ref={panelRef}
-        className="drawer-panel w-full max-w-[100%] sm:max-w-[480px] md:max-w-[520px]"
+        className="drawer-panel w-full max-w-full rounded-none border-0 sm:max-w-[480px] sm:rounded-l-3xl sm:border sm:border-border-subtle md:max-w-[520px]"
         role="dialog"
         aria-modal="true"
       >
-        <header className="drawer-header">
+        <header className="drawer-header px-5 sm:px-6">
           <div className="flex items-start justify-between gap-3 sm:gap-4">
             <div className="min-w-0">
               <p className="text-xs font-semibold uppercase tracking-wide text-muted">Catat Pembayaran</p>
@@ -194,9 +194,9 @@ export default function PaymentDrawer({
           </div>
         </header>
 
-        <div className="drawer-body">
+        <div className="drawer-body px-5 sm:px-6">
           <div className="min-w-0 space-y-5">
-            <section className="grid min-w-0 grid-cols-2 gap-3 rounded-3xl border border-border-subtle bg-surface-alt/80 p-4 shadow-sm sm:gap-4">
+            <section className="grid min-w-0 grid-cols-1 gap-3 rounded-3xl border border-border-subtle bg-surface-alt/80 p-4 shadow-sm sm:grid-cols-2 sm:gap-4">
               <div className="min-w-0">
                 <p className="text-xs font-semibold uppercase tracking-wide text-muted">Sisa Tagihan</p>
                 <p className="mt-1 text-lg font-semibold text-text tabular-nums">{remainingLabel}</p>
@@ -289,7 +289,7 @@ export default function PaymentDrawer({
           </div>
         </div>
 
-        <footer className="drawer-footer">
+        <footer className="drawer-footer px-5 sm:px-6">
           <div className="flex w-full flex-col gap-3 sm:flex-row sm:justify-end sm:gap-4">
             <button
               type="button"
@@ -303,7 +303,7 @@ export default function PaymentDrawer({
               form="payment-form"
               disabled={Boolean(submitting)}
               aria-busy={Boolean(submitting)}
-              className="btn btn-primary w-full sm:w-auto"
+              className="btn btn-primary w-full flex-wrap justify-center text-center leading-snug sm:w-auto"
             >
               {submitting ? 'Menyimpan…' : 'Catat Pembayaran'}
             </button>


### PR DESCRIPTION
## Summary
- improve the debt form modal layout to scroll and fit better on small screens
- adjust the payment drawer spacing, grid layout, and action button wrapping for narrow viewports

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d6a9d1383483329135735b7850e17d