### PR TITLE
Improve debt modals responsiveness

### DIFF
--- a/src/components/debts/DebtForm.tsx
+++ b/src/components/debts/DebtForm.tsx
@@ -220,10 +220,14 @@ export default function DebtForm({ open, mode, initialData, submitting, onSubmit
   if (!open) return null;
 
   return createPortal(
-    <div className="fixed inset-0 z-[80] flex items-center justify-center bg-black/40 px-4 py-6" role="dialog" aria-modal="true">
+    <div
+      className="fixed inset-0 z-[80] flex items-end justify-center overflow-y-auto bg-black/40 px-4 py-6 sm:items-center sm:py-10"
+      role="dialog"
+      aria-modal="true"
+    >
       <div
         ref={dialogRef}
-        className="w-full max-w-2xl rounded-3xl border border-border/60 bg-surface-1/95 p-6 shadow-2xl backdrop-blur"
+        className="w-full max-w-2xl rounded-t-3xl border border-border/60 bg-surface-1/95 p-5 shadow-2xl backdrop-blur sm:rounded-3xl sm:p-6 max-h-[calc(100vh-3rem)] overflow-y-auto"
       >
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0">

--- a/src/components/debts/PaymentDrawer.tsx
+++ b/src/components/debts/PaymentDrawer.tsx
@@ -294,7 +294,7 @@ export default function PaymentDrawer({
             <button
               type="button"
               onClick={onClose}
-              className="btn btn-secondary w-full sm:w-auto"
+              className="btn btn-secondary w-full min-h-[48px] sm:w-auto sm:min-h-[40px]"
             >
               Tutup
             </button>
@@ -303,7 +303,7 @@ export default function PaymentDrawer({
               form="payment-form"
               disabled={Boolean(submitting)}
               aria-busy={Boolean(submitting)}
-              className="btn btn-primary w-full sm:w-auto"
+              className="btn btn-primary w-full min-h-[48px] sm:w-auto sm:min-h-[40px]"
             >
               {submitting ? 'Menyimpan…' : 'Catat Pembayaran'}
             </button>

--- a/src/index.css
+++ b/src/index.css
@@ -326,7 +326,13 @@
   }
 
   .drawer-panel {
-    @apply fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col overflow-hidden rounded-l-3xl border border-border-subtle bg-surface shadow-[0_24px_60px_-30px_rgb(15_23_42/0.35)] transition-transform duration-300 ease-out;
+    @apply fixed inset-x-0 bottom-0 z-50 flex w-full max-h-[calc(100vh-2rem)] flex-col overflow-hidden rounded-t-3xl border border-border-subtle bg-surface shadow-[0_24px_60px_-30px_rgb(15_23_42/0.35)] transition-transform duration-300 ease-out;
+  }
+
+  @screen sm {
+    .drawer-panel {
+      @apply inset-y-0 right-0 left-auto top-0 bottom-0 max-h-full max-w-md rounded-none rounded-l-3xl;
+    }
   }
 
   .drawer-header {


### PR DESCRIPTION
## Summary
- adjust the debt form modal layout to anchor as a mobile-friendly sheet with scrollable content
- update shared drawer styles so the payment drawer adapts between mobile sheets and desktop side panels
- increase the payment action buttons to provide larger, more responsive tap targets

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d6a9d1383483329135735b7850e17d