### PR TITLE
Improve debt modals responsiveness

### DIFF
--- a/src/components/debts/DebtForm.tsx
+++ b/src/components/debts/DebtForm.tsx
@@ -220,12 +220,16 @@ export default function DebtForm({ open, mode, initialData, submitting, onSubmit
   if (!open) return null;
 
   return createPortal(
-    <div className="fixed inset-0 z-[80] flex items-center justify-center bg-black/40 px-4 py-6" role="dialog" aria-modal="true">
+    <div
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/40 px-3 py-4 sm:px-4 sm:py-6"
+      role="dialog"
+      aria-modal="true"
+    >
       <div
         ref={dialogRef}
-        className="w-full max-w-2xl rounded-3xl border border-border/60 bg-surface-1/95 p-6 shadow-2xl backdrop-blur"
+        className="flex max-h-[min(92vh,760px)] w-full max-w-2xl flex-col overflow-hidden rounded-3xl border border-border/60 bg-surface-1/95 p-4 shadow-2xl backdrop-blur sm:p-6"
       >
-        <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-shrink-0 items-start justify-between gap-4">
           <div className="min-w-0">
             <h2 className="text-lg font-semibold text-text">
               {mode === 'create' ? 'Tambah Hutang / Piutang' : 'Edit Hutang / Piutang'}
@@ -242,118 +246,120 @@ export default function DebtForm({ open, mode, initialData, submitting, onSubmit
           </button>
         </div>
 
-        <form onSubmit={handleSubmit} className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="debt-type">
-            Tipe
-            <select
-              id="debt-type"
-              name="type"
-              value={values.type}
-              onChange={handleChange('type')}
-              className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-            >
-              <option value="debt">Hutang (kita berhutang)</option>
-              <option value="receivable">Piutang (orang berhutang)</option>
-            </select>
-          </label>
+        <form onSubmit={handleSubmit} className="mt-5 flex flex-1 flex-col overflow-hidden sm:mt-6">
+          <div className="grid flex-1 grid-cols-1 gap-4 overflow-y-auto pr-1 sm:grid-cols-2 sm:pr-2">
+            <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="debt-type">
+              Tipe
+              <select
+                id="debt-type"
+                name="type"
+                value={values.type}
+                onChange={handleChange('type')}
+                className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+              >
+                <option value="debt">Hutang (kita berhutang)</option>
+                <option value="receivable">Piutang (orang berhutang)</option>
+              </select>
+            </label>
 
-          <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="party-name">
-            Pihak
-            <input
-              ref={firstFieldRef}
-              id="party-name"
-              name="party_name"
-              value={values.party_name}
-              onChange={handleChange('party_name')}
-              className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-              placeholder="Nama pihak"
-              required
-            />
-            {errors.party_name ? <span className="text-xs text-danger">{errors.party_name}</span> : null}
-          </label>
+            <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="party-name">
+              Pihak
+              <input
+                ref={firstFieldRef}
+                id="party-name"
+                name="party_name"
+                value={values.party_name}
+                onChange={handleChange('party_name')}
+                className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+                placeholder="Nama pihak"
+                required
+              />
+              {errors.party_name ? <span className="text-xs text-danger">{errors.party_name}</span> : null}
+            </label>
 
-          <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="title">
-            Judul
-            <input
-              id="title"
-              name="title"
-              value={values.title}
-              onChange={handleChange('title')}
-              className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-              placeholder="Contoh: Pinjaman motor"
-              required
-            />
-            {errors.title ? <span className="text-xs text-danger">{errors.title}</span> : null}
-          </label>
+            <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="title">
+              Judul
+              <input
+                id="title"
+                name="title"
+                value={values.title}
+                onChange={handleChange('title')}
+                className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+                placeholder="Contoh: Pinjaman motor"
+                required
+              />
+              {errors.title ? <span className="text-xs text-danger">{errors.title}</span> : null}
+            </label>
 
-          <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="date">
-            Tanggal
-            <input
-              id="date"
-              name="date"
-              type="date"
-              value={values.date}
-              onChange={handleChange('date')}
-              className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-            />
-          </label>
+            <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="date">
+              Tanggal
+              <input
+                id="date"
+                name="date"
+                type="date"
+                value={values.date}
+                onChange={handleChange('date')}
+                className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+              />
+            </label>
 
-          <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="due-date">
-            Jatuh tempo
-            <input
-              id="due-date"
-              name="due_date"
-              type="date"
-              value={values.due_date}
-              onChange={handleChange('due_date')}
-              className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-            />
-            {dateWarning ? <span className="text-xs text-warning">{dateWarning}</span> : null}
-          </label>
+            <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="due-date">
+              Jatuh tempo
+              <input
+                id="due-date"
+                name="due_date"
+                type="date"
+                value={values.due_date}
+                onChange={handleChange('due_date')}
+                className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+              />
+              {dateWarning ? <span className="text-xs text-warning">{dateWarning}</span> : null}
+            </label>
 
-          <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="amount">
-            Jumlah
-            <input
-              id="amount"
-              name="amount"
-              value={values.amount}
-              onChange={handleChange('amount')}
-              inputMode="decimal"
-              placeholder="Masukkan nominal"
-              className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-              required
-            />
-            {errors.amount ? <span className="text-xs text-danger">{errors.amount}</span> : null}
-          </label>
+            <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="amount">
+              Jumlah
+              <input
+                id="amount"
+                name="amount"
+                value={values.amount}
+                onChange={handleChange('amount')}
+                inputMode="decimal"
+                placeholder="Masukkan nominal"
+                className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+                required
+              />
+              {errors.amount ? <span className="text-xs text-danger">{errors.amount}</span> : null}
+            </label>
 
-          <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="rate">
-            Bunga / Rate (%)
-            <input
-              id="rate"
-              name="rate_percent"
-              value={values.rate_percent}
-              onChange={handleChange('rate_percent')}
-              inputMode="decimal"
-              placeholder="Opsional"
-              className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-            />
-            {errors.rate_percent ? <span className="text-xs text-danger">{errors.rate_percent}</span> : null}
-          </label>
+            <label className="flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="rate">
+              Bunga / Rate (%)
+              <input
+                id="rate"
+                name="rate_percent"
+                value={values.rate_percent}
+                onChange={handleChange('rate_percent')}
+                inputMode="decimal"
+                placeholder="Opsional"
+                className="h-[40px] rounded-xl border border-border bg-surface-1 px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+              />
+              {errors.rate_percent ? <span className="text-xs text-danger">{errors.rate_percent}</span> : null}
+            </label>
 
-          <label className="sm:col-span-2 flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="notes">
-            Catatan
-            <textarea
-              id="notes"
-              name="notes"
-              value={values.notes}
-              onChange={handleChange('notes')}
-              rows={3}
-              className="rounded-xl border border-border bg-surface-1 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-              placeholder="Catatan tambahan (opsional)"
-            />
-          </label>
+            <label className="sm:col-span-2 flex min-w-0 flex-col gap-1 text-sm font-medium text-text" htmlFor="notes">
+              Catatan
+              <textarea
+                id="notes"
+                name="notes"
+                value={values.notes}
+                onChange={handleChange('notes')}
+                rows={3}
+                className="rounded-xl border border-border bg-surface-1 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+                placeholder="Catatan tambahan (opsional)"
+              />
+            </label>
+          </div>
 
-          <div className="sm:col-span-2 flex flex-col gap-3 pt-2 sm:flex-row sm:justify-end">
+          <div className="mt-5 flex flex-col gap-3 sm:mt-6 sm:flex-row sm:justify-end sm:gap-4">
             <button
               type="button"
               onClick={onClose}
@@ -364,7 +370,7 @@ export default function DebtForm({ open, mode, initialData, submitting, onSubmit
             <button
               type="submit"
               disabled={Boolean(submitting)}
-              className="inline-flex h-[42px] items-center justify-center rounded-xl bg-brand text-sm font-semibold text-brand-foreground px-6 transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)] disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex h-[42px] items-center justify-center rounded-xl bg-brand px-6 text-sm font-semibold text-brand-foreground transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)] disabled:cursor-not-allowed disabled:opacity-60"
             >
               {submitting ? 'Menyimpan…' : mode === 'create' ? 'Tambah' : 'Simpan perubahan'}
             </button>

--- a/src/components/debts/DebtsTableResponsive.tsx
+++ b/src/components/debts/DebtsTableResponsive.tsx
@@ -429,11 +429,11 @@ export default function DebtsTableResponsive({
                   </div>
                 </div>
 
-                <footer className="mt-4 flex items-center gap-2">
+                <footer className="mt-4 flex flex-wrap items-center gap-2">
                   <button
                     type="button"
                     onClick={() => onAddPayment(debt)}
-                    className="inline-flex flex-1 items-center justify-center gap-2 rounded-xl bg-brand px-3 py-2 text-sm font-semibold text-brand-foreground transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+                    className="inline-flex w-full min-w-[180px] flex-1 items-center justify-center gap-2 rounded-xl bg-brand px-3 py-2 text-sm font-semibold text-brand-foreground transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
                     aria-label="Catat pembayaran"
                   >
                     <Wallet className="h-4 w-4" aria-hidden="true" />
@@ -442,7 +442,7 @@ export default function DebtsTableResponsive({
                   <button
                     type="button"
                     onClick={() => onEdit(debt)}
-                    className="inline-flex flex-1 items-center justify-center gap-2 rounded-xl border border-border bg-card px-3 py-2 text-sm font-medium text-foreground transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+                    className="inline-flex w-full min-w-[150px] flex-1 items-center justify-center gap-2 rounded-xl border border-border bg-card px-3 py-2 text-sm font-medium text-foreground transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
                     aria-label="Ubah hutang"
                   >
                     <Pencil className="h-4 w-4" aria-hidden="true" />
@@ -451,7 +451,7 @@ export default function DebtsTableResponsive({
                   <button
                     type="button"
                     onClick={() => onDelete(debt)}
-                    className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border bg-card text-danger transition hover:bg-danger/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
+                    className="inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-border bg-card text-danger transition hover:bg-danger/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
                     aria-label="Hapus hutang"
                   >
                     <Trash2 className="h-4 w-4" aria-hidden="true" />

--- a/src/index.css
+++ b/src/index.css
@@ -326,19 +326,19 @@
   }
 
   .drawer-panel {
-    @apply fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col overflow-hidden rounded-l-3xl border border-border-subtle bg-surface shadow-[0_24px_60px_-30px_rgb(15_23_42/0.35)] transition-transform duration-300 ease-out;
+    @apply fixed inset-y-0 right-0 z-50 flex w-full max-w-full flex-col overflow-hidden rounded-none border border-border-subtle bg-surface shadow-[0_24px_60px_-30px_rgb(15_23_42/0.35)] transition-transform duration-300 ease-out sm:max-w-md sm:rounded-l-3xl;
   }
 
   .drawer-header {
-    @apply sticky top-0 z-10 flex items-center justify-between gap-3 border-b border-border-subtle bg-surface px-6 py-4;
+    @apply sticky top-0 z-10 flex items-center justify-between gap-3 border-b border-border-subtle bg-surface px-4 py-4 sm:px-6;
   }
 
   .drawer-footer {
-    @apply sticky bottom-0 z-10 flex flex-wrap items-center justify-end gap-2 border-t border-border-subtle bg-surface px-6 py-4;
+    @apply sticky bottom-0 z-10 flex flex-wrap items-center justify-end gap-2 border-t border-border-subtle bg-surface px-4 py-4 sm:px-6;
   }
 
   .drawer-body {
-    @apply flex-1 overflow-y-auto px-6 py-5;
+    @apply flex-1 overflow-y-auto px-4 py-5 sm:px-6;
   }
 
   .chip {


### PR DESCRIPTION
## Summary
- adjust the debt edit modal to use a scrollable layout with safer spacing on small screens
- relax drawer styles so the payment panel fills small viewports while keeping comfortable padding
- make the mobile "Catat pembayaran" actions wrap with full-width primary buttons for narrow devices

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d6a9d1383483329135735b7850e17d