### PR TITLE
Ensure daily digest opens when a session is established

### DIFF
--- a/src/hooks/useShowDigestOnLogin.ts
+++ b/src/hooks/useShowDigestOnLogin.ts
@@ -341,7 +341,7 @@ export default function useShowDigestOnLogin({
         autoOpenRef.current = false;
         return;
       }
-      if (event === 'SIGNED_IN') {
+      if (event === 'SIGNED_IN' || event === 'INITIAL_SESSION') {
         const uid = session?.user?.id ?? null;
         setUserId(uid);
         tryOpenForUser(uid, true);


### PR DESCRIPTION
## Summary
- treat Supabase INITIAL_SESSION events the same as SIGNED_IN for the daily digest hook
- ensure the digest modal opens automatically for users logging in with an existing session

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d6c2cf66188332aad3c8c881510c7e