### PR TITLE
Ensure daily digest auto-opens for unseen sessions

### DIFF
--- a/src/hooks/useShowDigestOnLogin.ts
+++ b/src/hooks/useShowDigestOnLogin.ts
@@ -309,7 +309,7 @@ export default function useShowDigestOnLogin({
       if (seenToday) {
         return;
       }
-      if (trigger || fromAuthEvent) {
+      if (trigger || fromAuthEvent || !autoOpenRef.current) {
         setOpen(true);
         autoOpenRef.current = true;
       }


### PR DESCRIPTION
## Summary
- ensure the daily digest modal auto-opens for signed-in users who have not seen today's digest yet, even without an auth trigger

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d6c2cf66188332aad3c8c881510c7e