### PR TITLE
Remove dashboard budget chart and sync status banner

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,6 @@ import {
 import AppSidebar from "./layout/AppSidebar";
 import MainLayout from "./layout/MainLayout";
 import SettingsPanel from "./components/SettingsPanel";
-import SyncBanner from "./components/SyncBanner";
 import BootGate from "./components/BootGate";
 
 import Dashboard from "./pages/Dashboard";
@@ -194,7 +193,6 @@ function ProtectedAppContainer({ theme, setTheme, brand, setBrand }) {
       }
     >
       <div className="flex min-h-full flex-col">
-        <SyncBanner />
         <div className="mx-auto w-full max-w-[1280px] px-4 py-6 sm:px-6 sm:py-8 lg:px-8 lg:py-10">
           <Outlet />
         </div>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from "react";
 import AchievementBadges from "../components/AchievementBadges";
 import QuickActions from "../components/QuickActions";
 import SectionHeader from "../components/SectionHeader";
-import MonthlyTrendChart from "../components/MonthlyTrendChart";
 import CategoryDonut from "../components/CategoryDonut";
 import TopSpendsTable from "../components/TopSpendsTable";
 import RecentTransactions from "../components/RecentTransactions";
@@ -126,8 +125,7 @@ export default function Dashboard({ stats, txs, budgets = [] }) {
 
         <section className="space-y-6 sm:space-y-8 lg:space-y-10">
           <SectionHeader title="Analisis Bulanan" />
-          <div className="grid gap-6 sm:gap-7 lg:gap-8 lg:grid-cols-2">
-            <MonthlyTrendChart data={insights.trend} />
+          <div className="grid gap-6 sm:gap-7 lg:gap-8">
             <CategoryDonut data={insights.categories} />
           </div>
           <div className="grid gap-6 sm:gap-7 lg:gap-8 lg:grid-cols-2">


### PR DESCRIPTION
## Summary
- remove the monthly analytics chart from the dashboard
- remove the sync status banner from the main layout so it no longer appears on each page

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d72257a8e483328f200ab99157f29e