### PR TITLE
feat: allow customizing admin dashboard hero content

### DIFF
--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,10 +1,12 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
 import { Icon } from '../components/icons';
 import AdminSidebarTab from './admin/AdminSidebarTab';
 import AdminUsersTab from './admin/AdminUsersTab';
 import AdminSettingsTab from './admin/AdminSettingsTab';
 import AdminAuditTab from './admin/AdminAuditTab';
+import { getAdminDashboardContent, type AdminDashboardContentSetting } from '../lib/adminApi';
+import { useToast } from '../context/ToastContext.jsx';
 
 export type AdminTabKey = 'sidebar' | 'users' | 'settings' | 'audit';
 
@@ -20,6 +22,14 @@ const TABS: TabDefinition[] = [
   { key: 'settings', label: 'App Settings', icon: 'settings' },
   { key: 'audit', label: 'Audit Log', icon: 'shield' },
 ];
+
+const DASHBOARD_CONTENT_DEFAULT = {
+  breadcrumb: 'Dashboard / Admin',
+  title: 'Admin Panel',
+  subtitle: '',
+  badge: 'Admin',
+  description: 'Kelola menu, pengguna, dan pengaturan aplikasi di satu tempat.',
+};
 
 function TabButton({
   tab,
@@ -50,6 +60,41 @@ function TabButton({
 
 export default function AdminPage() {
   const [activeTab, setActiveTab] = useState<AdminTabKey>('sidebar');
+  const { addToast } = useToast();
+  const [dashboardContent, setDashboardContent] = useState(() => ({ ...DASHBOARD_CONTENT_DEFAULT }));
+  const [loadingContent, setLoadingContent] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    const load = async () => {
+      setLoadingContent(true);
+      try {
+        const result: AdminDashboardContentSetting = await getAdminDashboardContent();
+        if (!active) return;
+        setDashboardContent({
+          breadcrumb: result.breadcrumb,
+          title: result.title,
+          subtitle: result.subtitle,
+          badge: result.badge,
+          description: result.description,
+        });
+      } catch (error) {
+        if (!active) return;
+        console.error('[AdminPage] load dashboard content failed', error);
+        const message = error instanceof Error ? error.message : 'Gagal memuat konten dashboard admin';
+        addToast(message, 'error');
+        setDashboardContent({ ...DASHBOARD_CONTENT_DEFAULT });
+      } finally {
+        if (active) {
+          setLoadingContent(false);
+        }
+      }
+    };
+    void load();
+    return () => {
+      active = false;
+    };
+  }, [addToast]);
 
   const ActiveSection = useMemo(() => {
     switch (activeTab) {
@@ -70,13 +115,42 @@ export default function AdminPage() {
       <header className="sticky top-0 z-20 border-b border-border/60 bg-background/80 backdrop-blur">
         <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-6 md:px-6 lg:px-8">
           <div>
-            <p className="text-xs font-medium text-muted-foreground">Dashboard / Admin</p>
-            <div className="mt-1 flex items-center gap-3">
-              <h1 className="text-2xl font-semibold tracking-tight">Admin Panel</h1>
-              <span className="inline-flex items-center rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
-                Admin
-              </span>
-            </div>
+            {loadingContent ? (
+              <div className="space-y-3">
+                <div className="h-3 w-32 animate-pulse rounded-full bg-muted/40" />
+                <div className="flex items-center gap-3">
+                  <div className="h-8 w-44 animate-pulse rounded-full bg-muted/40" />
+                  <div className="h-6 w-20 animate-pulse rounded-full bg-muted/30" />
+                </div>
+                <div className="h-4 w-72 animate-pulse rounded-full bg-muted/30" />
+              </div>
+            ) : (
+              <>
+                <p className="text-xs font-medium text-muted-foreground">
+                  {dashboardContent.breadcrumb?.trim() || DASHBOARD_CONTENT_DEFAULT.breadcrumb}
+                </p>
+                <div className="mt-1 flex flex-wrap items-center gap-3">
+                  <h1 className="text-2xl font-semibold tracking-tight">
+                    {dashboardContent.title?.trim() || DASHBOARD_CONTENT_DEFAULT.title}
+                  </h1>
+                  {dashboardContent.badge?.trim() ? (
+                    <span className="inline-flex items-center rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
+                      {dashboardContent.badge.trim()}
+                    </span>
+                  ) : null}
+                </div>
+                {dashboardContent.subtitle?.trim() ? (
+                  <p className="mt-2 text-sm font-medium text-muted-foreground">
+                    {dashboardContent.subtitle.trim()}
+                  </p>
+                ) : null}
+                {dashboardContent.description?.trim() ? (
+                  <p className="mt-3 max-w-2xl text-sm text-muted-foreground">
+                    {dashboardContent.description.trim()}
+                  </p>
+                ) : null}
+              </>
+            )}
           </div>
         </div>
       </header>

--- a/src/pages/admin/AdminSettingsTab.tsx
+++ b/src/pages/admin/AdminSettingsTab.tsx
@@ -2,10 +2,13 @@ import { FormEvent, useEffect, useState } from 'react';
 import clsx from 'clsx';
 import { useToast } from '../../context/ToastContext.jsx';
 import {
+  getAdminDashboardContent,
   getAppDescription,
   getBranding,
+  setAdminDashboardContent,
   setAppDescription,
   setBranding,
+  type AdminDashboardContentSetting,
   type AppDescriptionSetting,
   type BrandingSetting,
 } from '../../lib/adminApi';
@@ -26,27 +29,58 @@ type BrandingForm = {
   secondary: string;
 };
 
+type DashboardContentForm = {
+  breadcrumb: string;
+  title: string;
+  subtitle: string;
+  badge: string;
+  description: string;
+};
+
+const DASHBOARD_CONTENT_DEFAULT: DashboardContentForm = {
+  breadcrumb: 'Dashboard / Admin',
+  title: 'Admin Panel',
+  subtitle: '',
+  badge: 'Admin',
+  description: 'Kelola menu, pengguna, dan pengaturan aplikasi di satu tempat.',
+};
+
 export default function AdminSettingsTab() {
   const { addToast } = useToast();
   const [description, setDescription] = useState('');
   const [descriptionMeta, setDescriptionMeta] = useState<string | null>(null);
   const [branding, setBrandingState] = useState<BrandingForm>({ primary: '#1e40af', secondary: '#0ea5e9' });
   const [brandingMeta, setBrandingMeta] = useState<string | null>(null);
+  const [dashboardContent, setDashboardContent] = useState<DashboardContentForm>(DASHBOARD_CONTENT_DEFAULT);
+  const [dashboardMeta, setDashboardMeta] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [savingDesc, setSavingDesc] = useState(false);
   const [savingBrand, setSavingBrand] = useState(false);
+  const [savingDashboard, setSavingDashboard] = useState(false);
 
   useEffect(() => {
     let mounted = true;
     const load = async () => {
       setLoading(true);
       try {
-        const [desc, brand] = await Promise.all([getAppDescription(), getBranding()]);
+        const [desc, brand, content] = await Promise.all([
+          getAppDescription(),
+          getBranding(),
+          getAdminDashboardContent(),
+        ]);
         if (!mounted) return;
         setDescription(desc.text ?? '');
         setDescriptionMeta(desc.updated_at ?? null);
         setBrandingState({ primary: brand.primary, secondary: brand.secondary });
         setBrandingMeta(brand.updated_at ?? null);
+        setDashboardContent({
+          breadcrumb: content.breadcrumb,
+          title: content.title,
+          subtitle: content.subtitle,
+          badge: content.badge,
+          description: content.description,
+        });
+        setDashboardMeta(content.updated_at ?? null);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Gagal memuat pengaturan';
         if (mounted) {
@@ -110,9 +144,32 @@ export default function AdminSettingsTab() {
     }
   };
 
+  const handleDashboardContentSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (savingDashboard) return;
+    setSavingDashboard(true);
+    try {
+      const result: AdminDashboardContentSetting = await setAdminDashboardContent(dashboardContent);
+      setDashboardContent({
+        breadcrumb: result.breadcrumb,
+        title: result.title,
+        subtitle: result.subtitle,
+        badge: result.badge,
+        description: result.description,
+      });
+      setDashboardMeta(result.updated_at ?? null);
+      addToast('Konten dashboard admin diperbarui', 'success');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Gagal menyimpan konten dashboard';
+      addToast(message, 'error');
+    } finally {
+      setSavingDashboard(false);
+    }
+  };
+
   const renderSkeleton = () => (
     <div className="grid gap-6 lg:grid-cols-2">
-      {Array.from({ length: 2 }).map((_, index) => (
+      {Array.from({ length: 3 }).map((_, index) => (
         <div key={index} className="space-y-4 rounded-2xl border border-border/60 bg-muted/20 p-6">
           <div className="h-6 w-32 animate-pulse rounded-full bg-muted/40" />
           <div className="h-5 w-48 animate-pulse rounded-full bg-muted/40" />
@@ -136,6 +193,80 @@ export default function AdminSettingsTab() {
         renderSkeleton()
       ) : (
         <div className="grid gap-6 lg:grid-cols-2">
+          <form
+            onSubmit={handleDashboardContentSubmit}
+            className="space-y-4 rounded-2xl border border-border/60 bg-background p-6 shadow-sm"
+          >
+            <div>
+              <h3 className="text-base font-semibold">Konten Dashboard Admin</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Sesuaikan judul, deskripsi, dan label untuk halaman dashboard admin agar sesuai dengan identitas tim Anda.
+              </p>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="text-sm font-semibold text-muted-foreground">
+                Breadcrumb
+                <input
+                  value={dashboardContent.breadcrumb}
+                  onChange={(event) =>
+                    setDashboardContent((prev) => ({ ...prev, breadcrumb: event.target.value }))
+                  }
+                  className={clsx(INPUT_CLASS, 'mt-1')}
+                  placeholder="Dashboard / Admin"
+                />
+              </label>
+              <label className="text-sm font-semibold text-muted-foreground">
+                Label Badge
+                <input
+                  value={dashboardContent.badge}
+                  onChange={(event) => setDashboardContent((prev) => ({ ...prev, badge: event.target.value }))}
+                  className={clsx(INPUT_CLASS, 'mt-1')}
+                  placeholder="Admin"
+                />
+              </label>
+            </div>
+            <label className="text-sm font-semibold text-muted-foreground">
+              Judul Halaman
+              <input
+                value={dashboardContent.title}
+                onChange={(event) => setDashboardContent((prev) => ({ ...prev, title: event.target.value }))}
+                className={clsx(INPUT_CLASS, 'mt-1')}
+                placeholder="Admin Panel"
+              />
+            </label>
+            <label className="text-sm font-semibold text-muted-foreground">
+              Subjudul
+              <input
+                value={dashboardContent.subtitle}
+                onChange={(event) => setDashboardContent((prev) => ({ ...prev, subtitle: event.target.value }))}
+                className={clsx(INPUT_CLASS, 'mt-1')}
+                placeholder="Kelola kebutuhan operasional dengan mudah"
+              />
+            </label>
+            <label className="text-sm font-semibold text-muted-foreground">
+              Deskripsi Halaman
+              <textarea
+                value={dashboardContent.description}
+                onChange={(event) => setDashboardContent((prev) => ({ ...prev, description: event.target.value }))}
+                className={TEXTAREA_CLASS}
+                placeholder="Kelola menu, pengguna, dan pengaturan aplikasi di satu tempat."
+              />
+            </label>
+            <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
+              <span>
+                {dashboardMeta
+                  ? `Terakhir diperbarui ${dateFormatter.format(new Date(dashboardMeta))}`
+                  : 'Belum pernah disimpan'}
+              </span>
+              <button
+                type="submit"
+                className="h-11 rounded-2xl bg-primary px-6 text-sm font-medium text-white transition hover:bg-primary/90 disabled:opacity-50"
+                disabled={savingDashboard}
+              >
+                Simpan Konten
+              </button>
+            </div>
+          </form>
           <form
             onSubmit={handleDescriptionSubmit}
             className="space-y-4 rounded-2xl border border-border/60 bg-background p-6 shadow-sm"


### PR DESCRIPTION
## Summary
- add Supabase helpers to read and update admin dashboard hero content
- expose new controls in the admin settings tab for editing breadcrumb, title, subtitle, badge, and description
- render the admin dashboard header from the saved settings with loading skeletons and toast errors

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7267991c88332b352bd59a7654364