### PR TITLE
feat: redesign mobile sidebar header

### DIFF
--- a/src/layout/AppShell.jsx
+++ b/src/layout/AppShell.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { NavLink, useLocation, useRoutes } from "react-router-dom";
+import { Bell, CircleUserRound, Mail, Menu, Search } from "lucide-react";
 import { NAV_ITEMS } from "../router/nav.config";
 import { buildBreadcrumbs } from "../router/breadcrumbs";
 import { ROUTES } from "../router/routes";
@@ -13,6 +14,7 @@ function ShellContent() {
   const { mode } = useMode();
   const [theme, setTheme] = useState("dark");
   const [brand, setBrand] = useState({ h: 211, s: 92, l: 60 });
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
   return (
     <div className="flex min-h-screen w-full min-w-0">
@@ -21,23 +23,68 @@ function ShellContent() {
         setTheme={setTheme}
         brand={brand}
         setBrand={setBrand}
+        mobileOpen={mobileNavOpen}
+        onMobileOpenChange={setMobileNavOpen}
       />
       <div className="flex min-w-0 flex-1 flex-col">
-        <nav
-          aria-label="Breadcrumb"
-          className="border-b p-4 text-sm"
-        >
-          {breadcrumbs.map((b, idx) => (
-            <span key={b.path}>
-              {idx > 0 && " / "}
-              {idx < breadcrumbs.length - 1 ? (
-                <NavLink to={b.path}>{b.title}</NavLink>
-              ) : (
-                <span>{b.title}</span>
-              )}
-            </span>
-          ))}
-        </nav>
+        <header className="border-b border-border/40 bg-indigo-500 text-white shadow-sm">
+          <div className="flex items-center justify-between gap-3 px-4 py-3 lg:px-6">
+            <button
+              type="button"
+              onClick={() => setMobileNavOpen(true)}
+              aria-label="Buka navigasi"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white transition hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-indigo-500 lg:hidden"
+            >
+              <Menu className="h-5 w-5" />
+            </button>
+            <div className="ml-auto flex items-center gap-2">
+              <button
+                type="button"
+                aria-label="Cari"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white transition hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-indigo-500"
+              >
+                <Search className="h-5 w-5" />
+              </button>
+              <button
+                type="button"
+                aria-label="Pesan masuk"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white transition hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-indigo-500"
+              >
+                <Mail className="h-5 w-5" />
+              </button>
+              <button
+                type="button"
+                aria-label="Notifikasi"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white transition hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-indigo-500"
+              >
+                <Bell className="h-5 w-5" />
+              </button>
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-white/20 text-white">
+                <CircleUserRound className="h-5 w-5" />
+              </div>
+            </div>
+          </div>
+          <nav
+            aria-label="Breadcrumb"
+            className="px-4 pb-3 text-xs text-white/80 lg:px-6"
+          >
+            {breadcrumbs.map((b, idx) => (
+              <span key={b.path}>
+                {idx > 0 && <span className="px-1">/</span>}
+                {idx < breadcrumbs.length - 1 ? (
+                  <NavLink
+                    to={b.path}
+                    className="text-white/90 underline-offset-4 hover:text-white"
+                  >
+                    {b.title}
+                  </NavLink>
+                ) : (
+                  <span className="font-semibold text-white">{b.title}</span>
+                )}
+              </span>
+            ))}
+          </nav>
+        </header>
         <main className="flex-1 min-w-0 p-4">{element}</main>
         <div className="border-t p-2 text-right text-xs">
           {mode === "online" ? "✅ Online Mode aktif" : "📴 Local Mode aktif"}

--- a/src/layout/AppSidebar.tsx
+++ b/src/layout/AppSidebar.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
 import clsx from "clsx";
-import { Menu } from "lucide-react";
 import Sidebar from "../components/sidebar/Sidebar";
 import MobileDrawer from "../components/sidebar/MobileDrawer";
 
@@ -17,6 +16,8 @@ interface AppSidebarProps {
   setTheme: (mode: ThemeMode) => void;
   brand: BrandConfig;
   setBrand: (brand: BrandConfig) => void;
+  mobileOpen?: boolean;
+  onMobileOpenChange?: (open: boolean) => void;
 }
 
 const STORAGE_KEY = "hw:sidebar-collapsed";
@@ -26,6 +27,8 @@ export default function AppSidebar({
   setTheme,
   brand,
   setBrand,
+  mobileOpen: mobileOpenProp,
+  onMobileOpenChange,
 }: AppSidebarProps) {
   const [collapsed, setCollapsed] = useState(() => {
     try {
@@ -34,7 +37,13 @@ export default function AppSidebar({
       return false;
     }
   });
-  const [mobileOpen, setMobileOpen] = useState(false);
+  const [internalMobileOpen, setInternalMobileOpen] = useState(false);
+
+  const mobileOpen = mobileOpenProp ?? internalMobileOpen;
+  const handleMobileOpenChange = (open: boolean) => {
+    setInternalMobileOpen(open);
+    onMobileOpenChange?.(open);
+  };
 
   useEffect(() => {
     try {
@@ -66,25 +75,15 @@ export default function AppSidebar({
           {...sidebarProps}
         />
       </aside>
-      <MobileDrawer open={mobileOpen} onOpenChange={setMobileOpen}>
+      <MobileDrawer open={mobileOpen} onOpenChange={handleMobileOpenChange}>
         <Sidebar
           collapsed={false}
           onToggle={setCollapsed}
-          onNavigate={() => setMobileOpen(false)}
-          onClose={() => setMobileOpen(false)}
+          onNavigate={() => handleMobileOpenChange(false)}
+          onClose={() => handleMobileOpenChange(false)}
           {...sidebarProps}
         />
       </MobileDrawer>
-      <button
-        type="button"
-        onClick={() => setMobileOpen(true)}
-        aria-label="Buka navigasi"
-        aria-expanded={mobileOpen}
-        className="group fixed right-4 top-[1.125rem] z-[65] inline-flex h-12 w-12 items-center justify-center overflow-hidden rounded-2xl border border-border/70 bg-surface-1/95 text-text shadow-lg shadow-black/10 backdrop-blur transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background active:scale-95 lg:hidden"
-      >
-        <span className="sr-only">Buka navigasi</span>
-        <Menu className="h-5 w-5 transition-transform duration-200 group-hover:scale-110" />
-      </button>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- restyle the main header to match the requested mobile sidebar layout with action icons
- manage the mobile drawer state from the shell so the sidebar can be opened from the new header button
- simplify the sidebar component by removing the floating opener and supporting external control of the drawer

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d73f99bd648332aa9cc8f724a28779