### PR TITLE
Add topbar with navigation controls

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import {
 } from "react-router-dom";
 
 import AppSidebar from "./layout/AppSidebar";
+import AppTopbar from "./layout/AppTopbar";
 import MainLayout from "./layout/MainLayout";
 import SettingsPanel from "./components/SettingsPanel";
 import BootGate from "./components/BootGate";
@@ -177,6 +178,29 @@ function loadInitial() {
 function ProtectedAppContainer({ theme, setTheme, brand, setBrand }) {
   const location = useLocation();
   const hideNav = location.pathname.startsWith("/add");
+  const navigate = useNavigate();
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+
+  useEffect(() => {
+    if (hideNav) setMobileNavOpen(false);
+  }, [hideNav]);
+
+  const handleProfileClick = useCallback(() => {
+    navigate("/profile");
+  }, [navigate]);
+
+  const handleSettingsClick = useCallback(() => {
+    navigate("/settings");
+  }, [navigate]);
+
+  const handleLogout = useCallback(async () => {
+    try {
+      await supabase.auth.signOut();
+      navigate("/auth/login");
+    } catch (error) {
+      console.error("Gagal keluar dari aplikasi", error);
+    }
+  }, [navigate]);
 
   return (
     <MainLayout
@@ -188,6 +212,18 @@ function ProtectedAppContainer({ theme, setTheme, brand, setBrand }) {
             setTheme={setTheme}
             brand={brand}
             setBrand={setBrand}
+            mobileOpen={mobileNavOpen}
+            onMobileOpenChange={setMobileNavOpen}
+          />
+        ) : null
+      }
+      topbar={
+        !hideNav ? (
+          <AppTopbar
+            onMenuClick={() => setMobileNavOpen(true)}
+            onProfileClick={handleProfileClick}
+            onSettingsClick={handleSettingsClick}
+            onLogoutClick={handleLogout}
           />
         ) : null
       }

--- a/src/layout/AppSidebar.tsx
+++ b/src/layout/AppSidebar.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
 import clsx from "clsx";
-import { Menu } from "lucide-react";
 import Sidebar from "../components/sidebar/Sidebar";
 import MobileDrawer from "../components/sidebar/MobileDrawer";
 
@@ -17,6 +16,8 @@ interface AppSidebarProps {
   setTheme: (mode: ThemeMode) => void;
   brand: BrandConfig;
   setBrand: (brand: BrandConfig) => void;
+  mobileOpen: boolean;
+  onMobileOpenChange: (open: boolean) => void;
 }
 
 const STORAGE_KEY = "hw:sidebar-collapsed";
@@ -26,6 +27,8 @@ export default function AppSidebar({
   setTheme,
   brand,
   setBrand,
+  mobileOpen,
+  onMobileOpenChange,
 }: AppSidebarProps) {
   const [collapsed, setCollapsed] = useState(() => {
     try {
@@ -34,8 +37,6 @@ export default function AppSidebar({
       return false;
     }
   });
-  const [mobileOpen, setMobileOpen] = useState(false);
-
   useEffect(() => {
     try {
       localStorage.setItem(STORAGE_KEY, collapsed ? "1" : "0");
@@ -66,25 +67,15 @@ export default function AppSidebar({
           {...sidebarProps}
         />
       </aside>
-      <MobileDrawer open={mobileOpen} onOpenChange={setMobileOpen}>
+      <MobileDrawer open={mobileOpen} onOpenChange={onMobileOpenChange}>
         <Sidebar
           collapsed={false}
           onToggle={setCollapsed}
-          onNavigate={() => setMobileOpen(false)}
-          onClose={() => setMobileOpen(false)}
+          onNavigate={() => onMobileOpenChange(false)}
+          onClose={() => onMobileOpenChange(false)}
           {...sidebarProps}
         />
       </MobileDrawer>
-      <button
-        type="button"
-        onClick={() => setMobileOpen(true)}
-        aria-label="Buka navigasi"
-        aria-expanded={mobileOpen}
-        className="group fixed right-4 top-[1.125rem] z-[65] inline-flex h-12 w-12 items-center justify-center overflow-hidden rounded-2xl border border-border/70 bg-surface-1/95 text-text shadow-lg shadow-black/10 backdrop-blur transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background active:scale-95 lg:hidden"
-      >
-        <span className="sr-only">Buka navigasi</span>
-        <Menu className="h-5 w-5 transition-transform duration-200 group-hover:scale-110" />
-      </button>
     </>
   );
 }

--- a/src/layout/AppTopbar.jsx
+++ b/src/layout/AppTopbar.jsx
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Bell, ChevronDown, Menu, User2 } from "lucide-react";
+
+const noop = () => {};
+
+export default function AppTopbar({
+  onMenuClick = noop,
+  onProfileClick = noop,
+  onSettingsClick = noop,
+  onLogoutClick = noop,
+}) {
+  const [profileOpen, setProfileOpen] = useState(false);
+  const containerRef = useRef(null);
+  const triggerRef = useRef(null);
+
+  useEffect(() => {
+    if (!profileOpen) return;
+
+    const handlePointerDown = (event) => {
+      if (!containerRef.current) return;
+      if (containerRef.current.contains(event.target)) return;
+      setProfileOpen(false);
+    };
+
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setProfileOpen(false);
+        requestAnimationFrame(() => {
+          triggerRef.current?.focus?.();
+        });
+      }
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [profileOpen]);
+
+  const handleMenuItem = useCallback(
+    (handler) => () => {
+      setProfileOpen(false);
+      handler?.();
+    },
+    []
+  );
+
+  return (
+    <header
+      className="sticky top-0 z-[60] border-b border-border/70 bg-surface-1/95 text-text shadow-sm backdrop-blur supports-[backdrop-filter]:bg-surface-1/80"
+      style={{ "--app-topbar-h": "64px" }}
+    >
+      <div className="flex h-[var(--app-topbar-h)] items-center justify-between px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={onMenuClick}
+            className="inline-flex h-11 w-11 items-center justify-center rounded-2xl border border-border/70 bg-surface-1 text-text shadow-sm transition-colors duration-200 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background lg:hidden"
+          >
+            <span className="sr-only">Buka menu navigasi</span>
+            <Menu className="h-5 w-5" />
+          </button>
+          <span className="text-base font-semibold sm:text-lg">HematWoi</span>
+        </div>
+        <div className="flex items-center gap-2 sm:gap-3">
+          <button
+            type="button"
+            className="relative inline-flex h-11 w-11 items-center justify-center rounded-2xl border border-border/70 bg-surface-1 text-text shadow-sm transition-colors duration-200 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            aria-label="Lihat notifikasi"
+          >
+            <Bell className="h-5 w-5" />
+          </button>
+          <div className="relative" ref={containerRef}>
+            <button
+              type="button"
+              ref={triggerRef}
+              aria-haspopup="menu"
+              aria-expanded={profileOpen}
+              onClick={() => setProfileOpen((prev) => !prev)}
+              className="inline-flex items-center gap-2 rounded-2xl border border-border/70 bg-surface-1 px-3 py-2 text-sm font-medium shadow-sm transition-colors duration-200 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            >
+              <User2 className="h-5 w-5" aria-hidden="true" />
+              <span className="hidden text-sm sm:inline">Profil</span>
+              <ChevronDown className="h-4 w-4" aria-hidden="true" />
+            </button>
+            {profileOpen ? (
+              <div
+                className="absolute right-0 mt-2 w-48 overflow-hidden rounded-xl border border-border/70 bg-surface-1 text-sm shadow-lg shadow-black/10 focus:outline-none"
+                role="menu"
+                aria-label="Menu profil"
+              >
+                <button
+                  type="button"
+                  onClick={handleMenuItem(onProfileClick)}
+                  className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm font-medium text-text transition-colors duration-150 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+                  role="menuitem"
+                >
+                  Profil saya
+                </button>
+                <button
+                  type="button"
+                  onClick={handleMenuItem(onSettingsClick)}
+                  className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm font-medium text-text transition-colors duration-150 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+                  role="menuitem"
+                >
+                  Pengaturan
+                </button>
+                <button
+                  type="button"
+                  onClick={handleMenuItem(onLogoutClick)}
+                  className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm font-medium text-destructive transition-colors duration-150 hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40"
+                  role="menuitem"
+                >
+                  Keluar
+                </button>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add a sticky application topbar with hamburger, notification, and profile actions
- connect profile menu actions to navigation and Supabase sign-out handling
- refactor the sidebar mobile drawer to be controlled from the main layout

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7927b23008332ba4928e6637d6cb0