### PR TITLE
Add responsive top bar with profile controls

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import {
 } from "react-router-dom";
 
 import AppSidebar from "./layout/AppSidebar";
+import AppTopbar from "./layout/AppTopbar";
 import MainLayout from "./layout/MainLayout";
 import SettingsPanel from "./components/SettingsPanel";
 import BootGate from "./components/BootGate";
@@ -177,6 +178,13 @@ function loadInitial() {
 function ProtectedAppContainer({ theme, setTheme, brand, setBrand }) {
   const location = useLocation();
   const hideNav = location.pathname.startsWith("/add");
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+
+  useEffect(() => {
+    if (hideNav && mobileSidebarOpen) {
+      setMobileSidebarOpen(false);
+    }
+  }, [hideNav, mobileSidebarOpen]);
 
   return (
     <MainLayout
@@ -188,7 +196,14 @@ function ProtectedAppContainer({ theme, setTheme, brand, setBrand }) {
             setTheme={setTheme}
             brand={brand}
             setBrand={setBrand}
+            mobileOpen={mobileSidebarOpen}
+            onMobileOpenChange={setMobileSidebarOpen}
           />
+        ) : null
+      }
+      topbar={
+        !hideNav ? (
+          <AppTopbar onMenuClick={() => setMobileSidebarOpen(true)} />
         ) : null
       }
     >

--- a/src/layout/AppSidebar.tsx
+++ b/src/layout/AppSidebar.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
 import clsx from "clsx";
-import { Menu } from "lucide-react";
 import Sidebar from "../components/sidebar/Sidebar";
 import MobileDrawer from "../components/sidebar/MobileDrawer";
 
@@ -17,6 +16,8 @@ interface AppSidebarProps {
   setTheme: (mode: ThemeMode) => void;
   brand: BrandConfig;
   setBrand: (brand: BrandConfig) => void;
+  mobileOpen: boolean;
+  onMobileOpenChange: (open: boolean) => void;
 }
 
 const STORAGE_KEY = "hw:sidebar-collapsed";
@@ -26,6 +27,8 @@ export default function AppSidebar({
   setTheme,
   brand,
   setBrand,
+  mobileOpen,
+  onMobileOpenChange,
 }: AppSidebarProps) {
   const [collapsed, setCollapsed] = useState(() => {
     try {
@@ -34,7 +37,6 @@ export default function AppSidebar({
       return false;
     }
   });
-  const [mobileOpen, setMobileOpen] = useState(false);
 
   useEffect(() => {
     try {
@@ -66,25 +68,15 @@ export default function AppSidebar({
           {...sidebarProps}
         />
       </aside>
-      <MobileDrawer open={mobileOpen} onOpenChange={setMobileOpen}>
+      <MobileDrawer open={mobileOpen} onOpenChange={onMobileOpenChange}>
         <Sidebar
           collapsed={false}
           onToggle={setCollapsed}
-          onNavigate={() => setMobileOpen(false)}
-          onClose={() => setMobileOpen(false)}
+          onNavigate={() => onMobileOpenChange(false)}
+          onClose={() => onMobileOpenChange(false)}
           {...sidebarProps}
         />
       </MobileDrawer>
-      <button
-        type="button"
-        onClick={() => setMobileOpen(true)}
-        aria-label="Buka navigasi"
-        aria-expanded={mobileOpen}
-        className="group fixed right-4 top-[1.125rem] z-[65] inline-flex h-12 w-12 items-center justify-center overflow-hidden rounded-2xl border border-border/70 bg-surface-1/95 text-text shadow-lg shadow-black/10 backdrop-blur transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background active:scale-95 lg:hidden"
-      >
-        <span className="sr-only">Buka navigasi</span>
-        <Menu className="h-5 w-5 transition-transform duration-200 group-hover:scale-110" />
-      </button>
     </>
   );
 }

--- a/src/layout/AppTopbar.jsx
+++ b/src/layout/AppTopbar.jsx
@@ -1,0 +1,221 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  Bell,
+  ChevronDown,
+  LogOut,
+  Menu,
+  Settings,
+  User as UserIcon,
+} from "lucide-react";
+import Logo from "../components/Logo";
+import { supabase } from "../lib/supabase";
+
+function useCurrentUser() {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    let active = true;
+    supabase.auth
+      .getUser()
+      .then(({ data }) => {
+        if (!active) return;
+        setUser(data.user ?? null);
+      })
+      .catch(() => {
+        if (!active) return;
+        setUser(null);
+      });
+
+    const { data: subscription } = supabase.auth.onAuthStateChange(
+      (_event, session) => {
+        if (!active) return;
+        setUser(session?.user ?? null);
+      }
+    );
+
+    return () => {
+      active = false;
+      subscription.subscription?.unsubscribe?.();
+    };
+  }, []);
+
+  return user;
+}
+
+function ProfileMenu() {
+  const user = useCurrentUser();
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef(null);
+
+  const displayName = useMemo(() => {
+    if (!user) return "Pengguna";
+    const fullName = user.user_metadata?.full_name;
+    if (fullName && String(fullName).trim()) {
+      return String(fullName).trim();
+    }
+    const email = user.email;
+    if (email && String(email).trim()) {
+      return String(email).trim();
+    }
+    return "Pengguna";
+  }, [user]);
+
+  const initials = useMemo(() => {
+    const source = displayName || "Pengguna";
+    const parts = source.split(/\s+/).filter(Boolean);
+    if (!parts.length) return "P";
+    const first = parts[0]?.[0];
+    const last = parts.length > 1 ? parts[parts.length - 1]?.[0] : parts[0]?.[1];
+    const chars = `${first ?? ""}${last ?? ""}`.toUpperCase();
+    return chars || "P";
+  }, [displayName]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const handlePointerDown = (event) => {
+      if (!menuRef.current) return;
+      if (menuRef.current.contains(event.target)) return;
+      setOpen(false);
+    };
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  const handleLogout = async () => {
+    try {
+      await supabase.auth.signOut();
+    } catch {
+      /* ignore */
+    } finally {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="group flex items-center gap-3 rounded-2xl border border-border/70 bg-surface-1 px-2.5 py-1.5 text-left text-sm font-medium text-text shadow-sm transition-colors hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      >
+        <span className="flex h-9 w-9 items-center justify-center rounded-full bg-brand/15 text-sm font-semibold text-brand">
+          {initials}
+        </span>
+        <span className="hidden min-w-0 flex-col sm:flex">
+          <span className="truncate text-xs text-muted">Akun</span>
+          <span className="truncate text-sm font-semibold text-text">
+            {displayName}
+          </span>
+        </span>
+        <ChevronDown
+          aria-hidden="true"
+          className={`h-4 w-4 text-muted transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+      {open ? (
+        <div
+          role="menu"
+          aria-label="Menu profil"
+          className="absolute right-0 mt-3 w-56 rounded-2xl border border-border/70 bg-surface-1 p-2 text-sm shadow-lg shadow-black/10"
+        >
+          <Link
+            to="/profile"
+            role="menuitem"
+            onClick={() => setOpen(false)}
+            className="flex items-center gap-2 rounded-xl px-3 py-2 text-text transition-colors hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+          >
+            <UserIcon className="h-4 w-4" aria-hidden="true" />
+            Profil Saya
+          </Link>
+          <Link
+            to="/settings"
+            role="menuitem"
+            onClick={() => setOpen(false)}
+            className="mt-1 flex items-center gap-2 rounded-xl px-3 py-2 text-text transition-colors hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+          >
+            <Settings className="h-4 w-4" aria-hidden="true" />
+            Pengaturan
+          </Link>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={handleLogout}
+            className="mt-1 flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-text transition-colors hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+          >
+            <LogOut className="h-4 w-4" aria-hidden="true" />
+            Keluar
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default function AppTopbar({ onMenuClick = () => {} }) {
+  useEffect(() => {
+    const root = document.documentElement;
+    const previousHeaderHeight = root.style.getPropertyValue("--app-header-height");
+    const previousTopbarHeight = root.style.getPropertyValue("--app-topbar-h");
+    root.style.setProperty("--app-header-height", "64px");
+    root.style.setProperty("--app-topbar-h", "64px");
+    return () => {
+      if (previousHeaderHeight) {
+        root.style.setProperty("--app-header-height", previousHeaderHeight);
+      } else {
+        root.style.removeProperty("--app-header-height");
+      }
+      if (previousTopbarHeight) {
+        root.style.setProperty("--app-topbar-h", previousTopbarHeight);
+      } else {
+        root.style.removeProperty("--app-topbar-h");
+      }
+    };
+  }, []);
+
+  return (
+    <header
+      className="sticky top-0 z-[60] w-full border-b border-border/70 bg-surface-1/95 backdrop-blur supports-[backdrop-filter]:bg-surface-1/80"
+      style={{ "--app-topbar-h": "64px" }}
+    >
+      <div className="mx-auto flex h-[var(--app-topbar-h)] w-full max-w-[1280px] items-center justify-between px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={onMenuClick}
+            className="inline-flex h-11 w-11 items-center justify-center rounded-2xl border border-border/70 bg-surface-1 text-text shadow-sm transition-colors hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            aria-label="Buka menu navigasi"
+          >
+            <Menu className="h-5 w-5" aria-hidden="true" />
+          </button>
+          <div className="flex items-center gap-2">
+            <Logo className="h-8 w-auto" />
+            <span className="text-base font-semibold text-text">HematWoi</span>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 sm:gap-3">
+          <button
+            type="button"
+            aria-label="Lihat notifikasi"
+            className="relative inline-flex h-11 w-11 items-center justify-center rounded-2xl border border-border/70 bg-surface-1 text-text shadow-sm transition-colors hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          >
+            <Bell className="h-5 w-5" aria-hidden="true" />
+            <span className="pointer-events-none absolute right-2 top-2 inline-flex h-2 w-2 rounded-full bg-brand" />
+          </button>
+          <ProfileMenu />
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add a sticky top bar that shows the app logo, hamburger menu trigger, notifications, and a profile dropdown
- connect the new top bar with the existing mobile sidebar drawer state and remove the standalone floating trigger button

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7927b23008332ba4928e6637d6cb0