### PR TITLE
Add wishlist management page with filtering and batch actions

### DIFF
--- a/src/components/wishlist/WishlistBatchToolbar.tsx
+++ b/src/components/wishlist/WishlistBatchToolbar.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import { Trash2 } from 'lucide-react';
+import type { WishlistStatus } from '../../lib/wishlistApi';
+
+interface WishlistBatchToolbarProps {
+  selectedCount: number;
+  onClear: () => void;
+  onDelete: () => void;
+  onStatusChange: (status: WishlistStatus) => void;
+  onPriorityChange: (priority: number) => void;
+  disabled?: boolean;
+}
+
+export default function WishlistBatchToolbar({
+  selectedCount,
+  onClear,
+  onDelete,
+  onStatusChange,
+  onPriorityChange,
+  disabled = false,
+}: WishlistBatchToolbarProps) {
+  const [statusValue, setStatusValue] = useState('');
+  const [priorityValue, setPriorityValue] = useState('');
+
+  return (
+    <div className="fixed inset-x-0 bottom-4 z-40 flex justify-center px-4">
+      <div className="flex w-full max-w-3xl flex-wrap items-center gap-3 rounded-3xl border border-slate-800/80 bg-slate-950/90 px-5 py-3 shadow-2xl backdrop-blur">
+        <div className="flex flex-1 flex-wrap items-center gap-3 text-sm text-slate-200">
+          <span className="font-semibold text-slate-100">{selectedCount} dipilih</span>
+          <div className="flex items-center gap-2 text-xs text-slate-400">
+            <label className="flex items-center gap-2">
+              <span>Status</span>
+              <select
+                value={statusValue}
+                onChange={(event) => {
+                  const value = event.target.value;
+                  setStatusValue(value);
+                  if (value) {
+                    onStatusChange(value as WishlistStatus);
+                    setTimeout(() => setStatusValue(''), 200);
+                  }
+                }}
+                className="h-9 rounded-2xl border-none bg-slate-900/80 px-3 text-sm text-slate-100 ring-2 ring-slate-800 transition focus-visible:outline-none focus-visible:ring-[var(--accent)]"
+                disabled={disabled}
+              >
+                <option value="">Ubah status…</option>
+                <option value="planned">Direncanakan</option>
+                <option value="deferred">Ditunda</option>
+                <option value="purchased">Dibeli</option>
+                <option value="archived">Diarsipkan</option>
+              </select>
+            </label>
+            <label className="flex items-center gap-2">
+              <span>Prioritas</span>
+              <select
+                value={priorityValue}
+                onChange={(event) => {
+                  const value = event.target.value;
+                  setPriorityValue(value);
+                  if (value) {
+                    onPriorityChange(Number(value));
+                    setTimeout(() => setPriorityValue(''), 200);
+                  }
+                }}
+                className="h-9 rounded-2xl border-none bg-slate-900/80 px-3 text-sm text-slate-100 ring-2 ring-slate-800 transition focus-visible:outline-none focus-visible:ring-[var(--accent)]"
+                disabled={disabled}
+              >
+                <option value="">Set prioritas…</option>
+                <option value="1">1</option>
+                <option value="2">2</option>
+                <option value="3">3</option>
+                <option value="4">4</option>
+                <option value="5">5</option>
+              </select>
+            </label>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onClear}
+            className="inline-flex h-10 items-center justify-center rounded-2xl px-4 text-sm font-medium text-slate-300 transition hover:bg-slate-800/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+            disabled={disabled}
+          >
+            Batalkan
+          </button>
+          <button
+            type="button"
+            onClick={onDelete}
+            className="inline-flex h-10 items-center gap-2 rounded-2xl bg-rose-500/90 px-4 text-sm font-semibold text-white transition hover:bg-rose-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400"
+            disabled={disabled}
+          >
+            <Trash2 className="h-4 w-4" aria-hidden="true" /> Hapus
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/wishlist/WishlistCard.tsx
+++ b/src/components/wishlist/WishlistCard.tsx
@@ -1,0 +1,239 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  CheckCircle2,
+  EllipsisVertical,
+  ExternalLink,
+  Goal,
+  NotebookPen,
+  ShoppingBag,
+  Trash2,
+} from 'lucide-react';
+import type { WishlistItem, WishlistStatus } from '../../lib/wishlistApi';
+
+interface WishlistCardProps {
+  item: WishlistItem;
+  selected: boolean;
+  onSelectChange: (selected: boolean) => void;
+  onEdit: (item: WishlistItem) => void;
+  onDelete: (item: WishlistItem) => void;
+  onMarkPurchased: (item: WishlistItem) => void;
+  onMakeGoal: (item: WishlistItem) => void;
+  onCopyToTransaction: (item: WishlistItem) => void;
+  disabled?: boolean;
+}
+
+const STATUS_LABEL: Record<WishlistStatus, string> = {
+  planned: 'Direncanakan',
+  deferred: 'Ditunda',
+  purchased: 'Dibeli',
+  archived: 'Diarsipkan',
+};
+
+const STATUS_STYLE: Record<WishlistStatus, string> = {
+  planned: 'bg-slate-800/80 text-slate-200 border border-slate-700',
+  deferred: 'bg-amber-500/10 text-amber-300 border border-amber-400/30',
+  purchased: 'bg-emerald-500/10 text-emerald-300 border border-emerald-400/30',
+  archived: 'bg-slate-800/60 text-slate-400 border border-slate-700/70',
+};
+
+const PRIORITY_STYLE: Record<number, string> = {
+  1: 'bg-emerald-500/15 text-emerald-300 border border-emerald-400/30',
+  2: 'bg-teal-500/15 text-teal-200 border border-teal-400/30',
+  3: 'bg-sky-500/15 text-sky-200 border border-sky-400/30',
+  4: 'bg-violet-500/15 text-violet-200 border border-violet-400/30',
+  5: 'bg-rose-500/15 text-rose-200 border border-rose-400/30',
+};
+
+function formatCurrencyIDR(value: number | null): string {
+  if (value == null) return '—';
+  return new Intl.NumberFormat('id-ID', {
+    style: 'currency',
+    currency: 'IDR',
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+export default function WishlistCard({
+  item,
+  selected,
+  onSelectChange,
+  onEdit,
+  onDelete,
+  onMarkPurchased,
+  onMakeGoal,
+  onCopyToTransaction,
+  disabled = false,
+}: WishlistCardProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  const hasImage = Boolean(item.image_url);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handleClick = (event: MouseEvent) => {
+      if (!menuRef.current) return;
+      if (!menuRef.current.contains(event.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [menuOpen]);
+
+  useEffect(() => {
+    if (disabled) {
+      setMenuOpen(false);
+    }
+  }, [disabled]);
+
+  const priorityBadge = useMemo(() => {
+    const value = item.priority != null ? Math.round(item.priority) : null;
+    if (!value || value < 1 || value > 5) return null;
+    return (
+      <span
+        className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium ${PRIORITY_STYLE[value]}`}
+      >
+        Prioritas {value}
+      </span>
+    );
+  }, [item.priority]);
+
+  return (
+    <article
+      className={`group relative flex h-full flex-col overflow-hidden rounded-2xl bg-slate-950/80 ring-1 ring-slate-800 transition hover:ring-[var(--accent)]/70 ${
+        selected ? 'ring-2 ring-[var(--accent)]/80' : ''
+      } ${disabled ? 'opacity-60' : ''}`}
+    >
+      {hasImage ? (
+        <div className="relative aspect-video w-full overflow-hidden bg-slate-900">
+          <img
+            src={item.image_url ?? ''}
+            alt={item.title}
+            loading="lazy"
+            className="h-full w-full object-cover transition duration-500 group-hover:scale-[1.03]"
+          />
+        </div>
+      ) : null}
+      <div className="flex flex-1 flex-col gap-4 p-4">
+        <div className="flex items-start gap-3">
+          <label className="mt-0.5 flex items-center">
+            <input
+              type="checkbox"
+              checked={selected}
+              onChange={(event) => onSelectChange(event.target.checked)}
+              className="h-4 w-4 cursor-pointer rounded border-slate-600 bg-slate-900 text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+              aria-label={`Pilih wishlist ${item.title}`}
+              disabled={disabled}
+            />
+          </label>
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <h3 className="truncate text-base font-semibold text-slate-100">{item.title}</h3>
+              <div className="flex items-center gap-2">
+                {priorityBadge}
+                <span
+                  className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${STATUS_STYLE[item.status]}`}
+                >
+                  {STATUS_LABEL[item.status]}
+                </span>
+              </div>
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-slate-400">
+              <span className="font-medium text-slate-100">{formatCurrencyIDR(item.estimated_price)}</span>
+              {item.category?.name ? <span className="text-xs uppercase tracking-wide text-slate-500">{item.category.name}</span> : null}
+              {item.store_url ? (
+                <a
+                  href={item.store_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-xs text-[var(--accent)] transition hover:text-[var(--accent)]/80"
+                >
+                  <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" /> Toko
+                </a>
+              ) : null}
+            </div>
+          </div>
+          <div className="relative" ref={menuRef}>
+            <button
+              type="button"
+              className="flex h-9 w-9 items-center justify-center rounded-full text-slate-400 transition hover:bg-slate-800/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+              aria-label={`Menu tindakan untuk ${item.title}`}
+              onClick={() => setMenuOpen((prev) => !prev)}
+              disabled={disabled}
+            >
+              <EllipsisVertical className="h-5 w-5" aria-hidden="true" />
+            </button>
+            {menuOpen ? (
+              <div className="absolute right-0 top-11 z-20 w-48 overflow-hidden rounded-2xl border border-slate-800/80 bg-slate-950/95 shadow-xl">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setMenuOpen(false);
+                    onMakeGoal(item);
+                  }}
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-slate-100 transition hover:bg-slate-900"
+                >
+                  <Goal className="h-4 w-4" aria-hidden="true" /> Jadikan Goal
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setMenuOpen(false);
+                    onMarkPurchased(item);
+                  }}
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-slate-100 transition hover:bg-slate-900"
+                  disabled={item.status === 'purchased'}
+                >
+                  <CheckCircle2 className="h-4 w-4" aria-hidden="true" /> Tandai Dibeli
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setMenuOpen(false);
+                    onCopyToTransaction(item);
+                  }}
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-slate-100 transition hover:bg-slate-900"
+                >
+                  <ShoppingBag className="h-4 w-4" aria-hidden="true" /> Salin ke Transaksi
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setMenuOpen(false);
+                    onEdit(item);
+                  }}
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-slate-100 transition hover:bg-slate-900"
+                >
+                  <NotebookPen className="h-4 w-4" aria-hidden="true" /> Edit
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setMenuOpen(false);
+                    onDelete(item);
+                  }}
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-rose-300 transition hover:bg-rose-500/10"
+                >
+                  <Trash2 className="h-4 w-4" aria-hidden="true" /> Hapus
+                </button>
+              </div>
+            ) : null}
+          </div>
+        </div>
+        {item.note ? (
+          <p className="line-clamp-3 text-sm text-slate-400">{item.note}</p>
+        ) : null}
+      </div>
+    </article>
+  );
+}

--- a/src/components/wishlist/WishlistFilterBar.tsx
+++ b/src/components/wishlist/WishlistFilterBar.tsx
@@ -1,0 +1,193 @@
+import { ChangeEvent, FormEvent } from 'react';
+import { RotateCcw, Search } from 'lucide-react';
+import type { WishlistStatus } from '../../lib/wishlistApi';
+import type { WishlistFilters } from '../../hooks/useWishlist';
+
+export interface WishlistFilterState extends WishlistFilters {
+  search: string;
+  status: WishlistStatus | 'all';
+  priority: number | 'all';
+  categoryId: string | 'all';
+  priceMin: string;
+  priceMax: string;
+  sort: NonNullable<WishlistFilters['sort']>;
+}
+
+interface CategoryOption {
+  id: string;
+  name: string;
+}
+
+interface WishlistFilterBarProps {
+  filters: WishlistFilterState;
+  categories: CategoryOption[];
+  onChange: (next: WishlistFilterState) => void;
+  onReset?: () => void;
+}
+
+const STATUS_OPTIONS: { value: WishlistFilterState['status']; label: string }[] = [
+  { value: 'all', label: 'Semua status' },
+  { value: 'planned', label: 'Direncanakan' },
+  { value: 'deferred', label: 'Ditunda' },
+  { value: 'purchased', label: 'Dibeli' },
+  { value: 'archived', label: 'Diarsipkan' },
+];
+
+const PRIORITY_OPTIONS: { value: WishlistFilterState['priority']; label: string }[] = [
+  { value: 'all', label: 'Semua prioritas' },
+  { value: 1, label: 'Prioritas 1' },
+  { value: 2, label: 'Prioritas 2' },
+  { value: 3, label: 'Prioritas 3' },
+  { value: 4, label: 'Prioritas 4' },
+  { value: 5, label: 'Prioritas 5' },
+];
+
+const SORT_OPTIONS: { value: WishlistFilterState['sort']; label: string }[] = [
+  { value: 'newest', label: 'Terbaru' },
+  { value: 'oldest', label: 'Terlama' },
+  { value: 'price-asc', label: 'Harga naik' },
+  { value: 'price-desc', label: 'Harga turun' },
+  { value: 'priority-desc', label: 'Prioritas tinggi' },
+  { value: 'priority-asc', label: 'Prioritas rendah' },
+];
+
+export default function WishlistFilterBar({ filters, categories, onChange, onReset }: WishlistFilterBarProps) {
+  const handleSelect = <Key extends keyof WishlistFilterState>(
+    event: ChangeEvent<HTMLSelectElement>,
+    key: Key
+  ) => {
+    const value = event.target.value as WishlistFilterState[Key];
+    onChange({ ...filters, [key]: value });
+  };
+
+  const handleInput = <Key extends keyof WishlistFilterState>(event: ChangeEvent<HTMLInputElement>, key: Key) => {
+    const value = event.target.value as WishlistFilterState[Key];
+    onChange({ ...filters, [key]: value });
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+  };
+
+  const handleReset = () => {
+    onReset?.();
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="min-w-0 rounded-3xl border border-slate-800/70 bg-slate-900/70 p-4 shadow-sm backdrop-blur"
+    >
+      <div className="grid grid-cols-2 items-center gap-3 md:grid-cols-8">
+        <label className="flex min-w-0 flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+          <span className="truncate">Status</span>
+          <select
+            value={filters.status}
+            onChange={(event) => handleSelect(event, 'status')}
+            className="h-11 w-full rounded-2xl border border-slate-800 bg-slate-950/60 px-3 text-sm text-slate-100 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          >
+            {STATUS_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex min-w-0 flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+          <span className="truncate">Prioritas</span>
+          <select
+            value={filters.priority}
+            onChange={(event) => handleSelect(event, 'priority')}
+            className="h-11 w-full rounded-2xl border border-slate-800 bg-slate-950/60 px-3 text-sm text-slate-100 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          >
+            {PRIORITY_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex min-w-0 flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+          <span className="truncate">Kategori</span>
+          <select
+            value={filters.categoryId}
+            onChange={(event) => handleSelect(event, 'categoryId')}
+            className="h-11 w-full rounded-2xl border border-slate-800 bg-slate-950/60 px-3 text-sm text-slate-100 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          >
+            <option value="all">Semua kategori</option>
+            {categories.map((category) => (
+              <option key={category.id} value={category.id}>
+                {category.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex min-w-0 flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+          <span className="truncate">Harga minimum</span>
+          <input
+            type="number"
+            inputMode="decimal"
+            min="0"
+            value={filters.priceMin}
+            onChange={(event) => handleInput(event, 'priceMin')}
+            className="h-11 w-full rounded-2xl border border-slate-800 bg-slate-950/60 px-3 text-sm text-slate-100 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+            placeholder="0"
+          />
+        </label>
+
+        <label className="flex min-w-0 flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+          <span className="truncate">Harga maksimum</span>
+          <input
+            type="number"
+            inputMode="decimal"
+            min="0"
+            value={filters.priceMax}
+            onChange={(event) => handleInput(event, 'priceMax')}
+            className="h-11 w-full rounded-2xl border border-slate-800 bg-slate-950/60 px-3 text-sm text-slate-100 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+            placeholder="0"
+          />
+        </label>
+
+        <label className="flex min-w-0 flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+          <span className="truncate">Urutkan</span>
+          <select
+            value={filters.sort}
+            onChange={(event) => handleSelect(event, 'sort')}
+            className="h-11 w-full rounded-2xl border border-slate-800 bg-slate-950/60 px-3 text-sm text-slate-100 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          >
+            {SORT_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="col-span-2 flex h-11 min-w-0 items-center gap-2 rounded-2xl border border-slate-800 bg-slate-950/60 px-3 text-sm text-slate-100 shadow-sm transition focus-within:ring-2 focus-within:ring-[var(--accent)] md:col-span-2 lg:col-span-3">
+          <Search className="h-4 w-4 text-slate-400" aria-hidden="true" />
+          <input
+            type="search"
+            value={filters.search}
+            onChange={(event) => handleInput(event, 'search')}
+            placeholder="Cari judul atau catatan"
+            className="h-full w-full min-w-0 bg-transparent text-sm text-slate-100 placeholder:text-slate-500 focus-visible:outline-none"
+            aria-label="Pencarian wishlist"
+          />
+          {onReset ? (
+            <button
+              type="button"
+              onClick={handleReset}
+              className="inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-slate-400 transition hover:bg-slate-800/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+              aria-label="Reset filter wishlist"
+            >
+              <RotateCcw className="h-4 w-4" aria-hidden="true" />
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/src/components/wishlist/WishlistFormDialog.tsx
+++ b/src/components/wishlist/WishlistFormDialog.tsx
@@ -1,0 +1,357 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import type { WishlistCreatePayload, WishlistItem, WishlistStatus } from '../../lib/wishlistApi';
+
+interface CategoryOption {
+  id: string;
+  name: string;
+}
+
+export interface WishlistFormValues {
+  title: string;
+  estimated_price: string;
+  priority: string;
+  category_id: string;
+  store_url: string;
+  status: WishlistStatus;
+  note: string;
+  image_url: string;
+}
+
+interface WishlistFormDialogProps {
+  open: boolean;
+  mode: 'create' | 'edit';
+  initialData?: WishlistItem | null;
+  categories: CategoryOption[];
+  submitting?: boolean;
+  onClose: () => void;
+  onSubmit: (payload: WishlistCreatePayload | (WishlistCreatePayload & { id?: string })) => Promise<void>;
+}
+
+const STATUS_OPTIONS: { value: WishlistStatus; label: string }[] = [
+  { value: 'planned', label: 'Direncanakan' },
+  { value: 'deferred', label: 'Ditunda' },
+  { value: 'purchased', label: 'Dibeli' },
+  { value: 'archived', label: 'Diarsipkan' },
+];
+
+const INPUT_CLASS =
+  'h-11 w-full rounded-2xl border-none bg-slate-900/80 px-4 text-sm text-slate-100 ring-2 ring-slate-800 transition focus-visible:outline-none focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60';
+
+const TEXTAREA_CLASS =
+  'w-full rounded-2xl border-none bg-slate-900/80 px-4 py-3 text-sm text-slate-100 ring-2 ring-slate-800 transition focus-visible:outline-none focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60';
+
+export default function WishlistFormDialog({
+  open,
+  mode,
+  initialData,
+  categories,
+  submitting = false,
+  onClose,
+  onSubmit,
+}: WishlistFormDialogProps) {
+  const initialValues = useMemo<WishlistFormValues>(
+    () => ({
+      title: initialData?.title ?? '',
+      estimated_price: initialData?.estimated_price != null ? String(initialData.estimated_price) : '',
+      priority: initialData?.priority != null ? String(initialData.priority) : '',
+      category_id: initialData?.category_id ?? '',
+      store_url: initialData?.store_url ?? '',
+      status: initialData?.status ?? 'planned',
+      note: initialData?.note ?? '',
+      image_url: initialData?.image_url ?? '',
+    }),
+    [initialData]
+  );
+
+  const [values, setValues] = useState<WishlistFormValues>(initialValues);
+  const [errors, setErrors] = useState<Record<keyof WishlistFormValues, string | null>>({
+    title: null,
+    estimated_price: null,
+    priority: null,
+    category_id: null,
+    store_url: null,
+    status: null,
+    note: null,
+    image_url: null,
+  });
+
+  useEffect(() => {
+    if (open) {
+      setValues(initialValues);
+      setErrors({
+        title: null,
+        estimated_price: null,
+        priority: null,
+        category_id: null,
+        store_url: null,
+        status: null,
+        note: null,
+        image_url: null,
+      });
+    }
+  }, [open, initialValues]);
+
+  const setField = (field: keyof WishlistFormValues, value: string) => {
+    setValues((prev) => ({ ...prev, [field]: value }));
+    setErrors((prev) => ({ ...prev, [field]: null }));
+  };
+
+  const validate = (): boolean => {
+    let valid = true;
+    const nextErrors: Record<keyof WishlistFormValues, string | null> = { ...errors };
+
+    if (!values.title.trim()) {
+      nextErrors.title = 'Judul wajib diisi.';
+      valid = false;
+    }
+
+    if (values.estimated_price) {
+      const numeric = Number(values.estimated_price);
+      if (Number.isNaN(numeric) || numeric < 0) {
+        nextErrors.estimated_price = 'Perkiraan harga harus angka positif.';
+        valid = false;
+      }
+    }
+
+    if (values.priority) {
+      const numeric = Number(values.priority);
+      if (!Number.isInteger(numeric) || numeric < 1 || numeric > 5) {
+        nextErrors.priority = 'Prioritas harus 1 sampai 5.';
+        valid = false;
+      }
+    }
+
+    if (values.store_url) {
+      try {
+        // eslint-disable-next-line no-new
+        new URL(values.store_url);
+      } catch (error) {
+        nextErrors.store_url = 'URL toko tidak valid.';
+        valid = false;
+      }
+    }
+
+    if (values.image_url) {
+      try {
+        // eslint-disable-next-line no-new
+        new URL(values.image_url);
+      } catch (error) {
+        nextErrors.image_url = 'URL gambar tidak valid.';
+        valid = false;
+      }
+    }
+
+    setErrors(nextErrors);
+    return valid;
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!validate()) return;
+
+    const payload: WishlistCreatePayload = {
+      title: values.title.trim(),
+      estimated_price: values.estimated_price ? Number(values.estimated_price) : null,
+      priority: values.priority ? Number(values.priority) : null,
+      category_id: values.category_id ? values.category_id : null,
+      store_url: values.store_url.trim() || undefined,
+      note: values.note.trim() || undefined,
+      status: values.status,
+      image_url: values.image_url.trim() || undefined,
+    };
+
+    await onSubmit(payload);
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 px-4 py-10 backdrop-blur">
+      <div className="relative w-full max-w-xl overflow-hidden rounded-3xl border border-slate-800 bg-slate-950/95 shadow-[0_30px_80px_-40px_rgba(15,23,42,0.8)]">
+        <form onSubmit={handleSubmit} className="flex max-h-[85vh] flex-col">
+          <header className="flex items-start justify-between gap-3 border-b border-slate-800/70 bg-slate-950/80 px-6 py-4">
+            <div>
+              <h2 className="text-lg font-semibold text-slate-100">
+                {mode === 'create' ? 'Tambah Wishlist' : 'Edit Wishlist'}
+              </h2>
+              <p className="text-xs text-slate-400">Kelola item wishlist Anda dengan mudah.</p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex h-9 w-9 items-center justify-center rounded-full text-slate-400 transition hover:bg-slate-800/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+              aria-label="Tutup form wishlist"
+            >
+              ✕
+            </button>
+          </header>
+          <div className="flex-1 space-y-4 overflow-y-auto px-6 py-5">
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-200" htmlFor="wishlist-title">
+                Judul*
+              </label>
+              <input
+                id="wishlist-title"
+                type="text"
+                className={INPUT_CLASS}
+                value={values.title}
+                onChange={(event) => setField('title', event.target.value)}
+                placeholder="Contoh: iPad Mini untuk belajar"
+                required
+                disabled={submitting}
+              />
+              {errors.title ? <p className="text-sm text-rose-300">{errors.title}</p> : null}
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-slate-200" htmlFor="wishlist-price">
+                  Perkiraan harga (Rp)
+                </label>
+                <input
+                  id="wishlist-price"
+                  type="number"
+                  inputMode="decimal"
+                  min="0"
+                  className={INPUT_CLASS}
+                  value={values.estimated_price}
+                  onChange={(event) => setField('estimated_price', event.target.value)}
+                  placeholder="0"
+                  disabled={submitting}
+                />
+                {errors.estimated_price ? <p className="text-sm text-rose-300">{errors.estimated_price}</p> : null}
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-slate-200" htmlFor="wishlist-priority">
+                  Prioritas (1-5)
+                </label>
+                <select
+                  id="wishlist-priority"
+                  className={INPUT_CLASS}
+                  value={values.priority}
+                  onChange={(event) => setField('priority', event.target.value)}
+                  disabled={submitting}
+                >
+                  <option value="">Pilih prioritas</option>
+                  <option value="1">1 - Mendesak</option>
+                  <option value="2">2</option>
+                  <option value="3">3</option>
+                  <option value="4">4</option>
+                  <option value="5">5 - Nice to have</option>
+                </select>
+                {errors.priority ? <p className="text-sm text-rose-300">{errors.priority}</p> : null}
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-slate-200" htmlFor="wishlist-category">
+                  Kategori
+                </label>
+                <select
+                  id="wishlist-category"
+                  className={INPUT_CLASS}
+                  value={values.category_id}
+                  onChange={(event) => setField('category_id', event.target.value)}
+                  disabled={submitting}
+                >
+                  <option value="">Tanpa kategori</option>
+                  {categories.map((category) => (
+                    <option key={category.id} value={category.id}>
+                      {category.name}
+                    </option>
+                  ))}
+                </select>
+                {errors.category_id ? <p className="text-sm text-rose-300">{errors.category_id}</p> : null}
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-slate-200" htmlFor="wishlist-status">
+                  Status
+                </label>
+                <select
+                  id="wishlist-status"
+                  className={INPUT_CLASS}
+                  value={values.status}
+                  onChange={(event) => setField('status', event.target.value)}
+                  disabled={submitting}
+                >
+                  {STATUS_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+                {errors.status ? <p className="text-sm text-rose-300">{errors.status}</p> : null}
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-slate-200" htmlFor="wishlist-store">
+                  URL toko
+                </label>
+                <input
+                  id="wishlist-store"
+                  type="url"
+                  className={INPUT_CLASS}
+                  value={values.store_url}
+                  onChange={(event) => setField('store_url', event.target.value)}
+                  placeholder="https://"
+                  disabled={submitting}
+                />
+                {errors.store_url ? <p className="text-sm text-rose-300">{errors.store_url}</p> : null}
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-slate-200" htmlFor="wishlist-image">
+                  URL gambar
+                </label>
+                <input
+                  id="wishlist-image"
+                  type="url"
+                  className={INPUT_CLASS}
+                  value={values.image_url}
+                  onChange={(event) => setField('image_url', event.target.value)}
+                  placeholder="https://"
+                  disabled={submitting}
+                />
+                {errors.image_url ? <p className="text-sm text-rose-300">{errors.image_url}</p> : null}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-200" htmlFor="wishlist-note">
+                Catatan
+              </label>
+              <textarea
+                id="wishlist-note"
+                className={TEXTAREA_CLASS}
+                rows={4}
+                value={values.note}
+                onChange={(event) => setField('note', event.target.value)}
+                placeholder="Tambahkan catatan, alasan, atau rencana pembelian"
+                disabled={submitting}
+              />
+            </div>
+          </div>
+          <footer className="flex items-center justify-between gap-3 border-t border-slate-800/70 bg-slate-950/80 px-6 py-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="inline-flex h-11 items-center justify-center rounded-2xl px-4 text-sm font-semibold text-slate-300 transition hover:bg-slate-800/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+              disabled={submitting}
+            >
+              Batal
+            </button>
+            <button
+              type="submit"
+              className="inline-flex h-11 items-center justify-center rounded-2xl bg-[var(--accent)] px-5 text-sm font-semibold text-slate-950 transition hover:bg-[var(--accent)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+              disabled={submitting}
+            >
+              {submitting ? 'Menyimpan…' : mode === 'create' ? 'Tambah Wishlist' : 'Simpan Perubahan'}
+            </button>
+          </footer>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useWishlist.ts
+++ b/src/hooks/useWishlist.ts
@@ -1,0 +1,348 @@
+import { useMemo } from 'react';
+import {
+  QueryKey,
+  UseMutationResult,
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+  type InfiniteData,
+} from '@tanstack/react-query';
+import {
+  bulkDeleteWishlist,
+  bulkUpdateWishlist,
+  createWishlistItem,
+  deleteWishlistItem,
+  listWishlist,
+  type WishlistCreatePayload,
+  type WishlistItem,
+  type WishlistListParams,
+  type WishlistListResult,
+  type WishlistStatus,
+  type WishlistUpdatePayload,
+} from '../lib/wishlistApi';
+
+export interface WishlistFilters {
+  search?: string;
+  status?: WishlistStatus;
+  priority?: number;
+  categoryId?: string;
+  priceMin?: number;
+  priceMax?: number;
+  sort?: WishlistListParams['sort'];
+}
+
+const PAGE_SIZE = 20;
+
+function buildQueryKey(filters: WishlistFilters): QueryKey {
+  return ['wishlist', filters];
+}
+
+function updateFirstPage(
+  data: InfiniteData<WishlistListResult> | undefined,
+  updater: (page: WishlistListResult) => WishlistListResult
+): InfiniteData<WishlistListResult> | undefined {
+  if (!data) return data;
+  const [first, ...rest] = data.pages;
+  if (!first) return data;
+  const updatedFirst = updater(first);
+  return {
+    pageParams: data.pageParams,
+    pages: [updatedFirst, ...rest],
+  };
+}
+
+function replaceItem(
+  data: InfiniteData<WishlistListResult> | undefined,
+  id: string,
+  replacer: (item: WishlistItem) => WishlistItem
+): InfiniteData<WishlistListResult> | undefined {
+  if (!data) return data;
+  return {
+    pageParams: data.pageParams,
+    pages: data.pages.map((page) => ({
+      ...page,
+      items: page.items.map((item) => (item.id === id ? replacer(item) : item)),
+    })),
+  };
+}
+
+function removeItems(
+  data: InfiniteData<WishlistListResult> | undefined,
+  ids: Set<string>
+): InfiniteData<WishlistListResult> | undefined {
+  if (!data) return data;
+  return {
+    pageParams: data.pageParams,
+    pages: data.pages.map((page, index) => {
+      const filtered = page.items.filter((item) => !ids.has(item.id));
+      return {
+        ...page,
+        items: filtered,
+        total: index === 0 ? Math.max(0, page.total - (page.items.length - filtered.length)) : page.total,
+      };
+    }),
+  };
+}
+
+export interface UseWishlistResult {
+  items: WishlistItem[];
+  total: number;
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+  isFetchingNextPage: boolean;
+  hasNextPage: boolean;
+  fetchNextPage: () => Promise<void>;
+  refetch: () => Promise<void>;
+  createItem: UseMutationResult<WishlistItem, unknown, WishlistCreatePayload>['mutateAsync'];
+  updateItem: UseMutationResult<WishlistItem, unknown, { id: string; patch: WishlistUpdatePayload }>['mutateAsync'];
+  deleteItem: UseMutationResult<void, unknown, { id: string }>['mutateAsync'];
+  bulkUpdate: UseMutationResult<void, unknown, { ids: string[]; patch: WishlistUpdatePayload }>['mutateAsync'];
+  bulkDelete: UseMutationResult<void, unknown, { ids: string[] }>['mutateAsync'];
+  isCreating: boolean;
+  isUpdating: boolean;
+  isDeleting: boolean;
+  isBulkUpdating: boolean;
+  isBulkDeleting: boolean;
+}
+
+export function useWishlist(filters: WishlistFilters): UseWishlistResult {
+  const queryClient = useQueryClient();
+  const queryKey = useMemo(() => buildQueryKey(filters), [filters]);
+
+  const listQuery = useInfiniteQuery({
+    queryKey,
+    initialPageParam: 1,
+    queryFn: async ({ pageParam = 1 }) =>
+      listWishlist({ page: pageParam, pageSize: PAGE_SIZE, ...filters }),
+    getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.page + 1 : undefined),
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    networkMode: 'offlineFirst',
+  });
+
+  const createMutation = useMutation({
+    mutationFn: createWishlistItem,
+    networkMode: 'offlineFirst',
+    onMutate: async (payload) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<InfiniteData<WishlistListResult>>(queryKey);
+      const optimisticId = `optimistic-${Date.now()}`;
+      const optimisticItem: WishlistItem = {
+        id: optimisticId,
+        user_id: 'optimistic',
+        title: payload.title.trim(),
+        estimated_price: payload.estimated_price ?? null,
+        priority: payload.priority ?? null,
+        category_id: payload.category_id ?? null,
+        category: null,
+        store_url: payload.store_url?.trim() || null,
+        note: payload.note?.trim() || null,
+        status: payload.status ?? 'planned',
+        image_url: payload.image_url?.trim() || null,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      };
+
+      queryClient.setQueryData<InfiniteData<WishlistListResult>>(queryKey, (old) => {
+        if (!old) {
+          return {
+            pageParams: [1],
+            pages: [
+              {
+                items: [optimisticItem],
+                page: 1,
+                pageSize: PAGE_SIZE,
+                total: 1,
+                hasMore: false,
+              },
+            ],
+          };
+        }
+        return updateFirstPage(old, (page) => {
+          const items = [optimisticItem, ...page.items];
+          if (items.length > page.pageSize) {
+            items.pop();
+          }
+          return {
+            ...page,
+            items,
+            total: page.total + 1,
+          };
+        });
+      });
+
+      return { previous, optimisticId };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKey, context.previous);
+      }
+    },
+    onSuccess: (result, _variables, context) => {
+      queryClient.setQueryData<InfiniteData<WishlistListResult>>(queryKey, (old) => {
+        if (!old) return old;
+        const optimisticId = context?.optimisticId;
+        if (!optimisticId) return old;
+        return replaceItem(old, optimisticId, () => result);
+      });
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, patch }: { id: string; patch: WishlistUpdatePayload }) =>
+      updateWishlistItem(id, patch),
+    networkMode: 'offlineFirst',
+    onMutate: async ({ id, patch }) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<InfiniteData<WishlistListResult>>(queryKey);
+      queryClient.setQueryData<InfiniteData<WishlistListResult>>(queryKey, (old) => {
+        if (!old) return old;
+        return replaceItem(old, id, (item) => ({
+          ...item,
+          ...patch,
+          title: patch.title?.trim() ?? item.title,
+          store_url: patch.store_url?.trim() ?? (patch.store_url === '' ? null : item.store_url),
+          note: patch.note?.trim() ?? (patch.note === '' ? null : item.note),
+          image_url: patch.image_url?.trim() ?? (patch.image_url === '' ? null : item.image_url),
+          updated_at: new Date().toISOString(),
+        }));
+      });
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKey, context.previous);
+      }
+    },
+    onSuccess: (result) => {
+      queryClient.setQueryData<InfiniteData<WishlistListResult>>(queryKey, (old) => {
+        if (!old) return old;
+        return replaceItem(old, result.id, () => result);
+      });
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: ({ id }: { id: string }) => deleteWishlistItem(id),
+    networkMode: 'offlineFirst',
+    onMutate: async ({ id }) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<InfiniteData<WishlistListResult>>(queryKey);
+      queryClient.setQueryData<InfiniteData<WishlistListResult>>(queryKey, (old) => {
+        if (!old) return old;
+        return removeItems(old, new Set([id]));
+      });
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKey, context.previous);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+  });
+
+  const bulkUpdateMutation = useMutation({
+    mutationFn: ({ ids, patch }: { ids: string[]; patch: WishlistUpdatePayload }) =>
+      bulkUpdateWishlist(ids, patch),
+    networkMode: 'offlineFirst',
+    onMutate: async ({ ids, patch }) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<InfiniteData<WishlistListResult>>(queryKey);
+      const idSet = new Set(ids);
+      queryClient.setQueryData<InfiniteData<WishlistListResult>>(queryKey, (old) => {
+        if (!old) return old;
+        return {
+          pageParams: old.pageParams,
+          pages: old.pages.map((page) => ({
+            ...page,
+            items: page.items.map((item) => {
+              if (!idSet.has(item.id)) return item;
+              return {
+                ...item,
+                ...patch,
+                priority: patch.priority ?? item.priority,
+                status: patch.status ?? item.status,
+                updated_at: new Date().toISOString(),
+              };
+            }),
+          })),
+        };
+      });
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKey, context.previous);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+  });
+
+  const bulkDeleteMutation = useMutation({
+    mutationFn: ({ ids }: { ids: string[] }) => bulkDeleteWishlist(ids),
+    networkMode: 'offlineFirst',
+    onMutate: async ({ ids }) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<InfiniteData<WishlistListResult>>(queryKey);
+      queryClient.setQueryData<InfiniteData<WishlistListResult>>(queryKey, (old) => {
+        if (!old) return old;
+        return removeItems(old, new Set(ids));
+      });
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKey, context.previous);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+  });
+
+  const items = useMemo(
+    () => listQuery.data?.pages.flatMap((page) => page.items) ?? [],
+    [listQuery.data]
+  );
+  const total = listQuery.data?.pages[0]?.total ?? 0;
+
+  return {
+    items,
+    total,
+    isLoading: listQuery.isLoading,
+    isError: listQuery.isError,
+    error: listQuery.error,
+    isFetchingNextPage: listQuery.isFetchingNextPage,
+    hasNextPage: Boolean(listQuery.hasNextPage),
+    fetchNextPage: async () => {
+      if (listQuery.hasNextPage) {
+        await listQuery.fetchNextPage();
+      }
+    },
+    refetch: async () => {
+      await listQuery.refetch();
+    },
+    createItem: createMutation.mutateAsync,
+    updateItem: updateMutation.mutateAsync,
+    deleteItem: deleteMutation.mutateAsync,
+    bulkUpdate: bulkUpdateMutation.mutateAsync,
+    bulkDelete: bulkDeleteMutation.mutateAsync,
+    isCreating: createMutation.isPending,
+    isUpdating: updateMutation.isPending,
+    isDeleting: deleteMutation.isPending,
+    isBulkUpdating: bulkUpdateMutation.isPending,
+    isBulkDeleting: bulkDeleteMutation.isPending,
+  };
+}

--- a/src/lib/wishlistApi.ts
+++ b/src/lib/wishlistApi.ts
@@ -1,0 +1,350 @@
+import { supabase } from './supabase';
+import { getCurrentUserId } from './session';
+
+export type WishlistStatus = 'planned' | 'deferred' | 'purchased' | 'archived';
+
+export interface WishlistCategoryRef {
+  id: string;
+  name: string;
+}
+
+export interface WishlistItem {
+  id: string;
+  user_id: string;
+  title: string;
+  estimated_price: number | null;
+  priority: number | null;
+  category_id: string | null;
+  category: WishlistCategoryRef | null;
+  store_url: string | null;
+  note: string | null;
+  status: WishlistStatus;
+  image_url: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export type WishlistSortOption =
+  | 'newest'
+  | 'oldest'
+  | 'price-asc'
+  | 'price-desc'
+  | 'priority-desc'
+  | 'priority-asc';
+
+export interface WishlistListParams {
+  page?: number;
+  pageSize?: number;
+  search?: string;
+  status?: WishlistStatus;
+  priority?: number;
+  categoryId?: string;
+  priceMin?: number;
+  priceMax?: number;
+  sort?: WishlistSortOption;
+}
+
+export interface WishlistListResult {
+  items: WishlistItem[];
+  page: number;
+  pageSize: number;
+  total: number;
+  hasMore: boolean;
+}
+
+const DEFAULT_PAGE_SIZE = 20;
+
+function sanitizeNumber(value: number | null | undefined): number | null {
+  if (value == null) return null;
+  if (!Number.isFinite(value)) return null;
+  return value;
+}
+
+function mapWishlistRow(row: Record<string, any>): WishlistItem {
+  return {
+    id: row.id,
+    user_id: row.user_id,
+    title: row.title,
+    estimated_price: row.estimated_price != null ? Number(row.estimated_price) : null,
+    priority: row.priority != null ? Number(row.priority) : null,
+    category_id: row.category_id ?? null,
+    category: row.category ?? null,
+    store_url: row.store_url ?? null,
+    note: row.note ?? null,
+    status: row.status as WishlistStatus,
+    image_url: row.image_url ?? null,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+export async function listWishlist(params: WishlistListParams = {}): Promise<WishlistListResult> {
+  const userId = await getCurrentUserId();
+  if (!userId) {
+    throw new Error('Anda harus masuk untuk melihat wishlist.');
+  }
+
+  const {
+    page = 1,
+    pageSize = DEFAULT_PAGE_SIZE,
+    search,
+    status,
+    priority,
+    categoryId,
+    priceMin,
+    priceMax,
+    sort = 'newest',
+  } = params;
+
+  const pageNumber = Number.isFinite(page) && page > 0 ? Math.floor(page) : 1;
+  const size = Number.isFinite(pageSize) && pageSize > 0 ? Math.min(Math.floor(pageSize), 100) : DEFAULT_PAGE_SIZE;
+  const from = (pageNumber - 1) * size;
+  const to = from + size - 1;
+
+  let query = supabase
+    .from('wishlist_items')
+    .select(
+      `id, user_id, title, estimated_price, priority, category_id, store_url, note, status, image_url, created_at, updated_at,
+       category:categories(id, name)`
+    , { count: 'exact' })
+    .eq('user_id', userId);
+
+  if (search) {
+    const term = `%${search.trim().replace(/%/g, '\\%').replace(/_/g, '\\_')}%`;
+    query = query.or(`title.ilike.${term},note.ilike.${term}`);
+  }
+
+  if (status) {
+    query = query.eq('status', status);
+  }
+
+  if (priority != null) {
+    query = query.eq('priority', priority);
+  }
+
+  if (categoryId) {
+    query = query.eq('category_id', categoryId);
+  }
+
+  if (priceMin != null && Number.isFinite(priceMin)) {
+    query = query.gte('estimated_price', priceMin);
+  }
+
+  if (priceMax != null && Number.isFinite(priceMax)) {
+    query = query.lte('estimated_price', priceMax);
+  }
+
+  switch (sort) {
+    case 'oldest':
+      query = query.order('created_at', { ascending: true });
+      break;
+    case 'price-asc':
+      query = query.order('estimated_price', { ascending: true, nullsFirst: true });
+      break;
+    case 'price-desc':
+      query = query.order('estimated_price', { ascending: false, nullsLast: true });
+      break;
+    case 'priority-asc':
+      query = query.order('priority', { ascending: true, nullsLast: false });
+      break;
+    case 'priority-desc':
+      query = query.order('priority', { ascending: false, nullsFirst: false });
+      break;
+    case 'newest':
+    default:
+      query = query.order('created_at', { ascending: false });
+      break;
+  }
+
+  const { data, error, count } = await query.range(from, to);
+
+  if (error) {
+    throw new Error(error.message || 'Gagal memuat wishlist.');
+  }
+
+  const total = count ?? 0;
+  const items = (data ?? []).map(mapWishlistRow);
+  const hasMore = to + 1 < total;
+
+  return {
+    items,
+    page: pageNumber,
+    pageSize: size,
+    total,
+    hasMore,
+  };
+}
+
+export interface WishlistCreatePayload {
+  title: string;
+  estimated_price?: number | null;
+  priority?: number | null;
+  category_id?: string | null;
+  store_url?: string | null;
+  note?: string | null;
+  status?: WishlistStatus;
+  image_url?: string | null;
+}
+
+export async function createWishlistItem(payload: WishlistCreatePayload): Promise<WishlistItem> {
+  const userId = await getCurrentUserId();
+  if (!userId) {
+    throw new Error('Anda harus masuk untuk menambah wishlist.');
+  }
+
+  const {
+    title,
+    estimated_price,
+    priority,
+    category_id,
+    store_url,
+    note,
+    status = 'planned',
+    image_url,
+  } = payload;
+
+  const trimmedTitle = title.trim();
+  if (!trimmedTitle) {
+    throw new Error('Judul wajib diisi.');
+  }
+
+  const insertPayload = {
+    user_id: userId,
+    title: trimmedTitle,
+    estimated_price: sanitizeNumber(estimated_price) ?? null,
+    priority: priority != null ? Math.min(Math.max(priority, 1), 5) : null,
+    category_id: category_id || null,
+    store_url: store_url?.trim() || null,
+    note: note?.trim() || null,
+    status,
+    image_url: image_url?.trim() || null,
+  };
+
+  const { data, error } = await supabase
+    .from('wishlist_items')
+    .insert(insertPayload)
+    .select(
+      `id, user_id, title, estimated_price, priority, category_id, store_url, note, status, image_url, created_at, updated_at,
+       category:categories(id, name)`
+    )
+    .single();
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Gagal menambah wishlist.');
+  }
+
+  return mapWishlistRow(data);
+}
+
+export type WishlistUpdatePayload = Partial<Omit<WishlistCreatePayload, 'title'>> & { title?: string };
+
+export async function updateWishlistItem(id: string, payload: WishlistUpdatePayload): Promise<WishlistItem> {
+  if (!id) {
+    throw new Error('ID wishlist tidak valid.');
+  }
+
+  const userId = await getCurrentUserId();
+  if (!userId) {
+    throw new Error('Anda harus masuk untuk memperbarui wishlist.');
+  }
+
+  const patch: Record<string, any> = {};
+  if (payload.title != null) {
+    const trimmed = payload.title.trim();
+    if (!trimmed) {
+      throw new Error('Judul wajib diisi.');
+    }
+    patch.title = trimmed;
+  }
+  if (payload.estimated_price !== undefined) {
+    patch.estimated_price = sanitizeNumber(payload.estimated_price);
+  }
+  if (payload.priority !== undefined) {
+    patch.priority = payload.priority != null ? Math.min(Math.max(payload.priority, 1), 5) : null;
+  }
+  if (payload.category_id !== undefined) {
+    patch.category_id = payload.category_id || null;
+  }
+  if (payload.store_url !== undefined) {
+    patch.store_url = payload.store_url?.trim() || null;
+  }
+  if (payload.note !== undefined) {
+    patch.note = payload.note?.trim() || null;
+  }
+  if (payload.status !== undefined) {
+    patch.status = payload.status;
+  }
+  if (payload.image_url !== undefined) {
+    patch.image_url = payload.image_url?.trim() || null;
+  }
+  patch.updated_at = new Date().toISOString();
+
+  const { data, error } = await supabase
+    .from('wishlist_items')
+    .update(patch)
+    .eq('id', id)
+    .eq('user_id', userId)
+    .select(
+      `id, user_id, title, estimated_price, priority, category_id, store_url, note, status, image_url, created_at, updated_at,
+       category:categories(id, name)`
+    )
+    .single();
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Gagal memperbarui wishlist.');
+  }
+
+  return mapWishlistRow(data);
+}
+
+export async function deleteWishlistItem(id: string): Promise<void> {
+  if (!id) {
+    throw new Error('ID wishlist tidak valid.');
+  }
+
+  const userId = await getCurrentUserId();
+  if (!userId) {
+    throw new Error('Anda harus masuk untuk menghapus wishlist.');
+  }
+
+  const { error } = await supabase.from('wishlist_items').delete().eq('id', id).eq('user_id', userId);
+  if (error) {
+    throw new Error(error.message || 'Gagal menghapus wishlist.');
+  }
+}
+
+export async function bulkUpdateWishlist(ids: string[], patch: WishlistUpdatePayload): Promise<void> {
+  if (!Array.isArray(ids) || ids.length === 0) return;
+
+  const userId = await getCurrentUserId();
+  if (!userId) {
+    throw new Error('Anda harus masuk untuk memperbarui wishlist.');
+  }
+
+  const updatePayload: Record<string, any> = { updated_at: new Date().toISOString() };
+  if (patch.priority !== undefined) {
+    updatePayload.priority = patch.priority != null ? Math.min(Math.max(patch.priority, 1), 5) : null;
+  }
+  if (patch.status !== undefined) {
+    updatePayload.status = patch.status;
+  }
+
+  const { error } = await supabase.from('wishlist_items').update(updatePayload).in('id', ids).eq('user_id', userId);
+  if (error) {
+    throw new Error(error.message || 'Gagal memperbarui wishlist secara massal.');
+  }
+}
+
+export async function bulkDeleteWishlist(ids: string[]): Promise<void> {
+  if (!Array.isArray(ids) || ids.length === 0) return;
+
+  const userId = await getCurrentUserId();
+  if (!userId) {
+    throw new Error('Anda harus masuk untuk menghapus wishlist.');
+  }
+
+  const { error } = await supabase.from('wishlist_items').delete().in('id', ids).eq('user_id', userId);
+  if (error) {
+    throw new Error(error.message || 'Gagal menghapus wishlist secara massal.');
+  }
+}

--- a/src/pages/WishlistPage.tsx
+++ b/src/pages/WishlistPage.tsx
@@ -1,0 +1,636 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
+import { ArrowDownToLine, FileUp, Plus } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import Page from '../layout/Page';
+import PageHeader from '../layout/PageHeader';
+import WishlistFilterBar, {
+  type WishlistFilterState,
+} from '../components/wishlist/WishlistFilterBar';
+import WishlistCard from '../components/wishlist/WishlistCard';
+import WishlistFormDialog from '../components/wishlist/WishlistFormDialog';
+import WishlistBatchToolbar from '../components/wishlist/WishlistBatchToolbar';
+import { useToast } from '../context/ToastContext';
+import { useWishlist } from '../hooks/useWishlist';
+import { listCategories } from '../lib/api-categories';
+import type { WishlistCreatePayload, WishlistItem, WishlistStatus } from '../lib/wishlistApi';
+import { listWishlist } from '../lib/wishlistApi';
+
+interface CategoryOption {
+  id: string;
+  name: string;
+}
+
+const INITIAL_FILTERS: WishlistFilterState = {
+  search: '',
+  status: 'all',
+  priority: 'all',
+  categoryId: 'all',
+  priceMin: '',
+  priceMax: '',
+  sort: 'newest',
+};
+
+function normalizeFilters(filters: WishlistFilterState) {
+  return {
+    search: filters.search.trim() || undefined,
+    status: filters.status === 'all' ? undefined : filters.status,
+    priority: filters.priority === 'all' ? undefined : Number(filters.priority),
+    categoryId: filters.categoryId === 'all' ? undefined : filters.categoryId,
+    priceMin: filters.priceMin ? Number(filters.priceMin) : undefined,
+    priceMax: filters.priceMax ? Number(filters.priceMax) : undefined,
+    sort: filters.sort,
+  } as const;
+}
+
+function escapeCsvValue(value: string | number | null | undefined): string {
+  if (value == null) return '';
+  const stringValue = String(value);
+  if (stringValue.includes(',') || stringValue.includes('"') || stringValue.includes('\n')) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+  return stringValue;
+}
+
+function parseCsv(content: string): Record<string, string>[] {
+  const rows: string[][] = [];
+  let current = '';
+  let row: string[] = [];
+  let insideQuotes = false;
+
+  for (let i = 0; i < content.length; i += 1) {
+    const char = content[i];
+    if (char === '"') {
+      const nextChar = content[i + 1];
+      if (insideQuotes && nextChar === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        insideQuotes = !insideQuotes;
+      }
+      continue;
+    }
+
+    if (char === ',' && !insideQuotes) {
+      row.push(current);
+      current = '';
+      continue;
+    }
+
+    if ((char === '\n' || char === '\r') && !insideQuotes) {
+      if (char === '\r' && content[i + 1] === '\n') {
+        i += 1;
+      }
+      row.push(current);
+      rows.push(row);
+      row = [];
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current.length > 0 || row.length) {
+    row.push(current);
+    rows.push(row);
+  }
+
+  if (rows.length === 0) return [];
+  const header = rows.shift() ?? [];
+  const cleanedHeader = header.map((cell) => cell.trim());
+
+  return rows
+    .filter((cells) => cells.some((cell) => cell.trim().length > 0))
+    .map((cells) => {
+      const record: Record<string, string> = {};
+      cleanedHeader.forEach((key, index) => {
+        record[key] = (cells[index] ?? '').trim();
+      });
+      return record;
+    });
+}
+
+export default function WishlistPage() {
+  const { addToast } = useToast();
+  const navigate = useNavigate();
+  const [filters, setFilters] = useState<WishlistFilterState>(INITIAL_FILTERS);
+  const [categories, setCategories] = useState<CategoryOption[]>([]);
+  const [formOpen, setFormOpen] = useState(false);
+  const [formMode, setFormMode] = useState<'create' | 'edit'>('create');
+  const [editingItem, setEditingItem] = useState<WishlistItem | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+
+  const normalizedFilters = useMemo(() => normalizeFilters(filters), [filters]);
+
+  const {
+    items,
+    total,
+    isLoading,
+    isError,
+    error,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+    createItem,
+    updateItem,
+    deleteItem,
+    bulkUpdate,
+    bulkDelete,
+    isCreating,
+    isUpdating,
+    isDeleting,
+    isBulkUpdating,
+    isBulkDeleting,
+  } = useWishlist(normalizedFilters);
+
+  const isMutating = isCreating || isUpdating || isDeleting || isBulkUpdating || isBulkDeleting;
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const list = await listCategories();
+        if (!active) return;
+        setCategories(list.map((category) => ({ id: category.id, name: category.name })));
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          // eslint-disable-next-line no-console
+          console.error('[Wishlist] gagal memuat kategori', err);
+        }
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    setSelectedIds((prev) => {
+      const next = new Set<string>();
+      for (const item of items) {
+        if (prev.has(item.id)) {
+          next.add(item.id);
+        }
+      }
+      return next.size === prev.size ? prev : next;
+    });
+  }, [items]);
+
+  useEffect(() => {
+    if (!hasNextPage) return;
+    const node = loadMoreRef.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const firstEntry = entries[0];
+        if (firstEntry?.isIntersecting && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { rootMargin: '240px' }
+    );
+    observer.observe(node);
+    return () => {
+      observer.disconnect();
+    };
+  }, [hasNextPage, fetchNextPage, isFetchingNextPage, items.length]);
+
+  const handleFilterChange = (next: WishlistFilterState) => {
+    setFilters(next);
+  };
+
+  const handleResetFilters = () => {
+    setFilters(INITIAL_FILTERS);
+  };
+
+  const handleAdd = () => {
+    setFormMode('create');
+    setEditingItem(null);
+    setFormOpen(true);
+  };
+
+  const handleEdit = (item: WishlistItem) => {
+    setFormMode('edit');
+    setEditingItem(item);
+    setFormOpen(true);
+  };
+
+  const handleSelectChange = (id: string, selected: boolean) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (selected) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  };
+
+  const handleClearSelection = () => {
+    setSelectedIds(() => new Set());
+  };
+
+  const selectedCount = selectedIds.size;
+
+  const handleDelete = async (item: WishlistItem) => {
+    const confirmed = window.confirm(`Hapus "${item.title}" dari wishlist?`);
+    if (!confirmed) return;
+    try {
+      await deleteItem({ id: item.id });
+      addToast('Wishlist berhasil dihapus', 'success');
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.error('[Wishlist] delete error', err);
+      }
+      addToast('Gagal menghapus wishlist', 'error');
+    }
+  };
+
+  const handleFormSubmit = async (payload: WishlistCreatePayload) => {
+    if (formMode === 'create') {
+      try {
+        await createItem(payload);
+        addToast('Wishlist berhasil ditambahkan', 'success');
+        setFormOpen(false);
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          // eslint-disable-next-line no-console
+          console.error('[Wishlist] create error', err);
+        }
+        addToast('Gagal menambahkan wishlist', 'error');
+      }
+      return;
+    }
+
+    if (!editingItem) return;
+
+    try {
+      await updateItem({ id: editingItem.id, patch: payload });
+      addToast('Wishlist berhasil diperbarui', 'success');
+      setFormOpen(false);
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.error('[Wishlist] update error', err);
+      }
+      addToast('Gagal memperbarui wishlist', 'error');
+    }
+  };
+
+  const handleMarkPurchased = async (item: WishlistItem) => {
+    try {
+      await updateItem({ id: item.id, patch: { status: 'purchased' } });
+      addToast('Ditandai sebagai dibeli', 'success');
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.error('[Wishlist] mark purchased error', err);
+      }
+      addToast('Gagal memperbarui status', 'error');
+    }
+  };
+
+  const handleMakeGoal = (item: WishlistItem) => {
+    const params = new URLSearchParams();
+    params.set('title', item.title);
+    if (item.estimated_price != null) {
+      params.set('target', String(Math.round(item.estimated_price)));
+    }
+    if (item.category_id) {
+      params.set('category_id', item.category_id);
+    }
+    navigate(`/goals/new?${params.toString()}`);
+  };
+
+  const handleCopyToTransaction = (item: WishlistItem) => {
+    const params = new URLSearchParams();
+    params.set('type', 'expense');
+    if (item.estimated_price != null) {
+      params.set('amount', String(item.estimated_price));
+    }
+    params.set('note', item.title);
+    if (item.category_id) {
+      params.set('category_id', item.category_id);
+    }
+    navigate(`/add?${params.toString()}`);
+    addToast('Form transaksi terisi dari wishlist', 'info');
+  };
+
+  const handleBatchDelete = async () => {
+    if (!selectedCount) return;
+    const confirmed = window.confirm(`Hapus ${selectedCount} item wishlist terpilih?`);
+    if (!confirmed) return;
+    try {
+      await bulkDelete({ ids: Array.from(selectedIds) });
+      addToast('Wishlist terpilih dihapus', 'success');
+      setSelectedIds(() => new Set());
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.error('[Wishlist] bulk delete error', err);
+      }
+      addToast('Gagal menghapus wishlist terpilih', 'error');
+    }
+  };
+
+  const handleBatchStatus = async (status: WishlistStatus) => {
+    if (!selectedCount) return;
+    try {
+      await bulkUpdate({ ids: Array.from(selectedIds), patch: { status } });
+      addToast('Status wishlist diperbarui', 'success');
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.error('[Wishlist] bulk status error', err);
+      }
+      addToast('Gagal memperbarui status', 'error');
+    }
+  };
+
+  const handleBatchPriority = async (priority: number) => {
+    if (!selectedCount) return;
+    try {
+      await bulkUpdate({ ids: Array.from(selectedIds), patch: { priority } });
+      addToast('Prioritas wishlist diperbarui', 'success');
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.error('[Wishlist] bulk priority error', err);
+      }
+      addToast('Gagal memperbarui prioritas', 'error');
+    }
+  };
+
+  const handleImportClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleImportFile = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setImporting(true);
+    try {
+      const text = await file.text();
+      const records = parseCsv(text);
+      if (!records.length) {
+        addToast('CSV kosong atau tidak valid', 'warning');
+        return;
+      }
+      let successCount = 0;
+      const allowedStatus: WishlistStatus[] = ['planned', 'deferred', 'purchased', 'archived'];
+      for (const record of records) {
+        if (!record.title) continue;
+        const estimated = record.estimated_price ? Number(record.estimated_price) : null;
+        const priority = record.priority ? Number(record.priority) : null;
+        const status = allowedStatus.includes(record.status as WishlistStatus)
+          ? (record.status as WishlistStatus)
+          : 'planned';
+        const payload: WishlistCreatePayload = {
+          title: record.title,
+          estimated_price: Number.isFinite(estimated ?? NaN) && (estimated ?? 0) >= 0 ? estimated : null,
+          priority: Number.isInteger(priority ?? NaN) && priority != null && priority >= 1 && priority <= 5 ? priority : null,
+          status,
+          category_id: record.category_id || null,
+          store_url: record.store_url || undefined,
+          note: record.note || undefined,
+          image_url: record.image_url || undefined,
+        };
+        try {
+          await createItem(payload);
+          successCount += 1;
+        } catch (err) {
+          if (import.meta.env.DEV) {
+            // eslint-disable-next-line no-console
+            console.error('[Wishlist] import item error', err);
+          }
+        }
+      }
+      addToast(`Berhasil mengimpor ${successCount} wishlist`, successCount ? 'success' : 'warning');
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.error('[Wishlist] import error', err);
+      }
+      addToast('Gagal mengimpor CSV', 'error');
+    } finally {
+      setImporting(false);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+    }
+  };
+
+  const handleExport = useCallback(async () => {
+    setExporting(true);
+    try {
+      const rows: WishlistItem[] = [];
+      let page = 1;
+      const filterPayload = normalizeFilters(filters);
+      for (let i = 0; i < 20; i += 1) {
+        const result = await listWishlist({ ...filterPayload, page, pageSize: 200 });
+        rows.push(...result.items);
+        if (!result.hasMore) break;
+        page += 1;
+      }
+      const header = [
+        'title',
+        'estimated_price',
+        'priority',
+        'status',
+        'category_id',
+        'category_name',
+        'store_url',
+        'note',
+        'image_url',
+        'created_at',
+        'updated_at',
+      ];
+      const lines = [header.join(',')];
+      for (const row of rows) {
+        lines.push(
+          [
+            escapeCsvValue(row.title),
+            escapeCsvValue(row.estimated_price ?? ''),
+            escapeCsvValue(row.priority ?? ''),
+            escapeCsvValue(row.status),
+            escapeCsvValue(row.category_id ?? ''),
+            escapeCsvValue(row.category?.name ?? ''),
+            escapeCsvValue(row.store_url ?? ''),
+            escapeCsvValue(row.note ?? ''),
+            escapeCsvValue(row.image_url ?? ''),
+            escapeCsvValue(row.created_at),
+            escapeCsvValue(row.updated_at),
+          ].join(',')
+        );
+      }
+      const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `wishlist-${new Date().toISOString().slice(0, 10)}.csv`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+      addToast('Wishlist diekspor sebagai CSV', 'success');
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.error('[Wishlist] export error', err);
+      }
+      addToast('Gagal mengekspor wishlist', 'error');
+    } finally {
+      setExporting(false);
+    }
+  }, [filters, addToast]);
+
+  const renderSkeletons = () => {
+    return (
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <div
+            // eslint-disable-next-line react/no-array-index-key
+            key={index}
+            className="h-48 animate-pulse rounded-2xl bg-slate-900/60 ring-1 ring-slate-800"
+          />
+        ))}
+      </div>
+    );
+  };
+
+  const renderEmptyState = () => (
+    <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border border-dashed border-slate-800 bg-slate-950/60 px-6 py-16 text-center">
+      <div className="rounded-full border border-slate-800 bg-slate-900/80 px-4 py-2 text-sm text-slate-400">
+        Wishlist Anda masih kosong
+      </div>
+      <p className="max-w-sm text-balance text-sm text-slate-400">
+        Simpan ide belanja tanpa komitmen finansial. Tambahkan item wishlist dan ubah menjadi goal atau transaksi kapan saja.
+      </p>
+      <button
+        type="button"
+        onClick={handleAdd}
+        className="inline-flex h-11 items-center gap-2 rounded-2xl bg-[var(--accent)] px-5 text-sm font-semibold text-slate-950 transition hover:bg-[var(--accent)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+      >
+        <Plus className="h-4 w-4" aria-hidden="true" /> Tambah Wishlist
+      </button>
+    </div>
+  );
+
+  const hasError = isError && !isLoading;
+
+  return (
+    <Page>
+      <PageHeader title="Wishlist" description="Kelola daftar keinginan dan siap jadikan goal atau transaksi kapan pun.">
+        <button
+          type="button"
+          onClick={handleImportClick}
+          className="inline-flex h-10 items-center gap-2 rounded-2xl border border-slate-700 bg-slate-900/70 px-4 text-sm font-medium text-slate-100 transition hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          disabled={importing || isMutating}
+        >
+          <FileUp className="h-4 w-4" aria-hidden="true" /> {importing ? 'Mengimpor…' : 'Impor CSV'}
+        </button>
+        <button
+          type="button"
+          onClick={handleExport}
+          className="inline-flex h-10 items-center gap-2 rounded-2xl border border-slate-700 bg-slate-900/70 px-4 text-sm font-medium text-slate-100 transition hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          disabled={exporting}
+        >
+          <ArrowDownToLine className="h-4 w-4" aria-hidden="true" /> {exporting ? 'Menyiapkan…' : 'Ekspor CSV'}
+        </button>
+        <button
+          type="button"
+          onClick={handleAdd}
+          className="inline-flex h-10 items-center gap-2 rounded-2xl bg-[var(--accent)] px-4 text-sm font-semibold text-slate-950 transition hover:bg-[var(--accent)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+        >
+          <Plus className="h-4 w-4" aria-hidden="true" /> Wishlist Baru
+        </button>
+      </PageHeader>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".csv,text/csv"
+        className="hidden"
+        onChange={handleImportFile}
+      />
+
+      <div className="space-y-6">
+        <WishlistFilterBar filters={filters} categories={categories} onChange={handleFilterChange} onReset={handleResetFilters} />
+
+        {hasError ? (
+          <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+            Terjadi kesalahan saat memuat wishlist. {error instanceof Error ? error.message : ''}
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="ml-3 inline-flex items-center text-rose-100 underline-offset-4 hover:underline"
+            >
+              Muat ulang
+            </button>
+          </div>
+        ) : null}
+
+        {isLoading ? (
+          renderSkeletons()
+        ) : items.length === 0 ? (
+          renderEmptyState()
+        ) : (
+          <div className="space-y-6">
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+              {items.map((item) => (
+                <WishlistCard
+                  key={item.id}
+                  item={item}
+                  selected={selectedIds.has(item.id)}
+                  onSelectChange={(selected) => handleSelectChange(item.id, selected)}
+                  onEdit={handleEdit}
+                  onDelete={handleDelete}
+                  onMarkPurchased={handleMarkPurchased}
+                  onMakeGoal={handleMakeGoal}
+                  onCopyToTransaction={handleCopyToTransaction}
+                  disabled={isMutating}
+                />
+              ))}
+            </div>
+            {hasNextPage ? (
+              <div className="flex justify-center">
+                <div ref={loadMoreRef} className="h-10 w-full max-w-[200px] rounded-full bg-transparent text-center text-sm text-slate-500">
+                  {isFetchingNextPage ? 'Memuat…' : 'Memuat lainnya'}
+                </div>
+              </div>
+            ) : null}
+            {total ? (
+              <p className="text-center text-xs text-slate-500">
+                Menampilkan {items.length} dari {total} wishlist
+              </p>
+            ) : null}
+          </div>
+        )}
+      </div>
+
+      {selectedCount > 0 ? (
+        <WishlistBatchToolbar
+          selectedCount={selectedCount}
+          onClear={handleClearSelection}
+          onDelete={handleBatchDelete}
+          onStatusChange={handleBatchStatus}
+          onPriorityChange={handleBatchPriority}
+          disabled={isMutating}
+        />
+      ) : null}
+
+      <WishlistFormDialog
+        open={formOpen}
+        mode={formMode}
+        initialData={editingItem}
+        categories={categories}
+        submitting={isMutating}
+        onClose={() => setFormOpen(false)}
+        onSubmit={handleFormSubmit}
+      />
+    </Page>
+  );
+}

--- a/src/router/nav.config.tsx
+++ b/src/router/nav.config.tsx
@@ -18,6 +18,7 @@ import {
   Wallet,
   Flag,
   HandCoins,
+  Heart,
   Tags,
   Database,
   Repeat,
@@ -65,10 +66,18 @@ export const NAV_ITEMS: NavItem[] = [
     inSidebar: true,
     protected: true,
   },
-  {
+  {  
     title: 'Goals',
     path: '/goals',
     icon: <Flag className="h-5 w-5" />,
+    section: 'primary',
+    inSidebar: true,
+    protected: true,
+  },
+  {
+    title: 'Wishlist',
+    path: '/wishlist',
+    icon: <Heart className="h-5 w-5" />,
     section: 'primary',
     inSidebar: true,
     protected: true,

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -20,6 +20,8 @@ function loadComponent(path: string) {
       return lazy(() => import('../pages/Budgets'));
     case '/goals':
       return lazy(() => import('../pages/Goals'));
+    case '/wishlist':
+      return lazy(() => import('../pages/WishlistPage'));
     case '/debts':
     case '/debs':
       return lazy(() => import('../pages/Debts'));


### PR DESCRIPTION
## Summary
- implement wishlist Supabase helpers and a React Query hook with optimistic mutations
- build wishlist UI (filter bar, cards, form dialog, batch toolbar) and page features including filters, batch actions, quick actions, and CSV import/export
- register the new wishlist route and expose it from the navigation

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d799ed45dc833293b83b2de2d9018b