### PR TITLE
Refresh wishlist page with modern responsive UI

### DIFF
--- a/src/components/wishlist/WishlistCard.tsx
+++ b/src/components/wishlist/WishlistCard.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
+  Banknote,
   CheckCircle2,
   EllipsisVertical,
   ExternalLink,
   Goal,
+  Link2,
   NotebookPen,
   ShoppingBag,
+  Tag,
   Trash2,
 } from 'lucide-react';
 import type { WishlistItem, WishlistStatus } from '../../lib/wishlistApi';
@@ -110,8 +113,8 @@ export default function WishlistCard({
 
   return (
     <article
-      className={`group relative flex h-full flex-col overflow-hidden rounded-2xl bg-slate-950/80 ring-1 ring-slate-800 transition hover:ring-[var(--accent)]/70 ${
-        selected ? 'ring-2 ring-[var(--accent)]/80' : ''
+      className={`group relative flex h-full flex-col overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-950/80 shadow-lg shadow-slate-950/40 transition duration-300 hover:-translate-y-0.5 hover:border-[var(--accent)]/60 ${
+        selected ? 'border-2 border-[var(--accent)]/70 shadow-[var(--accent)]/20' : ''
       } ${disabled ? 'opacity-60' : ''}`}
     >
       {hasImage ? (
@@ -122,9 +125,10 @@ export default function WishlistCard({
             loading="lazy"
             className="h-full w-full object-cover transition duration-500 group-hover:scale-[1.03]"
           />
+          <div className="absolute inset-0 bg-gradient-to-t from-slate-950/80 via-transparent to-transparent" aria-hidden="true" />
         </div>
       ) : null}
-      <div className="flex flex-1 flex-col gap-4 p-4">
+      <div className="flex flex-1 flex-col gap-4 p-5">
         <div className="flex items-start gap-3">
           <label className="mt-0.5 flex items-center">
             <input
@@ -148,17 +152,33 @@ export default function WishlistCard({
                 </span>
               </div>
             </div>
-            <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-slate-400">
-              <span className="font-medium text-slate-100">{formatCurrencyIDR(item.estimated_price)}</span>
-              {item.category?.name ? <span className="text-xs uppercase tracking-wide text-slate-500">{item.category.name}</span> : null}
+            <div className="mt-3 space-y-2 text-sm text-slate-400">
+              <div className="flex items-center gap-2 text-slate-300">
+                <span className="flex h-7 w-7 items-center justify-center rounded-full bg-slate-900/80">
+                  <Banknote className="h-3.5 w-3.5 text-[var(--accent)]" aria-hidden="true" />
+                </span>
+                <span className="font-semibold text-slate-100">{formatCurrencyIDR(item.estimated_price)}</span>
+              </div>
+              {item.category?.name ? (
+                <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-slate-400">
+                  <span className="flex h-7 w-7 items-center justify-center rounded-full bg-slate-900/80">
+                    <Tag className="h-3.5 w-3.5 text-[var(--accent)]" aria-hidden="true" />
+                  </span>
+                  <span>{item.category.name}</span>
+                </div>
+              ) : null}
               {item.store_url ? (
                 <a
                   href={item.store_url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-xs text-[var(--accent)] transition hover:text-[var(--accent)]/80"
+                  className="flex items-center gap-2 text-xs font-medium text-[var(--accent)] transition hover:text-[var(--accent)]/80"
                 >
-                  <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" /> Toko
+                  <span className="flex h-7 w-7 items-center justify-center rounded-full bg-[var(--accent)]/10">
+                    <Link2 className="h-3.5 w-3.5" aria-hidden="true" />
+                  </span>
+                  Lihat toko
+                  <ExternalLink className="h-3 w-3" aria-hidden="true" />
                 </a>
               ) : null}
             </div>
@@ -166,7 +186,7 @@ export default function WishlistCard({
           <div className="relative" ref={menuRef}>
             <button
               type="button"
-              className="flex h-9 w-9 items-center justify-center rounded-full text-slate-400 transition hover:bg-slate-800/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+              className="flex h-9 w-9 items-center justify-center rounded-full bg-slate-900/70 text-slate-400 transition hover:bg-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
               aria-label={`Menu tindakan untuk ${item.title}`}
               onClick={() => setMenuOpen((prev) => !prev)}
               disabled={disabled}

--- a/src/pages/WishlistPage.tsx
+++ b/src/pages/WishlistPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
-import { ArrowDownToLine, FileUp, Plus } from 'lucide-react';
+import { ArrowDownToLine, FileUp, Plus, Sparkles } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import Page from '../layout/Page';
 import PageHeader from '../layout/PageHeader';
@@ -502,17 +502,17 @@ export default function WishlistPage() {
   };
 
   const renderEmptyState = () => (
-    <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border border-dashed border-slate-800 bg-slate-950/60 px-6 py-16 text-center">
-      <div className="rounded-full border border-slate-800 bg-slate-900/80 px-4 py-2 text-sm text-slate-400">
-        Wishlist Anda masih kosong
+    <div className="flex flex-col items-center justify-center gap-5 rounded-3xl border border-dashed border-slate-800/70 bg-gradient-to-b from-slate-950/80 via-slate-950/60 to-slate-950/80 px-8 py-16 text-center shadow-inner">
+      <div className="flex items-center gap-2 rounded-full border border-slate-800/80 bg-slate-950/80 px-4 py-2 text-sm text-slate-300">
+        <Sparkles className="h-4 w-4 text-[var(--accent)]" aria-hidden="true" /> Wishlist Anda masih kosong
       </div>
-      <p className="max-w-sm text-balance text-sm text-slate-400">
+      <p className="max-w-md text-balance text-sm text-slate-400">
         Simpan ide belanja tanpa komitmen finansial. Tambahkan item wishlist dan ubah menjadi goal atau transaksi kapan saja.
       </p>
       <button
         type="button"
         onClick={handleAdd}
-        className="inline-flex h-11 items-center gap-2 rounded-2xl bg-[var(--accent)] px-5 text-sm font-semibold text-slate-950 transition hover:bg-[var(--accent)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+        className="inline-flex h-11 items-center gap-2 rounded-full bg-[var(--accent)] px-6 text-sm font-semibold text-slate-950 shadow-lg shadow-[var(--accent)]/30 transition hover:-translate-y-0.5 hover:bg-[var(--accent)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
       >
         <Plus className="h-4 w-4" aria-hidden="true" /> Tambah Wishlist
       </button>
@@ -524,29 +524,31 @@ export default function WishlistPage() {
   return (
     <Page>
       <PageHeader title="Wishlist" description="Kelola daftar keinginan dan siap jadikan goal atau transaksi kapan pun.">
-        <button
-          type="button"
-          onClick={handleImportClick}
-          className="inline-flex h-10 items-center gap-2 rounded-2xl border border-slate-700 bg-slate-900/70 px-4 text-sm font-medium text-slate-100 transition hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
-          disabled={importing || isMutating}
-        >
-          <FileUp className="h-4 w-4" aria-hidden="true" /> {importing ? 'Mengimpor…' : 'Impor CSV'}
-        </button>
-        <button
-          type="button"
-          onClick={handleExport}
-          className="inline-flex h-10 items-center gap-2 rounded-2xl border border-slate-700 bg-slate-900/70 px-4 text-sm font-medium text-slate-100 transition hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
-          disabled={exporting}
-        >
-          <ArrowDownToLine className="h-4 w-4" aria-hidden="true" /> {exporting ? 'Menyiapkan…' : 'Ekspor CSV'}
-        </button>
-        <button
-          type="button"
-          onClick={handleAdd}
-          className="inline-flex h-10 items-center gap-2 rounded-2xl bg-[var(--accent)] px-4 text-sm font-semibold text-slate-950 transition hover:bg-[var(--accent)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
-        >
-          <Plus className="h-4 w-4" aria-hidden="true" /> Wishlist Baru
-        </button>
+        <div className="flex w-full flex-wrap items-center justify-start gap-2 rounded-3xl border border-slate-800/80 bg-slate-950/70 p-2 shadow-inner shadow-slate-950/40 sm:justify-end">
+          <button
+            type="button"
+            onClick={handleImportClick}
+            className="inline-flex min-w-[140px] items-center justify-center gap-2 rounded-full border border-slate-800 bg-slate-950/80 px-4 py-2 text-sm font-medium text-slate-100 transition hover:border-[var(--accent)] hover:bg-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+            disabled={importing || isMutating}
+          >
+            <FileUp className="h-4 w-4" aria-hidden="true" /> {importing ? 'Mengimpor…' : 'Impor CSV'}
+          </button>
+          <button
+            type="button"
+            onClick={handleExport}
+            className="inline-flex min-w-[140px] items-center justify-center gap-2 rounded-full border border-slate-800 bg-slate-950/80 px-4 py-2 text-sm font-medium text-slate-100 transition hover:border-[var(--accent)] hover:bg-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+            disabled={exporting}
+          >
+            <ArrowDownToLine className="h-4 w-4" aria-hidden="true" /> {exporting ? 'Menyiapkan…' : 'Ekspor CSV'}
+          </button>
+          <button
+            type="button"
+            onClick={handleAdd}
+            className="inline-flex min-w-[160px] items-center justify-center gap-2 rounded-full bg-gradient-to-r from-[var(--accent)] to-[var(--accent)]/70 px-5 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-[var(--accent)]/30 transition hover:-translate-y-0.5 hover:from-[var(--accent)] hover:to-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+          >
+            <Plus className="h-4 w-4" aria-hidden="true" /> Tambah Wishlist
+          </button>
+        </div>
       </PageHeader>
 
       <input
@@ -561,12 +563,12 @@ export default function WishlistPage() {
         <WishlistFilterBar filters={filters} categories={categories} onChange={handleFilterChange} onReset={handleResetFilters} />
 
         {hasError ? (
-          <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+          <div className="rounded-3xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
             Terjadi kesalahan saat memuat wishlist. {error instanceof Error ? error.message : ''}
             <button
               type="button"
               onClick={() => window.location.reload()}
-              className="ml-3 inline-flex items-center text-rose-100 underline-offset-4 hover:underline"
+              className="ml-3 inline-flex items-center gap-1 text-rose-100 underline-offset-4 hover:underline"
             >
               Muat ulang
             </button>
@@ -579,7 +581,7 @@ export default function WishlistPage() {
           renderEmptyState()
         ) : (
           <div className="space-y-6">
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+            <div className="grid grid-cols-1 gap-3 sm:gap-4 md:grid-cols-2 xl:grid-cols-3">
               {items.map((item) => (
                 <WishlistCard
                   key={item.id}
@@ -597,7 +599,10 @@ export default function WishlistPage() {
             </div>
             {hasNextPage ? (
               <div className="flex justify-center">
-                <div ref={loadMoreRef} className="h-10 w-full max-w-[200px] rounded-full bg-transparent text-center text-sm text-slate-500">
+                <div
+                  ref={loadMoreRef}
+                  className="flex h-10 w-full max-w-[220px] items-center justify-center rounded-full border border-slate-800/80 bg-slate-950/70 text-center text-sm text-slate-400"
+                >
                   {isFetchingNextPage ? 'Memuat…' : 'Memuat lainnya'}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- redesign wishlist page header, empty state, and pagination container with a more contemporary responsive layout
- add a dedicated wishlist creation button beside the import/export controls
- enhance wishlist cards with icon-rich metadata presentation and refreshed styling

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7c343ba388332beeb5c2d06b3197f