### PR TITLE
feat: refresh wishlist page interface

### DIFF
--- a/src/components/wishlist/WishlistBatchToolbar.tsx
+++ b/src/components/wishlist/WishlistBatchToolbar.tsx
@@ -24,10 +24,10 @@ export default function WishlistBatchToolbar({
 
   return (
     <div className="fixed inset-x-0 bottom-4 z-40 flex justify-center px-4">
-      <div className="flex w-full max-w-3xl flex-wrap items-center gap-3 rounded-3xl border border-slate-800/80 bg-slate-950/90 px-5 py-3 shadow-2xl backdrop-blur">
-        <div className="flex flex-1 flex-wrap items-center gap-3 text-sm text-slate-200">
-          <span className="font-semibold text-slate-100">{selectedCount} dipilih</span>
-          <div className="flex items-center gap-2 text-xs text-slate-400">
+      <div className="flex w-full max-w-3xl flex-wrap items-center gap-3 rounded-3xl border border-border-subtle bg-surface-elevated/95 px-5 py-3 shadow-2xl shadow-black/20 backdrop-blur">
+        <div className="flex flex-1 flex-wrap items-center gap-3 text-sm text-muted">
+          <span className="font-semibold text-text">{selectedCount} dipilih</span>
+          <div className="flex items-center gap-2 text-xs text-muted">
             <label className="flex items-center gap-2">
               <span>Status</span>
               <select
@@ -40,7 +40,7 @@ export default function WishlistBatchToolbar({
                     setTimeout(() => setStatusValue(''), 200);
                   }
                 }}
-                className="h-9 rounded-2xl border-none bg-slate-900/80 px-3 text-sm text-slate-100 ring-2 ring-slate-800 transition focus-visible:outline-none focus-visible:ring-[var(--accent)]"
+                className="h-9 rounded-2xl border border-border-subtle bg-surface px-3 text-sm text-text shadow-sm transition focus-visible:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
                 disabled={disabled}
               >
                 <option value="">Ubah status…</option>
@@ -62,7 +62,7 @@ export default function WishlistBatchToolbar({
                     setTimeout(() => setPriorityValue(''), 200);
                   }
                 }}
-                className="h-9 rounded-2xl border-none bg-slate-900/80 px-3 text-sm text-slate-100 ring-2 ring-slate-800 transition focus-visible:outline-none focus-visible:ring-[var(--accent)]"
+                className="h-9 rounded-2xl border border-border-subtle bg-surface px-3 text-sm text-text shadow-sm transition focus-visible:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
                 disabled={disabled}
               >
                 <option value="">Set prioritas…</option>
@@ -79,7 +79,7 @@ export default function WishlistBatchToolbar({
           <button
             type="button"
             onClick={onClear}
-            className="inline-flex h-10 items-center justify-center rounded-2xl px-4 text-sm font-medium text-slate-300 transition hover:bg-slate-800/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+            className="inline-flex h-10 items-center justify-center rounded-full border border-border-subtle bg-surface px-4 text-sm font-medium text-text transition hover:border-primary/40 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
             disabled={disabled}
           >
             Batalkan
@@ -87,7 +87,7 @@ export default function WishlistBatchToolbar({
           <button
             type="button"
             onClick={onDelete}
-            className="inline-flex h-10 items-center gap-2 rounded-2xl bg-rose-500/90 px-4 text-sm font-semibold text-white transition hover:bg-rose-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400"
+            className="inline-flex h-10 items-center gap-2 rounded-full bg-danger px-4 text-sm font-semibold text-inverse shadow transition hover:bg-danger/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger/40"
             disabled={disabled}
           >
             <Trash2 className="h-4 w-4" aria-hidden="true" /> Hapus

--- a/src/components/wishlist/WishlistCard.tsx
+++ b/src/components/wishlist/WishlistCard.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   CheckCircle2,
+  Coins,
   EllipsisVertical,
-  ExternalLink,
   Goal,
+  Link2,
   NotebookPen,
   ShoppingBag,
+  StickyNote,
+  Tag,
   Trash2,
 } from 'lucide-react';
 import type { WishlistItem, WishlistStatus } from '../../lib/wishlistApi';
@@ -30,18 +33,18 @@ const STATUS_LABEL: Record<WishlistStatus, string> = {
 };
 
 const STATUS_STYLE: Record<WishlistStatus, string> = {
-  planned: 'bg-slate-800/80 text-slate-200 border border-slate-700',
-  deferred: 'bg-amber-500/10 text-amber-300 border border-amber-400/30',
-  purchased: 'bg-emerald-500/10 text-emerald-300 border border-emerald-400/30',
-  archived: 'bg-slate-800/60 text-slate-400 border border-slate-700/70',
+  planned: 'bg-primary/10 text-primary border border-primary/30',
+  deferred: 'bg-warning/10 text-warning border border-warning/30',
+  purchased: 'bg-success/10 text-success border border-success/30',
+  archived: 'bg-muted/10 text-muted border border-border-subtle',
 };
 
 const PRIORITY_STYLE: Record<number, string> = {
-  1: 'bg-emerald-500/15 text-emerald-300 border border-emerald-400/30',
-  2: 'bg-teal-500/15 text-teal-200 border border-teal-400/30',
-  3: 'bg-sky-500/15 text-sky-200 border border-sky-400/30',
-  4: 'bg-violet-500/15 text-violet-200 border border-violet-400/30',
-  5: 'bg-rose-500/15 text-rose-200 border border-rose-400/30',
+  1: 'bg-success/10 text-success border border-success/30',
+  2: 'bg-teal-500/10 text-teal-500 border border-teal-500/30',
+  3: 'bg-sky-500/10 text-sky-500 border border-sky-500/30',
+  4: 'bg-violet-500/10 text-violet-500 border border-violet-500/30',
+  5: 'bg-danger/10 text-danger border border-danger/30',
 };
 
 function formatCurrencyIDR(value: number | null): string {
@@ -110,12 +113,12 @@ export default function WishlistCard({
 
   return (
     <article
-      className={`group relative flex h-full flex-col overflow-hidden rounded-2xl bg-slate-950/80 ring-1 ring-slate-800 transition hover:ring-[var(--accent)]/70 ${
-        selected ? 'ring-2 ring-[var(--accent)]/80' : ''
+      className={`group relative flex h-full flex-col overflow-hidden rounded-3xl border bg-surface-elevated shadow-sm transition duration-300 hover:border-primary/40 hover:shadow-lg ${
+        selected ? 'border-primary shadow-lg ring-1 ring-primary/40' : 'border-border-subtle/80'
       } ${disabled ? 'opacity-60' : ''}`}
     >
       {hasImage ? (
-        <div className="relative aspect-video w-full overflow-hidden bg-slate-900">
+        <div className="relative aspect-video w-full overflow-hidden bg-surface">
           <img
             src={item.image_url ?? ''}
             alt={item.title}
@@ -124,41 +127,49 @@ export default function WishlistCard({
           />
         </div>
       ) : null}
-      <div className="flex flex-1 flex-col gap-4 p-4">
+      <div className="flex flex-1 flex-col gap-5 p-5">
         <div className="flex items-start gap-3">
           <label className="mt-0.5 flex items-center">
             <input
               type="checkbox"
               checked={selected}
               onChange={(event) => onSelectChange(event.target.checked)}
-              className="h-4 w-4 cursor-pointer rounded border-slate-600 bg-slate-900 text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+              className="h-4 w-4 cursor-pointer rounded border-border-subtle bg-surface text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
               aria-label={`Pilih wishlist ${item.title}`}
               disabled={disabled}
             />
           </label>
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-start justify-between gap-2">
-              <h3 className="truncate text-base font-semibold text-slate-100">{item.title}</h3>
+              <h3 className="truncate text-base font-semibold text-text">{item.title}</h3>
               <div className="flex items-center gap-2">
                 {priorityBadge}
                 <span
-                  className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${STATUS_STYLE[item.status]}`}
+                  className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium ${STATUS_STYLE[item.status]}`}
                 >
                   {STATUS_LABEL[item.status]}
                 </span>
               </div>
             </div>
-            <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-slate-400">
-              <span className="font-medium text-slate-100">{formatCurrencyIDR(item.estimated_price)}</span>
-              {item.category?.name ? <span className="text-xs uppercase tracking-wide text-slate-500">{item.category.name}</span> : null}
+            <div className="mt-3 flex flex-wrap items-center gap-2 text-sm text-muted">
+              <span className="inline-flex items-center gap-2 rounded-full border border-border-subtle bg-surface px-3 py-1.5 font-medium text-text">
+                <Coins className="h-4 w-4 text-primary" aria-hidden="true" />
+                {formatCurrencyIDR(item.estimated_price)}
+              </span>
+              {item.category?.name ? (
+                <span className="inline-flex items-center gap-2 rounded-full border border-border-subtle bg-surface px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-muted">
+                  <Tag className="h-3.5 w-3.5 text-muted" aria-hidden="true" />
+                  {item.category.name}
+                </span>
+              ) : null}
               {item.store_url ? (
                 <a
                   href={item.store_url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-xs text-[var(--accent)] transition hover:text-[var(--accent)]/80"
+                  className="inline-flex items-center gap-2 rounded-full border border-border-subtle bg-surface px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-primary transition hover:border-primary/40 hover:bg-primary/5"
                 >
-                  <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" /> Toko
+                  <Link2 className="h-3.5 w-3.5" aria-hidden="true" /> Kunjungi Toko
                 </a>
               ) : null}
             </div>
@@ -166,7 +177,7 @@ export default function WishlistCard({
           <div className="relative" ref={menuRef}>
             <button
               type="button"
-              className="flex h-9 w-9 items-center justify-center rounded-full text-slate-400 transition hover:bg-slate-800/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+              className="flex h-9 w-9 items-center justify-center rounded-full text-muted transition hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
               aria-label={`Menu tindakan untuk ${item.title}`}
               onClick={() => setMenuOpen((prev) => !prev)}
               disabled={disabled}
@@ -174,14 +185,14 @@ export default function WishlistCard({
               <EllipsisVertical className="h-5 w-5" aria-hidden="true" />
             </button>
             {menuOpen ? (
-              <div className="absolute right-0 top-11 z-20 w-48 overflow-hidden rounded-2xl border border-slate-800/80 bg-slate-950/95 shadow-xl">
+              <div className="absolute right-0 top-11 z-20 w-52 overflow-hidden rounded-2xl border border-border-subtle bg-surface-elevated shadow-xl">
                 <button
                   type="button"
                   onClick={() => {
                     setMenuOpen(false);
                     onMakeGoal(item);
                   }}
-                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-slate-100 transition hover:bg-slate-900"
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-text transition hover:bg-surface"
                 >
                   <Goal className="h-4 w-4" aria-hidden="true" /> Jadikan Goal
                 </button>
@@ -191,7 +202,7 @@ export default function WishlistCard({
                     setMenuOpen(false);
                     onMarkPurchased(item);
                   }}
-                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-slate-100 transition hover:bg-slate-900"
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-text transition hover:bg-surface"
                   disabled={item.status === 'purchased'}
                 >
                   <CheckCircle2 className="h-4 w-4" aria-hidden="true" /> Tandai Dibeli
@@ -202,7 +213,7 @@ export default function WishlistCard({
                     setMenuOpen(false);
                     onCopyToTransaction(item);
                   }}
-                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-slate-100 transition hover:bg-slate-900"
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-text transition hover:bg-surface"
                 >
                   <ShoppingBag className="h-4 w-4" aria-hidden="true" /> Salin ke Transaksi
                 </button>
@@ -212,7 +223,7 @@ export default function WishlistCard({
                     setMenuOpen(false);
                     onEdit(item);
                   }}
-                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-slate-100 transition hover:bg-slate-900"
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-text transition hover:bg-surface"
                 >
                   <NotebookPen className="h-4 w-4" aria-hidden="true" /> Edit
                 </button>
@@ -222,7 +233,7 @@ export default function WishlistCard({
                     setMenuOpen(false);
                     onDelete(item);
                   }}
-                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-rose-300 transition hover:bg-rose-500/10"
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-danger transition hover:bg-danger/10"
                 >
                   <Trash2 className="h-4 w-4" aria-hidden="true" /> Hapus
                 </button>
@@ -231,7 +242,12 @@ export default function WishlistCard({
           </div>
         </div>
         {item.note ? (
-          <p className="line-clamp-3 text-sm text-slate-400">{item.note}</p>
+          <div className="flex items-start gap-3 rounded-2xl border border-border-subtle bg-surface px-4 py-3 text-sm text-muted">
+            <span className="mt-0.5 inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-surface-elevated text-primary">
+              <StickyNote className="h-4 w-4" aria-hidden="true" />
+            </span>
+            <p className="line-clamp-3 text-left text-sm leading-relaxed text-muted">{item.note}</p>
+          </div>
         ) : null}
       </div>
     </article>

--- a/src/components/wishlist/WishlistFilterBar.tsx
+++ b/src/components/wishlist/WishlistFilterBar.tsx
@@ -76,15 +76,15 @@ export default function WishlistFilterBar({ filters, categories, onChange, onRes
   return (
     <form
       onSubmit={handleSubmit}
-      className="min-w-0 rounded-3xl border border-slate-800/70 bg-slate-900/70 p-4 shadow-sm backdrop-blur"
+      className="min-w-0 rounded-3xl border border-border-subtle bg-surface-elevated/80 p-4 shadow-sm shadow-black/5 backdrop-blur"
     >
       <div className="grid grid-cols-2 items-center gap-3 md:grid-cols-8">
-        <label className="flex min-w-0 flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+        <label className="flex min-w-0 flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-muted">
           <span className="truncate">Status</span>
           <select
             value={filters.status}
             onChange={(event) => handleSelect(event, 'status')}
-            className="h-11 w-full rounded-2xl border border-slate-800 bg-slate-950/60 px-3 text-sm text-slate-100 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+            className="h-11 w-full rounded-2xl border border-border-subtle bg-surface px-3 text-sm text-text shadow-sm transition focus-visible:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
           >
             {STATUS_OPTIONS.map((option) => (
               <option key={option.value} value={option.value}>
@@ -94,12 +94,12 @@ export default function WishlistFilterBar({ filters, categories, onChange, onRes
           </select>
         </label>
 
-        <label className="flex min-w-0 flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+        <label className="flex min-w-0 flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-muted">
           <span className="truncate">Prioritas</span>
           <select
             value={filters.priority}
             onChange={(event) => handleSelect(event, 'priority')}
-            className="h-11 w-full rounded-2xl border border-slate-800 bg-slate-950/60 px-3 text-sm text-slate-100 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+            className="h-11 w-full rounded-2xl border border-border-subtle bg-surface px-3 text-sm text-text shadow-sm transition focus-visible:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
           >
             {PRIORITY_OPTIONS.map((option) => (
               <option key={option.value} value={option.value}>
@@ -109,12 +109,12 @@ export default function WishlistFilterBar({ filters, categories, onChange, onRes
           </select>
         </label>
 
-        <label className="flex min-w-0 flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+        <label className="flex min-w-0 flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-muted">
           <span className="truncate">Kategori</span>
           <select
             value={filters.categoryId}
             onChange={(event) => handleSelect(event, 'categoryId')}
-            className="h-11 w-full rounded-2xl border border-slate-800 bg-slate-950/60 px-3 text-sm text-slate-100 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+            className="h-11 w-full rounded-2xl border border-border-subtle bg-surface px-3 text-sm text-text shadow-sm transition focus-visible:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
           >
             <option value="all">Semua kategori</option>
             {categories.map((category) => (
@@ -125,7 +125,7 @@ export default function WishlistFilterBar({ filters, categories, onChange, onRes
           </select>
         </label>
 
-        <label className="flex min-w-0 flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+        <label className="flex min-w-0 flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-muted">
           <span className="truncate">Harga minimum</span>
           <input
             type="number"
@@ -133,12 +133,12 @@ export default function WishlistFilterBar({ filters, categories, onChange, onRes
             min="0"
             value={filters.priceMin}
             onChange={(event) => handleInput(event, 'priceMin')}
-            className="h-11 w-full rounded-2xl border border-slate-800 bg-slate-950/60 px-3 text-sm text-slate-100 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+            className="h-11 w-full rounded-2xl border border-border-subtle bg-surface px-3 text-sm text-text shadow-sm transition focus-visible:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
             placeholder="0"
           />
         </label>
 
-        <label className="flex min-w-0 flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+        <label className="flex min-w-0 flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-muted">
           <span className="truncate">Harga maksimum</span>
           <input
             type="number"
@@ -146,17 +146,17 @@ export default function WishlistFilterBar({ filters, categories, onChange, onRes
             min="0"
             value={filters.priceMax}
             onChange={(event) => handleInput(event, 'priceMax')}
-            className="h-11 w-full rounded-2xl border border-slate-800 bg-slate-950/60 px-3 text-sm text-slate-100 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+            className="h-11 w-full rounded-2xl border border-border-subtle bg-surface px-3 text-sm text-text shadow-sm transition focus-visible:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
             placeholder="0"
           />
         </label>
 
-        <label className="flex min-w-0 flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+        <label className="flex min-w-0 flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-muted">
           <span className="truncate">Urutkan</span>
           <select
             value={filters.sort}
             onChange={(event) => handleSelect(event, 'sort')}
-            className="h-11 w-full rounded-2xl border border-slate-800 bg-slate-950/60 px-3 text-sm text-slate-100 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+            className="h-11 w-full rounded-2xl border border-border-subtle bg-surface px-3 text-sm text-text shadow-sm transition focus-visible:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
           >
             {SORT_OPTIONS.map((option) => (
               <option key={option.value} value={option.value}>
@@ -166,21 +166,21 @@ export default function WishlistFilterBar({ filters, categories, onChange, onRes
           </select>
         </label>
 
-        <div className="col-span-2 flex h-11 min-w-0 items-center gap-2 rounded-2xl border border-slate-800 bg-slate-950/60 px-3 text-sm text-slate-100 shadow-sm transition focus-within:ring-2 focus-within:ring-[var(--accent)] md:col-span-2 lg:col-span-3">
-          <Search className="h-4 w-4 text-slate-400" aria-hidden="true" />
+        <div className="col-span-2 flex h-11 min-w-0 items-center gap-2 rounded-2xl border border-border-subtle bg-surface px-3 text-sm text-text shadow-sm transition focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/40 md:col-span-2 lg:col-span-3">
+          <Search className="h-4 w-4 text-muted" aria-hidden="true" />
           <input
             type="search"
             value={filters.search}
             onChange={(event) => handleInput(event, 'search')}
             placeholder="Cari judul atau catatan"
-            className="h-full w-full min-w-0 bg-transparent text-sm text-slate-100 placeholder:text-slate-500 focus-visible:outline-none"
+            className="h-full w-full min-w-0 bg-transparent text-sm text-text placeholder:text-muted focus-visible:outline-none"
             aria-label="Pencarian wishlist"
           />
           {onReset ? (
             <button
               type="button"
               onClick={handleReset}
-              className="inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-slate-400 transition hover:bg-slate-800/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+              className="inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-muted transition hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
               aria-label="Reset filter wishlist"
             >
               <RotateCcw className="h-4 w-4" aria-hidden="true" />

--- a/src/components/wishlist/WishlistFormDialog.tsx
+++ b/src/components/wishlist/WishlistFormDialog.tsx
@@ -35,10 +35,10 @@ const STATUS_OPTIONS: { value: WishlistStatus; label: string }[] = [
 ];
 
 const INPUT_CLASS =
-  'h-11 w-full rounded-2xl border-none bg-slate-900/80 px-4 text-sm text-slate-100 ring-2 ring-slate-800 transition focus-visible:outline-none focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60';
+  'h-11 w-full rounded-2xl border border-border-subtle bg-surface px-4 text-sm text-text shadow-sm transition focus-visible:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-60';
 
 const TEXTAREA_CLASS =
-  'w-full rounded-2xl border-none bg-slate-900/80 px-4 py-3 text-sm text-slate-100 ring-2 ring-slate-800 transition focus-visible:outline-none focus-visible:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60';
+  'w-full rounded-2xl border border-border-subtle bg-surface px-4 py-3 text-sm text-text shadow-sm transition focus-visible:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-60';
 
 export default function WishlistFormDialog({
   open,
@@ -166,20 +166,20 @@ export default function WishlistFormDialog({
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 px-4 py-10 backdrop-blur">
-      <div className="relative w-full max-w-xl overflow-hidden rounded-3xl border border-slate-800 bg-slate-950/95 shadow-[0_30px_80px_-40px_rgba(15,23,42,0.8)]">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 py-10 backdrop-blur">
+      <div className="relative w-full max-w-xl overflow-hidden rounded-3xl border border-border-subtle bg-surface-elevated shadow-[0_30px_80px_-40px_rgba(15,23,42,0.4)]">
         <form onSubmit={handleSubmit} className="flex max-h-[85vh] flex-col">
-          <header className="flex items-start justify-between gap-3 border-b border-slate-800/70 bg-slate-950/80 px-6 py-4">
+          <header className="flex items-start justify-between gap-3 border-b border-border-subtle bg-surface px-6 py-4">
             <div>
-              <h2 className="text-lg font-semibold text-slate-100">
+              <h2 className="text-lg font-semibold text-text">
                 {mode === 'create' ? 'Tambah Wishlist' : 'Edit Wishlist'}
               </h2>
-              <p className="text-xs text-slate-400">Kelola item wishlist Anda dengan mudah.</p>
+              <p className="text-xs text-muted">Kelola item wishlist Anda dengan mudah.</p>
             </div>
             <button
               type="button"
               onClick={onClose}
-              className="flex h-9 w-9 items-center justify-center rounded-full text-slate-400 transition hover:bg-slate-800/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+              className="flex h-9 w-9 items-center justify-center rounded-full text-muted transition hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
               aria-label="Tutup form wishlist"
             >
               ✕
@@ -187,7 +187,7 @@ export default function WishlistFormDialog({
           </header>
           <div className="flex-1 space-y-4 overflow-y-auto px-6 py-5">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-200" htmlFor="wishlist-title">
+              <label className="text-sm font-medium text-text" htmlFor="wishlist-title">
                 Judul*
               </label>
               <input
@@ -200,12 +200,12 @@ export default function WishlistFormDialog({
                 required
                 disabled={submitting}
               />
-              {errors.title ? <p className="text-sm text-rose-300">{errors.title}</p> : null}
+              {errors.title ? <p className="text-sm text-danger">{errors.title}</p> : null}
             </div>
 
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
-                <label className="text-sm font-medium text-slate-200" htmlFor="wishlist-price">
+                <label className="text-sm font-medium text-text" htmlFor="wishlist-price">
                   Perkiraan harga (Rp)
                 </label>
                 <input
@@ -219,10 +219,10 @@ export default function WishlistFormDialog({
                   placeholder="0"
                   disabled={submitting}
                 />
-                {errors.estimated_price ? <p className="text-sm text-rose-300">{errors.estimated_price}</p> : null}
+                {errors.estimated_price ? <p className="text-sm text-danger">{errors.estimated_price}</p> : null}
               </div>
               <div className="space-y-2">
-                <label className="text-sm font-medium text-slate-200" htmlFor="wishlist-priority">
+                <label className="text-sm font-medium text-text" htmlFor="wishlist-priority">
                   Prioritas (1-5)
                 </label>
                 <select
@@ -239,13 +239,13 @@ export default function WishlistFormDialog({
                   <option value="4">4</option>
                   <option value="5">5 - Nice to have</option>
                 </select>
-                {errors.priority ? <p className="text-sm text-rose-300">{errors.priority}</p> : null}
+                {errors.priority ? <p className="text-sm text-danger">{errors.priority}</p> : null}
               </div>
             </div>
 
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
-                <label className="text-sm font-medium text-slate-200" htmlFor="wishlist-category">
+                <label className="text-sm font-medium text-text" htmlFor="wishlist-category">
                   Kategori
                 </label>
                 <select
@@ -262,10 +262,10 @@ export default function WishlistFormDialog({
                     </option>
                   ))}
                 </select>
-                {errors.category_id ? <p className="text-sm text-rose-300">{errors.category_id}</p> : null}
+                {errors.category_id ? <p className="text-sm text-danger">{errors.category_id}</p> : null}
               </div>
               <div className="space-y-2">
-                <label className="text-sm font-medium text-slate-200" htmlFor="wishlist-status">
+                <label className="text-sm font-medium text-text" htmlFor="wishlist-status">
                   Status
                 </label>
                 <select
@@ -281,13 +281,13 @@ export default function WishlistFormDialog({
                     </option>
                   ))}
                 </select>
-                {errors.status ? <p className="text-sm text-rose-300">{errors.status}</p> : null}
+                {errors.status ? <p className="text-sm text-danger">{errors.status}</p> : null}
               </div>
             </div>
 
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
-                <label className="text-sm font-medium text-slate-200" htmlFor="wishlist-store">
+                <label className="text-sm font-medium text-text" htmlFor="wishlist-store">
                   URL toko
                 </label>
                 <input
@@ -299,10 +299,10 @@ export default function WishlistFormDialog({
                   placeholder="https://"
                   disabled={submitting}
                 />
-                {errors.store_url ? <p className="text-sm text-rose-300">{errors.store_url}</p> : null}
+                {errors.store_url ? <p className="text-sm text-danger">{errors.store_url}</p> : null}
               </div>
               <div className="space-y-2">
-                <label className="text-sm font-medium text-slate-200" htmlFor="wishlist-image">
+                <label className="text-sm font-medium text-text" htmlFor="wishlist-image">
                   URL gambar
                 </label>
                 <input
@@ -314,12 +314,12 @@ export default function WishlistFormDialog({
                   placeholder="https://"
                   disabled={submitting}
                 />
-                {errors.image_url ? <p className="text-sm text-rose-300">{errors.image_url}</p> : null}
+                {errors.image_url ? <p className="text-sm text-danger">{errors.image_url}</p> : null}
               </div>
             </div>
 
             <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-200" htmlFor="wishlist-note">
+              <label className="text-sm font-medium text-text" htmlFor="wishlist-note">
                 Catatan
               </label>
               <textarea
@@ -333,18 +333,18 @@ export default function WishlistFormDialog({
               />
             </div>
           </div>
-          <footer className="flex items-center justify-between gap-3 border-t border-slate-800/70 bg-slate-950/80 px-6 py-4">
+          <footer className="flex items-center justify-between gap-3 border-t border-border-subtle bg-surface px-6 py-4">
             <button
               type="button"
               onClick={onClose}
-              className="inline-flex h-11 items-center justify-center rounded-2xl px-4 text-sm font-semibold text-slate-300 transition hover:bg-slate-800/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+              className="inline-flex h-11 items-center justify-center rounded-full border border-border-subtle bg-surface px-4 text-sm font-semibold text-text transition hover:border-primary/40 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
               disabled={submitting}
             >
               Batal
             </button>
             <button
               type="submit"
-              className="inline-flex h-11 items-center justify-center rounded-2xl bg-[var(--accent)] px-5 text-sm font-semibold text-slate-950 transition hover:bg-[var(--accent)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+              className="inline-flex h-11 items-center justify-center rounded-full bg-primary px-5 text-sm font-semibold text-primary-foreground shadow transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
               disabled={submitting}
             >
               {submitting ? 'Menyimpan…' : mode === 'create' ? 'Tambah Wishlist' : 'Simpan Perubahan'}

--- a/src/pages/WishlistPage.tsx
+++ b/src/pages/WishlistPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
-import { ArrowDownToLine, FileUp, Plus } from 'lucide-react';
+import { ArrowDownToLine, FileUp, Plus, Sparkles } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import Page from '../layout/Page';
 import PageHeader from '../layout/PageHeader';
@@ -489,12 +489,12 @@ export default function WishlistPage() {
 
   const renderSkeletons = () => {
     return (
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
         {Array.from({ length: 6 }).map((_, index) => (
           <div
             // eslint-disable-next-line react/no-array-index-key
             key={index}
-            className="h-48 animate-pulse rounded-2xl bg-slate-900/60 ring-1 ring-slate-800"
+            className="h-52 animate-pulse rounded-3xl border border-border-subtle bg-surface/60"
           />
         ))}
       </div>
@@ -502,17 +502,17 @@ export default function WishlistPage() {
   };
 
   const renderEmptyState = () => (
-    <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border border-dashed border-slate-800 bg-slate-950/60 px-6 py-16 text-center">
-      <div className="rounded-full border border-slate-800 bg-slate-900/80 px-4 py-2 text-sm text-slate-400">
-        Wishlist Anda masih kosong
-      </div>
-      <p className="max-w-sm text-balance text-sm text-slate-400">
+    <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border border-dashed border-border-subtle/80 bg-surface/60 px-6 py-16 text-center shadow-sm">
+      <span className="inline-flex items-center gap-2 rounded-full border border-border-subtle bg-surface-elevated/80 px-4 py-2 text-sm font-medium text-muted">
+        <Sparkles className="h-4 w-4" aria-hidden="true" /> Wishlist Anda masih kosong
+      </span>
+      <p className="max-w-sm text-balance text-sm text-muted">
         Simpan ide belanja tanpa komitmen finansial. Tambahkan item wishlist dan ubah menjadi goal atau transaksi kapan saja.
       </p>
       <button
         type="button"
         onClick={handleAdd}
-        className="inline-flex h-11 items-center gap-2 rounded-2xl bg-[var(--accent)] px-5 text-sm font-semibold text-slate-950 transition hover:bg-[var(--accent)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+        className="inline-flex h-11 items-center gap-2 rounded-full bg-primary px-5 text-sm font-semibold text-primary-foreground shadow transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
       >
         <Plus className="h-4 w-4" aria-hidden="true" /> Tambah Wishlist
       </button>
@@ -524,29 +524,31 @@ export default function WishlistPage() {
   return (
     <Page>
       <PageHeader title="Wishlist" description="Kelola daftar keinginan dan siap jadikan goal atau transaksi kapan pun.">
-        <button
-          type="button"
-          onClick={handleImportClick}
-          className="inline-flex h-10 items-center gap-2 rounded-2xl border border-slate-700 bg-slate-900/70 px-4 text-sm font-medium text-slate-100 transition hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
-          disabled={importing || isMutating}
-        >
-          <FileUp className="h-4 w-4" aria-hidden="true" /> {importing ? 'Mengimpor…' : 'Impor CSV'}
-        </button>
-        <button
-          type="button"
-          onClick={handleExport}
-          className="inline-flex h-10 items-center gap-2 rounded-2xl border border-slate-700 bg-slate-900/70 px-4 text-sm font-medium text-slate-100 transition hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
-          disabled={exporting}
-        >
-          <ArrowDownToLine className="h-4 w-4" aria-hidden="true" /> {exporting ? 'Menyiapkan…' : 'Ekspor CSV'}
-        </button>
-        <button
-          type="button"
-          onClick={handleAdd}
-          className="inline-flex h-10 items-center gap-2 rounded-2xl bg-[var(--accent)] px-4 text-sm font-semibold text-slate-950 transition hover:bg-[var(--accent)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
-        >
-          <Plus className="h-4 w-4" aria-hidden="true" /> Wishlist Baru
-        </button>
+        <div className="flex flex-wrap justify-end gap-2 rounded-full bg-surface-elevated/80 p-1.5 shadow-sm shadow-black/5 backdrop-blur supports-[backdrop-filter]:backdrop-blur">
+          <button
+            type="button"
+            onClick={handleImportClick}
+            className="inline-flex h-10 items-center gap-2 rounded-full border border-border-subtle bg-surface px-4 text-sm font-medium text-text transition hover:border-primary/40 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+            disabled={importing || isMutating}
+          >
+            <FileUp className="h-4 w-4" aria-hidden="true" /> {importing ? 'Mengimpor…' : 'Impor CSV'}
+          </button>
+          <button
+            type="button"
+            onClick={handleExport}
+            className="inline-flex h-10 items-center gap-2 rounded-full border border-border-subtle bg-surface px-4 text-sm font-medium text-text transition hover:border-primary/40 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+            disabled={exporting}
+          >
+            <ArrowDownToLine className="h-4 w-4" aria-hidden="true" /> {exporting ? 'Menyiapkan…' : 'Ekspor CSV'}
+          </button>
+          <button
+            type="button"
+            onClick={handleAdd}
+            className="inline-flex h-10 items-center gap-2 rounded-full bg-primary px-4 text-sm font-semibold text-primary-foreground shadow transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+          >
+            <Plus className="h-4 w-4" aria-hidden="true" /> Tambah Wishlist
+          </button>
+        </div>
       </PageHeader>
 
       <input
@@ -557,16 +559,16 @@ export default function WishlistPage() {
         onChange={handleImportFile}
       />
 
-      <div className="space-y-6">
+      <div className="space-y-8">
         <WishlistFilterBar filters={filters} categories={categories} onChange={handleFilterChange} onReset={handleResetFilters} />
 
         {hasError ? (
-          <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+          <div className="rounded-2xl border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger">
             Terjadi kesalahan saat memuat wishlist. {error instanceof Error ? error.message : ''}
             <button
               type="button"
               onClick={() => window.location.reload()}
-              className="ml-3 inline-flex items-center text-rose-100 underline-offset-4 hover:underline"
+              className="ml-3 inline-flex items-center text-danger underline-offset-4 hover:underline"
             >
               Muat ulang
             </button>
@@ -578,8 +580,8 @@ export default function WishlistPage() {
         ) : items.length === 0 ? (
           renderEmptyState()
         ) : (
-          <div className="space-y-6">
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+          <div className="space-y-8">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
               {items.map((item) => (
                 <WishlistCard
                   key={item.id}
@@ -597,13 +599,16 @@ export default function WishlistPage() {
             </div>
             {hasNextPage ? (
               <div className="flex justify-center">
-                <div ref={loadMoreRef} className="h-10 w-full max-w-[200px] rounded-full bg-transparent text-center text-sm text-slate-500">
+                <div
+                  ref={loadMoreRef}
+                  className="h-10 w-full max-w-[240px] rounded-full border border-dashed border-border-subtle/80 text-center text-sm text-muted"
+                >
                   {isFetchingNextPage ? 'Memuat…' : 'Memuat lainnya'}
                 </div>
               </div>
             ) : null}
             {total ? (
-              <p className="text-center text-xs text-slate-500">
+              <p className="text-center text-xs text-muted">
                 Menampilkan {items.length} dari {total} wishlist
               </p>
             ) : null}


### PR DESCRIPTION
## Summary
- restyle the wishlist page layout with modern action toolbar, responsive spacing, and refreshed empty/skeleton states
- redesign wishlist cards with icon-enhanced metadata chips and updated theme-aware styling
- update wishlist filters, batch toolbar, and form dialog to use shared design tokens for light and dark themes

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7d85deaac8332b3af233c6546974f