### PR TITLE
Revamp wishlist page layout and styling

### DIFF
--- a/src/components/wishlist/WishlistCard.tsx
+++ b/src/components/wishlist/WishlistCard.tsx
@@ -1,11 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   CheckCircle2,
+  CircleDollarSign,
   EllipsisVertical,
-  ExternalLink,
   Goal,
+  Link2,
   NotebookPen,
   ShoppingBag,
+  Star,
+  StickyNote,
+  Tag,
   Trash2,
 } from 'lucide-react';
 import type { WishlistItem, WishlistStatus } from '../../lib/wishlistApi';
@@ -30,18 +34,22 @@ const STATUS_LABEL: Record<WishlistStatus, string> = {
 };
 
 const STATUS_STYLE: Record<WishlistStatus, string> = {
-  planned: 'bg-slate-800/80 text-slate-200 border border-slate-700',
-  deferred: 'bg-amber-500/10 text-amber-300 border border-amber-400/30',
-  purchased: 'bg-emerald-500/10 text-emerald-300 border border-emerald-400/30',
-  archived: 'bg-slate-800/60 text-slate-400 border border-slate-700/70',
+  planned:
+    'bg-emerald-50 text-emerald-700 ring-emerald-200 dark:bg-emerald-500/10 dark:text-emerald-200 dark:ring-emerald-500/30',
+  deferred:
+    'bg-amber-50 text-amber-700 ring-amber-200 dark:bg-amber-500/10 dark:text-amber-200 dark:ring-amber-500/30',
+  purchased:
+    'bg-sky-50 text-sky-700 ring-sky-200 dark:bg-sky-500/10 dark:text-sky-200 dark:ring-sky-500/30',
+  archived:
+    'bg-surface-2 text-muted ring-border-subtle dark:bg-slate-900/70 dark:text-slate-400 dark:ring-slate-700/60',
 };
 
 const PRIORITY_STYLE: Record<number, string> = {
-  1: 'bg-emerald-500/15 text-emerald-300 border border-emerald-400/30',
-  2: 'bg-teal-500/15 text-teal-200 border border-teal-400/30',
-  3: 'bg-sky-500/15 text-sky-200 border border-sky-400/30',
-  4: 'bg-violet-500/15 text-violet-200 border border-violet-400/30',
-  5: 'bg-rose-500/15 text-rose-200 border border-rose-400/30',
+  1: 'bg-emerald-50 text-emerald-700 ring-emerald-200 dark:bg-emerald-500/10 dark:text-emerald-200 dark:ring-emerald-500/30',
+  2: 'bg-teal-50 text-teal-700 ring-teal-200 dark:bg-teal-500/10 dark:text-teal-200 dark:ring-teal-500/30',
+  3: 'bg-sky-50 text-sky-700 ring-sky-200 dark:bg-sky-500/10 dark:text-sky-200 dark:ring-sky-500/30',
+  4: 'bg-violet-50 text-violet-700 ring-violet-200 dark:bg-violet-500/10 dark:text-violet-200 dark:ring-violet-500/30',
+  5: 'bg-rose-50 text-rose-700 ring-rose-200 dark:bg-rose-500/10 dark:text-rose-200 dark:ring-rose-500/30',
 };
 
 function formatCurrencyIDR(value: number | null): string {
@@ -101,21 +109,21 @@ export default function WishlistCard({
     if (!value || value < 1 || value > 5) return null;
     return (
       <span
-        className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium ${PRIORITY_STYLE[value]}`}
+        className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium ring-1 ring-inset ${PRIORITY_STYLE[value]}`}
       >
-        Prioritas {value}
+        <Star className="h-3.5 w-3.5" aria-hidden="true" /> Prioritas {value}
       </span>
     );
   }, [item.priority]);
 
   return (
     <article
-      className={`group relative flex h-full flex-col overflow-hidden rounded-2xl bg-slate-950/80 ring-1 ring-slate-800 transition hover:ring-[var(--accent)]/70 ${
-        selected ? 'ring-2 ring-[var(--accent)]/80' : ''
+      className={`group relative flex h-full flex-col overflow-hidden rounded-3xl bg-card shadow-sm ring-1 ring-border-subtle transition duration-200 hover:-translate-y-1 hover:shadow-lg hover:ring-[var(--accent)]/40 ${
+        selected ? 'ring-2 ring-[var(--accent)]/70 shadow-lg' : ''
       } ${disabled ? 'opacity-60' : ''}`}
     >
       {hasImage ? (
-        <div className="relative aspect-video w-full overflow-hidden bg-slate-900">
+        <div className="relative aspect-video w-full overflow-hidden bg-surface-2">
           <img
             src={item.image_url ?? ''}
             alt={item.title}
@@ -123,42 +131,54 @@ export default function WishlistCard({
             className="h-full w-full object-cover transition duration-500 group-hover:scale-[1.03]"
           />
         </div>
-      ) : null}
-      <div className="flex flex-1 flex-col gap-4 p-4">
+      ) : (
+        <div className="flex aspect-video w-full items-center justify-center bg-surface-2 text-muted">
+          <ShoppingBag className="h-8 w-8" aria-hidden="true" />
+        </div>
+      )}
+      <div className="flex flex-1 flex-col gap-4 p-5">
         <div className="flex items-start gap-3">
           <label className="mt-0.5 flex items-center">
             <input
               type="checkbox"
               checked={selected}
               onChange={(event) => onSelectChange(event.target.checked)}
-              className="h-4 w-4 cursor-pointer rounded border-slate-600 bg-slate-900 text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+              className="h-4 w-4 cursor-pointer rounded border-border-subtle bg-background text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               aria-label={`Pilih wishlist ${item.title}`}
               disabled={disabled}
             />
           </label>
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-start justify-between gap-2">
-              <h3 className="truncate text-base font-semibold text-slate-100">{item.title}</h3>
+              <h3 className="truncate text-base font-semibold text-text">{item.title}</h3>
               <div className="flex items-center gap-2">
                 {priorityBadge}
                 <span
-                  className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${STATUS_STYLE[item.status]}`}
+                  className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ring-1 ring-inset ${STATUS_STYLE[item.status]}`}
                 >
                   {STATUS_LABEL[item.status]}
                 </span>
               </div>
             </div>
-            <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-slate-400">
-              <span className="font-medium text-slate-100">{formatCurrencyIDR(item.estimated_price)}</span>
-              {item.category?.name ? <span className="text-xs uppercase tracking-wide text-slate-500">{item.category.name}</span> : null}
+            <div className="mt-3 space-y-2 text-sm text-muted">
+              <div className="flex items-center gap-2 text-text">
+                <CircleDollarSign className="h-4 w-4 text-muted" aria-hidden="true" />
+                <span className="font-medium">{formatCurrencyIDR(item.estimated_price)}</span>
+              </div>
+              {item.category?.name ? (
+                <div className="flex items-center gap-2">
+                  <Tag className="h-4 w-4 text-muted" aria-hidden="true" />
+                  <span className="text-sm font-medium text-text">{item.category.name}</span>
+                </div>
+              ) : null}
               {item.store_url ? (
                 <a
                   href={item.store_url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-xs text-[var(--accent)] transition hover:text-[var(--accent)]/80"
+                  className="flex items-center gap-2 text-sm font-medium text-[var(--accent)] transition hover:text-[var(--accent)]/80"
                 >
-                  <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" /> Toko
+                  <Link2 className="h-4 w-4" aria-hidden="true" /> Kunjungi toko
                 </a>
               ) : null}
             </div>
@@ -166,7 +186,7 @@ export default function WishlistCard({
           <div className="relative" ref={menuRef}>
             <button
               type="button"
-              className="flex h-9 w-9 items-center justify-center rounded-full text-slate-400 transition hover:bg-slate-800/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+              className="flex h-9 w-9 items-center justify-center rounded-full text-muted transition hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               aria-label={`Menu tindakan untuk ${item.title}`}
               onClick={() => setMenuOpen((prev) => !prev)}
               disabled={disabled}
@@ -174,14 +194,14 @@ export default function WishlistCard({
               <EllipsisVertical className="h-5 w-5" aria-hidden="true" />
             </button>
             {menuOpen ? (
-              <div className="absolute right-0 top-11 z-20 w-48 overflow-hidden rounded-2xl border border-slate-800/80 bg-slate-950/95 shadow-xl">
+              <div className="absolute right-0 top-11 z-20 w-52 overflow-hidden rounded-2xl border border-border bg-card shadow-xl">
                 <button
                   type="button"
                   onClick={() => {
                     setMenuOpen(false);
                     onMakeGoal(item);
                   }}
-                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-slate-100 transition hover:bg-slate-900"
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-text transition hover:bg-surface-2"
                 >
                   <Goal className="h-4 w-4" aria-hidden="true" /> Jadikan Goal
                 </button>
@@ -191,7 +211,7 @@ export default function WishlistCard({
                     setMenuOpen(false);
                     onMarkPurchased(item);
                   }}
-                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-slate-100 transition hover:bg-slate-900"
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-text transition hover:bg-surface-2 disabled:opacity-50"
                   disabled={item.status === 'purchased'}
                 >
                   <CheckCircle2 className="h-4 w-4" aria-hidden="true" /> Tandai Dibeli
@@ -202,7 +222,7 @@ export default function WishlistCard({
                     setMenuOpen(false);
                     onCopyToTransaction(item);
                   }}
-                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-slate-100 transition hover:bg-slate-900"
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-text transition hover:bg-surface-2"
                 >
                   <ShoppingBag className="h-4 w-4" aria-hidden="true" /> Salin ke Transaksi
                 </button>
@@ -212,7 +232,7 @@ export default function WishlistCard({
                     setMenuOpen(false);
                     onEdit(item);
                   }}
-                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-slate-100 transition hover:bg-slate-900"
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-text transition hover:bg-surface-2"
                 >
                   <NotebookPen className="h-4 w-4" aria-hidden="true" /> Edit
                 </button>
@@ -222,7 +242,7 @@ export default function WishlistCard({
                     setMenuOpen(false);
                     onDelete(item);
                   }}
-                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-rose-300 transition hover:bg-rose-500/10"
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-danger transition hover:bg-danger/10"
                 >
                   <Trash2 className="h-4 w-4" aria-hidden="true" /> Hapus
                 </button>
@@ -231,7 +251,10 @@ export default function WishlistCard({
           </div>
         </div>
         {item.note ? (
-          <p className="line-clamp-3 text-sm text-slate-400">{item.note}</p>
+          <div className="flex items-start gap-2 rounded-2xl bg-surface-2/70 p-3 text-sm text-muted">
+            <StickyNote className="mt-0.5 h-4 w-4 flex-shrink-0 text-muted" aria-hidden="true" />
+            <p className="line-clamp-3 text-left text-sm text-muted">{item.note}</p>
+          </div>
         ) : null}
       </div>
     </article>

--- a/src/pages/WishlistPage.tsx
+++ b/src/pages/WishlistPage.tsx
@@ -489,12 +489,12 @@ export default function WishlistPage() {
 
   const renderSkeletons = () => {
     return (
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
         {Array.from({ length: 6 }).map((_, index) => (
           <div
             // eslint-disable-next-line react/no-array-index-key
             key={index}
-            className="h-48 animate-pulse rounded-2xl bg-slate-900/60 ring-1 ring-slate-800"
+            className="h-48 animate-pulse rounded-3xl bg-surface-elevated/70 ring-1 ring-border-subtle"
           />
         ))}
       </div>
@@ -502,17 +502,17 @@ export default function WishlistPage() {
   };
 
   const renderEmptyState = () => (
-    <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border border-dashed border-slate-800 bg-slate-950/60 px-6 py-16 text-center">
-      <div className="rounded-full border border-slate-800 bg-slate-900/80 px-4 py-2 text-sm text-slate-400">
+    <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border border-dashed border-border-subtle bg-surface-elevated/70 px-6 py-16 text-center shadow-sm backdrop-blur">
+      <div className="rounded-full border border-border-subtle bg-surface px-4 py-2 text-sm text-muted">
         Wishlist Anda masih kosong
       </div>
-      <p className="max-w-sm text-balance text-sm text-slate-400">
+      <p className="max-w-sm text-balance text-sm text-muted">
         Simpan ide belanja tanpa komitmen finansial. Tambahkan item wishlist dan ubah menjadi goal atau transaksi kapan saja.
       </p>
       <button
         type="button"
         onClick={handleAdd}
-        className="inline-flex h-11 items-center gap-2 rounded-2xl bg-[var(--accent)] px-5 text-sm font-semibold text-slate-950 transition hover:bg-[var(--accent)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+        className="inline-flex h-11 items-center gap-2 rounded-2xl bg-[var(--accent)] px-5 text-sm font-semibold text-slate-900 shadow-sm transition hover:bg-[var(--accent)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:text-slate-950"
       >
         <Plus className="h-4 w-4" aria-hidden="true" /> Tambah Wishlist
       </button>
@@ -527,7 +527,7 @@ export default function WishlistPage() {
         <button
           type="button"
           onClick={handleImportClick}
-          className="inline-flex h-10 items-center gap-2 rounded-2xl border border-slate-700 bg-slate-900/70 px-4 text-sm font-medium text-slate-100 transition hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          className="inline-flex h-11 items-center gap-2 rounded-2xl border border-border bg-surface-elevated px-4 text-sm font-medium text-text transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-60"
           disabled={importing || isMutating}
         >
           <FileUp className="h-4 w-4" aria-hidden="true" /> {importing ? 'Mengimpor…' : 'Impor CSV'}
@@ -535,7 +535,7 @@ export default function WishlistPage() {
         <button
           type="button"
           onClick={handleExport}
-          className="inline-flex h-10 items-center gap-2 rounded-2xl border border-slate-700 bg-slate-900/70 px-4 text-sm font-medium text-slate-100 transition hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          className="inline-flex h-11 items-center gap-2 rounded-2xl border border-border bg-surface-elevated px-4 text-sm font-medium text-text transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-60"
           disabled={exporting}
         >
           <ArrowDownToLine className="h-4 w-4" aria-hidden="true" /> {exporting ? 'Menyiapkan…' : 'Ekspor CSV'}
@@ -543,9 +543,9 @@ export default function WishlistPage() {
         <button
           type="button"
           onClick={handleAdd}
-          className="inline-flex h-10 items-center gap-2 rounded-2xl bg-[var(--accent)] px-4 text-sm font-semibold text-slate-950 transition hover:bg-[var(--accent)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          className="inline-flex h-11 items-center gap-2 rounded-2xl bg-[var(--accent)] px-4 text-sm font-semibold text-slate-900 shadow-sm transition hover:bg-[var(--accent)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:text-slate-950"
         >
-          <Plus className="h-4 w-4" aria-hidden="true" /> Wishlist Baru
+          <Plus className="h-4 w-4" aria-hidden="true" /> Tambah Wishlist
         </button>
       </PageHeader>
 
@@ -561,12 +561,12 @@ export default function WishlistPage() {
         <WishlistFilterBar filters={filters} categories={categories} onChange={handleFilterChange} onReset={handleResetFilters} />
 
         {hasError ? (
-          <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+          <div className="rounded-2xl border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger">
             Terjadi kesalahan saat memuat wishlist. {error instanceof Error ? error.message : ''}
             <button
               type="button"
               onClick={() => window.location.reload()}
-              className="ml-3 inline-flex items-center text-rose-100 underline-offset-4 hover:underline"
+              className="ml-3 inline-flex items-center font-medium text-danger underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-background"
             >
               Muat ulang
             </button>
@@ -579,7 +579,7 @@ export default function WishlistPage() {
           renderEmptyState()
         ) : (
           <div className="space-y-6">
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
               {items.map((item) => (
                 <WishlistCard
                   key={item.id}
@@ -597,13 +597,16 @@ export default function WishlistPage() {
             </div>
             {hasNextPage ? (
               <div className="flex justify-center">
-                <div ref={loadMoreRef} className="h-10 w-full max-w-[200px] rounded-full bg-transparent text-center text-sm text-slate-500">
+                <div
+                  ref={loadMoreRef}
+                  className="h-10 w-full max-w-[200px] rounded-full bg-transparent text-center text-sm text-muted"
+                >
                   {isFetchingNextPage ? 'Memuat…' : 'Memuat lainnya'}
                 </div>
               </div>
             ) : null}
             {total ? (
-              <p className="text-center text-xs text-slate-500">
+              <p className="text-center text-xs text-muted">
                 Menampilkan {items.length} dari {total} wishlist
               </p>
             ) : null}


### PR DESCRIPTION
## Summary
- refresh the wishlist page structure with accent action buttons, responsive spacing, and updated theming for light and dark modes
- enhance wishlist cards with icon-supported metadata, modern badges, and improved empty/skeleton states

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7d85deaac8332b3af233c6546974f