### PR TITLE
Fix wishlist UI overlays and remove CSV import button

### DIFF
--- a/src/components/wishlist/WishlistCard.tsx
+++ b/src/components/wishlist/WishlistCard.tsx
@@ -112,12 +112,12 @@ export default function WishlistCard({
 
   return (
     <article
-      className={`group relative flex h-full flex-col overflow-hidden rounded-3xl border border-border-subtle bg-surface shadow-sm transition-all duration-200 hover:border-brand/40 hover:shadow-lg ${
+      className={`group relative flex h-full flex-col overflow-visible rounded-3xl border border-border-subtle bg-surface shadow-sm transition-all duration-200 hover:border-brand/40 hover:shadow-lg ${
         selected ? 'border-brand/60 ring-2 ring-brand/40' : 'ring-1 ring-transparent'
       } ${disabled ? 'opacity-60' : ''}`}
     >
       {hasImage ? (
-        <div className="relative aspect-video w-full overflow-hidden bg-surface-alt">
+        <div className="relative aspect-video w-full overflow-hidden rounded-t-3xl bg-surface-alt">
           <img
             src={item.image_url ?? ''}
             alt={item.title}

--- a/src/components/wishlist/WishlistFormDialog.tsx
+++ b/src/components/wishlist/WishlistFormDialog.tsx
@@ -166,7 +166,7 @@ export default function WishlistFormDialog({
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 px-4 py-10 backdrop-blur">
+    <div className="fixed inset-0 z-[70] flex items-center justify-center bg-slate-950/70 px-4 py-10 backdrop-blur">
       <div className="relative w-full max-w-xl overflow-hidden rounded-3xl border border-slate-800 bg-slate-950/95 shadow-[0_30px_80px_-40px_rgba(15,23,42,0.8)]">
         <form onSubmit={handleSubmit} className="flex max-h-[85vh] flex-col">
           <header className="flex items-start justify-between gap-3 border-b border-slate-800/70 bg-slate-950/80 px-6 py-4">


### PR DESCRIPTION
## Summary
- remove the wishlist CSV import control and supporting handlers from the page
- raise the wishlist form dialog z-index so it renders above the fixed topbar
- allow wishlist card menus to overflow without clipping and keep image corners rounded

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7de3d4b808332bd3359c0d53704b5