### PR TITLE
feat: enable admin to manage app info settings

### DIFF
--- a/src/pages/admin/AdminSettingsTab.tsx
+++ b/src/pages/admin/AdminSettingsTab.tsx
@@ -1,12 +1,12 @@
-import { FormEvent, useEffect, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
 import { useToast } from '../../context/ToastContext.jsx';
 import {
-  getAppDescription,
+  getAppInfo,
   getBranding,
-  setAppDescription,
+  setAppInfo,
   setBranding,
-  type AppDescriptionSetting,
+  type AppInfoSetting,
   type BrandingSetting,
 } from '../../lib/adminApi';
 
@@ -26,14 +26,28 @@ type BrandingForm = {
   secondary: string;
 };
 
+type AppInfoForm = {
+  title: string;
+  tagline: string;
+  description: string;
+  logoUrl: string;
+  faviconUrl: string;
+};
+
 export default function AdminSettingsTab() {
   const { addToast } = useToast();
-  const [description, setDescription] = useState('');
-  const [descriptionMeta, setDescriptionMeta] = useState<string | null>(null);
+  const [appInfo, setAppInfoState] = useState<AppInfoForm>({
+    title: '',
+    tagline: '',
+    description: '',
+    logoUrl: '',
+    faviconUrl: '',
+  });
+  const [appInfoMeta, setAppInfoMeta] = useState<string | null>(null);
   const [branding, setBrandingState] = useState<BrandingForm>({ primary: '#1e40af', secondary: '#0ea5e9' });
   const [brandingMeta, setBrandingMeta] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
-  const [savingDesc, setSavingDesc] = useState(false);
+  const [savingInfo, setSavingInfo] = useState(false);
   const [savingBrand, setSavingBrand] = useState(false);
 
   useEffect(() => {
@@ -41,10 +55,16 @@ export default function AdminSettingsTab() {
     const load = async () => {
       setLoading(true);
       try {
-        const [desc, brand] = await Promise.all([getAppDescription(), getBranding()]);
+        const [info, brand] = await Promise.all([getAppInfo(), getBranding()]);
         if (!mounted) return;
-        setDescription(desc.text ?? '');
-        setDescriptionMeta(desc.updated_at ?? null);
+        setAppInfoState({
+          title: info.title ?? '',
+          tagline: info.tagline ?? '',
+          description: info.description ?? '',
+          logoUrl: info.logo_url ?? '',
+          faviconUrl: info.favicon_url ?? '',
+        });
+        setAppInfoMeta(info.updated_at ?? null);
         setBrandingState({ primary: brand.primary, secondary: brand.secondary });
         setBrandingMeta(brand.updated_at ?? null);
       } catch (err) {
@@ -64,20 +84,38 @@ export default function AdminSettingsTab() {
     };
   }, [addToast]);
 
-  const handleDescriptionSubmit = async (event: FormEvent<HTMLFormElement>) => {
+  const logoPreviewUrl = useMemo(() => appInfo.logoUrl.trim(), [appInfo.logoUrl]);
+
+  const faviconPreviewUrl = useMemo(() => appInfo.faviconUrl.trim(), [appInfo.faviconUrl]);
+
+  const handleAppInfoSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (savingDesc) return;
-    setSavingDesc(true);
+    if (savingInfo) return;
+    setSavingInfo(true);
     try {
-      const result: AppDescriptionSetting = await setAppDescription(description);
-      setDescription(result.text);
-      setDescriptionMeta(result.updated_at ?? null);
-      addToast('Deskripsi aplikasi disimpan', 'success');
+      const payload = {
+        title: appInfo.title,
+        tagline: appInfo.tagline,
+        description: appInfo.description,
+        logo_url: appInfo.logoUrl,
+        favicon_url: appInfo.faviconUrl,
+      };
+
+      const result: AppInfoSetting = await setAppInfo(payload);
+      setAppInfoState({
+        title: result.title,
+        tagline: result.tagline,
+        description: result.description,
+        logoUrl: result.logo_url,
+        faviconUrl: result.favicon_url,
+      });
+      setAppInfoMeta(result.updated_at ?? null);
+      addToast('Informasi aplikasi disimpan', 'success');
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Gagal menyimpan deskripsi';
+      const message = err instanceof Error ? err.message : 'Gagal menyimpan informasi aplikasi';
       addToast(message, 'error');
     } finally {
-      setSavingDesc(false);
+      setSavingInfo(false);
     }
   };
 
@@ -128,7 +166,7 @@ export default function AdminSettingsTab() {
       <div>
         <h2 className="text-lg font-semibold">Pengaturan Aplikasi</h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          Kelola deskripsi aplikasi dan elemen branding agar konsisten dengan identitas produk.
+          Kelola informasi utama, deskripsi aplikasi, dan elemen branding agar konsisten dengan identitas produk.
         </p>
       </div>
 
@@ -136,32 +174,125 @@ export default function AdminSettingsTab() {
         renderSkeleton()
       ) : (
         <div className="grid gap-6 lg:grid-cols-2">
-          <form
-            onSubmit={handleDescriptionSubmit}
-            className="space-y-4 rounded-2xl border border-border/60 bg-background p-6 shadow-sm"
-          >
+          <form onSubmit={handleAppInfoSubmit} className="space-y-4 rounded-2xl border border-border/60 bg-background p-6 shadow-sm">
             <div>
-              <h3 className="text-base font-semibold">Deskripsi Aplikasi</h3>
+              <h3 className="text-base font-semibold">Informasi Aplikasi</h3>
               <p className="mt-1 text-sm text-muted-foreground">
-                Teks ini akan tampil sebagai penjelasan singkat aplikasi pada halaman publik atau meta data.
+                Atur judul, tagline, deskripsi, dan logo aplikasi. Informasi ini akan muncul pada area publik maupun dashboard.
               </p>
             </div>
-            <textarea
-              value={description}
-              onChange={(event) => setDescription(event.target.value)}
-              className={TEXTAREA_CLASS}
-              placeholder="Tuliskan deskripsi aplikasi di sini"
-            />
+
+            <div className="space-y-3">
+              <label className="block text-sm font-semibold text-muted-foreground">
+                Judul Aplikasi
+                <input
+                  value={appInfo.title}
+                  onChange={(event) =>
+                    setAppInfoState((prev) => ({ ...prev, title: event.target.value }))
+                  }
+                  className={clsx(INPUT_CLASS, 'mt-1')}
+                  placeholder="HematWoi"
+                  required
+                />
+              </label>
+
+              <label className="block text-sm font-semibold text-muted-foreground">
+                Tagline
+                <input
+                  value={appInfo.tagline}
+                  onChange={(event) =>
+                    setAppInfoState((prev) => ({ ...prev, tagline: event.target.value }))
+                  }
+                  className={clsx(INPUT_CLASS, 'mt-1')}
+                  placeholder="Kelola keuangan lebih mudah"
+                />
+              </label>
+
+              <label className="block text-sm font-semibold text-muted-foreground">
+                Logo URL
+                <input
+                  value={appInfo.logoUrl}
+                  onChange={(event) =>
+                    setAppInfoState((prev) => ({ ...prev, logoUrl: event.target.value }))
+                  }
+                  className={clsx(INPUT_CLASS, 'mt-1')}
+                  placeholder="https://example.com/logo.png"
+                />
+              </label>
+
+              {logoPreviewUrl ? (
+                <div className="flex items-center gap-3 rounded-2xl border border-dashed border-border/60 p-3">
+                  <div className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-xl border border-border/40 bg-muted/30">
+                    <img
+                      src={logoPreviewUrl}
+                      alt="Logo preview"
+                      className="h-full w-full object-contain"
+                      onError={(event) => {
+                        (event.currentTarget as HTMLImageElement).style.display = 'none';
+                      }}
+                    />
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    <p className="font-medium">Pratinjau Logo</p>
+                    <p className="line-clamp-1 break-all">{logoPreviewUrl}</p>
+                  </div>
+                </div>
+              ) : null}
+
+              <label className="block text-sm font-semibold text-muted-foreground">
+                Favicon URL
+                <input
+                  value={appInfo.faviconUrl}
+                  onChange={(event) =>
+                    setAppInfoState((prev) => ({ ...prev, faviconUrl: event.target.value }))
+                  }
+                  className={clsx(INPUT_CLASS, 'mt-1')}
+                  placeholder="https://example.com/favicon.ico"
+                />
+              </label>
+
+              {faviconPreviewUrl ? (
+                <div className="flex items-center gap-3 rounded-2xl border border-dashed border-border/60 p-3">
+                  <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-lg border border-border/40 bg-muted/30">
+                    <img
+                      src={faviconPreviewUrl}
+                      alt="Favicon preview"
+                      className="h-full w-full object-contain"
+                      onError={(event) => {
+                        (event.currentTarget as HTMLImageElement).style.display = 'none';
+                      }}
+                    />
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    <p className="font-medium">Pratinjau Favicon</p>
+                    <p className="line-clamp-1 break-all">{faviconPreviewUrl}</p>
+                  </div>
+                </div>
+              ) : null}
+
+              <label className="block text-sm font-semibold text-muted-foreground">
+                Deskripsi
+                <textarea
+                  value={appInfo.description}
+                  onChange={(event) =>
+                    setAppInfoState((prev) => ({ ...prev, description: event.target.value }))
+                  }
+                  className={clsx(TEXTAREA_CLASS, 'mt-1')}
+                  placeholder="Tuliskan deskripsi aplikasi di sini"
+                />
+              </label>
+            </div>
+
             <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
               <span>
-                {descriptionMeta ? `Terakhir diperbarui ${dateFormatter.format(new Date(descriptionMeta))}` : 'Belum pernah disimpan'}
+                {appInfoMeta ? `Terakhir diperbarui ${dateFormatter.format(new Date(appInfoMeta))}` : 'Belum pernah disimpan'}
               </span>
               <button
                 type="submit"
                 className="h-11 rounded-2xl bg-primary px-6 text-sm font-medium text-white transition hover:bg-primary/90 disabled:opacity-50"
-                disabled={savingDesc}
+                disabled={savingInfo}
               >
-                Simpan Deskripsi
+                Simpan Informasi
               </button>
             </div>
           </form>

--- a/supabase/migrations/20250415000000_create_app_settings.sql
+++ b/supabase/migrations/20250415000000_create_app_settings.sql
@@ -1,0 +1,87 @@
+create extension if not exists "pgcrypto";
+
+create table if not exists public.app_settings (
+  key text primary key,
+  value jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+insert into public.app_settings (key, value)
+select
+  'app_info',
+  jsonb_build_object(
+    'title', coalesce(
+      (select value ->> 'title' from public.app_settings where key = 'app_info'),
+      'HematWoi'
+    ),
+    'tagline', coalesce((select value ->> 'tagline' from public.app_settings where key = 'app_info'), ''),
+    'description', coalesce(
+      (select value ->> 'description' from public.app_settings where key = 'app_info'),
+      (select value ->> 'text' from public.app_settings where key = 'app_description'),
+      ''
+    ),
+    'logo_url', coalesce((select value ->> 'logo_url' from public.app_settings where key = 'app_info'), ''),
+    'favicon_url', coalesce((select value ->> 'favicon_url' from public.app_settings where key = 'app_info'), '')
+  )
+where not exists (
+  select 1 from public.app_settings where key = 'app_info'
+);
+
+insert into public.app_settings (key, value)
+select 'branding', jsonb_build_object(
+    'primary', '#1e40af',
+    'secondary', '#0ea5e9'
+  )
+where not exists (
+  select 1 from public.app_settings where key = 'branding'
+);
+
+insert into public.app_settings (key, value)
+select
+  'app_description',
+  jsonb_build_object(
+    'text', coalesce(
+      (select value ->> 'text' from public.app_settings where key = 'app_description'),
+      (select value ->> 'description' from public.app_settings where key = 'app_info'),
+      ''
+    )
+  )
+where not exists (
+  select 1 from public.app_settings where key = 'app_description'
+);
+
+drop trigger if exists app_settings_set_updated_at on public.app_settings;
+create trigger app_settings_set_updated_at
+before update on public.app_settings
+for each row
+execute function public.set_updated_at();
+
+alter table public.app_settings enable row level security;
+
+create policy if not exists "App settings select"
+  on public.app_settings
+  for select
+  using (true);
+
+create policy if not exists "App settings manage"
+  on public.app_settings
+  for all
+  using (
+    auth.role() = 'service_role'
+    or exists (
+      select 1
+      from public.user_profiles up
+      where up.id = auth.uid()
+        and up.role = 'admin'
+    )
+  )
+  with check (
+    auth.role() = 'service_role'
+    or exists (
+      select 1
+      from public.user_profiles up
+      where up.id = auth.uid()
+        and up.role = 'admin'
+    )
+  );


### PR DESCRIPTION
## Summary
- add Supabase migration to create and secure the app_settings table with defaults for app information and branding
- expose admin API helpers to read and persist comprehensive app metadata alongside existing branding options
- redesign the admin settings tab to edit title, tagline, logo, favicon, and description with previews and status feedback

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d80742e76083328b6268175b12f0af