### PR TITLE
Enhance transaction cards and enforce latest-first ordering

### DIFF
--- a/src/components/transactions/TransactionsCardList.tsx
+++ b/src/components/transactions/TransactionsCardList.tsx
@@ -1,5 +1,14 @@
 import clsx from "clsx";
-import { Pencil, Trash2 } from "lucide-react";
+import {
+  ArrowDownCircle,
+  ArrowRightLeft,
+  ArrowUpCircle,
+  CalendarDays,
+  Pencil,
+  Tag,
+  Trash2,
+  Wallet2,
+} from "lucide-react";
 import { ChangeEvent, ReactNode } from "react";
 import CategoryDot from "./CategoryDot";
 
@@ -41,10 +50,33 @@ interface TransactionsCardListProps {
   emptyState: ReactNode;
 }
 
-const AMOUNT_CLASS: Record<string, string> = {
-  income: "text-emerald-400",
-  expense: "text-rose-400",
-  transfer: "text-slate-300",
+const TYPE_META: Record<
+  string,
+  {
+    icon: typeof ArrowUpCircle;
+    amountClass: string;
+    badgeClass: string;
+    iconWrapper: string;
+  }
+> = {
+  income: {
+    icon: ArrowUpCircle,
+    amountClass: "text-emerald-400",
+    badgeClass: "bg-emerald-500/10 text-emerald-200 ring-emerald-500/30",
+    iconWrapper: "bg-emerald-500/10 text-emerald-300 ring-emerald-500/40",
+  },
+  expense: {
+    icon: ArrowDownCircle,
+    amountClass: "text-rose-400",
+    badgeClass: "bg-rose-500/10 text-rose-200 ring-rose-500/30",
+    iconWrapper: "bg-rose-500/10 text-rose-300 ring-rose-500/40",
+  },
+  transfer: {
+    icon: ArrowRightLeft,
+    amountClass: "text-slate-200",
+    badgeClass: "bg-slate-500/10 text-slate-200 ring-slate-500/30",
+    iconWrapper: "bg-slate-500/10 text-slate-200 ring-slate-500/30",
+  },
 };
 
 export default function TransactionsCardList({
@@ -111,65 +143,105 @@ export default function TransactionsCardList({
               const note = item.title || item.description || item.notes || item.note || "";
               const description = note.trim() || "(Tanpa judul)";
               const formattedDate = formatDate(item.date);
-              const amountTone = AMOUNT_CLASS[item.type] || AMOUNT_CLASS.transfer;
+              const meta = TYPE_META[item.type] || TYPE_META.transfer;
+              const TypeIcon = meta.icon;
 
               return (
                 <article
                   key={item.id}
                   className={clsx(
-                    "rounded-2xl bg-slate-900 ring-1 ring-slate-800 p-3",
-                    selected && "ring-[var(--accent)]/60",
+                    "relative overflow-hidden rounded-3xl border border-white/5 bg-slate-900/80 p-4 shadow-lg shadow-slate-950/40 ring-1 ring-slate-800 transition hover:border-white/10",
+                    selected && "ring-2 ring-[var(--accent)]/60",
                   )}
                 >
-                  <header className="flex items-start gap-3">
-                    <div className="pt-1">
+                  <div className="pointer-events-none absolute -right-10 -top-10 h-36 w-36 rounded-full bg-gradient-to-br from-white/10 via-white/0 to-transparent blur-2xl" />
+                  <header className="flex items-start justify-between gap-3">
+                    <div className="flex items-start gap-3">
+                      <span
+                        className={clsx(
+                          "flex h-10 w-10 items-center justify-center rounded-2xl ring-1 backdrop-blur",
+                          meta.iconWrapper,
+                        )}
+                        aria-hidden="true"
+                      >
+                        <TypeIcon className="h-5 w-5" />
+                      </span>
+                      <div className="space-y-1">
+                        <span
+                          className={clsx(
+                            "inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ring-1",
+                            meta.badgeClass,
+                          )}
+                        >
+                          {typeLabels[item.type] || item.type}
+                        </span>
+                        <div className="flex items-center gap-2 text-sm font-semibold text-slate-100">
+                          <CategoryDot color={item.category_color} />
+                          <span>{item.category || "(Tanpa kategori)"}</span>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex items-start gap-3">
+                      <time
+                        dateTime={toDateValue(item.date)}
+                        className="inline-flex items-center gap-2 rounded-full bg-slate-800/60 px-3 py-1 text-xs font-medium text-slate-300 ring-1 ring-slate-700"
+                      >
+                        <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
+                        {formattedDate}
+                      </time>
                       <input
                         type="checkbox"
                         checked={selected}
                         onChange={(event) => onToggleSelect(item.id, event)}
-                        className="h-4 w-4 rounded border-slate-700 bg-slate-900 text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+                        className="mt-0.5 h-4 w-4 rounded border-slate-600 bg-slate-900 text-[var(--accent)] shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
                         aria-label="Pilih transaksi"
                       />
                     </div>
-                    <div className="flex flex-1 items-start justify-between gap-3">
-                      <div className="space-y-1">
-                        <div className="flex items-center gap-2">
-                          <CategoryDot color={item.category_color} />
-                          <p className="text-sm font-semibold text-slate-200">{item.category || "(Tanpa kategori)"}</p>
-                        </div>
-                        <p className="text-xs uppercase tracking-wide text-slate-400">{typeLabels[item.type] || item.type}</p>
-                      </div>
-                      <time dateTime={toDateValue(item.date)} className="text-xs text-slate-400">
-                        {formattedDate}
-                      </time>
-                    </div>
                   </header>
-                  <div className="mt-3 space-y-2">
-                    <p className="text-sm font-medium text-slate-200 line-clamp-2" title={description}>
+                  <div className="mt-4 space-y-3">
+                    <p className="text-base font-semibold text-slate-100 line-clamp-2" title={description}>
                       {description}
                     </p>
-                    <div className="flex flex-wrap items-center gap-2 text-xs text-slate-400">
-                      <span className="rounded-full bg-slate-800/80 px-2 py-1">{item.account || "—"}</span>
-                      {item.type === "transfer" && (
-                        <span className="rounded-full bg-slate-800/80 px-2 py-1">→ {item.to_account || "—"}</span>
-                      )}
-                      {tags.map((tag) => (
-                        <span
-                          key={tag}
-                          className="rounded-full bg-slate-800/80 px-2 py-1 text-slate-300"
-                        >
-                          #{tag}
+                    <div className="grid gap-2 text-sm text-slate-300">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="inline-flex items-center gap-2 rounded-full bg-slate-800/70 px-3 py-1 text-xs font-medium text-slate-200 ring-1 ring-slate-700/70">
+                          <Wallet2 className="h-3.5 w-3.5" aria-hidden="true" />
+                          {item.account || "—"}
                         </span>
-                      ))}
+                        {item.type === "transfer" && (
+                          <span className="inline-flex items-center gap-2 rounded-full bg-slate-800/70 px-3 py-1 text-xs font-medium text-slate-200 ring-1 ring-slate-700/70">
+                            <ArrowRightLeft className="h-3.5 w-3.5" aria-hidden="true" />
+                            {item.to_account || "—"}
+                          </span>
+                        )}
+                      </div>
+                      {tags.length > 0 && (
+                        <div className="flex flex-wrap items-center gap-2 text-xs">
+                          <span className="inline-flex items-center gap-2 rounded-full bg-slate-800/70 px-3 py-1 font-medium text-slate-300 ring-1 ring-slate-700/70">
+                            <Tag className="h-3.5 w-3.5" aria-hidden="true" />
+                            Tags
+                          </span>
+                          {tags.map((tag) => (
+                            <span
+                              key={tag}
+                              className="rounded-full bg-slate-800/60 px-2 py-1 font-medium text-slate-200 ring-1 ring-slate-700/60"
+                            >
+                              #{tag}
+                            </span>
+                          ))}
+                        </div>
+                      )}
                     </div>
                   </div>
-                  <footer className="mt-4 flex items-center justify-between gap-3">
-                    <span className={clsx("text-lg font-semibold", amountTone)}>{formatAmount(item.amount)}</span>
+                  <footer className="mt-5 flex items-center justify-between gap-3">
+                    <span className={clsx("text-2xl font-semibold", meta.amountClass)}>
+                      {formatAmount(item.amount)}
+                    </span>
                     <div className="flex items-center gap-2">
                       <button
                         type="button"
                         onClick={() => onEdit(item)}
-                        className="flex h-9 w-9 items-center justify-center rounded-full bg-slate-900 text-slate-300 ring-1 ring-slate-700 transition hover:bg-slate-800 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+                        className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-900/80 text-slate-200 ring-1 ring-slate-700 transition hover:bg-slate-800 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
                         aria-label="Edit transaksi"
                       >
                         <Pencil className="h-4 w-4" aria-hidden="true" />
@@ -178,7 +250,7 @@ export default function TransactionsCardList({
                         type="button"
                         onClick={() => onDelete(item)}
                         disabled={deleteDisabled}
-                        className="flex h-9 w-9 items-center justify-center rounded-full bg-rose-500/10 text-rose-300 ring-1 ring-rose-400/40 transition hover:bg-rose-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-60"
+                        className="flex h-10 w-10 items-center justify-center rounded-full bg-rose-500/10 text-rose-300 ring-1 ring-rose-400/40 transition hover:bg-rose-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-60"
                         aria-label="Hapus transaksi"
                       >
                         <Trash2 className="h-4 w-4" aria-hidden="true" />
@@ -218,24 +290,29 @@ export default function TransactionsCardList({
 
 function SkeletonCard() {
   return (
-    <div className="space-y-3 rounded-2xl bg-slate-900/80 p-3 ring-1 ring-slate-800 animate-pulse">
-      <div className="flex items-center gap-3">
-        <div className="h-4 w-4 rounded bg-slate-800" />
-        <div className="flex-1 space-y-2">
-          <div className="h-3 w-32 rounded-full bg-slate-800" />
-          <div className="h-3 w-24 rounded-full bg-slate-800/70" />
+    <div className="relative overflow-hidden rounded-3xl border border-white/5 bg-slate-900/70 p-4 ring-1 ring-slate-800/60 animate-pulse">
+      <div className="pointer-events-none absolute -right-10 -top-10 h-32 w-32 rounded-full bg-white/5 blur-2xl" />
+      <div className="flex items-start gap-3">
+        <span className="h-10 w-10 rounded-2xl bg-slate-800/80" />
+        <div className="flex-1 space-y-3">
+          <div className="h-4 w-24 rounded-full bg-slate-800" />
+          <div className="h-3 w-32 rounded-full bg-slate-800/80" />
+        </div>
+        <span className="h-4 w-20 rounded-full bg-slate-800/60" />
+      </div>
+      <div className="mt-5 space-y-3">
+        <div className="h-4 w-full rounded-full bg-slate-800" />
+        <div className="h-4 w-2/3 rounded-full bg-slate-800/70" />
+        <div className="flex gap-2">
+          <span className="h-6 w-20 rounded-full bg-slate-800/80" />
+          <span className="h-6 w-24 rounded-full bg-slate-800/70" />
         </div>
       </div>
-      <div className="h-3 w-full rounded-full bg-slate-800" />
-      <div className="flex gap-2">
-        <span className="h-5 w-16 rounded-full bg-slate-800" />
-        <span className="h-5 w-16 rounded-full bg-slate-800/80" />
-      </div>
-      <div className="flex items-center justify-between">
-        <span className="h-4 w-24 rounded-full bg-slate-800" />
+      <div className="mt-6 flex items-center justify-between">
+        <span className="h-6 w-28 rounded-full bg-slate-800" />
         <div className="flex gap-2">
-          <span className="h-9 w-9 rounded-full bg-slate-800" />
-          <span className="h-9 w-9 rounded-full bg-slate-800/80" />
+          <span className="h-10 w-10 rounded-full bg-slate-800" />
+          <span className="h-10 w-10 rounded-full bg-slate-800/80" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- restyle the mobile transaction card list with richer badges, icons, and metadata chips
- update skeleton loaders to match the refreshed card layout
- ensure transactions default to newest first by adding updated_at tie-breakers in both API sorting paths

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d808852a608332b0a810969b26dba9