### PR TITLE
Fix transaction date sorting tie-breakers

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -466,7 +466,9 @@ export async function listTransactions(options = {}) {
   const orderField = sortField === "amount" ? "amount" : "date";
   query = query.order(orderField, { ascending });
   if (orderField === "date") {
-    query = query.order("updated_at", { ascending });
+    query = query
+      .order("updated_at", { ascending, nullsLast: !ascending })
+      .order("inserted_at", { ascending, nullsLast: !ascending });
   }
 
   if (normalized.type && normalized.type !== "all") {


### PR DESCRIPTION
## Summary
- ensure Supabase transaction queries apply consistent tie-breakers when sorting by date

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d80d0a2c1c8332a2b1ff02cde0c188