### PR TITLE
Remove sidebar account controls and prompt guests to log in

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,13 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import clsx from "clsx";
 import {
   ChevronLeft,
   ChevronRight,
   Cloud,
   CloudOff,
-  LogIn,
-  LogOut,
   Monitor,
   Moon,
   Sun,
@@ -51,12 +48,6 @@ interface SidebarProps {
 function isBrandSelected(current: BrandConfig, candidate: BrandConfig) {
   return current.h === candidate.h && current.s === candidate.s && current.l === candidate.l;
 }
-
-function formatEmail(email?: string | null) {
-  if (!email) return "";
-  return email.length > 24 ? `${email.slice(0, 21)}…` : email;
-}
-
 
 type SidebarMenuEntry = {
   id: string;
@@ -102,7 +93,6 @@ export default function Sidebar({
   onNavigate,
   onClose,
 }: SidebarProps) {
-  const navigate = useNavigate();
   const { mode, setMode } = useMode();
   const [sessionUser, setSessionUser] = useState<User | null>(null);
   const [menuItems, setMenuItems] = useState<SidebarMenuEntry[]>([]);
@@ -226,11 +216,6 @@ export default function Sidebar({
       cancelled = true;
     };
   }, [sessionUser]);
-
-  const handleLogout = async () => {
-    await supabase.auth.signOut();
-    onNavigate?.();
-  };
 
   const themeOptions: { value: ThemeMode; label: string; icon: JSX.Element }[] = [
     { value: "light", label: "Sun", icon: <Sun className="h-4 w-4" /> },
@@ -492,67 +477,20 @@ export default function Sidebar({
             collapsed ? "px-2" : "px-4"
           )}
         >
-          <div className="flex items-center justify-between gap-3">
-            <div className="min-w-0 flex-1">
-              {sessionUser ? (
-                <p
-                  className={clsx(
-                    "truncate text-sm font-medium",
-                    collapsed && "sr-only"
-                  )}
-                >
-                  {formatEmail(sessionUser.email)}
-                </p>
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={() => onToggle?.(!collapsed)}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-border bg-surface-2 text-text transition-colors duration-200 hover:border-brand/40 hover:text-brand"
+              title={collapsed ? "Perluas" : "Ciutkan"}
+              aria-label={collapsed ? "Perluas sidebar" : "Ciutkan sidebar"}
+            >
+              {collapsed ? (
+                <ChevronRight className="h-4 w-4" />
               ) : (
-                <p
-                  className={clsx(
-                    "text-sm text-muted",
-                    collapsed && "sr-only"
-                  )}
-                >
-                  Belum masuk
-                </p>
+                <ChevronLeft className="h-4 w-4" />
               )}
-            </div>
-            <div className="flex items-center gap-2">
-              {sessionUser ? (
-                <button
-                  type="button"
-                  onClick={handleLogout}
-                  className="inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-border px-3 text-sm font-medium text-text transition-colors duration-200 hover:border-brand/50 hover:text-brand"
-                >
-                  <LogOut className="h-4 w-4" />
-                  {!collapsed && <span>Keluar</span>}
-                  {collapsed && <span className="sr-only">Keluar</span>}
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => {
-                    navigate("/auth");
-                    onNavigate?.();
-                  }}
-                  className="inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-border px-3 text-sm font-medium text-text transition-colors duration-200 hover:border-brand/50 hover:text-brand"
-                >
-                  <LogIn className="h-4 w-4" />
-                  {!collapsed && <span>Masuk</span>}
-                  {collapsed && <span className="sr-only">Masuk</span>}
-                </button>
-              )}
-              <button
-                type="button"
-                onClick={() => onToggle?.(!collapsed)}
-                className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-border bg-surface-2 text-text transition-colors duration-200 hover:border-brand/40 hover:text-brand"
-                title={collapsed ? "Perluas" : "Ciutkan"}
-                aria-label={collapsed ? "Perluas sidebar" : "Ciutkan sidebar"}
-              >
-                {collapsed ? (
-                  <ChevronRight className="h-4 w-4" />
-                ) : (
-                  <ChevronLeft className="h-4 w-4" />
-                )}
-              </button>
-            </div>
+            </button>
           </div>
         </footer>
       </nav>

--- a/src/layout/AppTopbar.jsx
+++ b/src/layout/AppTopbar.jsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useState } from "react";
-import { Bell, LogOut, Menu, Settings, UserRound } from "lucide-react";
+import { Bell, LogIn, LogOut, Menu, Settings, UserRound } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "../lib/supabase";
 
 function getDisplayName(user) {
-  if (!user) return "Tamu";
+  if (!user) return "Masuk";
   const metadataName = user.user_metadata?.full_name;
   if (metadataName && typeof metadataName === "string" && metadataName.trim()) {
     return metadataName.trim();
@@ -19,6 +19,7 @@ export default function AppTopbar() {
   const dropdownRef = useRef(null);
   const profileButtonRef = useRef(null);
   const navigate = useNavigate();
+  const isAuthenticated = Boolean(user);
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data }) => {
@@ -121,7 +122,7 @@ export default function AppTopbar() {
               aria-expanded={profileOpen}
             >
               <span className="flex h-8 w-8 items-center justify-center rounded-full bg-brand/15 text-sm font-semibold uppercase text-brand">
-                {initial}
+                {isAuthenticated ? initial : <UserRound className="h-4 w-4" />}
               </span>
               <span className="hidden max-w-[8.5rem] truncate text-left md:block">{displayName}</span>
             </button>
@@ -130,33 +131,55 @@ export default function AppTopbar() {
                 role="menu"
                 className="absolute right-0 mt-2 w-52 overflow-hidden rounded-2xl border border-border/70 bg-surface-1 text-sm shadow-lg focus:outline-none"
               >
-                <button
-                  type="button"
-                  onClick={() => handleNavigate("/profile")}
-                  className="flex w-full items-center gap-2 px-4 py-2 text-left text-text transition hover:bg-surface-2 focus-visible:outline-none focus-visible:bg-surface-2"
-                  role="menuitem"
-                >
-                  <UserRound className="h-4 w-4" />
-                  Profil Saya
-                </button>
-                <button
-                  type="button"
-                  onClick={() => handleNavigate("/settings")}
-                  className="flex w-full items-center gap-2 px-4 py-2 text-left text-text transition hover:bg-surface-2 focus-visible:outline-none focus-visible:bg-surface-2"
-                  role="menuitem"
-                >
-                  <Settings className="h-4 w-4" />
-                  Pengaturan
-                </button>
-                <button
-                  type="button"
-                  onClick={handleSignOut}
-                  className="flex w-full items-center gap-2 px-4 py-2 text-left text-danger transition hover:bg-danger/10 focus-visible:outline-none focus-visible:bg-danger/10"
-                  role="menuitem"
-                >
-                  <LogOut className="h-4 w-4" />
-                  Keluar
-                </button>
+                {isAuthenticated ? (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => handleNavigate("/profile")}
+                      className="flex w-full items-center gap-2 px-4 py-2 text-left text-text transition hover:bg-surface-2 focus-visible:outline-none focus-visible:bg-surface-2"
+                      role="menuitem"
+                    >
+                      <UserRound className="h-4 w-4" />
+                      Profil Saya
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleNavigate("/settings")}
+                      className="flex w-full items-center gap-2 px-4 py-2 text-left text-text transition hover:bg-surface-2 focus-visible:outline-none focus-visible:bg-surface-2"
+                      role="menuitem"
+                    >
+                      <Settings className="h-4 w-4" />
+                      Pengaturan
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleSignOut}
+                      className="flex w-full items-center gap-2 px-4 py-2 text-left text-danger transition hover:bg-danger/10 focus-visible:outline-none focus-visible:bg-danger/10"
+                      role="menuitem"
+                    >
+                      <LogOut className="h-4 w-4" />
+                      Keluar
+                    </button>
+                  </>
+                ) : (
+                  <div className="flex flex-col gap-3 px-4 py-3">
+                    <p className="text-sm text-muted">
+                      Kamu belum login. Masuk untuk mengakses profil dan pengaturan.
+                    </p>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setProfileOpen(false);
+                        navigate("/auth");
+                      }}
+                      className="inline-flex items-center justify-center gap-2 rounded-xl border border-brand/40 bg-brand/10 px-3 py-2 text-sm font-semibold text-brand transition-colors duration-200 hover:border-brand/60 hover:bg-brand/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                      role="menuitem"
+                    >
+                      <LogIn className="h-4 w-4" />
+                      Masuk
+                    </button>
+                  </div>
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- remove the account display and actions from the sidebar footer
- show a login prompt in the topbar profile menu for unauthenticated visitors that links to the auth page

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d80ec373ec8332b15427659380ae75