### PR TITLE
Fix wishlist card action menu overflow issues

### DIFF
--- a/src/components/wishlist/WishlistCard.tsx
+++ b/src/components/wishlist/WishlistCard.tsx
@@ -110,14 +110,14 @@ export default function WishlistCard({
     );
   }, [item.priority]);
 
+  const cardClasses = `group relative flex h-full flex-col rounded-3xl border border-border-subtle bg-surface shadow-sm transition-all duration-200 hover:border-brand/40 hover:shadow-lg ${
+    selected ? 'border-brand/60 ring-2 ring-brand/40' : 'ring-1 ring-transparent'
+  } ${disabled ? 'opacity-60' : ''} ${menuOpen ? 'z-20' : 'z-0'}`;
+
   return (
-    <article
-      className={`group relative flex h-full flex-col overflow-hidden rounded-3xl border border-border-subtle bg-surface shadow-sm transition-all duration-200 hover:border-brand/40 hover:shadow-lg ${
-        selected ? 'border-brand/60 ring-2 ring-brand/40' : 'ring-1 ring-transparent'
-      } ${disabled ? 'opacity-60' : ''}`}
-    >
+    <article className={cardClasses}>
       {hasImage ? (
-        <div className="relative aspect-video w-full overflow-hidden bg-surface-alt">
+        <div className="relative aspect-video w-full overflow-hidden rounded-t-3xl bg-surface-alt">
           <img
             src={item.image_url ?? ''}
             alt={item.title}


### PR DESCRIPTION
## Summary
- remove the card overflow clipping so the wishlist action menu can render fully
- raise the card stacking context while the menu is open and keep image corners rounded

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d8171cd47483328fbb101bd7fa88e0