### PR TITLE
Fix transaction card actions and edit form

### DIFF
--- a/src/components/transactions/TransactionsCardList.tsx
+++ b/src/components/transactions/TransactionsCardList.tsx
@@ -169,11 +169,14 @@ export default function TransactionsCardList({
                       <div className="space-y-1">
                         <span
                           className={clsx(
-                            "inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ring-1",
+                            "inline-flex items-center justify-center rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ring-1",
                             meta.badgeClass,
                           )}
+                          aria-label={typeLabels[item.type] || item.type}
+                          title={typeLabels[item.type] || item.type}
                         >
-                          {typeLabels[item.type] || item.type}
+                          <TypeIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                          <span className="sr-only">{typeLabels[item.type] || item.type}</span>
                         </span>
                         <div className="flex items-center gap-2 text-sm font-semibold text-slate-100">
                           <CategoryDot color={item.category_color} />


### PR DESCRIPTION
## Summary
- make the delete action on transaction cards trigger directly on the button
- replace the transaction type text badge with an icon-only badge on cards
- remove the merchant picker from the edit transaction modal while preserving existing values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d87dc2c03c8332b1634cd212a61891