### PR TITLE
Fix transaction card delete button and simplify edit form

### DIFF
--- a/src/components/transactions/TransactionsCardList.tsx
+++ b/src/components/transactions/TransactionsCardList.tsx
@@ -36,7 +36,7 @@ interface TransactionsCardListProps {
   selectedIds: Set<string>;
   onToggleSelect: (id: string, event?: ChangeEvent<HTMLInputElement>) => void;
   onEdit: (item: TransactionRowData) => void;
-  onDelete: (item: TransactionRowData) => void;
+  onDelete: (id: string) => void;
   formatAmount: (value: number) => string;
   formatDate: (value?: string | null) => string;
   toDateValue: (value?: string | null) => string;
@@ -55,26 +55,22 @@ const TYPE_META: Record<
   {
     icon: typeof ArrowUpCircle;
     amountClass: string;
-    badgeClass: string;
     iconWrapper: string;
   }
 > = {
   income: {
     icon: ArrowUpCircle,
     amountClass: "text-emerald-400",
-    badgeClass: "bg-emerald-500/10 text-emerald-200 ring-emerald-500/30",
     iconWrapper: "bg-emerald-500/10 text-emerald-300 ring-emerald-500/40",
   },
   expense: {
     icon: ArrowDownCircle,
     amountClass: "text-rose-400",
-    badgeClass: "bg-rose-500/10 text-rose-200 ring-rose-500/30",
     iconWrapper: "bg-rose-500/10 text-rose-300 ring-rose-500/40",
   },
   transfer: {
     icon: ArrowRightLeft,
     amountClass: "text-slate-200",
-    badgeClass: "bg-slate-500/10 text-slate-200 ring-slate-500/30",
     iconWrapper: "bg-slate-500/10 text-slate-200 ring-slate-500/30",
   },
 };
@@ -162,19 +158,11 @@ export default function TransactionsCardList({
                           "flex h-10 w-10 items-center justify-center rounded-2xl ring-1 backdrop-blur",
                           meta.iconWrapper,
                         )}
-                        aria-hidden="true"
                       >
-                        <TypeIcon className="h-5 w-5" />
+                        <TypeIcon className="h-5 w-5" aria-hidden="true" />
+                        <span className="sr-only">{typeLabels[item.type] || item.type}</span>
                       </span>
                       <div className="space-y-1">
-                        <span
-                          className={clsx(
-                            "inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ring-1",
-                            meta.badgeClass,
-                          )}
-                        >
-                          {typeLabels[item.type] || item.type}
-                        </span>
                         <div className="flex items-center gap-2 text-sm font-semibold text-slate-100">
                           <CategoryDot color={item.category_color} />
                           <span>{item.category || "(Tanpa kategori)"}</span>
@@ -248,7 +236,7 @@ export default function TransactionsCardList({
                       </button>
                       <button
                         type="button"
-                        onClick={() => onDelete(item)}
+                        onClick={() => onDelete(item.id)}
                         disabled={deleteDisabled}
                         className="flex h-10 w-10 items-center justify-center rounded-full bg-rose-500/10 text-rose-300 ring-1 ring-rose-400/40 transition hover:bg-rose-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-60"
                         aria-label="Hapus transaksi"

--- a/src/components/transactions/TransactionsTable.tsx
+++ b/src/components/transactions/TransactionsTable.tsx
@@ -29,7 +29,7 @@ interface TransactionsTableProps {
   onToggleSelectAll: () => void;
   allSelected: boolean;
   onEdit: (item: TransactionRowData) => void;
-  onDelete: (item: TransactionRowData) => void;
+  onDelete: (id: string) => void;
   formatAmount: (value: number) => string;
   formatDate: (value?: string | null) => string;
   toDateValue: (value?: string | null) => string;
@@ -266,7 +266,7 @@ export default function TransactionsTable({
                             </button>
                             <button
                               type="button"
-                              onClick={() => onDelete(item)}
+                              onClick={() => onDelete(item.id)}
                               disabled={deleteDisabled}
                               className="flex h-9 w-9 items-center justify-center rounded-full bg-rose-500/10 text-rose-300 ring-1 ring-rose-400/40 transition hover:bg-rose-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-60"
                               aria-label="Hapus transaksi"

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -22,7 +22,7 @@ import useTransactionsQuery from "../hooks/useTransactionsQuery";
 import useNetworkStatus from "../hooks/useNetworkStatus";
 import { useToast } from "../context/ToastContext";
 import PageHeader from "../layout/PageHeader";
-import { addTransaction, listAccounts, listMerchants, updateTransaction } from "../lib/api";
+import { addTransaction, listAccounts, updateTransaction } from "../lib/api";
 import {
   listTransactions,
   removeTransaction,
@@ -1243,7 +1243,6 @@ function TransactionFormDialog({ open, onClose, initialData, categories, onSucce
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [accounts, setAccounts] = useState([]);
-  const [merchants, setMerchants] = useState([]);
   const [type, setType] = useState(initialData?.type || "expense");
   const [amount, setAmount] = useState(() => String(initialData?.amount ?? 0));
   const [date, setDate] = useState(() => toDateInput(initialData?.date) || new Date().toISOString().slice(0, 10));
@@ -1251,16 +1250,15 @@ function TransactionFormDialog({ open, onClose, initialData, categories, onSucce
   const [title, setTitle] = useState(initialData?.title || "");
   const [notes, setNotes] = useState(initialData?.notes ?? initialData?.note ?? "");
   const [accountId, setAccountId] = useState(initialData?.account_id || "");
-  const [merchantId, setMerchantId] = useState(initialData?.merchant_id || "");
   const [receiptUrl, setReceiptUrl] = useState(initialData?.receipt_url || "");
+  const initialMerchantId = initialData?.merchant_id ?? null;
 
   useEffect(() => {
     if (!open) return;
     setLoading(true);
-    Promise.all([listAccounts(), listMerchants()])
-      .then(([accountRows, merchantRows]) => {
+    listAccounts()
+      .then((accountRows) => {
         setAccounts(accountRows || []);
-        setMerchants(merchantRows || []);
         setLoading(false);
       })
       .catch((err) => {
@@ -1279,7 +1277,6 @@ function TransactionFormDialog({ open, onClose, initialData, categories, onSucce
     setTitle(initialData.title || "");
     setNotes(initialData.notes ?? initialData.note ?? "");
     setAccountId(initialData.account_id || "");
-    setMerchantId(initialData.merchant_id || "");
     setReceiptUrl(initialData.receipt_url || "");
   }, [open, initialData]);
 
@@ -1312,7 +1309,7 @@ function TransactionFormDialog({ open, onClose, initialData, categories, onSucce
         title,
         notes,
         account_id: accountId || null,
-        merchant_id: merchantId || null,
+        merchant_id: initialMerchantId,
         receipt_url: receiptUrl || null,
       };
       await updateTransaction(initialData.id, payload);
@@ -1400,21 +1397,6 @@ function TransactionFormDialog({ open, onClose, initialData, categories, onSucce
                 {accounts.map((acc) => (
                   <option key={acc.id} value={acc.id}>
                     {acc.name || "(Tanpa nama)"}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="flex flex-col gap-2 text-sm">
-              <span className="text-xs font-semibold uppercase tracking-wide text-white/60">Merchant</span>
-              <select
-                value={merchantId}
-                onChange={(event) => setMerchantId(event.target.value)}
-                className="rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white focus-visible:outline-none focus-visible:ring focus-visible:ring-brand/60"
-              >
-                <option value="">Pilih merchant</option>
-                {merchants.map((merchant) => (
-                  <option key={merchant.id} value={merchant.id}>
-                    {merchant.name || "(Tanpa nama)"}
                   </option>
                 ))}
               </select>


### PR DESCRIPTION
## Summary
- make transaction card delete actions call the single-item confirmation flow directly
- rely on icons instead of text badges for transaction types in the mobile cards while keeping screen reader labels
- remove the merchant selector from the edit dialog but retain the existing merchant value when saving

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d87dc2c03c8332b1634cd212a61891