### PR TITLE
Refactor budget list into progress cards

### DIFF
--- a/src/pages/budgets/components/BudgetTable.tsx
+++ b/src/pages/budgets/components/BudgetTable.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { Pencil, Trash2 } from 'lucide-react';
 import { formatCurrency } from '../../../lib/format';
 import type { BudgetWithSpent } from '../../../lib/budgetApi';
@@ -10,116 +11,159 @@ interface BudgetTableProps {
   onToggleCarryover: (row: BudgetWithSpent, carryover: boolean) => void;
 }
 
-const TABLE_WRAPPER_CLASS =
-  'rounded-2xl border border-white/20 dark:border-white/5 bg-gradient-to-b from-white/80 to-white/50 dark:from-zinc-900/60 dark:to-zinc-900/30 backdrop-blur shadow-sm overflow-hidden';
+const CARD_WRAPPER_CLASS =
+  'grid gap-4 md:grid-cols-2 xl:grid-cols-3';
 
-function LoadingRows() {
+const CARD_CLASS =
+  'flex flex-col gap-4 rounded-2xl border border-white/20 bg-gradient-to-b from-white/80 to-white/40 p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-white/5 dark:from-zinc-900/60 dark:to-zinc-900/30';
+
+function LoadingCards() {
   return (
-    <tbody>
-      {Array.from({ length: 5 }).map((_, index) => (
-        <tr key={index} className="animate-pulse border-b border-white/10 last:border-0">
-          {Array.from({ length: 7 }).map((__, cellIndex) => (
-            <td key={cellIndex} className="px-4 py-4">
-              <div className="h-4 w-full rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
-            </td>
-          ))}
-        </tr>
+    <div className={clsx(CARD_WRAPPER_CLASS)}>
+      {Array.from({ length: 6 }).map((_, index) => (
+        <div
+          // eslint-disable-next-line react/no-array-index-key
+          key={index}
+          className={clsx(CARD_CLASS, 'animate-pulse')}
+        >
+          <div className="h-4 w-24 rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
+          <div className="space-y-3">
+            <div className="h-3 w-full rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
+            <div className="h-3 w-3/4 rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
+          </div>
+          <div className="h-2 w-full rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
+          <div className="space-y-2">
+            <div className="h-3 w-1/3 rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
+            <div className="h-3 w-1/2 rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
+          </div>
+        </div>
       ))}
-    </tbody>
+    </div>
   );
 }
 
 function EmptyState() {
   return (
-    <tbody>
-      <tr>
-        <td colSpan={7} className="px-4 py-10 text-center text-sm text-zinc-500 dark:text-zinc-400">
-          Belum ada anggaran untuk periode ini. Tambahkan kategori agar pengeluaran lebih terkontrol.
-        </td>
-      </tr>
-    </tbody>
+    <div className="rounded-2xl border border-dashed border-zinc-200 bg-white/60 p-8 text-center text-sm text-zinc-500 shadow-sm dark:border-zinc-700 dark:bg-zinc-900/40 dark:text-zinc-400">
+      Belum ada anggaran untuk periode ini. Tambahkan kategori agar pengeluaran lebih terkontrol.
+    </div>
   );
 }
 
 export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleCarryover }: BudgetTableProps) {
+  if (loading) {
+    return <LoadingCards />;
+  }
+
+  if (rows.length === 0) {
+    return <EmptyState />;
+  }
+
   return (
-    <div className={TABLE_WRAPPER_CLASS}>
-      <div className="max-h-[520px] overflow-auto">
-        <table className="min-w-full border-collapse text-left text-sm">
-          <thead className="sticky top-0 z-10 bg-white/90 text-xs uppercase tracking-wide text-zinc-500 backdrop-blur dark:bg-zinc-950/70 dark:text-zinc-400">
-            <tr>
-              <th scope="col" className="px-4 py-3 font-semibold">Kategori</th>
-              <th scope="col" className="px-4 py-3 font-semibold">Planned</th>
-              <th scope="col" className="px-4 py-3 font-semibold">Spent</th>
-              <th scope="col" className="px-4 py-3 font-semibold">Remaining</th>
-              <th scope="col" className="px-4 py-3 font-semibold">Carryover</th>
-              <th scope="col" className="px-4 py-3 font-semibold">Catatan</th>
-              <th scope="col" className="px-4 py-3 font-semibold">Aksi</th>
-            </tr>
-          </thead>
-          {loading ? (
-            <LoadingRows />
-          ) : rows.length === 0 ? (
-            <EmptyState />
-          ) : (
-            <tbody className="divide-y divide-white/10 text-sm text-zinc-700 dark:text-zinc-200">
-              {rows.map((row) => {
-                const remainingClass = row.remaining < 0 ? 'text-rose-500 dark:text-rose-400' : 'text-emerald-600 dark:text-emerald-400';
-                return (
-                  <tr
-                    key={row.id}
-                    className="transition-colors odd:bg-white/50 even:bg-white/40 hover:bg-white/70 dark:odd:bg-zinc-900/40 dark:even:bg-zinc-900/20 dark:hover:bg-zinc-900/60"
-                  >
-                    <td className="px-4 py-4 font-medium text-zinc-900 dark:text-zinc-50">
-                      {row.category?.name ?? 'Tanpa kategori'}
-                    </td>
-                    <td className="px-4 py-4">{formatCurrency(row.amount_planned, 'IDR')}</td>
-                    <td className="px-4 py-4">{formatCurrency(row.spent, 'IDR')}</td>
-                    <td className={`px-4 py-4 font-semibold ${remainingClass}`}>
-                      {formatCurrency(row.remaining, 'IDR')}
-                    </td>
-                    <td className="px-4 py-4">
-                      <label className="relative inline-flex h-6 w-12 cursor-pointer items-center">
-                        <input
-                          type="checkbox"
-                          checked={row.carryover_enabled}
-                          onChange={(event) => onToggleCarryover(row, event.target.checked)}
-                          className="peer sr-only"
-                        />
-                        <span className="absolute inset-0 rounded-full bg-zinc-200/70 transition peer-checked:bg-emerald-500/80 dark:bg-zinc-800/70 dark:peer-checked:bg-emerald-500/70" />
-                        <span className="relative ml-1 h-4 w-4 rounded-full bg-white shadow-sm transition-transform peer-checked:translate-x-6" />
-                      </label>
-                    </td>
-                    <td className="px-4 py-4 text-sm text-zinc-500 dark:text-zinc-400">
-                      {row.notes?.trim() ? row.notes : '—'}
-                    </td>
-                    <td className="px-4 py-4">
-                      <div className="flex items-center gap-2">
-                        <button
-                          type="button"
-                          onClick={() => onEdit(row)}
-                          className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-white/30 bg-white/60 text-zinc-600 shadow-sm transition hover:-translate-y-0.5 hover:bg-white dark:border-white/10 dark:bg-zinc-900/60 dark:text-zinc-200"
-                          aria-label={`Edit ${row.category?.name ?? 'budget'}`}
-                        >
-                          <Pencil className="h-4 w-4" />
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => onDelete(row)}
-                          className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-rose-200/50 bg-rose-50/60 text-rose-500 shadow-sm transition hover:-translate-y-0.5 hover:bg-rose-100 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-300"
-                          aria-label={`Hapus ${row.category?.name ?? 'budget'}`}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          )}
-        </table>
-      </div>
+    <div className={CARD_WRAPPER_CLASS}>
+      {rows.map((row) => {
+        const planned = Number(row.amount_planned ?? 0);
+        const spent = Number(row.spent ?? 0);
+        const remaining = Number(row.remaining ?? 0);
+        const percentage = planned > 0 ? Math.min(200, Math.round((spent / planned) * 100)) : spent > 0 ? 200 : 0;
+        const displayPercentage = Math.min(100, percentage);
+        const overBudget = remaining < 0;
+        const progressColor = overBudget ? 'bg-rose-500 dark:bg-rose-400' : 'bg-brand dark:bg-brand';
+
+        return (
+          <article key={row.id} className={CARD_CLASS}>
+            <header className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Kategori</p>
+                <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+                  {row.category?.name ?? 'Tanpa kategori'}
+                </h3>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => onEdit(row)}
+                  className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-white/30 bg-white/60 text-zinc-600 shadow-sm transition hover:-translate-y-0.5 hover:bg-white dark:border-white/10 dark:bg-zinc-900/60 dark:text-zinc-200"
+                  aria-label={`Edit ${row.category?.name ?? 'budget'}`}
+                >
+                  <Pencil className="h-4 w-4" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onDelete(row)}
+                  className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-rose-200/50 bg-rose-50/60 text-rose-500 shadow-sm transition hover:-translate-y-0.5 hover:bg-rose-100 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-300"
+                  aria-label={`Hapus ${row.category?.name ?? 'budget'}`}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            </header>
+
+            <div className="space-y-1 text-sm text-zinc-600 dark:text-zinc-300">
+              <div className="flex items-center justify-between">
+                <span>Anggaran</span>
+                <span className="font-semibold text-zinc-900 dark:text-zinc-100">
+                  {formatCurrency(planned, 'IDR')}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span>Terpakai</span>
+                <span>{formatCurrency(spent, 'IDR')}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span>Sisa</span>
+                <span className={clsx('font-semibold', overBudget ? 'text-rose-500 dark:text-rose-400' : 'text-emerald-600 dark:text-emerald-400')}>
+                  {formatCurrency(remaining, 'IDR')}
+                </span>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center justify-between text-xs font-medium text-zinc-500 dark:text-zinc-400">
+                <span>Progres penggunaan</span>
+                <span>{displayPercentage}%</span>
+              </div>
+              <div className="h-2 w-full overflow-hidden rounded-full bg-zinc-200/70 dark:bg-zinc-800/70">
+                <div
+                  className={clsx('h-full rounded-full transition-all', progressColor)}
+                  style={{ width: `${displayPercentage}%` }}
+                />
+              </div>
+              {percentage > 100 ? (
+                <p className="text-xs font-medium text-rose-500 dark:text-rose-400">
+                  Pengeluaran sudah melebihi anggaran sebesar {formatCurrency(Math.abs(remaining), 'IDR')}.
+                </p>
+              ) : null}
+            </div>
+
+            <div className="flex flex-col gap-3 rounded-xl bg-white/50 p-4 text-sm shadow-sm dark:bg-zinc-900/40">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Carryover</p>
+                  <p className="font-medium text-zinc-800 dark:text-zinc-100">
+                    {row.carryover_enabled ? 'Aktif' : 'Nonaktif'}
+                  </p>
+                </div>
+                <label className="relative inline-flex h-6 w-12 cursor-pointer items-center">
+                  <input
+                    type="checkbox"
+                    checked={row.carryover_enabled}
+                    onChange={(event) => onToggleCarryover(row, event.target.checked)}
+                    className="peer sr-only"
+                  />
+                  <span className="absolute inset-0 rounded-full bg-zinc-200/70 transition peer-checked:bg-emerald-500/80 dark:bg-zinc-800/70 dark:peer-checked:bg-emerald-500/70" />
+                  <span className="relative ml-1 h-4 w-4 rounded-full bg-white shadow-sm transition-transform peer-checked:translate-x-6" />
+                </label>
+              </div>
+
+              <div className="space-y-1 text-sm text-zinc-500 dark:text-zinc-300">
+                <p className="text-xs uppercase tracking-wide">Catatan</p>
+                <p>{row.notes?.trim() ? row.notes : 'Tidak ada catatan.'}</p>
+              </div>
+            </div>
+          </article>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the budgets table with responsive cards that highlight each category
- show key totals, remaining balance styling, and carryover controls per card
- add progress indicators and empty/loading states tailored to the card layout

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d87dec8b1c8332b91f105caa97c8c7