### PR TITLE
Refactor budget overview table into card layout

### DIFF
--- a/src/components/budgets/BudgetsTable.tsx
+++ b/src/components/budgets/BudgetsTable.tsx
@@ -63,7 +63,7 @@ export default function BudgetsTable({
 
   return (
     <div className="overflow-hidden rounded-2xl border border-border">
-      <div className="flex items-center justify-between border-b border-border bg-surface-2 px-4 py-3">
+      <div className="flex flex-col gap-3 border-b border-border bg-surface-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-sm font-medium">Daftar Anggaran</p>
         <div className="flex flex-wrap gap-2 text-sm">
           <button
@@ -82,66 +82,64 @@ export default function BudgetsTable({
           </button>
         </div>
       </div>
-      <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-border">
-          <thead className="bg-surface-2 text-xs uppercase tracking-wide text-muted">
-            <tr>
-              <th scope="col" className="sticky top-0 px-4 py-3 text-left">Kategori / Envelope</th>
-              <th scope="col" className="sticky top-0 px-4 py-3 text-right">Rencana</th>
-              <th scope="col" className="sticky top-0 px-4 py-3 text-right">Rollover in</th>
-              <th scope="col" className="sticky top-0 px-4 py-3 text-right">Aktual</th>
-              <th scope="col" className="sticky top-0 px-4 py-3 text-right">Sisa</th>
-              <th scope="col" className="sticky top-0 px-4 py-3">Aturan</th>
-              <th scope="col" className="sticky top-0 px-4 py-3">Aksi</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-border">
-            {loading && !budgets.length ? (
-              <tr>
-                <td colSpan={7} className="px-4 py-8 text-center text-sm text-muted">
-                  Memuat anggaran…
-                </td>
-              </tr>
-            ) : budgets.length === 0 ? (
-              <tr>
-                <td colSpan={7} className="px-4 py-10 text-center text-sm text-muted">
-                  Belum ada anggaran untuk periode ini.
-                </td>
-              </tr>
-            ) : (
-              budgets.map((budget) => (
-                <tr key={budget.id} className="bg-surface-1">
-                  <td className="max-w-[260px] px-4 py-3">
+      {loading && !budgets.length ? (
+        <div className="px-4 py-8 text-center text-sm text-muted">Memuat anggaran…</div>
+      ) : budgets.length === 0 ? (
+        <div className="px-4 py-10 text-center text-sm text-muted">
+          Belum ada anggaran untuk periode ini.
+        </div>
+      ) : (
+        <div className="grid gap-4 p-4 sm:grid-cols-2 xl:grid-cols-3">
+          {budgets.map((budget) => {
+            const progress = Math.min(100, Math.round(budget.progress * 100));
+            return (
+              <div key={budget.id} className="flex h-full flex-col gap-4 rounded-2xl border border-border bg-surface-1 p-4">
+                <div className="flex flex-col gap-3">
+                  <div className="flex items-start justify-between gap-3">
                     <button
                       type="button"
                       onClick={() => onOpenDetail(budget)}
-                      className="flex w-full flex-col items-start text-left"
+                      className="text-left"
                     >
-                      <span className="font-medium text-text">{budget.label}</span>
-                      <span
-                        className={`mt-1 inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold ${
-                          budget.status === 'overspend'
-                            ? 'bg-red-500/10 text-red-500'
-                            : budget.status === 'warning'
-                            ? 'bg-amber-500/10 text-amber-600'
-                            : 'bg-emerald-500/10 text-emerald-600'
-                        }`}
-                      >
-                        {budget.status === 'overspend'
-                          ? 'Overspend'
-                          : budget.status === 'warning'
-                          ? 'Mendekati batas'
-                          : 'On track'}
-                      </span>
+                      <p className="text-sm font-semibold text-text">{budget.label}</p>
+                      <p className="text-xs text-muted">Klik untuk detail transaksi</p>
                     </button>
-                  </td>
-                  <td className="px-4 py-3 text-right">
+                    <span
+                      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold ${
+                        budget.status === 'overspend'
+                          ? 'bg-red-500/10 text-red-500'
+                          : budget.status === 'warning'
+                          ? 'bg-amber-500/10 text-amber-600'
+                          : 'bg-emerald-500/10 text-emerald-600'
+                      }`}
+                    >
+                      {budget.status === 'overspend'
+                        ? 'Overspend'
+                        : budget.status === 'warning'
+                        ? 'Mendekati batas'
+                        : 'On track'}
+                    </span>
+                  </div>
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between text-[11px] uppercase tracking-wide text-muted">
+                      <span>Progres</span>
+                      <span>{progress}%</span>
+                    </div>
+                    <div className="h-2 w-full rounded-full bg-border">
+                      <div className={`h-2 rounded-full ${getProgressColor(budget.status)}`} style={{ width: `${progress}%` }} />
+                    </div>
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-1 gap-3 text-sm text-muted-foreground sm:grid-cols-2">
+                  <label className="space-y-1 text-left">
+                    <span className="text-xs font-medium uppercase tracking-wide text-muted">Rencana</span>
                     <input
                       type="number"
                       defaultValue={budget.planned.toFixed(2)}
                       min={0}
                       step="1000"
-                      className="h-11 w-full rounded-2xl border border-border bg-surface-2 px-3 text-right text-sm tabular-nums"
+                      className="h-11 w-full rounded-2xl border border-border bg-surface-2 px-3 text-right text-sm tabular-nums text-text"
                       onBlur={(event) => handleCommit(budget, 'planned', event.target.value)}
                       onKeyDown={(event) => {
                         if (event.key === 'Enter') {
@@ -149,13 +147,14 @@ export default function BudgetsTable({
                         }
                       }}
                     />
-                  </td>
-                  <td className="px-4 py-3 text-right">
+                  </label>
+                  <label className="space-y-1 text-left">
+                    <span className="text-xs font-medium uppercase tracking-wide text-muted">Rollover In</span>
                     <input
                       type="number"
                       defaultValue={budget.rolloverIn.toFixed(2)}
                       step="1000"
-                      className="h-11 w-full rounded-2xl border border-border bg-surface-2 px-3 text-right text-sm tabular-nums"
+                      className="h-11 w-full rounded-2xl border border-border bg-surface-2 px-3 text-right text-sm tabular-nums text-text"
                       onBlur={(event) => handleCommit(budget, 'rollover_in', event.target.value)}
                       onKeyDown={(event) => {
                         if (event.key === 'Enter') {
@@ -163,35 +162,31 @@ export default function BudgetsTable({
                         }
                       }}
                     />
-                  </td>
-                  <td className="px-4 py-3 text-right">
-                    <div className="space-y-1">
-                      <p className="text-sm font-semibold tabular-nums">
-                        {formatBudgetAmount(budget.actual)}
-                      </p>
-                      <div className="h-2 w-full rounded-full bg-border">
-                        <div
-                          className={`h-2 rounded-full ${getProgressColor(budget.status)}`}
-                          style={{ width: `${Math.min(100, Math.round(budget.progress * 100))}%` }}
-                        />
-                      </div>
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 text-right">
-                    <div className="space-y-1 text-sm tabular-nums">
-                      <p className={budget.remaining < 0 ? 'text-red-500' : ''}>
-                        {formatBudgetAmount(budget.remaining)}
-                      </p>
-                      {budget.coverageDays != null && (
-                        <span className="inline-flex items-center rounded-full bg-surface-2 px-2 py-0.5 text-[11px] text-muted">
-                          Aman {budget.coverageDays} hari
-                        </span>
-                      )}
-                    </div>
-                  </td>
-                  <td className="px-4 py-3">
+                  </label>
+                  <div className="space-y-1 text-left">
+                    <span className="text-xs font-medium uppercase tracking-wide text-muted">Aktual</span>
+                    <p className="text-sm font-semibold tabular-nums text-text">
+                      {formatBudgetAmount(budget.actual)}
+                    </p>
+                  </div>
+                  <div className="space-y-1 text-left">
+                    <span className="text-xs font-medium uppercase tracking-wide text-muted">Sisa</span>
+                    <p className={`text-sm font-semibold tabular-nums ${budget.remaining < 0 ? 'text-red-500' : 'text-text'}`}>
+                      {formatBudgetAmount(budget.remaining)}
+                    </p>
+                    {budget.coverageDays != null && (
+                      <span className="inline-flex items-center rounded-full bg-surface-2 px-2 py-0.5 text-[11px] text-muted">
+                        Aman {budget.coverageDays} hari
+                      </span>
+                    )}
+                  </div>
+                </div>
+
+                <div className="flex flex-col gap-3 text-sm">
+                  <label className="space-y-1 text-left">
+                    <span className="text-xs font-medium uppercase tracking-wide text-muted">Aturan Rollover</span>
                     <select
-                      className="h-11 w-full rounded-2xl border border-border bg-surface-2 px-3 text-sm"
+                      className="h-11 w-full rounded-2xl border border-border bg-surface-2 px-3 text-sm text-text"
                       value={budget.carryRule}
                       onChange={(event) => handleSelect(budget, event.target.value)}
                     >
@@ -200,38 +195,36 @@ export default function BudgetsTable({
                       <option value="carry-all">Bawa semua</option>
                       <option value="reset-zero">Reset ke nol</option>
                     </select>
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex flex-wrap gap-2 text-xs">
-                      <button
-                        type="button"
-                        className="rounded-xl border border-border px-3 py-1"
-                        onClick={() => onManageRule(budget)}
-                      >
-                        Atur Aturan
-                      </button>
-                      <button
-                        type="button"
-                        className="rounded-xl border border-border px-3 py-1"
-                        onClick={() => onOpenDetail(budget)}
-                      >
-                        Detail
-                      </button>
-                      <button
-                        type="button"
-                        className="rounded-xl border border-border px-3 py-1 text-red-500"
-                        onClick={() => onDelete(budget.id)}
-                      >
-                        Hapus
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
+                  </label>
+                  <div className="flex flex-wrap gap-2 text-xs">
+                    <button
+                      type="button"
+                      className="rounded-xl border border-border px-3 py-1"
+                      onClick={() => onManageRule(budget)}
+                    >
+                      Atur Aturan
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded-xl border border-border px-3 py-1"
+                      onClick={() => onOpenDetail(budget)}
+                    >
+                      Detail
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded-xl border border-border px-3 py-1 text-red-500"
+                      onClick={() => onDelete(budget.id)}
+                    >
+                      Hapus
+                    </button>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the budgets table with a responsive card grid for each budget item
- surface progress, rollover controls, and remaining balance details directly on every card
- maintain loading and empty states tailored to the new layout

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d87dec8b1c8332b91f105caa97c8c7