### PR TITLE
Revamp dashboard spend and transaction cards

### DIFF
--- a/src/components/RecentTransactions.jsx
+++ b/src/components/RecentTransactions.jsx
@@ -1,7 +1,20 @@
 import { useMemo, useState } from "react";
 import clsx from "clsx";
 import Segmented from "./ui/Segmented";
-import DataList from "./dashboard/DataList";
+import Card, { CardBody, CardHeader } from "./Card";
+
+function EmptyState({ message }) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-3 py-12 text-center text-sm text-muted/90">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-brand/10 text-brand">
+        <span className="text-lg">🧾</span>
+      </div>
+      <p className="max-w-[220px] font-medium text-text/80 dark:text-slate-100/80">
+        {message}
+      </p>
+    </div>
+  );
+}
 
 function formatCurrency(n = 0) {
   return new Intl.NumberFormat("id-ID", {
@@ -9,6 +22,16 @@ function formatCurrency(n = 0) {
     currency: "IDR",
     minimumFractionDigits: 0,
   }).format(n);
+}
+
+function formatDate(date) {
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return date;
+  return new Intl.DateTimeFormat("id-ID", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(parsed);
 }
 
 export default function RecentTransactions({ txs = [] }) {
@@ -32,53 +55,75 @@ export default function RecentTransactions({ txs = [] }) {
     period === "day" ? "24 jam" : period === "week" ? "7 hari" : "30 hari";
 
   return (
-    <DataList
-      title="Transaksi Terbaru"
-      subtext={`Ringkasan transaksi ${periodLabel} terakhir`}
-      actions={
-        <Segmented
-          value={period}
-          onChange={setPeriod}
-          options={[
-            { label: "Hari", value: "day" },
-            { label: "Minggu", value: "week" },
-            { label: "Bulan", value: "month" },
-          ]}
-        />
-      }
-      rows={filtered}
-      emptyMessage="Belum ada transaksi periode ini."
-      columns={[
-        {
-          key: "note",
-          label: "Transaksi",
-          render: (row) => (
-            <div className="flex flex-col gap-1">
-              <span className="truncate font-medium text-text dark:text-slate-100">
-                {row.note || row.category}
-              </span>
-              <span className="text-xs text-muted/80">{row.date}</span>
-            </div>
-          ),
-        },
-        {
-          key: "amount",
-          label: "Jumlah",
-          align: "right",
-          render: (row) => (
-            <span
-              className={clsx(
-                "inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold",
-                row.type === "income"
-                  ? "bg-success/10 text-success"
-                  : "bg-danger/10 text-danger"
-              )}
-            >
-              {formatCurrency(row.amount)}
-            </span>
-          ),
-        },
-      ]}
-    />
+    <Card className="flex min-h-[360px] flex-col">
+      <CardHeader
+        title="Transaksi Terbaru"
+        subtext={`Ringkasan transaksi ${periodLabel} terakhir`}
+        actions={
+          <Segmented
+            value={period}
+            onChange={setPeriod}
+            options={[
+              { label: "Hari", value: "day" },
+              { label: "Minggu", value: "week" },
+              { label: "Bulan", value: "month" },
+            ]}
+          />
+        }
+      />
+
+      <CardBody className="flex flex-1 flex-col gap-6">
+        {filtered.length ? (
+          <ul className="flex flex-1 flex-col gap-4">
+            {filtered.map((row) => (
+              <li
+                key={`${row.id || row.note}-${row.date}-${row.amount}`}
+                className="group flex items-start gap-3 rounded-xl px-2 py-2 transition hover:bg-white/5"
+              >
+                <div
+                  className={clsx(
+                    "mt-1 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border-2 text-sm font-semibold",
+                    row.type === "income"
+                      ? "border-success/50 bg-success/10 text-success"
+                      : "border-danger/50 bg-danger/10 text-danger"
+                  )}
+                >
+                  {row.category?.[0]?.toUpperCase() || "?"}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-semibold text-text">
+                        {row.note || row.category || "Transaksi"}
+                      </p>
+                      <p className="text-xs text-muted/80">
+                        {formatDate(row.date)} • {row.category || "Tanpa kategori"}
+                      </p>
+                    </div>
+                    <span
+                      className={clsx(
+                        "inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold",
+                        row.type === "income"
+                          ? "bg-success/10 text-success"
+                          : "bg-danger/10 text-danger"
+                      )}
+                    >
+                      {formatCurrency(row.amount)}
+                    </span>
+                  </div>
+                  {row.merchant && (
+                    <p className="mt-2 text-xs text-muted/70">
+                      {row.merchant}
+                    </p>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <EmptyState message="Belum ada transaksi periode ini." />
+        )}
+      </CardBody>
+    </Card>
   );
 }

--- a/src/components/TopSpendsTable.jsx
+++ b/src/components/TopSpendsTable.jsx
@@ -1,6 +1,28 @@
 import { useMemo, useState } from "react";
-import clsx from "clsx";
-import DataList from "./dashboard/DataList";
+import Card, { CardBody, CardHeader } from "./Card";
+
+function formatDate(date) {
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return date;
+  return new Intl.DateTimeFormat("id-ID", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(parsed);
+}
+
+function EmptyState({ message }) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-3 py-12 text-center text-sm text-muted/90">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-brand/10 text-brand">
+        <span className="text-lg">📉</span>
+      </div>
+      <p className="max-w-[220px] font-medium text-text/80 dark:text-slate-100/80">
+        {message}
+      </p>
+    </div>
+  );
+}
 
 function toRupiah(n = 0) {
   return new Intl.NumberFormat("id-ID", {
@@ -14,76 +36,121 @@ export default function TopSpendsTable({ data = [], onSelect }) {
   const [sort, setSort] = useState("desc");
 
   const sorted = useMemo(() => {
-    return [...data].sort((a, b) =>
-      sort === "asc" ? a.amount - b.amount : b.amount - a.amount
-    );
+    return [...data]
+      .sort((a, b) =>
+        sort === "asc"
+          ? Number(a.amount || 0) - Number(b.amount || 0)
+          : Number(b.amount || 0) - Number(a.amount || 0)
+      )
+      .slice(0, 6);
   }, [data, sort]);
+
+  const stats = useMemo(() => {
+    if (!sorted.length) return null;
+    const total = sorted.reduce(
+      (sum, row) => sum + Number(row.amount || 0),
+      0
+    );
+    const top = sorted[0];
+    return {
+      total,
+      top,
+      shares: sorted.map((row) => ({
+        row,
+        pct: total ? Number(row.amount || 0) / total : 0,
+      })),
+    };
+  }, [sorted]);
 
   const toggleSort = () => setSort((s) => (s === "asc" ? "desc" : "asc"));
 
   return (
-    <DataList
-      title="Top Pengeluaran"
-      subtext="Pengeluaran terbesar dalam periode ini"
-      actions={
-        <button
-          onClick={toggleSort}
-          className="inline-flex items-center gap-1 rounded-full border border-white/15 px-3 py-1 text-xs font-medium text-text transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-          aria-label="Urutkan pengeluaran"
-        >
-          Sortir {sort === "asc" ? "↑" : "↓"}
-        </button>
-      }
-      rows={sorted}
-      onRowClick={onSelect}
-      columns={[
-        {
-          key: "note",
-          label: "Catatan",
-          render: (row) => (
-            <div className="flex flex-col gap-1">
-              <span className="truncate font-medium text-text dark:text-slate-100">
-                {row.note || row.category || "-"}
-              </span>
-              <span className="text-xs text-muted/80">{row.category}</span>
-            </div>
-          ),
-        },
-        {
-          key: "date",
-          label: "Tanggal",
-          render: (row) => (
-            <span className="whitespace-nowrap text-sm text-muted/80">
-              {row.date}
-            </span>
-          ),
-        },
-        {
-          key: "amount",
-          label: "Jumlah",
-          align: "right",
-          className: (row) =>
-            clsx(
-              "text-right",
-              row.amount < 0
-                ? "text-danger"
-                : "text-success"
-            ),
-          render: (row) => (
-            <span
-              className={clsx(
-                "inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold",
-                row.amount < 0
-                  ? "bg-danger/10 text-danger"
-                  : "bg-success/10 text-success"
-              )}
+    <Card className="flex min-h-[360px] flex-col">
+      <CardHeader
+        title="Top Pengeluaran"
+        subtext="Pengeluaran terbesar dalam periode ini"
+        actions={
+          <button
+            onClick={toggleSort}
+            className="inline-flex items-center gap-1 rounded-full border border-white/15 px-3 py-1 text-xs font-medium text-text transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+            aria-label="Urutkan pengeluaran"
+          >
+            Sortir {sort === "asc" ? "↑" : "↓"}
+          </button>
+        }
+      />
+
+      <CardBody className="flex flex-1 flex-col gap-6">
+        {stats ? (
+          <>
+            <button
+              type="button"
+              onClick={() => onSelect?.(stats.top)}
+              className="group flex w-full items-start justify-between gap-4 rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-4 text-left transition hover:border-brand/40 hover:bg-brand/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
             >
-              {toRupiah(row.amount)}
-            </span>
-          ),
-        },
-      ]}
-    />
+              <div className="space-y-1">
+                <p className="text-xs uppercase tracking-wide text-muted/80">
+                  Pengeluaran terbesar
+                </p>
+                <p className="text-base font-semibold text-text">
+                  {stats.top.note || stats.top.category || "Tanpa catatan"}
+                </p>
+                <p className="text-xs text-muted/70">
+                  {stats.top.category} • {formatDate(stats.top.date)}
+                </p>
+              </div>
+              <div className="flex flex-col items-end">
+                <span className="rounded-full bg-danger/10 px-3 py-1 text-sm font-semibold text-danger">
+                  {toRupiah(stats.top.amount)}
+                </span>
+                <span className="mt-2 text-xs font-medium text-muted/80">
+                  {stats.total
+                    ? Math.round(
+                        (Number(stats.top.amount || 0) / stats.total) * 100
+                      )
+                    : 0}
+                  % dari total
+                </span>
+              </div>
+            </button>
+
+            <div className="space-y-4">
+              {stats.shares.map(({ row, pct }) => (
+                <button
+                  type="button"
+                  onClick={() => onSelect?.(row)}
+                  key={`${row.id || row.note}-${row.date}`}
+                  className="group flex w-full items-center gap-4 rounded-xl px-2 py-2 text-left transition hover:bg-white/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center justify-between gap-4">
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold text-text">
+                          {row.note || row.category || "Tanpa catatan"}
+                        </p>
+                        <p className="mt-1 text-xs text-muted/70">{row.category}</p>
+                      </div>
+                      <span className="whitespace-nowrap rounded-full bg-danger/10 px-3 py-1 text-xs font-semibold text-danger">
+                        {toRupiah(row.amount)}
+                      </span>
+                    </div>
+                    <div className="mt-3 h-2 rounded-full bg-white/5">
+                      <div
+                        className="h-2 rounded-full bg-gradient-to-r from-danger/80 to-danger"
+                        style={{ width: `${Math.max(pct * 100, 4)}%` }}
+                      />
+                    </div>
+                  </div>
+                  <span className="text-xs text-muted/60">{formatDate(row.date)}</span>
+                </button>
+              ))}
+            </div>
+          </>
+        ) : (
+          <EmptyState message="Belum ada pengeluaran pada periode yang dipilih." />
+        )}
+      </CardBody>
+    </Card>
   );
 }
 


### PR DESCRIPTION
## Summary
- redesign the dashboard top pengeluaran card with a richer highlight state and share bars while keeping sorting functionality
- refresh the transaksi terbaru card with a timeline-style list, improved period switching, and resilient date formatting

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d87a3ee29483328701f98ecb75ee59