### PR TITLE
Enhance dashboard spend and transaction analytics cards

### DIFF
--- a/src/components/RecentTransactions.jsx
+++ b/src/components/RecentTransactions.jsx
@@ -31,10 +31,43 @@ export default function RecentTransactions({ txs = [] }) {
   const periodLabel =
     period === "day" ? "24 jam" : period === "week" ? "7 hari" : "30 hari";
 
+  const { totalIncome, totalExpense, netFlow } = useMemo(() => {
+    return filtered.reduce(
+      (acc, tx) => {
+        const amount = Number(tx.amount) || 0;
+        if (tx.type === "income") {
+          acc.totalIncome += amount;
+        } else {
+          acc.totalExpense += amount;
+        }
+        acc.netFlow = acc.totalIncome - acc.totalExpense;
+        return acc;
+      },
+      { totalIncome: 0, totalExpense: 0, netFlow: 0 }
+    );
+  }, [filtered]);
+
   return (
     <DataList
       title="Transaksi Terbaru"
       subtext={`Ringkasan transaksi ${periodLabel} terakhir`}
+      summary={[
+        {
+          label: "Pemasukan",
+          value: formatCurrency(totalIncome),
+          hint: `${filtered.filter((tx) => tx.type === "income").length} transaksi`,
+        },
+        {
+          label: "Pengeluaran",
+          value: formatCurrency(totalExpense),
+          hint: `${filtered.filter((tx) => tx.type === "expense").length} transaksi`,
+        },
+        {
+          label: "Arus Bersih",
+          value: formatCurrency(netFlow),
+          hint: netFlow >= 0 ? "Surplus periode ini" : "Defisit periode ini",
+        },
+      ]}
       actions={
         <Segmented
           value={period}

--- a/src/components/dashboard/DataList.jsx
+++ b/src/components/dashboard/DataList.jsx
@@ -24,13 +24,35 @@ export default function DataList({
   emptyMessage = "Belum ada data bulan ini.",
   className = "",
   maxHeight = 320,
+  summary = [],
 }) {
   const hasData = rows?.length > 0;
+  const hasSummary = summary?.length > 0;
 
   return (
     <Card className={clsx("flex min-h-[360px] flex-col", className)}>
       <CardHeader title={title} subtext={subtext} actions={actions} />
-      <div className="mt-4 flex-1">
+      {hasSummary ? (
+        <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {summary.map((item, idx) => (
+            <div
+              key={idx}
+              className="rounded-2xl border border-border/40 bg-surface-alt/40 p-4 shadow-inner backdrop-blur-sm"
+            >
+              <p className="text-xs font-medium uppercase tracking-wide text-muted/70">
+                {item.label}
+              </p>
+              <p className="mt-1 text-lg font-semibold text-text dark:text-slate-100">
+                {item.value}
+              </p>
+              {item.hint ? (
+                <p className="mt-2 text-xs text-muted/70">{item.hint}</p>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
+      <div className={clsx("flex-1", hasSummary ? "mt-5" : "mt-4")}> 
         {hasData ? (
           <div
             className="max-h-[320px] overflow-y-auto pr-1"


### PR DESCRIPTION
## Summary
- add a reusable summary metrics strip to dashboard data list cards
- highlight totals and ordering controls on the Top Pengeluaran card
- show recent income, expense, and net flow stats in the Transaksi Terbaru card

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d87a3ee29483328701f98ecb75ee59