### PR TITLE
Remove sidebar collapse toggle button

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import clsx from "clsx";
 import {
-  ChevronLeft,
-  ChevronRight,
   Cloud,
   CloudOff,
   Monitor,
@@ -476,23 +474,7 @@ export default function Sidebar({
             "border-t border-border/60 py-4",
             collapsed ? "px-2" : "px-4"
           )}
-        >
-          <div className="flex justify-end">
-            <button
-              type="button"
-              onClick={() => onToggle?.(!collapsed)}
-              className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-border bg-surface-2 text-text transition-colors duration-200 hover:border-brand/40 hover:text-brand"
-              title={collapsed ? "Perluas" : "Ciutkan"}
-              aria-label={collapsed ? "Perluas sidebar" : "Ciutkan sidebar"}
-            >
-              {collapsed ? (
-                <ChevronRight className="h-4 w-4" />
-              ) : (
-                <ChevronLeft className="h-4 w-4" />
-              )}
-            </button>
-          </div>
-        </footer>
+        />
       </nav>
     </>
   );


### PR DESCRIPTION
## Summary
- remove the bottom arrow toggle button from the sidebar footer
- clean up unused chevron icon imports after removing the toggle

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d882862400833285038a44185f6096