### PR TITLE
Refine dashboard spend and recent transaction cards

### DIFF
--- a/src/components/TopSpendsTable.jsx
+++ b/src/components/TopSpendsTable.jsx
@@ -42,10 +42,6 @@ export default function TopSpendsTable({ data = [], onSelect }) {
   }, [expenses, sort]);
 
   const items = sorted.slice(0, 5);
-  const totalTopSpend = useMemo(
-    () => items.reduce((sum, tx) => sum + tx.amount, 0),
-    [items]
-  );
   const totalExpense = useMemo(
     () => expenses.reduce((sum, tx) => sum + tx.amount, 0),
     [expenses]
@@ -70,15 +66,9 @@ export default function TopSpendsTable({ data = [], onSelect }) {
         }
       />
       <CardBody className="flex-1 space-y-6">
-        <div className="flex items-end justify-between gap-3 rounded-2xl bg-surface-alt/60 px-4 py-3">
-          <div>
-            <p className="text-xs font-medium uppercase tracking-wide text-muted">Total 5 pengeluaran teratas</p>
-            <p className="text-2xl font-semibold text-text">{toRupiah(totalTopSpend)}</p>
-          </div>
-          <span className="inline-flex items-center gap-1 rounded-xl bg-danger/10 px-3 py-1 text-xs font-semibold text-danger">
-            <ArrowDownRight className="h-4 w-4" aria-hidden="true" />
-            {sort === "asc" ? "Terkecil" : "Terbesar"}
-          </span>
+        <div className="inline-flex items-center gap-2 self-start rounded-xl bg-danger/10 px-3 py-1 text-xs font-semibold text-danger">
+          <ArrowDownRight className="h-4 w-4" aria-hidden="true" />
+          {sort === "asc" ? "Terkecil" : "Terbesar"}
         </div>
         {items.length > 0 ? (
           <ul className="space-y-4">

--- a/src/components/ui/Segmented.jsx
+++ b/src/components/ui/Segmented.jsx
@@ -1,15 +1,18 @@
+import clsx from "clsx";
+
 export default function Segmented({ value, onChange, options = [] }) {
   return (
-    <div className="inline-flex rounded-xl border border-border overflow-hidden">
+    <div className="inline-flex overflow-hidden rounded-xl border border-border-subtle bg-surface-alt/30 p-0.5">
       {options.map((opt) => (
         <button
           key={opt.value}
           type="button"
-          className={`px-3 py-2 text-sm flex-1 ${
+          className={clsx(
+            "flex-1 rounded-lg px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-offset-background focus-visible:ring-[color:var(--brand-ring)]",
             value === opt.value
-              ? "bg-brand-var text-brand-foreground"
-              : "bg-surface-1"
-          }`}
+              ? "bg-brand-var text-brand-foreground shadow"
+              : "text-muted-foreground hover:bg-surface-alt/60 hover:text-text"
+          )}
           onClick={() => onChange(opt.value)}
         >
           {opt.label}


### PR DESCRIPTION
## Summary
- remove the aggregated top 5 spend total from the top spends widget while keeping sort controls
- adjust the recent transactions filter to use calendar day, week, and month ranges with clearer helper text
- refresh the segmented control styling so the period buttons respect light and dark themes

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d8858bff048332924dcd56e63a9621