### PR TITLE
Adjust dashboard spending card and recent transaction filters

### DIFF
--- a/src/components/TopSpendsTable.jsx
+++ b/src/components/TopSpendsTable.jsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from "react";
-import { ArrowDownRight } from "lucide-react";
 import Card, { CardBody, CardHeader } from "./Card";
 
 function toRupiah(n = 0) {
@@ -42,10 +41,6 @@ export default function TopSpendsTable({ data = [], onSelect }) {
   }, [expenses, sort]);
 
   const items = sorted.slice(0, 5);
-  const totalTopSpend = useMemo(
-    () => items.reduce((sum, tx) => sum + tx.amount, 0),
-    [items]
-  );
   const totalExpense = useMemo(
     () => expenses.reduce((sum, tx) => sum + tx.amount, 0),
     [expenses]
@@ -69,17 +64,14 @@ export default function TopSpendsTable({ data = [], onSelect }) {
           </button>
         }
       />
-      <CardBody className="flex-1 space-y-6">
-        <div className="flex items-end justify-between gap-3 rounded-2xl bg-surface-alt/60 px-4 py-3">
-          <div>
-            <p className="text-xs font-medium uppercase tracking-wide text-muted">Total 5 pengeluaran teratas</p>
-            <p className="text-2xl font-semibold text-text">{toRupiah(totalTopSpend)}</p>
+      <CardBody className="flex-1 space-y-4">
+        {items.length > 0 && (
+          <div className="flex items-center justify-end">
+            <span className="inline-flex items-center gap-1 rounded-xl bg-danger/10 px-3 py-1 text-xs font-semibold text-danger">
+              {sort === "asc" ? "Terkecil" : "Terbesar"}
+            </span>
           </div>
-          <span className="inline-flex items-center gap-1 rounded-xl bg-danger/10 px-3 py-1 text-xs font-semibold text-danger">
-            <ArrowDownRight className="h-4 w-4" aria-hidden="true" />
-            {sort === "asc" ? "Terkecil" : "Terbesar"}
-          </span>
-        </div>
+        )}
         {items.length > 0 ? (
           <ul className="space-y-4">
             {items.map((row, index) => {

--- a/src/components/ui/Segmented.jsx
+++ b/src/components/ui/Segmented.jsx
@@ -1,20 +1,23 @@
 export default function Segmented({ value, onChange, options = [] }) {
   return (
-    <div className="inline-flex rounded-xl border border-border overflow-hidden">
-      {options.map((opt) => (
-        <button
-          key={opt.value}
-          type="button"
-          className={`px-3 py-2 text-sm flex-1 ${
-            value === opt.value
-              ? "bg-brand-var text-brand-foreground"
-              : "bg-surface-1"
-          }`}
-          onClick={() => onChange(opt.value)}
-        >
-          {opt.label}
-        </button>
-      ))}
+    <div className="inline-flex overflow-hidden rounded-xl border border-border-subtle bg-surface-alt/60">
+      {options.map((opt) => {
+        const isActive = value === opt.value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            className={`flex-1 px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+              isActive
+                ? "bg-brand-var text-brand-foreground"
+                : "bg-transparent text-muted-foreground hover:bg-surface-alt dark:text-slate-200"
+            }`}
+            onClick={() => onChange(opt.value)}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove the total-top-five banner from the Top Pengeluaran card while preserving sort controls
- ensure the recent transactions list filters by calendar day, week, and month ranges and updates its copy accordingly
- refresh the segmented control styling so the period labels remain legible in both light and dark modes

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d8858bff048332924dcd56e63a9621