### PR TITLE
Handle existing sessions on auth callback

### DIFF
--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -49,8 +49,28 @@ export default function AuthCallback() {
     }
 
     if (!code && !hasImplicitSession) {
-      setErrorMessage('Kode otorisasi tidak ditemukan. Silakan coba login ulang.');
-      setStatus('error');
+      const verifyExistingSession = async () => {
+        try {
+          const { data, error } = await supabase.auth.getSession();
+          if (cancelled) return;
+          if (error) {
+            throw error;
+          }
+          if (data.session) {
+            handleSuccess(data.session.user?.id ?? null);
+            return;
+          }
+        } catch (error) {
+          console.error('[AuthCallback] Failed to verify existing session', error);
+        }
+
+        if (cancelled) return;
+        setErrorMessage('Kode otorisasi tidak ditemukan. Silakan coba login ulang.');
+        setStatus('error');
+      };
+
+      void verifyExistingSession();
+
       return () => {
         cancelled = true;
       };


### PR DESCRIPTION
## Summary
- check for an existing Supabase session before surfacing the authorization code missing error
- reuse the success flow when a session already exists to avoid false error states

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d8ba2684188332af20db9d2eabf8ee