### PR TITLE
Support native Google login trigger in HematWoi WebView

### DIFF
--- a/src/components/GoogleLoginButton.tsx
+++ b/src/components/GoogleLoginButton.tsx
@@ -1,0 +1,47 @@
+import type { ButtonHTMLAttributes, MouseEvent } from 'react';
+import { isHematWoiApp } from '../lib/ua';
+
+const DEFAULT_GOOGLE_WEB_LOGIN_URL = 'https://hw.bydev.me/auth/google';
+const DEFAULT_NATIVE_TRIGGER_URL = 'https://hw.bydev.me/native-google-login';
+
+type GoogleLoginButtonProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'type'> & {
+  text?: string;
+  nativeTriggerUrl?: string;
+  webLoginUrl?: string;
+  onWebLogin?: (event: MouseEvent<HTMLButtonElement>) => void | Promise<void>;
+};
+
+export default function GoogleLoginButton({
+  text = 'Login dengan Google',
+  nativeTriggerUrl = DEFAULT_NATIVE_TRIGGER_URL,
+  webLoginUrl = DEFAULT_GOOGLE_WEB_LOGIN_URL,
+  onWebLogin,
+  children,
+  ...rest
+}: GoogleLoginButtonProps) {
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+
+    if (isHematWoiApp()) {
+      if (typeof window !== 'undefined') {
+        window.location.href = nativeTriggerUrl;
+      }
+      return;
+    }
+
+    if (onWebLogin) {
+      void onWebLogin(event);
+      return;
+    }
+
+    if (typeof window !== 'undefined') {
+      window.location.href = webLoginUrl;
+    }
+  };
+
+  return (
+    <button type="button" onClick={handleClick} {...rest}>
+      {children ?? text}
+    </button>
+  );
+}

--- a/src/lib/ua.ts
+++ b/src/lib/ua.ts
@@ -1,0 +1,4 @@
+export function isHematWoiApp(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return navigator.userAgent?.includes('HematWoiWebView') ?? false;
+}

--- a/src/pages/AuthLogin.tsx
+++ b/src/pages/AuthLogin.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import GoogleLoginButton from '../components/GoogleLoginButton';
 import LoginCard from '../components/auth/LoginCard';
 import ErrorBoundary from '../components/system/ErrorBoundary';
 import { getSession, onAuthStateChange } from '../lib/auth';
@@ -35,10 +36,11 @@ export default function AuthLogin() {
     }
   }, []);
 
-  const handleGoogleSignIn = useCallback(async () => {
+  const handleGoogleWebSignIn = useCallback(async () => {
     if (googleLoading) return;
     setGoogleError(null);
     setGoogleLoading(true);
+    
     try {
       const origin = typeof window !== 'undefined' ? window.location.origin : '';
       const redirectTo = origin ? `${origin.replace(/\/$/, '')}/auth/callback` : undefined;
@@ -216,9 +218,8 @@ export default function AuthLogin() {
                       </div>
                     </div>
                     <div className="space-y-2">
-                      <button
-                        type="button"
-                        onClick={handleGoogleSignIn}
+                      <GoogleLoginButton
+                        onWebLogin={handleGoogleWebSignIn}
                         disabled={googleLoading}
                         className="inline-flex h-11 w-full items-center justify-center gap-3 rounded-2xl border border-border-subtle bg-white px-4 text-sm font-semibold text-slate-900 shadow-sm transition hover:shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-70"
                       >
@@ -233,7 +234,7 @@ export default function AuthLogin() {
                           </span>
                         )}
                         <span>{googleLoading ? 'Menghubungkan…' : 'Lanjutkan dengan Google'}</span>
-                      </button>
+                      </GoogleLoginButton>
                       <p className="text-xs text-muted">
                         Jika pop-up tertutup, cukup tekan tombol lagi atau pilih metode email di samping.
                       </p>


### PR DESCRIPTION
## Summary
- add a user-agent helper to detect the HematWoi Android WebView
- introduce a reusable Google login button that redirects to the native trigger when needed
- update the login page to use the new component while preserving the Supabase OAuth flow for browsers

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d8c4782c98833291135b53f68bd36a