### PR TITLE
Fix Google OAuth login by enabling PKCE flow

### DIFF
--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -19,6 +19,13 @@ if (!supabaseUrl || !supabaseKey) {
   )
 }
 
-export const supabase = createClient(supabaseUrl, supabaseKey)
+export const supabase = createClient(supabaseUrl, supabaseKey, {
+  auth: {
+    autoRefreshToken: true,
+    persistSession: true,
+    detectSessionInUrl: false,
+    flowType: 'pkce',
+  },
+})
 export const SUPABASE_URL = supabaseUrl
 export const SUPABASE_ANON_KEY = supabaseKey

--- a/src/lib/supabase.test.js
+++ b/src/lib/supabase.test.js
@@ -33,7 +33,14 @@ describe('supabase client env handling', () => {
 
     await import('./supabase.js')
 
-    expect(createClient).toHaveBeenCalledWith('http://localhost', 'anon-key')
+    expect(createClient).toHaveBeenCalledWith('http://localhost', 'anon-key', {
+      auth: {
+        autoRefreshToken: true,
+        persistSession: true,
+        detectSessionInUrl: false,
+        flowType: 'pkce',
+      },
+    })
     expect(console.warn).not.toHaveBeenCalled()
   })
 })

--- a/src/pages/AuthLogin.tsx
+++ b/src/pages/AuthLogin.tsx
@@ -69,7 +69,6 @@ export default function AuthLogin() {
             access_type: 'offline',
             prompt: 'consent',
           },
-          flowType: 'pkce',
         },
       });
       if (error) throw error;


### PR DESCRIPTION
## Summary
- configure the Supabase client to use the PKCE auth flow with manual callback handling
- remove the invalid per-request flowType flag from the Google OAuth sign-in call
- update the Supabase client unit test to cover the new initialization options

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d8edeb45708332931c695827c6b7d9