### PR TITLE
Fix Google OAuth code exchange

### DIFF
--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -58,7 +58,7 @@ export default function AuthCallback() {
 
     const exchange = async (authCode: string) => {
       try {
-        const { data, error } = await supabase.auth.exchangeCodeForSession({ code: authCode });
+        const { data, error } = await supabase.auth.exchangeCodeForSession(authCode);
         if (error) throw error;
         handleSuccess(data.session?.user?.id ?? null);
       } catch (error) {


### PR DESCRIPTION
## Summary
- pass the PKCE authorization code directly to `exchangeCodeForSession`
- allow Google OAuth sign-in to complete successfully in the callback flow

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d8edeb45708332931c695827c6b7d9