### PR TITLE
Add mobile Google Supabase auth callback page

### DIFF
--- a/pages/auth/mobile/google.tsx
+++ b/pages/auth/mobile/google.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  { auth: { persistSession: true } }
+);
+
+export default function MobileGoogleCallback() {
+  const [msg, setMsg] = useState('Memproses login…');
+
+  useEffect(() => {
+    (async () => {
+      const p = new URLSearchParams(window.location.search);
+      const idToken = p.get('id_token');
+      if (!idToken) {
+        setMsg('Tidak ada id_token.');
+        return;
+      }
+
+      const { error } = await supabase.auth.signInWithIdToken({
+        provider: 'google',
+        token: idToken,
+      });
+      if (error) {
+        setMsg('Gagal login: ' + error.message);
+        return;
+      }
+
+      setMsg('Berhasil login. Mengalihkan…');
+      window.location.replace('/');
+    })();
+  }, []);
+
+  return <p style={{ textAlign: 'center', marginTop: 64 }}>{msg}</p>;
+}


### PR DESCRIPTION
## Summary
- add a mobile Google callback page that exchanges the id_token with Supabase and redirects on success

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8fc075a2c83329833e73fce316017