### PR TITLE
Add tenor support for recurring debt entries

### DIFF
--- a/src/components/debts/DebtsTableResponsive.tsx
+++ b/src/components/debts/DebtsTableResponsive.tsx
@@ -77,6 +77,12 @@ function isOverdue(debt: DebtRecord) {
   return due.getTime() < today.getTime();
 }
 
+function formatTenor(debt: DebtRecord) {
+  const total = Math.max(1, Math.floor(debt.tenor_months || 1));
+  const current = Math.max(1, Math.min(Math.floor(debt.tenor_sequence || 1), total));
+  return `${current}/${total}`;
+}
+
 export default function DebtsTableResponsive({
   debts,
   loading,
@@ -130,6 +136,9 @@ export default function DebtsTableResponsive({
                   <th scope="col" className="px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground text-left min-w-[150px]">
                     Jatuh Tempo
                   </th>
+                  <th scope="col" className="px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground text-center min-w-[110px]">
+                    Tenor
+                  </th>
                   <th scope="col" className="px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground text-right min-w-[120px]">
                     Bunga %
                   </th>
@@ -173,6 +182,9 @@ export default function DebtsTableResponsive({
                         <td className="px-4 py-3 align-middle">
                           <div className="h-3.5 w-36 animate-pulse rounded bg-border/40" />
                         </td>
+                        <td className="px-4 py-3 align-middle text-center">
+                          <div className="mx-auto h-3.5 w-12 animate-pulse rounded bg-border/40" />
+                        </td>
                         <td className="px-4 py-3 align-middle">
                           <div className="ml-auto h-3.5 w-16 animate-pulse rounded bg-border/40" />
                         </td>
@@ -201,7 +213,7 @@ export default function DebtsTableResponsive({
 
                 {showEmpty ? (
                   <tr>
-                    <td colSpan={11} className="px-6 py-12 text-center text-sm text-muted-foreground">
+                    <td colSpan={12} className="px-6 py-12 text-center text-sm text-muted-foreground">
                       Tidak ada data hutang sesuai filter.
                     </td>
                   </tr>
@@ -249,6 +261,9 @@ export default function DebtsTableResponsive({
                               </span>
                             ) : null}
                           </div>
+                        </td>
+                        <td className="px-4 py-3 align-middle text-center text-sm tabular-nums text-muted-foreground">
+                          <span className={debt.tenor_months > 1 ? 'font-semibold text-foreground' : ''}>{formatTenor(debt)}</span>
                         </td>
                         <td className="px-4 py-3 align-middle text-right text-sm tabular-nums text-muted-foreground">
                           {formatPercent(debt.rate_percent)}
@@ -299,7 +314,7 @@ export default function DebtsTableResponsive({
 
                 {debts.length > 0 && loading ? (
                   <tr>
-                    <td colSpan={11} className="px-4 py-4">
+                    <td colSpan={12} className="px-4 py-4">
                       <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
                         <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
                         Memuat data hutang…
@@ -330,6 +345,7 @@ export default function DebtsTableResponsive({
                     <div className="h-3 w-20 animate-pulse rounded bg-border/30" />
                     <div className="h-3 w-24 animate-pulse rounded bg-border/30" />
                     <div className="h-3 w-16 animate-pulse rounded bg-border/30" />
+                    <div className="h-3 w-20 animate-pulse rounded bg-border/30" />
                   </div>
                   <div className="space-y-2 text-right">
                     <div className="ml-auto h-3 w-24 animate-pulse rounded bg-border/30" />
@@ -401,6 +417,12 @@ export default function DebtsTableResponsive({
                           </span>
                         ) : null}
                       </div>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-[11px] uppercase tracking-wide text-muted-foreground/70">Tenor</p>
+                      <p className={`text-sm font-semibold ${debt.tenor_months > 1 ? 'text-foreground' : 'text-muted-foreground'}`}>
+                        {formatTenor(debt)}
+                      </p>
                     </div>
                     <div className="space-y-1">
                       <p className="text-[11px] uppercase tracking-wide text-muted-foreground/70">Bunga</p>

--- a/src/components/debts/PaymentDrawer.tsx
+++ b/src/components/debts/PaymentDrawer.tsx
@@ -124,6 +124,13 @@ export default function PaymentDrawer({
     return currencyFormatter.format(Math.max(0, debt.paid_total));
   }, [debt]);
 
+  const tenorLabel = useMemo(() => {
+    if (!debt) return '1/1';
+    const total = Math.max(1, Math.floor(debt.tenor_months || 1));
+    const current = Math.max(1, Math.min(Math.floor(debt.tenor_sequence || 1), total));
+    return `${current}/${total}`;
+  }, [debt]);
+
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const parsedAmount = parseDecimal(amount);
@@ -175,13 +182,13 @@ export default function PaymentDrawer({
       >
         <header className="drawer-header">
           <div className="flex items-start justify-between gap-3 sm:gap-4">
-            <div className="min-w-0">
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted">Catat Pembayaran</p>
-              <h2 className="mt-1 break-words text-lg font-semibold text-text">{debt.title}</h2>
-              <p className="break-words text-sm text-muted">
-                {debt.party_name} • {dateFormatter.format(new Date(debt.date))}
-              </p>
-            </div>
+              <div className="min-w-0">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted">Catat Pembayaran</p>
+                <h2 className="mt-1 break-words text-lg font-semibold text-text">{debt.title}</h2>
+                <p className="break-words text-sm text-muted">
+                  {debt.party_name} • {dateFormatter.format(new Date(debt.date))} • Tenor {tenorLabel}
+                </p>
+              </div>
             <button
               ref={closeButtonRef}
               type="button"

--- a/src/pages/Debts.tsx
+++ b/src/pages/Debts.tsx
@@ -179,6 +179,8 @@ export default function Debts() {
         remaining: payload.amount,
         status: computeStatus(payload.amount, 0, toISO(payload.due_date ?? null)),
         notes: payload.notes ?? null,
+        tenor_months: payload.tenor_months,
+        tenor_sequence: 1,
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
       };
@@ -213,6 +215,7 @@ export default function Debts() {
             amount: payload.amount,
             rate_percent: payload.rate_percent ?? item.rate_percent ?? 0,
             notes: payload.notes ?? null,
+            tenor_months: payload.tenor_months,
             remaining: Math.max(payload.amount - item.paid_total, 0),
             status: computeStatus(payload.amount, item.paid_total, toISO(payload.due_date ?? null)),
           }
@@ -280,6 +283,7 @@ export default function Debts() {
         'Judul',
         'Tanggal',
         'Jatuh Tempo',
+        'Tenor',
         'Jumlah',
         'Terbayar',
         'Sisa',
@@ -292,6 +296,7 @@ export default function Debts() {
         item.title,
         item.date ? new Date(item.date).toLocaleDateString('id-ID') : '',
         item.due_date ? new Date(item.due_date).toLocaleDateString('id-ID') : '',
+        `${item.tenor_sequence}/${item.tenor_months}`,
         formatCurrency(item.amount),
         formatCurrency(item.paid_total),
         formatCurrency(item.remaining),

--- a/supabase/migrations/20250419000000_add_tenor_to_debts.sql
+++ b/supabase/migrations/20250419000000_add_tenor_to_debts.sql
@@ -1,0 +1,11 @@
+alter table public.debts
+  add column if not exists tenor_months integer not null default 1 check (tenor_months >= 1);
+
+alter table public.debts
+  add column if not exists tenor_sequence integer not null default 1 check (tenor_sequence >= 1);
+
+alter table public.debts
+  add constraint debts_tenor_sequence_valid
+  check (tenor_sequence <= tenor_months);
+
+create index if not exists debts_user_tenor_idx on public.debts (user_id, tenor_sequence);


### PR DESCRIPTION
## Summary
- add tenor metadata to debts API and create repeating monthly rows when tenor exceeds one month
- expose tenor selection in the debt form and surface the sequence in the debts table, CSV export, and payment drawer
- add a Supabase migration to store tenor counts and enforce data integrity

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d88699c4988332b2fb7747a5355934