### PR TITLE
Adjust debt payment modal and record transactions for payments

### DIFF
--- a/src/components/debts/PaymentsList.tsx
+++ b/src/components/debts/PaymentsList.tsx
@@ -36,6 +36,9 @@ export default function PaymentsList({ payments, onDelete, deletingId }: Payment
             <div className="min-w-0">
               <p className="text-sm font-semibold text-text">{amountLabel}</p>
               <p className="text-xs text-muted">{dateLabel}</p>
+              {payment.account_name ? (
+                <p className="mt-1 text-xs text-muted">Akun: {payment.account_name}</p>
+              ) : null}
               {payment.notes ? (
                 <p className="mt-2 break-words text-sm text-text/80" title={payment.notes}>
                   {payment.notes}

--- a/supabase/migrations/20250504000000_alter_debt_payments_accounts.sql
+++ b/supabase/migrations/20250504000000_alter_debt_payments_accounts.sql
@@ -1,0 +1,8 @@
+alter table public.debt_payments
+  add column if not exists account_id uuid references public.accounts (id) on delete set null;
+
+alter table public.debt_payments
+  add column if not exists transaction_id uuid references public.transactions (id) on delete set null;
+
+create index if not exists debt_payments_account_idx on public.debt_payments (user_id, account_id);
+create index if not exists debt_payments_transaction_idx on public.debt_payments (user_id, transaction_id);


### PR DESCRIPTION
## Summary
- redesign the debt payment modal into a centered dialog with formatted amount input and an account selector
- load accounts when opening the payment sheet, submit the selected source account, and show account names in the history list
- extend the debts API to create linked transactions for payments, persist the account metadata, and add a migration for the new columns

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d918ce251c8332a19c6aed2cf386c7