### PR TITLE
Fix debt payment insert trigger usage

### DIFF
--- a/src/components/debts/PaymentsList.tsx
+++ b/src/components/debts/PaymentsList.tsx
@@ -36,6 +36,9 @@ export default function PaymentsList({ payments, onDelete, deletingId }: Payment
             <div className="min-w-0">
               <p className="text-sm font-semibold text-text">{amountLabel}</p>
               <p className="text-xs text-muted">{dateLabel}</p>
+              {payment.account_name ? (
+                <p className="mt-1 text-xs text-muted">Akun: {payment.account_name}</p>
+              ) : null}
               {payment.notes ? (
                 <p className="mt-2 break-words text-sm text-text/80" title={payment.notes}>
                   {payment.notes}

--- a/src/lib/api-debts.ts
+++ b/src/lib/api-debts.ts
@@ -35,6 +35,9 @@ export interface DebtPaymentRecord {
   amount: number;
   date: string;
   notes: string | null;
+  account_id: string | null;
+  account_name: string | null;
+  transaction_id: string | null;
   created_at: string;
 }
 
@@ -79,6 +82,7 @@ export interface DebtUpdateInput extends Partial<DebtInput> {
 export interface PaymentInput {
   amount: number;
   date: string;
+  account_id: string;
   notes?: string | null;
 }
 
@@ -193,6 +197,14 @@ function mapDebtRow(row: Record<string, any>): DebtRecord {
 }
 
 function mapPaymentRow(row: Record<string, any>): DebtPaymentRecord {
+  const accountRelation = row.account ?? row.accounts ?? null;
+  const rawAccountId =
+    row.account_id ?? accountRelation?.id ?? accountRelation?.account_id ?? null;
+  const accountId = rawAccountId ? String(rawAccountId) : null;
+  const accountName =
+    typeof row.account_name === 'string' && row.account_name.trim()
+      ? row.account_name
+      : accountRelation?.name ?? null;
   return {
     id: String(row.id),
     debt_id: String(row.debt_id),
@@ -200,6 +212,9 @@ function mapPaymentRow(row: Record<string, any>): DebtPaymentRecord {
     amount: safeNumber(row.amount),
     date: row.date ?? row.created_at ?? new Date().toISOString(),
     notes: row.notes ?? null,
+    account_id: accountId,
+    account_name: accountName ?? null,
+    transaction_id: row.transaction_id ? String(row.transaction_id) : null,
     created_at: row.created_at ?? new Date().toISOString(),
   };
 }
@@ -403,7 +418,7 @@ export async function getDebt(id: string): Promise<{ debt: DebtRecord | null; pa
 
     const { data: paymentRows, error: paymentsError } = await supabase
       .from('debt_payments')
-      .select('*')
+      .select('*, account:account_id (id, name)')
       .eq('debt_id', id)
       .eq('user_id', userId)
       .order('date', { ascending: false })
@@ -424,7 +439,7 @@ export async function listPayments(debtId: string): Promise<DebtPaymentRecord[]>
     const userId = await getUserId();
     const { data, error } = await supabase
       .from('debt_payments')
-      .select('*')
+      .select('*, account:account_id (id, name)')
       .eq('debt_id', debtId)
       .eq('user_id', userId)
       .order('date', { ascending: false })
@@ -631,19 +646,37 @@ export async function addPayment(
 {
   try {
     const userId = await getUserId();
+    const debtRow = await fetchDebtById(debtId, userId);
+    if (!debtRow) {
+      throw new Error('Hutang tidak ditemukan.');
+    }
+
+    const accountId = typeof payload.account_id === 'string' ? payload.account_id.trim() : '';
+    if (!accountId) {
+      throw new Error('Pilih akun sumber pembayaran.');
+    }
+
     const amount = Math.max(0, payload.amount);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      throw new Error('Nominal pembayaran tidak valid.');
+    }
+
+    const isoDate = toISODate(payload.date) ?? new Date().toISOString();
+    const trimmedNotes = payload.notes?.trim() ? payload.notes.trim() : null;
+
     const insertPayload = {
       debt_id: debtId,
       user_id: userId,
-      amount: amount.toFixed(2),
-      date: toISODate(payload.date) ?? new Date().toISOString(),
-      notes: payload.notes ?? null,
+      amount: Number(amount.toFixed(2)),
+      date: isoDate,
+      notes: trimmedNotes,
+      account_id: accountId,
     };
 
     const { data, error } = await supabase
       .from('debt_payments')
       .insert([insertPayload])
-      .select('*')
+      .select('*, account:account_id (id, name)')
       .single();
     if (error) throw error;
 

--- a/supabase/migrations/20250504000000_alter_debt_payments_accounts.sql
+++ b/supabase/migrations/20250504000000_alter_debt_payments_accounts.sql
@@ -1,0 +1,8 @@
+alter table public.debt_payments
+  add column if not exists account_id uuid references public.accounts (id) on delete set null;
+
+alter table public.debt_payments
+  add column if not exists transaction_id uuid references public.transactions (id) on delete set null;
+
+create index if not exists debt_payments_account_idx on public.debt_payments (user_id, account_id);
+create index if not exists debt_payments_transaction_idx on public.debt_payments (user_id, transaction_id);


### PR DESCRIPTION
## Summary
- rely on the database triggers to create linked transactions when adding a debt payment
- stop manually deleting linked transactions so the trigger-driven cleanup can run without conflicts

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d918ce251c8332a19c6aed2cf386c7