### PR TITLE
Fix debt payment note column mapping

### DIFF
--- a/src/lib/api-debts.ts
+++ b/src/lib/api-debts.ts
@@ -205,13 +205,16 @@ function mapPaymentRow(row: Record<string, any>): DebtPaymentRecord {
     typeof row.account_name === 'string' && row.account_name.trim()
       ? row.account_name
       : accountRelation?.name ?? null;
+  const rawNotes =
+    typeof row.notes === 'string' ? row.notes : typeof row.note === 'string' ? row.note : null;
+  const notes = rawNotes && rawNotes.trim() ? rawNotes : null;
   return {
     id: String(row.id),
     debt_id: String(row.debt_id),
     user_id: String(row.user_id),
     amount: safeNumber(row.amount),
     date: row.date ?? row.created_at ?? new Date().toISOString(),
-    notes: row.notes ?? null,
+    notes,
     account_id: accountId,
     account_name: accountName ?? null,
     transaction_id: row.transaction_id ? String(row.transaction_id) : null,
@@ -702,7 +705,7 @@ export async function addPayment(
       user_id: userId,
       amount: amount.toFixed(2),
       date: isoDate,
-      notes: trimmedNotes,
+      note: trimmedNotes,
       account_id: accountId,
       transaction_id: transactionId,
     };


### PR DESCRIPTION
## Summary
- normalize debt payment note mapping to support both note/notes column values
- send the correct note field when inserting a debt payment so Supabase accepts the payload

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d9241046388332ab849985874965bf