### PR TITLE
feat: add admin users management edge function and UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,6 +29,7 @@ import ProfilePage from "./pages/Profile";
 import AccountsPage from "./pages/AccountsPage";
 import AuthLogin from "./pages/AuthLogin";
 import AdminPage from "./pages/AdminPage";
+import UsersPage from "./pages/admin/UsersPage";
 import ChallengesPage from "./pages/Challenges.jsx";
 import WishlistPage from "./pages/WishlistPage";
 import useChallenges from "./hooks/useChallenges.js";
@@ -1103,6 +1104,14 @@ function AppShell({ prefs, setPrefs }) {
                   element={
                     <AdminGuard>
                       <AdminPage />
+                    </AdminGuard>
+                  }
+                />
+                <Route
+                  path="admin/users"
+                  element={
+                    <AdminGuard>
+                      <UsersPage />
                     </AdminGuard>
                   }
                 />

--- a/src/components/admin/users/UserFormModal.tsx
+++ b/src/components/admin/users/UserFormModal.tsx
@@ -1,0 +1,317 @@
+import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from 'react';
+import clsx from 'clsx';
+import Modal from '../../Modal.jsx';
+import type {
+  AdminUserItem,
+  AdminUserProfileInput,
+  CreateAdminUserPayload,
+  UpdateAdminUserPayload,
+} from '../../../lib/api/adminUsers.ts';
+
+const INPUT_CLASS =
+  'h-11 w-full rounded-2xl border border-border bg-background px-3 text-sm transition focus:outline-none focus:ring-2 focus:ring-primary';
+const LABEL_CLASS = 'text-xs font-semibold text-muted-foreground';
+
+export type CreateUserFormValues = CreateAdminUserPayload;
+export type UpdateUserFormValues = UpdateAdminUserPayload;
+
+type UserFormModalProps = {
+  open: boolean;
+  mode: 'create' | 'edit';
+  initialUser?: AdminUserItem | null;
+  submitting?: boolean;
+  forcePasswordReset?: boolean;
+  onClose: () => void;
+  onSubmit: (values: CreateUserFormValues | UpdateUserFormValues) => void;
+};
+
+type FormState = {
+  email: string;
+  password: string;
+  sendEmailInvite: boolean;
+  role: 'admin' | 'user';
+  is_active: boolean;
+  full_name: string;
+  username: string;
+  avatar_url: string;
+  locale: string;
+  timezone: string;
+  theme: 'system' | 'light' | 'dark';
+  showPasswordField: boolean;
+};
+
+const DEFAULT_FORM: FormState = {
+  email: '',
+  password: '',
+  sendEmailInvite: false,
+  role: 'user',
+  is_active: true,
+  full_name: '',
+  username: '',
+  avatar_url: '',
+  locale: 'id-ID',
+  timezone: 'Asia/Jakarta',
+  theme: 'system',
+  showPasswordField: false,
+};
+
+const THEMES: Array<'system' | 'light' | 'dark'> = ['system', 'light', 'dark'];
+
+function normalizeProfile(values: FormState): AdminUserProfileInput {
+  return {
+    role: values.role,
+    is_active: values.is_active,
+    full_name: values.full_name.trim() ? values.full_name.trim() : null,
+    username: values.username.trim() ? values.username.trim() : null,
+    avatar_url: values.avatar_url.trim() ? values.avatar_url.trim() : null,
+    locale: values.locale.trim() ? values.locale.trim() : null,
+    timezone: values.timezone.trim() ? values.timezone.trim() : null,
+    theme: values.theme,
+  };
+}
+
+function populateFromUser(user: AdminUserItem | null | undefined, forcePasswordReset = false): FormState {
+  if (!user) return { ...DEFAULT_FORM };
+  return {
+    email: user.email ?? '',
+    password: '',
+    sendEmailInvite: false,
+    role: user.profile.role,
+    is_active: user.profile.is_active,
+    full_name: user.profile.full_name ?? '',
+    username: user.profile.username ?? '',
+    avatar_url: user.profile.avatar_url ?? '',
+    locale: user.profile.locale ?? 'id-ID',
+    timezone: user.profile.timezone ?? 'Asia/Jakarta',
+    theme: (user.profile.theme ?? 'system') as 'system' | 'light' | 'dark',
+    showPasswordField: forcePasswordReset,
+  };
+}
+
+export default function UserFormModal({
+  open,
+  mode,
+  initialUser,
+  submitting = false,
+  forcePasswordReset = false,
+  onClose,
+  onSubmit,
+}: UserFormModalProps) {
+  const [form, setForm] = useState<FormState>({ ...DEFAULT_FORM });
+
+  useEffect(() => {
+    if (open) {
+      setForm(mode === 'edit' ? populateFromUser(initialUser, forcePasswordReset) : { ...DEFAULT_FORM });
+    }
+  }, [open, mode, initialUser, forcePasswordReset]);
+
+  const title = mode === 'create' ? 'Tambah Pengguna' : 'Edit Pengguna';
+
+  const passwordHint = useMemo(() => {
+    if (mode === 'create' && form.sendEmailInvite) {
+      return 'Password akan dibuat oleh pengguna melalui email undangan.';
+    }
+    return 'Minimal 8 karakter, mengandung huruf besar, huruf kecil, dan angka.';
+  }, [mode, form.sendEmailInvite]);
+
+  const canSubmit = useMemo(() => {
+    if (!form.email.trim()) return false;
+    if (mode === 'create' && !form.sendEmailInvite && !form.password.trim()) return false;
+    if (mode === 'edit' && form.showPasswordField && !form.password.trim()) return false;
+    return true;
+  }, [form.email, form.password, form.sendEmailInvite, form.showPasswordField, mode]);
+
+  const handleChange = (key: keyof FormState) => (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const value = event.target.type === 'checkbox' ? (event.target as HTMLInputElement).checked : event.target.value;
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (!canSubmit) return;
+
+    if (mode === 'create') {
+      const payload: CreateUserFormValues = {
+        email: form.email.trim(),
+        password: form.sendEmailInvite ? undefined : form.password,
+        sendEmailInvite: form.sendEmailInvite,
+        profile: normalizeProfile(form),
+      };
+      onSubmit(payload);
+      return;
+    }
+
+    const profile = normalizeProfile(form);
+    const updates: UpdateUserFormValues = {
+      email: form.email.trim(),
+      profile,
+    };
+    if (form.showPasswordField && form.password.trim()) {
+      updates.password = form.password;
+    }
+    onSubmit(updates);
+  };
+
+  const togglePasswordField = () => {
+    setForm((prev) => ({
+      ...prev,
+      showPasswordField: !prev.showPasswordField,
+      password: '',
+    }));
+  };
+
+  return (
+    <Modal open={open} title={title} onClose={onClose}>
+      <form className="space-y-5" onSubmit={handleSubmit}>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-1 md:col-span-2">
+            <span className={LABEL_CLASS}>Email</span>
+            <input
+              required
+              type="email"
+              value={form.email}
+              onChange={handleChange('email')}
+              className={INPUT_CLASS}
+              placeholder="nama@contoh.com"
+            />
+          </label>
+
+          {mode === 'create' ? (
+            <label className="space-y-1">
+              <span className={LABEL_CLASS}>Password Awal</span>
+              <input
+                type="password"
+                value={form.password}
+                onChange={handleChange('password')}
+                className={clsx(INPUT_CLASS, !form.sendEmailInvite ? '' : 'bg-muted/40 cursor-not-allowed')}
+                placeholder="Password sementara"
+                disabled={form.sendEmailInvite}
+              />
+              <p className="text-[11px] text-muted-foreground">{passwordHint}</p>
+            </label>
+          ) : (
+            <div className="space-y-2 md:col-span-2">
+              <button
+                type="button"
+                onClick={togglePasswordField}
+                className="h-10 rounded-2xl border border-border px-4 text-xs font-medium text-muted-foreground transition hover:border-primary hover:text-primary"
+              >
+                {form.showPasswordField ? 'Batalkan setel ulang password' : 'Setel password baru'}
+              </button>
+              {form.showPasswordField ? (
+                <label className="space-y-1">
+                  <span className={LABEL_CLASS}>Password Baru</span>
+                  <input
+                    type="password"
+                    value={form.password}
+                    onChange={handleChange('password')}
+                    className={INPUT_CLASS}
+                    placeholder="Password baru"
+                  />
+                  <p className="text-[11px] text-muted-foreground">{passwordHint}</p>
+                </label>
+              ) : null}
+            </div>
+          )}
+
+          {mode === 'create' ? (
+            <label className="flex items-center gap-3 text-xs font-medium text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={form.sendEmailInvite}
+                onChange={handleChange('sendEmailInvite')}
+              />
+              Kirim email undangan agar pengguna membuat password sendiri
+            </label>
+          ) : null}
+
+          <label className="space-y-1">
+            <span className={LABEL_CLASS}>Peran</span>
+            <select value={form.role} onChange={handleChange('role')} className={INPUT_CLASS}>
+              <option value="user">User</option>
+              <option value="admin">Admin</option>
+            </select>
+          </label>
+
+          <label className="flex items-center gap-3 text-xs font-medium text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={form.is_active}
+              onChange={handleChange('is_active')}
+            />
+            Akun aktif
+          </label>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-1">
+            <span className={LABEL_CLASS}>Nama Lengkap</span>
+            <input
+              value={form.full_name}
+              onChange={handleChange('full_name')}
+              className={INPUT_CLASS}
+              placeholder="Opsional"
+            />
+          </label>
+          <label className="space-y-1">
+            <span className={LABEL_CLASS}>Username</span>
+            <input
+              value={form.username}
+              onChange={handleChange('username')}
+              className={INPUT_CLASS}
+              placeholder="Opsional"
+            />
+          </label>
+          <label className="space-y-1 md:col-span-2">
+            <span className={LABEL_CLASS}>Avatar URL</span>
+            <input
+              value={form.avatar_url}
+              onChange={handleChange('avatar_url')}
+              className={INPUT_CLASS}
+              placeholder="https://..."
+            />
+          </label>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-3">
+          <label className="space-y-1">
+            <span className={LABEL_CLASS}>Locale</span>
+            <input value={form.locale} onChange={handleChange('locale')} className={INPUT_CLASS} />
+          </label>
+          <label className="space-y-1">
+            <span className={LABEL_CLASS}>Zona Waktu</span>
+            <input value={form.timezone} onChange={handleChange('timezone')} className={INPUT_CLASS} />
+          </label>
+          <label className="space-y-1">
+            <span className={LABEL_CLASS}>Tema</span>
+            <select value={form.theme} onChange={handleChange('theme')} className={INPUT_CLASS}>
+              {THEMES.map((item) => (
+                <option key={item} value={item}>
+                  {item}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="flex flex-wrap justify-end gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="h-11 rounded-2xl border border-border px-5 text-sm font-medium text-muted-foreground transition hover:border-primary hover:text-primary"
+            disabled={submitting}
+          >
+            Batal
+          </button>
+          <button
+            type="submit"
+            className="h-11 rounded-2xl bg-primary px-5 text-sm font-semibold text-white transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={submitting || !canSubmit}
+          >
+            {submitting ? 'Menyimpan…' : mode === 'create' ? 'Tambah Pengguna' : 'Simpan Perubahan'}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/src/components/admin/users/UserTable.tsx
+++ b/src/components/admin/users/UserTable.tsx
@@ -1,0 +1,392 @@
+import { Fragment, useMemo } from 'react';
+import clsx from 'clsx';
+import type { AdminUserItem } from '../../../lib/api/adminUsers.ts';
+
+export type UserTablePagination = {
+  limit: number;
+  offset: number;
+  total: number;
+  nextCursor: string | null;
+  previousCursor: string | null;
+};
+
+type UserTableProps = {
+  items: AdminUserItem[];
+  loading: boolean;
+  error: string | null;
+  pagination: UserTablePagination | null;
+  currentAdminId?: string | null;
+  togglingId?: string | null;
+  deletingId?: string | null;
+  disableToggleIds?: Set<string>;
+  onRetry: () => void;
+  onToggleActive: (user: AdminUserItem, nextState: boolean) => void;
+  onEdit: (user: AdminUserItem) => void;
+  onResetPassword: (user: AdminUserItem) => void;
+  onDelete: (user: AdminUserItem) => void;
+  onNavigate: (offset: number) => void;
+};
+
+const relativeFormatter = new Intl.RelativeTimeFormat('id-ID', { numeric: 'auto' });
+const longDateFormatter = new Intl.DateTimeFormat('id-ID', { dateStyle: 'medium', timeStyle: 'short' });
+
+function getRelativeTime(value: string | null): string {
+  if (!value) return 'Belum pernah';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Tidak diketahui';
+  const now = Date.now();
+  const diff = date.getTime() - now;
+  const seconds = Math.round(diff / 1000);
+  const minutes = Math.round(seconds / 60);
+  const hours = Math.round(minutes / 60);
+  const days = Math.round(hours / 24);
+  if (Math.abs(seconds) < 60) return relativeFormatter.format(seconds, 'second');
+  if (Math.abs(minutes) < 60) return relativeFormatter.format(minutes, 'minute');
+  if (Math.abs(hours) < 24) return relativeFormatter.format(hours, 'hour');
+  if (Math.abs(days) < 30) return relativeFormatter.format(days, 'day');
+  const months = Math.round(days / 30);
+  if (Math.abs(months) < 12) return relativeFormatter.format(months, 'month');
+  const years = Math.round(months / 12);
+  return relativeFormatter.format(years, 'year');
+}
+
+function ProviderBadge({ provider }: { provider: string }) {
+  const label = provider === 'email' ? 'Email' : provider === 'google' ? 'Google' : provider;
+  return (
+    <span className="inline-flex items-center rounded-full border border-border/60 bg-muted/20 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+      {label}
+    </span>
+  );
+}
+
+function StatusToggle({
+  active,
+  disabled,
+  onChange,
+}: {
+  active: boolean;
+  disabled?: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        if (!disabled) onChange(!active);
+      }}
+      className={clsx(
+        'flex h-9 w-20 items-center justify-between rounded-full border px-1 text-[11px] font-semibold transition',
+        active ? 'border-primary/70 bg-primary/10 text-primary' : 'border-border/60 bg-muted/30 text-muted-foreground',
+        disabled ? 'cursor-not-allowed opacity-60' : 'hover:border-primary'
+      )}
+      aria-pressed={active}
+      aria-label="Toggle status aktif"
+      disabled={disabled}
+    >
+      <span className={clsx('rounded-full px-2 py-0.5', active ? 'bg-primary text-white' : '')}>Aktif</span>
+      <span className={clsx('rounded-full px-2 py-0.5', !active ? 'bg-destructive/10 text-destructive' : '')}>Off</span>
+    </button>
+  );
+}
+
+function Avatar({ user }: { user: AdminUserItem }) {
+  const name = user.profile.full_name || user.profile.username || user.email || user.id;
+  const initial = name ? name.trim().charAt(0).toUpperCase() : 'U';
+  const avatarUrl = user.profile.avatar_url;
+  if (avatarUrl) {
+    return (
+      <img
+        src={avatarUrl}
+        alt={name}
+        className="h-10 w-10 rounded-2xl border border-border/60 object-cover"
+        referrerPolicy="no-referrer"
+        loading="lazy"
+      />
+    );
+  }
+  return (
+    <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-sm font-semibold text-primary">
+      {initial}
+    </div>
+  );
+}
+
+export default function UserTable({
+  items,
+  loading,
+  error,
+  pagination,
+  currentAdminId,
+  togglingId,
+  deletingId,
+  disableToggleIds,
+  onRetry,
+  onToggleActive,
+  onEdit,
+  onResetPassword,
+  onDelete,
+  onNavigate,
+}: UserTableProps) {
+  const disableSet = disableToggleIds ?? new Set<string>();
+
+  const content = useMemo(() => {
+    if (error) {
+      return (
+        <div className="rounded-2xl border border-destructive/30 bg-destructive/10 p-6 text-sm text-destructive">
+          <p>{error}</p>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="mt-3 h-10 rounded-2xl border border-destructive/40 px-3 text-xs font-semibold text-destructive transition hover:border-destructive hover:bg-destructive/10"
+          >
+            Coba lagi
+          </button>
+        </div>
+      );
+    }
+
+    if (loading) {
+      return (
+        <div className="space-y-3">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className="grid gap-3 rounded-2xl border border-border/40 bg-muted/10 p-4 md:grid-cols-[2fr_repeat(5,_1fr)]">
+              {Array.from({ length: 6 }).map((__item, col) => (
+                <div key={col} className="h-9 animate-pulse rounded-xl bg-muted/40" />
+              ))}
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    if (!items.length) {
+      return (
+        <div className="rounded-2xl border border-dashed border-border/60 bg-muted/10 p-10 text-center text-sm text-muted-foreground">
+          Belum ada pengguna yang sesuai dengan filter.
+        </div>
+      );
+    }
+
+    return (
+      <Fragment>
+        <div className="hidden overflow-hidden rounded-2xl border border-border/60 md:block">
+          <table className="min-w-full divide-y divide-border/60 text-sm">
+            <thead className="bg-muted/20 text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="px-4 py-3 text-left font-semibold">Pengguna</th>
+                <th className="px-4 py-3 text-left font-semibold">Email</th>
+                <th className="px-4 py-3 text-left font-semibold">Peran</th>
+                <th className="px-4 py-3 text-left font-semibold">Status</th>
+                <th className="px-4 py-3 text-left font-semibold">Last Sign-in</th>
+                <th className="px-4 py-3 text-left font-semibold">Dibuat</th>
+                <th className="px-4 py-3 text-left font-semibold">Provider</th>
+                <th className="px-4 py-3 text-left font-semibold">Aksi</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border/40">
+              {items.map((user) => {
+                const active = user.profile.is_active;
+                const disabled = disableSet.has(user.id) || togglingId === user.id || deletingId === user.id;
+                return (
+                  <tr key={user.id} className="bg-background">
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-3">
+                        <Avatar user={user} />
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-semibold">{user.profile.full_name || user.profile.username || 'Tanpa nama'}</p>
+                          <p className="truncate text-xs text-muted-foreground">ID: {user.id.slice(0, 8)}…</p>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-muted-foreground">{user.email}</td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={clsx(
+                          'inline-flex items-center rounded-full px-3 py-1 text-[11px] font-semibold',
+                          user.profile.role === 'admin'
+                            ? 'bg-primary/10 text-primary'
+                            : 'bg-muted/40 text-muted-foreground'
+                        )}
+                      >
+                        {user.profile.role}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <StatusToggle
+                        active={active}
+                        disabled={disabled}
+                        onChange={(next) => onToggleActive(user, next)}
+                      />
+                    </td>
+                    <td className="px-4 py-3 text-xs text-muted-foreground">
+                      <span title={user.last_sign_in_at ? longDateFormatter.format(new Date(user.last_sign_in_at)) : undefined}>
+                        {getRelativeTime(user.last_sign_in_at)}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-xs text-muted-foreground">
+                      {longDateFormatter.format(new Date(user.created_at))}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex flex-wrap gap-1">
+                        {user.identities.length > 0 ? (
+                          user.identities.map((identity, index) => (
+                            <ProviderBadge key={`${user.id}-${identity.provider}-${index}`} provider={identity.provider} />
+                          ))
+                        ) : (
+                          <ProviderBadge provider="email" />
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <button
+                          type="button"
+                          className="h-9 rounded-2xl border border-border px-3 text-xs font-semibold text-muted-foreground transition hover:border-primary hover:text-primary"
+                          onClick={() => onEdit(user)}
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          className="h-9 rounded-2xl border border-border px-3 text-xs font-semibold text-muted-foreground transition hover:border-primary hover:text-primary"
+                          onClick={() => onResetPassword(user)}
+                        >
+                          Reset Password
+                        </button>
+                        <button
+                          type="button"
+                          className="h-9 rounded-2xl border border-destructive/40 px-3 text-xs font-semibold text-destructive transition hover:border-destructive hover:bg-destructive/10"
+                          onClick={() => onDelete(user)}
+                          disabled={deletingId === user.id || currentAdminId === user.id}
+                        >
+                          Hapus
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="space-y-3 md:hidden">
+          {items.map((user) => {
+            const active = user.profile.is_active;
+            const disabled = disableSet.has(user.id) || togglingId === user.id || deletingId === user.id;
+            return (
+              <div key={user.id} className="rounded-2xl border border-border/60 bg-background p-4 shadow-sm">
+                <div className="flex items-center gap-3">
+                  <Avatar user={user} />
+                  <div>
+                    <p className="text-sm font-semibold">{user.profile.full_name || user.profile.username || 'Tanpa nama'}</p>
+                    <p className="text-xs text-muted-foreground">{user.email}</p>
+                  </div>
+                </div>
+                <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
+                  <span>Peran: {user.profile.role}</span>
+                  <span>•</span>
+                  <span>Dibuat {longDateFormatter.format(new Date(user.created_at))}</span>
+                </div>
+                <div className="mt-4 flex flex-wrap items-center gap-3">
+                  <StatusToggle active={active} disabled={disabled} onChange={(next) => onToggleActive(user, next)} />
+                  <div className="flex flex-wrap gap-1">
+                    {user.identities.length > 0 ? (
+                      user.identities.map((identity, index) => (
+                        <ProviderBadge key={`${user.id}-mobile-${identity.provider}-${index}`} provider={identity.provider} />
+                      ))
+                    ) : (
+                      <ProviderBadge provider="email" />
+                    )}
+                  </div>
+                </div>
+                <div className="mt-3 flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
+                  <span>
+                    Last sign-in:{' '}
+                    <span title={user.last_sign_in_at ? longDateFormatter.format(new Date(user.last_sign_in_at)) : undefined}>
+                      {getRelativeTime(user.last_sign_in_at)}
+                    </span>
+                  </span>
+                </div>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    className="h-9 flex-1 rounded-2xl border border-border px-3 text-xs font-semibold text-muted-foreground transition hover:border-primary hover:text-primary"
+                    onClick={() => onEdit(user)}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    className="h-9 flex-1 rounded-2xl border border-border px-3 text-xs font-semibold text-muted-foreground transition hover:border-primary hover:text-primary"
+                    onClick={() => onResetPassword(user)}
+                  >
+                    Reset Password
+                  </button>
+                  <button
+                    type="button"
+                    className="h-9 flex-1 rounded-2xl border border-destructive/40 px-3 text-xs font-semibold text-destructive transition hover:border-destructive hover:bg-destructive/10"
+                    onClick={() => onDelete(user)}
+                    disabled={deletingId === user.id || currentAdminId === user.id}
+                  >
+                    Hapus
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </Fragment>
+    );
+  }, [error, loading, items, disableSet, togglingId, deletingId, onRetry, onToggleActive, onEdit, onResetPassword, onDelete, currentAdminId]);
+
+  const pageInfo = useMemo(() => {
+    if (!pagination) return '0 dari 0';
+    const start = pagination.offset + 1;
+    const end = Math.min(pagination.offset + pagination.limit, pagination.total);
+    return `${start}-${end} dari ${pagination.total}`;
+  }, [pagination]);
+
+  const handlePrev = () => {
+    if (!pagination) return;
+    const nextOffset = Math.max(pagination.offset - pagination.limit, 0);
+    if (nextOffset === pagination.offset) return;
+    onNavigate(nextOffset);
+  };
+
+  const handleNext = () => {
+    if (!pagination) return;
+    const nextOffset = pagination.offset + pagination.limit;
+    if (nextOffset >= pagination.total) return;
+    onNavigate(nextOffset);
+  };
+
+  return (
+    <div className="space-y-4">
+      {content}
+      {pagination ? (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-border/60 bg-muted/10 px-4 py-3 text-xs">
+          <span className="font-medium text-muted-foreground">{pageInfo}</span>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="h-9 rounded-2xl border border-border px-3 font-semibold text-muted-foreground transition hover:border-primary hover:text-primary disabled:cursor-not-allowed disabled:opacity-50"
+              onClick={handlePrev}
+              disabled={!pagination.previousCursor || pagination.offset === 0 || loading}
+            >
+              Sebelumnya
+            </button>
+            <button
+              type="button"
+              className="h-9 rounded-2xl border border-border px-3 font-semibold text-muted-foreground transition hover:border-primary hover:text-primary disabled:cursor-not-allowed disabled:opacity-50"
+              onClick={handleNext}
+              disabled={!pagination.nextCursor || loading}
+            >
+              Selanjutnya
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/api/adminUsers.ts
+++ b/src/lib/api/adminUsers.ts
@@ -1,0 +1,195 @@
+import { supabase, SUPABASE_URL } from '../supabase.js';
+
+export type AdminUserProfile = {
+  role: 'admin' | 'user';
+  is_active: boolean;
+  full_name?: string | null;
+  username?: string | null;
+  avatar_url?: string | null;
+  locale?: string | null;
+  timezone?: string | null;
+  theme?: 'system' | 'light' | 'dark' | null;
+};
+
+export type AdminUserItem = {
+  id: string;
+  email: string;
+  created_at: string;
+  last_sign_in_at: string | null;
+  identities: { provider: string }[];
+  profile: AdminUserProfile;
+};
+
+export type ListUsersParams = {
+  q?: string;
+  role?: 'all' | 'admin' | 'user';
+  status?: 'all' | 'active' | 'inactive';
+  limit?: number;
+  offset?: number;
+  order?: `${'created_at' | 'last_sign_in_at' | 'email'}.${'asc' | 'desc'}`;
+};
+
+export type AdminUsersListResponse = {
+  items: AdminUserItem[];
+  limit: number;
+  offset: number;
+  total: number;
+  nextCursor: string | null;
+  previousCursor: string | null;
+};
+
+export type AdminUserProfileInput = Partial<{
+  role: 'admin' | 'user';
+  is_active: boolean;
+  full_name: string | null;
+  username: string | null;
+  avatar_url: string | null;
+  locale: string | null;
+  timezone: string | null;
+  theme: 'system' | 'light' | 'dark' | null;
+}>;
+
+export type CreateAdminUserPayload = {
+  email: string;
+  password?: string;
+  profile?: AdminUserProfileInput;
+  sendEmailInvite?: boolean;
+};
+
+export type UpdateAdminUserPayload = {
+  email?: string;
+  password?: string;
+  profile?: AdminUserProfileInput;
+};
+
+export type DeleteAdminUserOptions = {
+  mode?: 'soft' | 'hard';
+};
+
+type ApiErrorResponse = {
+  ok: false;
+  error: {
+    code?: string;
+    message?: string;
+    details?: unknown;
+  };
+};
+
+type ApiSuccessResponse<T> = {
+  ok: true;
+  data: T;
+};
+
+export class AdminUsersApiError extends Error {
+  code: string;
+  details?: unknown;
+
+  constructor(message: string, code = 'UNKNOWN', details?: unknown) {
+    super(message);
+    this.code = code;
+    this.details = details;
+  }
+}
+
+const BASE_URL = SUPABASE_URL ? `${SUPABASE_URL}/functions/v1/admin-users` : '/functions/v1/admin-users';
+
+async function getAccessToken(): Promise<string> {
+  const { data, error } = await supabase.auth.getSession();
+  if (error) {
+    throw new AdminUsersApiError(error.message ?? 'Gagal mendapatkan sesi', 'SESSION_ERROR');
+  }
+  const token = data.session?.access_token;
+  if (!token) {
+    throw new AdminUsersApiError('Harus login sebagai admin untuk mengakses fitur ini', 'NO_SESSION');
+  }
+  return token;
+}
+
+async function request<T>(
+  method: string,
+  path: string,
+  options: { body?: unknown; query?: URLSearchParams } = {}
+): Promise<T> {
+  const token = await getAccessToken();
+  const baseOrigin = BASE_URL.startsWith('http')
+    ? undefined
+    : typeof window !== 'undefined'
+      ? window.location.origin
+      : SUPABASE_URL ?? 'http://localhost';
+  const url = new URL(BASE_URL + path, baseOrigin);
+  if (options.query) {
+    options.query.forEach((value, key) => {
+      if (value != null) {
+        url.searchParams.set(key, value);
+      }
+    });
+  }
+
+  const response = await fetch(url.toString(), {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+
+  let payload: ApiErrorResponse | ApiSuccessResponse<T> | null = null;
+  try {
+    payload = (await response.json()) as typeof payload;
+  } catch (_error) {
+    payload = null;
+  }
+
+  if (!response.ok || !payload || !('ok' in payload)) {
+    throw new AdminUsersApiError('Permintaan ke server gagal', String(response.status));
+  }
+
+  if (!payload.ok) {
+    const code = payload.error?.code ?? String(response.status);
+    const message = payload.error?.message ?? 'Permintaan ke server gagal';
+    throw new AdminUsersApiError(message, code, payload.error?.details);
+  }
+
+  return payload.data as T;
+}
+
+function buildQuery(params: ListUsersParams | undefined): URLSearchParams {
+  const query = new URLSearchParams();
+  if (!params) return query;
+  if (params.q) query.set('q', params.q);
+  if (params.role && params.role !== 'all') query.set('role', params.role);
+  if (params.status && params.status !== 'all') query.set('status', params.status);
+  if (typeof params.limit === 'number') query.set('limit', String(params.limit));
+  if (typeof params.offset === 'number') query.set('offset', String(params.offset));
+  if (params.order) query.set('order', params.order);
+  return query;
+}
+
+export async function listAdminUsers(params?: ListUsersParams): Promise<AdminUsersListResponse> {
+  const query = buildQuery(params);
+  return await request<AdminUsersListResponse>('GET', '', { query });
+}
+
+export async function createAdminUser(payload: CreateAdminUserPayload): Promise<AdminUserItem> {
+  return await request<AdminUserItem>('POST', '', { body: payload });
+}
+
+export async function updateAdminUser(id: string, payload: UpdateAdminUserPayload): Promise<AdminUserItem> {
+  return await request<AdminUserItem>('PATCH', `/${encodeURIComponent(id)}`, { body: payload });
+}
+
+export async function deleteAdminUser(
+  id: string,
+  options: DeleteAdminUserOptions = {}
+): Promise<{ mode: 'soft' | 'hard'; user?: AdminUserItem }> {
+  const query = new URLSearchParams();
+  if (options.mode) {
+    query.set('mode', options.mode);
+  }
+  return await request<{ mode: 'soft' | 'hard'; user?: AdminUserItem }>(
+    'DELETE',
+    `/${encodeURIComponent(id)}`,
+    { query }
+  );
+}

--- a/src/pages/admin/UsersPage.tsx
+++ b/src/pages/admin/UsersPage.tsx
@@ -1,0 +1,423 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import clsx from 'clsx';
+import UserTable, { UserTablePagination } from '../../components/admin/users/UserTable';
+import UserFormModal, {
+  CreateUserFormValues,
+  UpdateUserFormValues,
+} from '../../components/admin/users/UserFormModal';
+import {
+  AdminUserItem,
+  AdminUsersApiError,
+  CreateAdminUserPayload,
+  DeleteAdminUserOptions,
+  ListUsersParams,
+  UpdateAdminUserPayload,
+  createAdminUser,
+  deleteAdminUser,
+  listAdminUsers,
+  updateAdminUser,
+} from '../../lib/api/adminUsers.ts';
+import { useToast } from '../../context/ToastContext.jsx';
+import { supabase } from '../../lib/supabase.js';
+import Modal from '../../components/Modal.jsx';
+
+type FilterState = {
+  q: string;
+  role: 'all' | 'admin' | 'user';
+  status: 'all' | 'active' | 'inactive';
+  order: `${'created_at' | 'last_sign_in_at' | 'email'}.${'asc' | 'desc'}`;
+};
+
+type DeleteState = {
+  user: AdminUserItem;
+  mode: 'hard' | 'soft';
+};
+
+const INPUT_CLASS =
+  'h-11 w-full rounded-2xl border border-border bg-background px-3 text-sm transition focus:outline-none focus:ring-2 focus:ring-primary';
+const SELECT_CLASS = clsx(INPUT_CLASS, 'pr-10');
+
+const ORDER_OPTIONS: Array<{ label: string; value: FilterState['order'] }> = [
+  { label: 'Dibuat terbaru', value: 'created_at.desc' },
+  { label: 'Dibuat terlama', value: 'created_at.asc' },
+  { label: 'Last sign-in terbaru', value: 'last_sign_in_at.desc' },
+  { label: 'Last sign-in terlama', value: 'last_sign_in_at.asc' },
+  { label: 'Email A-Z', value: 'email.asc' },
+  { label: 'Email Z-A', value: 'email.desc' },
+];
+
+function buildListParams(
+  filters: FilterState,
+  pagination: { limit: number; offset: number },
+  debouncedQuery: string
+): ListUsersParams {
+  return {
+    q: debouncedQuery || undefined,
+    role: filters.role,
+    status: filters.status,
+    order: filters.order,
+    limit: pagination.limit,
+    offset: pagination.offset,
+  };
+}
+
+export default function UsersPage() {
+  const { addToast } = useToast();
+  const [currentAdminId, setCurrentAdminId] = useState<string | null>(null);
+  const [users, setUsers] = useState<AdminUserItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filters, setFilters] = useState<FilterState>({
+    q: '',
+    role: 'all',
+    status: 'all',
+    order: 'created_at.desc',
+  });
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [pagination, setPagination] = useState<{ limit: number; offset: number }>({ limit: 20, offset: 0 });
+  const [pageMeta, setPageMeta] = useState<UserTablePagination | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [formMode, setFormMode] = useState<'create' | 'edit'>('create');
+  const [formSubmitting, setFormSubmitting] = useState(false);
+  const [selectedUser, setSelectedUser] = useState<AdminUserItem | null>(null);
+  const [forcePasswordReset, setForcePasswordReset] = useState(false);
+  const [deleteState, setDeleteState] = useState<DeleteState | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [togglingId, setTogglingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    supabase.auth.getUser().then(({ data }) => {
+      if (mounted) {
+        setCurrentAdminId(data.user?.id ?? null);
+      }
+    });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedQuery(filters.q.trim());
+    }, 400);
+    return () => window.clearTimeout(timeout);
+  }, [filters.q]);
+
+  const loadUsers = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = buildListParams(filters, pagination, debouncedQuery);
+      const response = await listAdminUsers(params);
+      setUsers(response.items);
+      setPageMeta({
+        limit: response.limit,
+        offset: response.offset,
+        total: response.total,
+        nextCursor: response.nextCursor,
+        previousCursor: response.previousCursor,
+      });
+    } catch (err) {
+      const message = err instanceof AdminUsersApiError ? err.message : 'Gagal memuat daftar pengguna';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [filters, pagination, debouncedQuery]);
+
+  useEffect(() => {
+    void loadUsers();
+  }, [loadUsers]);
+
+  const resetPagination = useCallback(() => {
+    setPagination((prev) => ({ ...prev, offset: 0 }));
+  }, []);
+
+  const handleFilterChange = <K extends keyof FilterState>(key: K, value: FilterState[K]) => {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+    resetPagination();
+  };
+
+  const handleNavigate = (offset: number) => {
+    setPagination((prev) => ({ ...prev, offset }));
+  };
+
+  const refresh = useCallback(async () => {
+    await loadUsers();
+  }, [loadUsers]);
+
+  const openCreateModal = () => {
+    setFormMode('create');
+    setSelectedUser(null);
+    setForcePasswordReset(false);
+    setShowForm(true);
+  };
+
+  const openEditModal = (user: AdminUserItem, forceReset = false) => {
+    setFormMode('edit');
+    setSelectedUser(user);
+    setForcePasswordReset(forceReset);
+    setShowForm(true);
+  };
+
+  const closeForm = () => {
+    setShowForm(false);
+    setSelectedUser(null);
+    setForcePasswordReset(false);
+  };
+
+  const handleCreateSubmit = async (values: CreateUserFormValues) => {
+    setFormSubmitting(true);
+    try {
+      await createAdminUser(values as CreateAdminUserPayload);
+      addToast('Pengguna berhasil dibuat', 'success');
+      closeForm();
+      await refresh();
+    } catch (err) {
+      const message = err instanceof AdminUsersApiError ? err.message : 'Gagal membuat pengguna baru';
+      addToast(message, 'error');
+    } finally {
+      setFormSubmitting(false);
+    }
+  };
+
+  const handleUpdateSubmit = async (values: UpdateUserFormValues) => {
+    if (!selectedUser) return;
+    setFormSubmitting(true);
+    try {
+      const updated = await updateAdminUser(selectedUser.id, values as UpdateAdminUserPayload);
+      setUsers((prev) => prev.map((user) => (user.id === updated.id ? updated : user)));
+      addToast('Perubahan pengguna disimpan', 'success');
+      closeForm();
+    } catch (err) {
+      const message = err instanceof AdminUsersApiError ? err.message : 'Gagal memperbarui pengguna';
+      addToast(message, 'error');
+    } finally {
+      setFormSubmitting(false);
+    }
+  };
+
+  const handleFormSubmit = (values: CreateUserFormValues | UpdateUserFormValues) => {
+    if (formMode === 'create') {
+      void handleCreateSubmit(values as CreateUserFormValues);
+    } else {
+      void handleUpdateSubmit(values as UpdateUserFormValues);
+    }
+  };
+
+  const handleToggleActive = async (user: AdminUserItem, nextState: boolean) => {
+    const previousState = user.profile.is_active;
+    setUsers((prev) =>
+      prev.map((item) =>
+        item.id === user.id ? { ...item, profile: { ...item.profile, is_active: nextState } } : item
+      )
+    );
+    setTogglingId(user.id);
+    try {
+      const updated = await updateAdminUser(user.id, { profile: { is_active: nextState } });
+      setUsers((prev) => prev.map((item) => (item.id === updated.id ? updated : item)));
+      addToast('Status pengguna diperbarui', 'success');
+    } catch (err) {
+      setUsers((prev) =>
+        prev.map((item) =>
+          item.id === user.id ? { ...item, profile: { ...item.profile, is_active: previousState } } : item
+        )
+      );
+      const message = err instanceof AdminUsersApiError ? err.message : 'Gagal memperbarui status pengguna';
+      addToast(message, 'error');
+    } finally {
+      setTogglingId(null);
+    }
+  };
+
+  const handleDelete = (user: AdminUserItem) => {
+    setDeleteState({ user, mode: 'hard' });
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteState) return;
+    const { user, mode } = deleteState;
+    setDeletingId(user.id);
+    try {
+      const options: DeleteAdminUserOptions = { mode };
+      const result = await deleteAdminUser(user.id, options);
+      if (result.mode === 'soft') {
+        if (result.user) {
+          setUsers((prev) => prev.map((item) => (item.id === user.id ? result.user! : item)));
+        } else {
+          await refresh();
+        }
+        addToast('Pengguna dinonaktifkan', 'success');
+      } else {
+        setUsers((prev) => prev.filter((item) => item.id !== user.id));
+        addToast('Pengguna dihapus', 'success');
+      }
+      setDeleteState(null);
+    } catch (err) {
+      const message = err instanceof AdminUsersApiError ? err.message : 'Gagal menghapus pengguna';
+      addToast(message, 'error');
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const cancelDelete = () => {
+    setDeleteState(null);
+  };
+
+  const disableToggleIds = useMemo(() => {
+    return new Set<string>();
+  }, []);
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <p className="text-xs font-medium text-muted-foreground">Dashboard / Admin / Users</p>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">Kelola Pengguna</h1>
+            <p className="text-sm text-muted-foreground">
+              Lihat, cari, dan kelola akun pengguna secara aman menggunakan Edge Function.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={openCreateModal}
+            className="h-11 rounded-2xl bg-primary px-5 text-sm font-semibold text-white transition hover:bg-primary/90"
+          >
+            Tambah Pengguna
+          </button>
+        </div>
+      </header>
+
+      <section className="grid gap-3 rounded-2xl border border-border/60 bg-muted/10 p-4 md:grid-cols-5 md:p-6">
+        <label className="md:col-span-2">
+          <span className="text-xs font-semibold text-muted-foreground">Cari</span>
+          <input
+            value={filters.q}
+            onChange={(event) => handleFilterChange('q', event.target.value)}
+            className={clsx(INPUT_CLASS, 'mt-1')}
+            placeholder="Cari email, nama, atau username"
+          />
+        </label>
+        <label>
+          <span className="text-xs font-semibold text-muted-foreground">Peran</span>
+          <select
+            value={filters.role}
+            onChange={(event) => handleFilterChange('role', event.target.value as FilterState['role'])}
+            className={clsx(SELECT_CLASS, 'mt-1')}
+          >
+            <option value="all">Semua</option>
+            <option value="admin">Admin</option>
+            <option value="user">User</option>
+          </select>
+        </label>
+        <label>
+          <span className="text-xs font-semibold text-muted-foreground">Status</span>
+          <select
+            value={filters.status}
+            onChange={(event) => handleFilterChange('status', event.target.value as FilterState['status'])}
+            className={clsx(SELECT_CLASS, 'mt-1')}
+          >
+            <option value="all">Semua</option>
+            <option value="active">Aktif</option>
+            <option value="inactive">Nonaktif</option>
+          </select>
+        </label>
+        <label>
+          <span className="text-xs font-semibold text-muted-foreground">Urutkan</span>
+          <select
+            value={filters.order}
+            onChange={(event) => handleFilterChange('order', event.target.value as FilterState['order'])}
+            className={clsx(SELECT_CLASS, 'mt-1')}
+          >
+            {ORDER_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </section>
+
+      <UserTable
+        items={users}
+        loading={loading}
+        error={error}
+        pagination={pageMeta}
+        currentAdminId={currentAdminId}
+        togglingId={togglingId}
+        deletingId={deletingId}
+        disableToggleIds={disableToggleIds}
+        onRetry={() => void loadUsers()}
+        onToggleActive={handleToggleActive}
+        onEdit={(user) => openEditModal(user)}
+        onResetPassword={(user) => openEditModal(user, true)}
+        onDelete={handleDelete}
+        onNavigate={handleNavigate}
+      />
+
+      <UserFormModal
+        open={showForm}
+        mode={formMode}
+        initialUser={selectedUser ?? undefined}
+        submitting={formSubmitting}
+        forcePasswordReset={forcePasswordReset}
+        onClose={closeForm}
+        onSubmit={handleFormSubmit}
+      />
+
+      <Modal open={deleteState != null} title="Konfirmasi penghapusan" onClose={cancelDelete}>
+        {deleteState ? (
+          <div className="space-y-5">
+            <p className="text-sm text-muted-foreground">
+              Anda akan {deleteState.mode === 'hard' ? 'menghapus permanen' : 'menonaktifkan'} akun{' '}
+              <span className="font-semibold text-foreground">{deleteState.user.email}</span>. Pilih mode penghapusan dan
+              konfirmasi aksi ini.
+            </p>
+            <div className="space-y-3">
+              <label className="flex items-center gap-3 text-sm">
+                <input
+                  type="radio"
+                  name="delete-mode"
+                  value="soft"
+                  checked={deleteState.mode === 'soft'}
+                  onChange={() => setDeleteState((prev) => (prev ? { ...prev, mode: 'soft' } : prev))}
+                />
+                Nonaktifkan akun (soft delete)
+              </label>
+              <label className="flex items-center gap-3 text-sm">
+                <input
+                  type="radio"
+                  name="delete-mode"
+                  value="hard"
+                  checked={deleteState.mode === 'hard'}
+                  onChange={() => setDeleteState((prev) => (prev ? { ...prev, mode: 'hard' } : prev))}
+                />
+                Hapus permanen akun dan profil (hard delete)
+              </label>
+            </div>
+            <div className="flex flex-wrap justify-end gap-3">
+              <button
+                type="button"
+                onClick={cancelDelete}
+                className="h-11 rounded-2xl border border-border px-4 text-sm font-medium text-muted-foreground transition hover:border-primary hover:text-primary"
+              >
+                Batal
+              </button>
+              <button
+                type="button"
+                onClick={confirmDelete}
+                className="h-11 rounded-2xl border border-destructive/40 px-4 text-sm font-semibold text-destructive transition hover:border-destructive hover:bg-destructive/10"
+                disabled={deletingId === deleteState.user.id}
+              >
+                {deleteState.mode === 'hard' ? 'Hapus' : 'Nonaktifkan'}
+              </button>
+            </div>
+          </div>
+        ) : null}
+      </Modal>
+    </div>
+  );
+}

--- a/supabase/functions/admin-users/index.ts
+++ b/supabase/functions/admin-users/index.ts
@@ -1,0 +1,661 @@
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { createClient, type SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2.57.4';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'GET, POST, PATCH, DELETE, OPTIONS',
+};
+
+type JsonRecord = Record<string, unknown>;
+
+type AdminUserProfile = {
+  role: 'admin' | 'user';
+  is_active: boolean;
+  full_name?: string | null;
+  username?: string | null;
+  avatar_url?: string | null;
+  locale?: string | null;
+  timezone?: string | null;
+  theme?: string | null;
+};
+
+type AdminUserItem = {
+  id: string;
+  email: string;
+  created_at: string;
+  last_sign_in_at: string | null;
+  identities: { provider: string }[];
+  profile: AdminUserProfile;
+};
+
+type PaginatedUsers = {
+  items: AdminUserItem[];
+  limit: number;
+  offset: number;
+  total: number;
+  nextCursor: string | null;
+  previousCursor: string | null;
+};
+
+type RequestContext = {
+  request: Request;
+  supabaseClient: SupabaseClient;
+  adminClient: SupabaseClient;
+  adminUserId: string;
+};
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL');
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+const SUPABASE_ANON_KEY =
+  Deno.env.get('SUPABASE_ANON_KEY') ?? Deno.env.get('SUPABASE_ANON_KEY'.toUpperCase());
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  console.error('Missing Supabase environment variables for Edge Function');
+  throw new Error('Missing Supabase environment configuration');
+}
+
+function buildResponse(status: number, payload: JsonRecord) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      ...corsHeaders,
+    },
+  });
+}
+
+function errorResponse(status: number, code: string, message: string, details?: JsonRecord) {
+  return buildResponse(status, {
+    ok: false,
+    error: { code, message, ...(details ? { details } : {}) },
+  });
+}
+
+function successResponse(data: unknown, status = 200) {
+  return buildResponse(status, { ok: true, data });
+}
+
+function parseBoolean(value: unknown, fallback = false): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value !== 0;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true' || normalized === '1' || normalized === 'yes') return true;
+    if (normalized === 'false' || normalized === '0' || normalized === 'no') return false;
+  }
+  return fallback;
+}
+
+function isValidEmail(email: string): boolean {
+  const trimmed = email.trim();
+  if (!trimmed) return false;
+  // Simple RFC compliant-ish regex
+  const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return EMAIL_REGEX.test(trimmed);
+}
+
+function isValidPassword(password: string): boolean {
+  if (password.length < 8) return false;
+  const hasUpper = /[A-Z]/.test(password);
+  const hasLower = /[a-z]/.test(password);
+  const hasDigit = /\d/.test(password);
+  return hasUpper && hasLower && hasDigit;
+}
+
+function normalizeOrder(orderParam: string | null | undefined): {
+  field: 'created_at' | 'last_sign_in_at' | 'email';
+  direction: 'asc' | 'desc';
+} {
+  const DEFAULT = { field: 'created_at', direction: 'desc' as const };
+  if (!orderParam) return DEFAULT;
+  const [fieldRaw, directionRaw] = orderParam.split('.');
+  const field = ['created_at', 'last_sign_in_at', 'email'].includes(fieldRaw ?? '')
+    ? (fieldRaw as 'created_at' | 'last_sign_in_at' | 'email')
+    : DEFAULT.field;
+  const direction = directionRaw === 'asc' ? 'asc' : directionRaw === 'desc' ? 'desc' : DEFAULT.direction;
+  return { field, direction };
+}
+
+function parseLimit(value: string | null): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 20;
+  return Math.min(parsed, 100);
+}
+
+function parseOffset(offsetParam: string | null, cursorParam: string | null, limit: number): number {
+  if (offsetParam) {
+    const parsed = Number.parseInt(offsetParam, 10);
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  }
+  if (cursorParam) {
+    const direct = Number.parseInt(cursorParam, 10);
+    if (Number.isFinite(direct) && direct >= 0) return direct;
+    try {
+      const decoded = Number.parseInt(atob(cursorParam), 10);
+      if (Number.isFinite(decoded) && decoded >= 0) return decoded;
+    } catch (_err) {
+      // Ignore invalid base64 cursor
+    }
+  }
+  return 0;
+}
+
+function normalizeProfilePayload(input: any): Partial<AdminUserProfile> {
+  if (!input || typeof input !== 'object') return {};
+  const profile: Partial<AdminUserProfile> = {};
+  if (input.role === 'admin' || input.role === 'user') {
+    profile.role = input.role;
+  }
+  if (typeof input.is_active === 'boolean') {
+    profile.is_active = input.is_active;
+  }
+  if (typeof input.full_name === 'string') profile.full_name = input.full_name.trim() || null;
+  if (typeof input.username === 'string') profile.username = input.username.trim() || null;
+  if (typeof input.avatar_url === 'string') profile.avatar_url = input.avatar_url.trim() || null;
+  if (typeof input.locale === 'string') profile.locale = input.locale.trim() || null;
+  if (typeof input.timezone === 'string') profile.timezone = input.timezone.trim() || null;
+  if (typeof input.theme === 'string' && ['system', 'light', 'dark'].includes(input.theme)) {
+    profile.theme = input.theme;
+  }
+  return profile;
+}
+
+function mapUser(row: any): AdminUserItem {
+  const identitiesData = Array.isArray(row?.identities)
+    ? (row.identities as any[])
+    : typeof row?.identities === 'string'
+      ? (() => {
+          try {
+            const parsed = JSON.parse(row.identities);
+            return Array.isArray(parsed) ? parsed : [];
+          } catch (_err) {
+            return [];
+          }
+        })()
+      : [];
+  const identities = identitiesData
+    .map((item: any) => ({ provider: String(item?.provider ?? 'unknown') }))
+    .filter((item: { provider: string }) => Boolean(item.provider));
+
+  const profile: AdminUserProfile = {
+    role: row?.profile_role === 'admin' ? 'admin' : 'user',
+    is_active: parseBoolean(row?.profile_is_active, true),
+    full_name: row?.profile_full_name ?? null,
+    username: row?.profile_username ?? null,
+    avatar_url: row?.profile_avatar_url ?? null,
+    locale: row?.profile_locale ?? null,
+    timezone: row?.profile_timezone ?? null,
+    theme: row?.profile_theme ?? null,
+  };
+
+  return {
+    id: String(row?.id ?? ''),
+    email: String(row?.email ?? ''),
+    created_at: new Date(row?.created_at ?? Date.now()).toISOString(),
+    last_sign_in_at: row?.last_sign_in_at ? new Date(row.last_sign_in_at).toISOString() : null,
+    identities,
+    profile,
+  };
+}
+
+async function fetchUserById(adminClient: SupabaseClient, userId: string): Promise<AdminUserItem | null> {
+  const { data: userData, error: userError } = await adminClient.auth.admin.getUserById(userId);
+  if (userError) {
+    console.error('[admin-users] failed to fetch auth user', userError);
+    return null;
+  }
+  const authUser = userData?.user;
+  if (!authUser) {
+    return null;
+  }
+
+  const { data: profileData, error: profileError } = await adminClient
+    .from('user_profiles')
+    .select('role, is_active, full_name, username, avatar_url, locale, timezone, theme')
+    .eq('id', userId)
+    .maybeSingle();
+
+  if (profileError) {
+    console.error('[admin-users] failed to fetch profile', profileError);
+  }
+
+  const profile: AdminUserProfile = {
+    role: profileData?.role === 'admin' ? 'admin' : 'user',
+    is_active: parseBoolean(profileData?.is_active, true),
+    full_name: profileData?.full_name ?? null,
+    username: profileData?.username ?? null,
+    avatar_url: profileData?.avatar_url ?? null,
+    locale: profileData?.locale ?? null,
+    timezone: profileData?.timezone ?? null,
+    theme: profileData?.theme ?? null,
+  };
+
+  const identities = Array.isArray(authUser.identities)
+    ? authUser.identities.map((item: any) => ({ provider: String(item?.provider ?? 'unknown') }))
+    : [];
+
+  return {
+    id: authUser.id,
+    email: authUser.email ?? '',
+    created_at: authUser.created_at ?? new Date().toISOString(),
+    last_sign_in_at: authUser.last_sign_in_at ?? null,
+    identities,
+    profile,
+  };
+}
+
+async function logAdminAction(
+  adminClient: SupabaseClient,
+  adminId: string,
+  action: string,
+  targetUserId: string,
+  details: JsonRecord = {}
+) {
+  const payload = {
+    admin_id: adminId,
+    action,
+    target_user_id: targetUserId,
+    details,
+  };
+  const { error } = await adminClient.from('admin_audit_logs').insert(payload);
+  if (error) {
+    console.error('[admin-users] failed to log audit entry', error);
+  }
+}
+
+async function ensureProfile(adminClient: SupabaseClient, userId: string, profile: Partial<AdminUserProfile>) {
+  const defaultProfile: Partial<AdminUserProfile> = {
+    role: profile.role ?? 'user',
+    is_active: profile.is_active ?? true,
+    full_name: profile.full_name ?? null,
+    username: profile.username ?? null,
+    avatar_url: profile.avatar_url ?? null,
+    locale: profile.locale ?? 'id-ID',
+    timezone: profile.timezone ?? 'Asia/Jakarta',
+    theme: profile.theme ?? 'system',
+  };
+
+  const { error } = await adminClient
+    .from('user_profiles')
+    .upsert(
+      { id: userId, ...defaultProfile },
+      { onConflict: 'id' }
+    );
+
+  if (error) {
+    console.error('[admin-users] failed to upsert profile', error);
+    throw error;
+  }
+}
+
+async function authenticate(request: Request): Promise<RequestContext> {
+  if (!SUPABASE_ANON_KEY) {
+    throw new Error('Missing anon key');
+  }
+  const authorization = request.headers.get('Authorization');
+  if (!authorization) {
+    throw new Error('MissingAuthorization');
+  }
+
+  const supabaseClient = createClient(SUPABASE_URL!, SUPABASE_ANON_KEY, {
+    global: { headers: { Authorization: authorization } },
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const adminClient = createClient(SUPABASE_URL!, SUPABASE_SERVICE_ROLE_KEY!, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const { data, error } = await supabaseClient.auth.getUser();
+  if (error || !data?.user) {
+    throw new Error('Unauthorized');
+  }
+  const authUser = data.user;
+
+  const { data: profile, error: profileError } = await adminClient
+    .from('user_profiles')
+    .select('role, is_active')
+    .eq('id', authUser.id)
+    .maybeSingle();
+
+  if (profileError) {
+    console.error('[admin-users] failed to load admin profile', profileError);
+    throw new Error('Unauthorized');
+  }
+
+  const isAdmin = profile?.role === 'admin' && parseBoolean(profile?.is_active, true);
+  if (!isAdmin) {
+    throw new Error('Forbidden');
+  }
+
+  return { request, supabaseClient, adminClient, adminUserId: authUser.id };
+}
+
+async function handleListUsers(context: RequestContext) {
+  const { request, adminClient } = context;
+  const url = new URL(request.url);
+  const q = url.searchParams.get('q') ?? url.searchParams.get('query');
+  const roleParam = url.searchParams.get('role');
+  const statusParam = url.searchParams.get('status');
+  const limit = parseLimit(url.searchParams.get('limit'));
+  const { field, direction } = normalizeOrder(url.searchParams.get('order'));
+  const offset = parseOffset(url.searchParams.get('offset'), url.searchParams.get('cursor'), limit);
+
+  const normalizedRole = roleParam === 'admin' || roleParam === 'user' ? roleParam : null;
+  const normalizedStatus = statusParam === 'active' || statusParam === 'inactive' ? statusParam : null;
+
+  const { data, error } = await adminClient.rpc('admin_list_users', {
+    search: q && q.trim() ? q.trim() : null,
+    role: normalizedRole,
+    status: normalizedStatus,
+    limit_count: limit,
+    offset_count: offset,
+    order_field: field,
+    order_direction: direction,
+  });
+
+  if (error) {
+    console.error('[admin-users] list users failed', error);
+    return errorResponse(500, 'LIST_USERS_FAILED', 'Gagal memuat daftar pengguna');
+  }
+
+  const items = Array.isArray(data) ? data.map(mapUser) : [];
+  const total = Array.isArray(data) && data.length > 0 && typeof data[0]?.total_count === 'number'
+    ? Number(data[0].total_count)
+    : items.length;
+
+  const nextOffset = offset + items.length;
+  const hasNext = nextOffset < total;
+  const previousOffset = Math.max(offset - limit, 0);
+  const pagination: PaginatedUsers = {
+    items,
+    limit,
+    offset,
+    total,
+    nextCursor: hasNext ? String(nextOffset) : null,
+    previousCursor: offset > 0 ? String(previousOffset) : null,
+  };
+
+  return successResponse(pagination);
+}
+
+async function handleCreateUser(context: RequestContext) {
+  const { request, adminClient, adminUserId } = context;
+  const payload = await request.json().catch(() => null);
+  if (!payload || typeof payload !== 'object') {
+    return errorResponse(400, 'INVALID_BODY', 'Payload tidak valid');
+  }
+
+  const email = typeof payload.email === 'string' ? payload.email.trim() : '';
+  const password = typeof payload.password === 'string' ? payload.password : '';
+  const sendEmailInvite = parseBoolean(payload.sendEmailInvite, false);
+  const profilePayload = normalizeProfilePayload((payload as any).profile ?? {});
+
+  if (!isValidEmail(email)) {
+    return errorResponse(400, 'INVALID_EMAIL', 'Email tidak valid');
+  }
+
+  if (!sendEmailInvite && !isValidPassword(password)) {
+    return errorResponse(400, 'INVALID_PASSWORD', 'Password harus minimal 8 karakter dan mengandung huruf besar, huruf kecil, serta angka');
+  }
+
+  try {
+    let userId: string | null = null;
+    if (sendEmailInvite) {
+      const response = await adminClient.auth.admin.inviteUserByEmail({ email });
+      if (response.error) {
+        const code = response.error.status === 409 ? 'EMAIL_CONFLICT' : 'INVITE_FAILED';
+        return errorResponse(response.error.status ?? 500, code, response.error.message ?? 'Gagal mengundang pengguna');
+      }
+      userId = response.data?.user?.id ?? null;
+    } else {
+      const response = await adminClient.auth.admin.createUser({
+        email,
+        password,
+        email_confirm: true,
+      });
+      if (response.error) {
+        const code = response.error.status === 409 ? 'EMAIL_CONFLICT' : 'CREATE_FAILED';
+        return errorResponse(response.error.status ?? 500, code, response.error.message ?? 'Gagal membuat pengguna');
+      }
+      userId = response.data?.user?.id ?? null;
+    }
+
+    if (!userId) {
+      return errorResponse(500, 'CREATE_FAILED', 'Tidak dapat menentukan ID pengguna baru');
+    }
+
+    await ensureProfile(adminClient, userId, profilePayload);
+    await logAdminAction(adminClient, adminUserId, 'create', userId, {
+      email,
+      sendEmailInvite,
+      profile: profilePayload,
+    });
+
+    const user = await fetchUserById(adminClient, userId);
+    if (!user) {
+      return errorResponse(500, 'FETCH_FAILED', 'Pengguna berhasil dibuat tetapi gagal dimuat ulang');
+    }
+
+    return successResponse(user, 201);
+  } catch (error) {
+    console.error('[admin-users] create user unexpected error', error);
+    return errorResponse(500, 'CREATE_FAILED', 'Terjadi kesalahan saat membuat pengguna');
+  }
+}
+
+async function validateAdminTransition(
+  adminClient: SupabaseClient,
+  targetUserId: string,
+  updates: Partial<AdminUserProfile>
+) {
+  if (!updates) return;
+  const willDemote = typeof updates.role === 'string' && updates.role !== 'admin';
+  const willDeactivate = typeof updates.is_active === 'boolean' && !updates.is_active;
+  if (!willDemote && !willDeactivate) {
+    return;
+  }
+
+  const { data: current, error } = await adminClient
+    .from('user_profiles')
+    .select('role, is_active')
+    .eq('id', targetUserId)
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  const currentRole = current?.role === 'admin' ? 'admin' : 'user';
+  const currentActive = parseBoolean(current?.is_active, true);
+
+  const nextRole = updates.role ?? currentRole;
+  const nextActive = typeof updates.is_active === 'boolean' ? updates.is_active : currentActive;
+
+  if (currentRole === 'admin' && (!nextActive || nextRole !== 'admin')) {
+    const { data: admins, error: adminsError } = await adminClient
+      .from('user_profiles')
+      .select('id')
+      .eq('role', 'admin')
+      .eq('is_active', true)
+      .neq('id', targetUserId);
+
+    if (adminsError) throw adminsError;
+    if (!admins || admins.length === 0) {
+      throw new Error('Tidak dapat menonaktifkan atau menurunkan admin terakhir');
+    }
+  }
+}
+
+async function handleUpdateUser(context: RequestContext, userId: string) {
+  const { request, adminClient, adminUserId } = context;
+  const payload = await request.json().catch(() => null);
+  if (!payload || typeof payload !== 'object') {
+    return errorResponse(400, 'INVALID_BODY', 'Payload tidak valid');
+  }
+
+  const authUpdate: { email?: string; password?: string } = {};
+  if (typeof payload.email === 'string') {
+    const email = payload.email.trim();
+    if (!isValidEmail(email)) {
+      return errorResponse(400, 'INVALID_EMAIL', 'Email tidak valid');
+    }
+    authUpdate.email = email;
+  }
+  if (typeof payload.password === 'string' && payload.password.trim()) {
+    if (!isValidPassword(payload.password)) {
+      return errorResponse(400, 'INVALID_PASSWORD', 'Password harus minimal 8 karakter dan mengandung huruf besar, huruf kecil, serta angka');
+    }
+    authUpdate.password = payload.password;
+  }
+
+  const profileUpdates = normalizeProfilePayload((payload as any).profile ?? {});
+
+  try {
+    if (Object.keys(authUpdate).length > 0) {
+      const response = await adminClient.auth.admin.updateUserById(userId, authUpdate);
+      if (response.error) {
+        return errorResponse(
+          response.error.status ?? 500,
+          'UPDATE_FAILED',
+          response.error.message ?? 'Gagal memperbarui pengguna'
+        );
+      }
+    }
+
+    if (Object.keys(profileUpdates).length > 0) {
+      await validateAdminTransition(adminClient, userId, profileUpdates);
+      const updatePayload: Record<string, unknown> = {};
+      if (profileUpdates.role) {
+        updatePayload.role = profileUpdates.role;
+      }
+      if (typeof profileUpdates.is_active === 'boolean') {
+        updatePayload.is_active = profileUpdates.is_active;
+      }
+      if (profileUpdates.full_name !== undefined) updatePayload.full_name = profileUpdates.full_name;
+      if (profileUpdates.username !== undefined) updatePayload.username = profileUpdates.username;
+      if (profileUpdates.avatar_url !== undefined) updatePayload.avatar_url = profileUpdates.avatar_url;
+      if (profileUpdates.locale !== undefined) updatePayload.locale = profileUpdates.locale ?? 'id-ID';
+      if (profileUpdates.timezone !== undefined) updatePayload.timezone = profileUpdates.timezone ?? 'Asia/Jakarta';
+      if (profileUpdates.theme !== undefined) updatePayload.theme = profileUpdates.theme ?? 'system';
+
+      const { error } = await adminClient
+        .from('user_profiles')
+        .update(updatePayload)
+        .eq('id', userId);
+
+      if (error) {
+        return errorResponse(500, 'UPDATE_PROFILE_FAILED', 'Gagal memperbarui profil pengguna');
+      }
+    }
+
+    if (Object.keys(authUpdate).length === 0 && Object.keys(profileUpdates).length === 0) {
+      return errorResponse(400, 'NO_CHANGES', 'Tidak ada perubahan yang diberikan');
+    }
+
+    await logAdminAction(adminClient, adminUserId, 'update', userId, {
+      auth: authUpdate,
+      profile: profileUpdates,
+    });
+
+    const user = await fetchUserById(adminClient, userId);
+    if (!user) {
+      return errorResponse(404, 'NOT_FOUND', 'Pengguna tidak ditemukan setelah diperbarui');
+    }
+
+    return successResponse(user);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Terjadi kesalahan saat memperbarui pengguna';
+    return errorResponse(500, 'UPDATE_FAILED', message);
+  }
+}
+
+async function handleDeleteUser(context: RequestContext, userId: string) {
+  const { request, adminClient, adminUserId } = context;
+  const url = new URL(request.url);
+  const mode = url.searchParams.get('mode') === 'soft' ? 'soft' : 'hard';
+
+  try {
+    if (mode === 'soft') {
+      const { error } = await adminClient
+        .from('user_profiles')
+        .update({ is_active: false })
+        .eq('id', userId);
+      if (error) {
+        return errorResponse(500, 'DEACTIVATE_FAILED', 'Gagal menonaktifkan pengguna');
+      }
+      await logAdminAction(adminClient, adminUserId, 'toggle_active', userId, { is_active: false });
+      const user = await fetchUserById(adminClient, userId);
+      return successResponse({ mode: 'soft', user });
+    }
+
+    const response = await adminClient.auth.admin.deleteUser(userId);
+    if (response.error) {
+      return errorResponse(
+        response.error.status ?? 500,
+        'DELETE_FAILED',
+        response.error.message ?? 'Gagal menghapus pengguna'
+      );
+    }
+
+    const { error } = await adminClient.from('user_profiles').delete().eq('id', userId);
+    if (error) {
+      console.error('[admin-users] failed to delete profile after auth deletion', error);
+    }
+
+    await logAdminAction(adminClient, adminUserId, 'delete', userId, { mode: 'hard' });
+    return successResponse({ mode: 'hard' });
+  } catch (error) {
+    console.error('[admin-users] delete user unexpected error', error);
+    return errorResponse(500, 'DELETE_FAILED', 'Terjadi kesalahan saat menghapus pengguna');
+  }
+}
+
+serve(async (request) => {
+  if (request.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  let context: RequestContext;
+  try {
+    context = await authenticate(request);
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message === 'MissingAuthorization') {
+        return errorResponse(401, 'MISSING_AUTHORIZATION', 'Header Authorization diperlukan');
+      }
+      if (error.message === 'Unauthorized') {
+        return errorResponse(401, 'UNAUTHORIZED', 'Sesi tidak valid atau kedaluwarsa');
+      }
+      if (error.message === 'Forbidden') {
+        return errorResponse(403, 'FORBIDDEN', 'Hanya admin aktif yang dapat mengakses fitur ini');
+      }
+    }
+    console.error('[admin-users] authentication error', error);
+    return errorResponse(401, 'UNAUTHORIZED', 'Autentikasi gagal');
+  }
+
+  const url = new URL(request.url);
+  const idMatch = url.pathname.match(/admin-users\/?([^/?]*)?$/);
+  const userId = idMatch && idMatch[1] ? idMatch[1] : null;
+
+  switch (request.method.toUpperCase()) {
+    case 'GET':
+      return await handleListUsers(context);
+    case 'POST':
+      return await handleCreateUser(context);
+    case 'PATCH':
+      if (!userId) {
+        return errorResponse(400, 'MISSING_ID', 'ID pengguna harus disediakan pada path');
+      }
+      return await handleUpdateUser(context, userId);
+    case 'DELETE':
+      if (!userId) {
+        return errorResponse(400, 'MISSING_ID', 'ID pengguna harus disediakan pada path');
+      }
+      return await handleDeleteUser(context, userId);
+    default:
+      return errorResponse(405, 'METHOD_NOT_ALLOWED', 'Metode tidak diizinkan');
+  }
+});

--- a/supabase/migrations/20250506000000_admin_users_support.sql
+++ b/supabase/migrations/20250506000000_admin_users_support.sql
@@ -1,0 +1,92 @@
+-- Ensure user_profiles has role and is_active columns for admin management
+alter table public.user_profiles
+  add column if not exists role text not null default 'user' check (role in ('user','admin')),
+  add column if not exists is_active boolean not null default true;
+
+create index if not exists user_profiles_role_idx on public.user_profiles (role);
+create index if not exists user_profiles_is_active_idx on public.user_profiles (is_active);
+
+-- Audit log table for admin actions
+create table if not exists public.admin_audit_logs (
+  id uuid primary key default gen_random_uuid(),
+  admin_id uuid not null references auth.users (id) on delete cascade,
+  action text not null,
+  target_user_id uuid not null,
+  details jsonb not null default '{}',
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists admin_audit_logs_admin_id_idx on public.admin_audit_logs (admin_id);
+create index if not exists admin_audit_logs_target_user_id_idx on public.admin_audit_logs (target_user_id);
+
+-- Helper view/function to list users with joined profile details
+create or replace function public.admin_list_users(
+  search text default null,
+  role text default null,
+  status text default null,
+  limit_count integer default 20,
+  offset_count integer default 0,
+  order_field text default 'created_at',
+  order_direction text default 'desc'
+)
+returns table (
+  id uuid,
+  email text,
+  created_at timestamptz,
+  last_sign_in_at timestamptz,
+  identities jsonb,
+  profile_role text,
+  profile_is_active boolean,
+  profile_full_name text,
+  profile_username text,
+  profile_avatar_url text,
+  profile_locale text,
+  profile_timezone text,
+  profile_theme text,
+  total_count bigint
+)
+security definer
+set search_path = public, extensions
+language sql
+as $$
+  select
+    u.id,
+    u.email,
+    u.created_at,
+    u.last_sign_in_at,
+    coalesce(u.identities, '[]'::jsonb) as identities,
+    p.role as profile_role,
+    p.is_active as profile_is_active,
+    p.full_name as profile_full_name,
+    p.username as profile_username,
+    p.avatar_url as profile_avatar_url,
+    p.locale as profile_locale,
+    p.timezone as profile_timezone,
+    p.theme as profile_theme,
+    count(*) over () as total_count
+  from auth.users u
+  join public.user_profiles p on p.id = u.id
+  where
+    (coalesce(role, '') = '' or role = 'all' or p.role = role)
+    and (
+      coalesce(status, '') = '' or status = 'all' or
+      (status = 'active' and coalesce(p.is_active, true) is true) or
+      (status = 'inactive' and coalesce(p.is_active, false) is false)
+    )
+    and (
+      coalesce(search, '') = '' or
+      u.email ilike '%' || search || '%' or
+      coalesce(p.username, '') ilike '%' || search || '%' or
+      coalesce(p.full_name, '') ilike '%' || search || '%'
+    )
+  order by
+    case when order_field = 'email' and lower(order_direction) = 'asc' then u.email end asc nulls last,
+    case when order_field = 'email' and lower(order_direction) = 'desc' then u.email end desc nulls last,
+    case when order_field = 'last_sign_in_at' and lower(order_direction) = 'asc' then u.last_sign_in_at end asc nulls last,
+    case when order_field = 'last_sign_in_at' and lower(order_direction) = 'desc' then u.last_sign_in_at end desc nulls last,
+    case when order_field = 'created_at' and lower(order_direction) = 'asc' then u.created_at end asc nulls last,
+    case when order_field = 'created_at' and lower(order_direction) = 'desc' then u.created_at end desc nulls last,
+    u.created_at desc
+  limit greatest(limit_count, 1)
+  offset greatest(offset_count, 0);
+$$;


### PR DESCRIPTION
## Summary
- introduce a Supabase Edge Function that authenticates admins, wraps auth.admin operations, and exposes paginated CRUD endpoints for users
- extend the database with role/is_active columns, an audit log, and a helper RPC used by the client to search/filter joined auth and profile data
- add a /admin/users React page with table, filters, modal forms, and delete confirmation that uses a new API client wrapper and integrates with the router

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d921f246d08332902795c5e39a9871