### PR TITLE
Add admin users management UI and Edge Function

### DIFF
--- a/src/components/admin/users/UserFormModal.tsx
+++ b/src/components/admin/users/UserFormModal.tsx
@@ -1,0 +1,305 @@
+import { useEffect, useMemo, useState } from 'react';
+import clsx from 'clsx';
+import type { AdminUserItem, AdminUserProfile } from '../../../lib/api/adminUsers';
+
+export type UserFormValues = {
+  email: string;
+  password: string;
+  role: 'admin' | 'user';
+  is_active: boolean;
+  full_name: string;
+  username: string;
+  avatar_url: string;
+  locale: string;
+  timezone: string;
+  theme: 'system' | 'light' | 'dark';
+  sendEmailInvite: boolean;
+};
+
+export type UserFormModalProps = {
+  open: boolean;
+  mode: 'create' | 'edit';
+  loading?: boolean;
+  initialUser?: AdminUserItem | null;
+  onClose: () => void;
+  onSubmit: (values: UserFormValues) => Promise<void> | void;
+};
+
+const defaultValues: UserFormValues = {
+  email: '',
+  password: '',
+  role: 'user',
+  is_active: true,
+  full_name: '',
+  username: '',
+  avatar_url: '',
+  locale: 'id-ID',
+  timezone: 'Asia/Jakarta',
+  theme: 'system',
+  sendEmailInvite: false,
+};
+
+export default function UserFormModal({
+  open,
+  mode,
+  loading = false,
+  initialUser = null,
+  onClose,
+  onSubmit,
+}: UserFormModalProps) {
+  const [formState, setFormState] = useState<UserFormValues>(defaultValues);
+  const [error, setError] = useState<string | null>(null);
+  const [touchPassword, setTouchPassword] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setFormState(defaultValues);
+      setTouchPassword(false);
+      setError(null);
+      return;
+    }
+
+    if (initialUser && mode === 'edit') {
+      const profile = initialUser.profile as AdminUserProfile;
+      setFormState({
+        email: initialUser.email,
+        password: '',
+        role: profile.role,
+        is_active: profile.is_active,
+        full_name: profile.full_name ?? '',
+        username: profile.username ?? '',
+        avatar_url: profile.avatar_url ?? '',
+        locale: profile.locale ?? 'id-ID',
+        timezone: profile.timezone ?? 'Asia/Jakarta',
+        theme: (profile.theme as UserFormValues['theme']) ?? 'system',
+        sendEmailInvite: false,
+      });
+    } else {
+      setFormState(defaultValues);
+    }
+  }, [open, initialUser, mode]);
+
+  const title = useMemo(() => (mode === 'create' ? 'Tambah Pengguna Baru' : 'Ubah Pengguna'), [mode]);
+
+  if (!open) return null;
+
+  const handleChange = (field: keyof UserFormValues, value: string | boolean) => {
+    setFormState((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError(null);
+
+    if (!formState.email.trim()) {
+      setError('Email wajib diisi');
+      return;
+    }
+
+    if (mode === 'create' && !formState.password) {
+      setError('Password awal wajib diisi');
+      return;
+    }
+
+    if (mode === 'create' && formState.password.length < 8 && !formState.sendEmailInvite) {
+      setError('Password minimal 8 karakter');
+      return;
+    }
+
+    if (touchPassword && formState.password && formState.password.length < 8) {
+      setError('Password minimal 8 karakter');
+      return;
+    }
+
+    await onSubmit(formState);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm">
+      <div className="w-full max-w-2xl rounded-2xl border border-border/60 bg-card shadow-xl">
+        <form onSubmit={handleSubmit} className="space-y-6 p-6 md:p-8">
+          <header className="space-y-1">
+            <h2 className="text-xl font-semibold">{title}</h2>
+            <p className="text-sm text-muted-foreground">
+              {mode === 'create'
+                ? 'Buat akun baru untuk anggota tim atau user aplikasi.'
+                : 'Ubah informasi profil, peran, dan status pengguna.'}
+            </p>
+          </header>
+
+          <section className="grid gap-4 md:grid-cols-2">
+            <label className="space-y-1 text-sm">
+              <span className="font-medium">Email</span>
+              <input
+                type="email"
+                className="h-11 w-full rounded-xl border border-border/60 bg-background px-3 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+                value={formState.email}
+                onChange={(event) => handleChange('email', event.target.value)}
+                required
+              />
+            </label>
+
+            <label className="space-y-1 text-sm">
+              <span className="font-medium">Peran</span>
+              <select
+                className="h-11 w-full rounded-xl border border-border/60 bg-background px-3 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+                value={formState.role}
+                onChange={(event) => handleChange('role', event.target.value as UserFormValues['role'])}
+              >
+                <option value="user">User</option>
+                <option value="admin">Admin</option>
+              </select>
+            </label>
+
+            <label className="space-y-1 text-sm">
+              <span className="font-medium">Status</span>
+              <select
+                className="h-11 w-full rounded-xl border border-border/60 bg-background px-3 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+                value={formState.is_active ? 'active' : 'inactive'}
+                onChange={(event) => handleChange('is_active', event.target.value === 'active')}
+              >
+                <option value="active">Aktif</option>
+                <option value="inactive">Nonaktif</option>
+              </select>
+            </label>
+
+            <label className="flex items-center gap-3 text-sm">
+              <input
+                type="checkbox"
+                className="h-4 w-4 rounded border-border/60 text-primary focus:ring-primary"
+                checked={formState.sendEmailInvite}
+                onChange={(event) => handleChange('sendEmailInvite', event.target.checked)}
+                disabled={mode === 'edit'}
+              />
+              <span>Kirim email undangan</span>
+            </label>
+
+            <label className="space-y-1 text-sm md:col-span-2">
+              <div className="flex items-center justify-between">
+                <span className="font-medium">Password</span>
+                {mode === 'edit' && (
+                  <button
+                    type="button"
+                    className="text-xs font-semibold text-primary hover:underline"
+                    onClick={() => {
+                      setTouchPassword((prev) => !prev);
+                      if (touchPassword) {
+                        setFormState((prev) => ({ ...prev, password: '' }));
+                      }
+                    }}
+                  >
+                    {touchPassword ? 'Batalkan' : 'Setel password baru'}
+                  </button>
+                )}
+              </div>
+              {(mode === 'create' || touchPassword) && (
+                <input
+                  type="password"
+                  className="h-11 w-full rounded-xl border border-border/60 bg-background px-3 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  value={formState.password}
+                  onChange={(event) => handleChange('password', event.target.value)}
+                  placeholder={mode === 'create' ? 'Minimal 8 karakter' : 'Kosongkan untuk tidak mengubah'}
+                  required={mode === 'create' && !formState.sendEmailInvite}
+                />
+              )}
+              {mode === 'create' && formState.sendEmailInvite && (
+                <p className="text-xs text-muted-foreground">
+                  Password tidak wajib ketika mengirim email undangan. User akan membuat password saat menerima email.
+                </p>
+              )}
+            </label>
+
+            <label className="space-y-1 text-sm">
+              <span className="font-medium">Nama Lengkap</span>
+              <input
+                type="text"
+                className="h-11 w-full rounded-xl border border-border/60 bg-background px-3 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+                value={formState.full_name}
+                onChange={(event) => handleChange('full_name', event.target.value)}
+              />
+            </label>
+
+            <label className="space-y-1 text-sm">
+              <span className="font-medium">Username</span>
+              <input
+                type="text"
+                className="h-11 w-full rounded-xl border border-border/60 bg-background px-3 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+                value={formState.username}
+                onChange={(event) => handleChange('username', event.target.value)}
+              />
+            </label>
+
+            <label className="space-y-1 text-sm md:col-span-2">
+              <span className="font-medium">Avatar URL</span>
+              <input
+                type="url"
+                className="h-11 w-full rounded-xl border border-border/60 bg-background px-3 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+                value={formState.avatar_url}
+                onChange={(event) => handleChange('avatar_url', event.target.value)}
+              />
+            </label>
+
+            <label className="space-y-1 text-sm">
+              <span className="font-medium">Locale</span>
+              <input
+                type="text"
+                className="h-11 w-full rounded-xl border border-border/60 bg-background px-3 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+                value={formState.locale}
+                onChange={(event) => handleChange('locale', event.target.value)}
+              />
+            </label>
+
+            <label className="space-y-1 text-sm">
+              <span className="font-medium">Zona Waktu</span>
+              <input
+                type="text"
+                className="h-11 w-full rounded-xl border border-border/60 bg-background px-3 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+                value={formState.timezone}
+                onChange={(event) => handleChange('timezone', event.target.value)}
+              />
+            </label>
+
+            <label className="space-y-1 text-sm">
+              <span className="font-medium">Tema</span>
+              <select
+                className="h-11 w-full rounded-xl border border-border/60 bg-background px-3 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+                value={formState.theme}
+                onChange={(event) => handleChange('theme', event.target.value as UserFormValues['theme'])}
+              >
+                <option value="system">Ikuti Sistem</option>
+                <option value="light">Terang</option>
+                <option value="dark">Gelap</option>
+              </select>
+            </label>
+          </section>
+
+          {error && <div className="rounded-xl border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">{error}</div>}
+
+          <footer className="flex items-center justify-end gap-3">
+            <button
+              type="button"
+              onClick={() => {
+                if (!loading) {
+                  onClose();
+                }
+              }}
+              className="inline-flex h-11 items-center rounded-xl border border-border/60 px-5 text-sm font-semibold text-muted-foreground transition hover:border-border hover:bg-muted/20"
+            >
+              Batal
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className={clsx(
+                'inline-flex h-11 items-center rounded-xl bg-primary px-5 text-sm font-semibold text-white shadow-sm transition',
+                loading ? 'opacity-70' : 'hover:bg-primary/90'
+              )}
+            >
+              {loading ? 'Menyimpan…' : mode === 'create' ? 'Buat Pengguna' : 'Simpan Perubahan'}
+            </button>
+          </footer>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/users/UserTable.tsx
+++ b/src/components/admin/users/UserTable.tsx
@@ -1,0 +1,208 @@
+import clsx from 'clsx';
+import { Edit3, Mail, Moon, ShieldCheck, Trash2, UserCheck2, UserCog } from 'lucide-react';
+import type { AdminUserItem } from '../../../lib/api/adminUsers';
+
+const relativeFormatter = new Intl.RelativeTimeFormat('id-ID', { numeric: 'auto' });
+const dateFormatter = new Intl.DateTimeFormat('id-ID', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+function formatRelative(dateString: string | null) {
+  if (!dateString) return 'Belum pernah login';
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) {
+    return 'Tidak diketahui';
+  }
+  const diff = date.getTime() - Date.now();
+  const diffSeconds = Math.round(diff / 1000);
+  const diffMinutes = Math.round(diffSeconds / 60);
+  const diffHours = Math.round(diffMinutes / 60);
+  const diffDays = Math.round(diffHours / 24);
+
+  if (Math.abs(diffSeconds) < 60) {
+    return relativeFormatter.format(Math.round(diffSeconds), 'second');
+  }
+  if (Math.abs(diffMinutes) < 60) {
+    return relativeFormatter.format(Math.round(diffMinutes), 'minute');
+  }
+  if (Math.abs(diffHours) < 24) {
+    return relativeFormatter.format(Math.round(diffHours), 'hour');
+  }
+  return relativeFormatter.format(Math.round(diffDays), 'day');
+}
+
+function ProviderBadge({ provider }: { provider: string }) {
+  const normalized = provider.toLowerCase();
+  if (normalized === 'google') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-600">
+        <span className="h-1.5 w-1.5 rounded-full bg-red-500" /> Google
+      </span>
+    );
+  }
+  if (normalized === 'email') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+        <Mail className="h-3 w-3" /> Email
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+      {provider}
+    </span>
+  );
+}
+
+export type UserTableProps = {
+  items: AdminUserItem[];
+  loading: boolean;
+  onToggleActive: (user: AdminUserItem, nextValue: boolean) => void;
+  onEdit: (user: AdminUserItem) => void;
+  onDelete: (user: AdminUserItem) => void;
+  onResetPassword: (user: AdminUserItem) => void;
+};
+
+export default function UserTable({
+  items,
+  loading,
+  onToggleActive,
+  onDelete,
+  onEdit,
+  onResetPassword,
+}: UserTableProps) {
+  if (loading) {
+    return (
+      <div className="space-y-3">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className="animate-pulse rounded-2xl border border-border/60 bg-muted/40 p-4" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!items.length) {
+    return (
+      <div className="flex min-h-[320px] flex-col items-center justify-center gap-3 rounded-2xl border border-border/60 bg-muted/10 p-8 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <UserCog className="h-6 w-6" />
+        </div>
+        <div className="space-y-1">
+          <h3 className="text-lg font-semibold">Belum ada pengguna</h3>
+          <p className="text-sm text-muted-foreground">Mulai dengan menambahkan pengguna baru atau ubah filter pencarian.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-border/60 text-left text-sm">
+        <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+          <tr>
+            <th className="px-4 py-3">Pengguna</th>
+            <th className="px-4 py-3">Email</th>
+            <th className="px-4 py-3">Peran</th>
+            <th className="px-4 py-3">Status</th>
+            <th className="px-4 py-3">Provider</th>
+            <th className="px-4 py-3">Terakhir login</th>
+            <th className="px-4 py-3">Dibuat</th>
+            <th className="px-4 py-3 text-right">Aksi</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border/50">
+          {items.map((user) => {
+            const providers = user.identities?.length ? user.identities : [{ provider: 'email' }];
+            const lastSignInLabel = formatRelative(user.last_sign_in_at);
+            const lastSignInTooltip = user.last_sign_in_at ? dateFormatter.format(new Date(user.last_sign_in_at)) : '—';
+            return (
+              <tr key={user.id} className="transition hover:bg-muted/30">
+                <td className="whitespace-nowrap px-4 py-3">
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">
+                      {(user.profile.full_name?.charAt(0) || user.profile.username?.charAt(0) || user.email.charAt(0) || 'U').toUpperCase()}
+                    </div>
+                    <div>
+                      <div className="text-sm font-medium">
+                        {user.profile.full_name || user.profile.username || user.email.split('@')[0]}
+                      </div>
+                      <div className="text-xs text-muted-foreground">{user.profile.username ?? '—'}</div>
+                    </div>
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-sm">{user.email}</td>
+                <td className="px-4 py-3">
+                  <span
+                    className={clsx(
+                      'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold',
+                      user.profile.role === 'admin'
+                        ? 'bg-amber-100 text-amber-800'
+                        : 'bg-slate-100 text-slate-700'
+                    )}
+                  >
+                    {user.profile.role === 'admin' ? <ShieldCheck className="h-3 w-3" /> : <UserCheck2 className="h-3 w-3" />}
+                    {user.profile.role === 'admin' ? 'Admin' : 'User'}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <button
+                    type="button"
+                    className={clsx(
+                      'inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold transition',
+                      user.profile.is_active
+                        ? 'border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100'
+                        : 'border-rose-200 bg-rose-50 text-rose-700 hover:bg-rose-100'
+                    )}
+                    onClick={() => onToggleActive(user, !user.profile.is_active)}
+                  >
+                    <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: user.profile.is_active ? '#047857' : '#e11d48' }} />
+                    {user.profile.is_active ? 'Aktif' : 'Nonaktif'}
+                  </button>
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex flex-wrap gap-1">
+                    {providers.map((identity, index) => (
+                      <ProviderBadge key={`${user.id}-${identity.provider}-${index}`} provider={identity.provider} />
+                    ))}
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-sm" title={lastSignInTooltip}>
+                  {lastSignInLabel}
+                </td>
+                <td className="px-4 py-3 text-sm" title={dateFormatter.format(new Date(user.created_at))}>
+                  {dateFormatter.format(new Date(user.created_at))}
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <div className="flex items-center justify-end gap-2">
+                    <button
+                      type="button"
+                      onClick={() => onResetPassword(user)}
+                      className="inline-flex h-9 items-center gap-1 rounded-full border border-border/60 px-3 text-xs font-semibold text-muted-foreground transition hover:border-primary hover:text-primary"
+                    >
+                      <Moon className="h-3.5 w-3.5" /> Reset
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onEdit(user)}
+                      className="inline-flex h-9 items-center gap-1 rounded-full border border-border/60 px-3 text-xs font-semibold text-muted-foreground transition hover:border-primary hover:text-primary"
+                    >
+                      <Edit3 className="h-3.5 w-3.5" /> Edit
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onDelete(user)}
+                      className="inline-flex h-9 items-center gap-1 rounded-full border border-destructive/40 bg-destructive/10 px-3 text-xs font-semibold text-destructive transition hover:bg-destructive/20"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" /> Hapus
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/lib/api/adminUsers.ts
+++ b/src/lib/api/adminUsers.ts
@@ -1,0 +1,149 @@
+import { SUPABASE_URL, supabase } from '../supabase.js';
+
+export type AdminUserProfile = {
+  role: 'admin' | 'user';
+  is_active: boolean;
+  full_name?: string | null;
+  username?: string | null;
+  avatar_url?: string | null;
+  locale?: string | null;
+  timezone?: string | null;
+  theme?: 'system' | 'light' | 'dark' | null;
+};
+
+export type AdminUserItem = {
+  id: string;
+  email: string;
+  created_at: string;
+  last_sign_in_at: string | null;
+  identities: { provider: string }[];
+  profile: AdminUserProfile;
+};
+
+export type ListUsersParams = {
+  q?: string;
+  role?: 'admin' | 'user' | 'all';
+  status?: 'active' | 'inactive' | 'all';
+  order?: string;
+  page?: number;
+  limit?: number;
+};
+
+export type PaginatedUsers = {
+  items: AdminUserItem[];
+  pagination: {
+    total: number;
+    page: number;
+    limit: number;
+    has_more: boolean;
+    next_cursor: string | null;
+  };
+};
+
+export type CreateUserPayload = {
+  email: string;
+  password: string;
+  profile?: Partial<AdminUserProfile>;
+  sendEmailInvite?: boolean;
+};
+
+export type UpdateUserPayload = {
+  email?: string;
+  password?: string;
+  profile?: Partial<AdminUserProfile>;
+};
+
+export async function listAdminUsers(params: ListUsersParams = {}): Promise<PaginatedUsers> {
+  const { data: sessionData } = await supabase.auth.getSession();
+  const accessToken = sessionData.session?.access_token;
+  if (!accessToken) {
+    throw new Error('Session tidak ditemukan. Harap login ulang.');
+  }
+
+  const url = new URL(`${SUPABASE_URL}/functions/v1/admin-users`);
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') return;
+    url.searchParams.set(key, String(value));
+  });
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  const body = await response.json().catch(() => null);
+  if (!response.ok) {
+    const message = body?.error?.message ?? 'Gagal memuat daftar pengguna';
+    throw new Error(message);
+  }
+
+  const fallback: PaginatedUsers = {
+    items: [],
+    pagination: {
+      total: 0,
+      page: params.page ?? 1,
+      limit: params.limit ?? 20,
+      has_more: false,
+      next_cursor: null,
+    },
+  };
+
+  if (!body?.data) {
+    return fallback;
+  }
+
+  return body.data as PaginatedUsers;
+}
+
+async function mutateUser<TPayload>(
+  method: 'POST' | 'PATCH' | 'DELETE',
+  payload?: TPayload,
+  id?: string,
+  options?: { query?: Record<string, string | number | boolean | undefined | null> }
+) {
+  const { data: sessionData } = await supabase.auth.getSession();
+  const accessToken = sessionData.session?.access_token;
+  if (!accessToken) {
+    throw new Error('Session tidak ditemukan. Harap login ulang.');
+  }
+
+  const path = id ? `${SUPABASE_URL}/functions/v1/admin-users/${id}` : `${SUPABASE_URL}/functions/v1/admin-users`;
+  const url = new URL(path);
+  if (options?.query) {
+    Object.entries(options.query).forEach(([key, value]) => {
+      if (value === undefined || value === null || value === '') return;
+      url.searchParams.set(key, String(value));
+    });
+  }
+
+  const response = await fetch(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: payload ? JSON.stringify(payload) : undefined,
+  });
+
+  const body = await response.json().catch(() => null);
+  if (!response.ok) {
+    const message = body?.error?.message ?? 'Operasi admin gagal';
+    throw new Error(message);
+  }
+
+  return body?.data as AdminUserItem;
+}
+
+export async function createAdminUser(payload: CreateUserPayload) {
+  return mutateUser('POST', payload);
+}
+
+export async function updateAdminUser(id: string, payload: UpdateUserPayload) {
+  return mutateUser('PATCH', payload, id);
+}
+
+export async function deleteAdminUser(id: string, mode: 'soft' | 'hard' = 'hard') {
+  await mutateUser('DELETE', undefined, id, { query: { mode } });
+}

--- a/src/pages/admin/UsersPage.tsx
+++ b/src/pages/admin/UsersPage.tsx
@@ -1,0 +1,411 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Filter, Loader2, Plus, RefreshCcw, Search } from 'lucide-react';
+import UserTable from '../../components/admin/users/UserTable';
+import UserFormModal, { type UserFormValues } from '../../components/admin/users/UserFormModal';
+import {
+  createAdminUser,
+  deleteAdminUser,
+  listAdminUsers,
+  type AdminUserItem,
+  type ListUsersParams,
+  updateAdminUser,
+} from '../../lib/api/adminUsers';
+import { useToast } from '../../context/ToastContext.jsx';
+import AdminGuard from '../../components/AdminGuard';
+
+const LIMIT_OPTIONS = [10, 20, 50];
+
+const STATUS_OPTIONS = [
+  { value: 'all', label: 'Semua status' },
+  { value: 'active', label: 'Aktif' },
+  { value: 'inactive', label: 'Nonaktif' },
+] as const;
+
+const ROLE_OPTIONS = [
+  { value: 'all', label: 'Semua peran' },
+  { value: 'user', label: 'User' },
+  { value: 'admin', label: 'Admin' },
+] as const;
+
+function UsersContent() {
+  const { addToast } = useToast();
+  const [items, setItems] = useState<AdminUserItem[]>([]);
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [filters, setFilters] = useState<Required<Pick<ListUsersParams, 'role' | 'status' | 'order' | 'page' | 'limit'>>>(
+    {
+      role: 'all',
+      status: 'all',
+      order: 'created_at.desc',
+      page: 1,
+      limit: 20,
+    }
+  );
+  const [pagination, setPagination] = useState({
+    total: 0,
+    page: 1,
+    limit: 20,
+    has_more: false,
+    next_cursor: null as string | null,
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [formMode, setFormMode] = useState<'create' | 'edit'>('create');
+  const [selectedUser, setSelectedUser] = useState<AdminUserItem | null>(null);
+  const [formSubmitting, setFormSubmitting] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setDebouncedSearch(search);
+    }, 350);
+    return () => window.clearTimeout(timer);
+  }, [search]);
+
+  const loadUsers = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await listAdminUsers({
+        role: filters.role,
+        status: filters.status,
+        order: filters.order,
+        page: filters.page,
+        limit: filters.limit,
+        q: debouncedSearch || undefined,
+      });
+      setItems(response.items);
+      setPagination(response.pagination);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Gagal memuat pengguna';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [filters.limit, filters.order, filters.page, filters.role, filters.status, debouncedSearch]);
+
+  useEffect(() => {
+    void loadUsers();
+  }, [loadUsers]);
+
+  const handleOpenCreate = () => {
+    setFormMode('create');
+    setSelectedUser(null);
+    setShowForm(true);
+  };
+
+  const handleOpenEdit = (user: AdminUserItem) => {
+    setFormMode('edit');
+    setSelectedUser(user);
+    setShowForm(true);
+  };
+
+  const handleSubmitForm = async (values: UserFormValues) => {
+    setFormSubmitting(true);
+    try {
+      if (formMode === 'create') {
+        const payload = {
+          email: values.email.trim(),
+          password: values.password,
+          profile: {
+            role: values.role,
+            is_active: values.is_active,
+            full_name: values.full_name || undefined,
+            username: values.username || undefined,
+            avatar_url: values.avatar_url || undefined,
+            locale: values.locale || undefined,
+            timezone: values.timezone || undefined,
+            theme: values.theme,
+          },
+          sendEmailInvite: values.sendEmailInvite,
+        };
+        const created = await createAdminUser(payload);
+        setItems((prev) => [created, ...prev]);
+        setPagination((prev) => ({ ...prev, total: prev.total + 1 }));
+        addToast('Pengguna berhasil dibuat', 'success');
+      } else if (selectedUser) {
+        const payload = {
+          email: values.email.trim(),
+          profile: {
+            role: values.role,
+            is_active: values.is_active,
+            full_name: values.full_name || undefined,
+            username: values.username || undefined,
+            avatar_url: values.avatar_url || undefined,
+            locale: values.locale || undefined,
+            timezone: values.timezone || undefined,
+            theme: values.theme,
+          },
+        } as const;
+
+        const updated = await updateAdminUser(selectedUser.id, {
+          ...payload,
+          password: values.password ? values.password : undefined,
+        });
+        setItems((prev) => prev.map((item) => (item.id === updated.id ? updated : item)));
+        addToast('Pengguna berhasil diperbarui', 'success');
+      }
+      setShowForm(false);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Operasi gagal';
+      addToast(message, 'error');
+    } finally {
+      setFormSubmitting(false);
+    }
+  };
+
+  const handleToggleActive = async (user: AdminUserItem, nextValue: boolean) => {
+    const previous = items;
+    setItems((prev) =>
+      prev.map((item) =>
+        item.id === user.id ? { ...item, profile: { ...item.profile, is_active: nextValue } } : item
+      )
+    );
+
+    try {
+      const updated = await updateAdminUser(user.id, { profile: { is_active: nextValue } });
+      setItems((prev) => prev.map((item) => (item.id === updated.id ? updated : item)));
+      addToast(`Pengguna ${nextValue ? 'diaktifkan' : 'dinonaktifkan'}`, 'success');
+    } catch (err) {
+      setItems(previous);
+      const message = err instanceof Error ? err.message : 'Gagal memperbarui status pengguna';
+      addToast(message, 'error');
+    }
+  };
+
+  const handleDelete = async (user: AdminUserItem) => {
+    const proceed = window.confirm(`Anda yakin ingin menghapus atau menonaktifkan ${user.email}?`);
+    if (!proceed) return;
+
+    const hardDelete = window.confirm(
+      'Pilih OK untuk hapus permanen. Pilih Cancel untuk menonaktifkan saja (soft delete).'
+    );
+    const mode: 'hard' | 'soft' = hardDelete ? 'hard' : 'soft';
+    try {
+      await deleteAdminUser(user.id, mode);
+      if (mode === 'soft') {
+        setItems((prev) =>
+          prev.map((item) =>
+            item.id === user.id ? { ...item, profile: { ...item.profile, is_active: false } } : item
+          )
+        );
+        addToast('Pengguna dinonaktifkan', 'success');
+      } else {
+        setItems((prev) => prev.filter((item) => item.id !== user.id));
+        setPagination((prev) => ({ ...prev, total: Math.max(0, prev.total - 1) }));
+        addToast('Pengguna berhasil dihapus', 'success');
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Gagal menghapus pengguna';
+      addToast(message, 'error');
+    }
+  };
+
+  const handleResetPassword = async (user: AdminUserItem) => {
+    const newPassword = window.prompt(`Masukkan password baru untuk ${user.email} (minimal 8 karakter)`, '');
+    if (newPassword == null) return;
+    if (newPassword.length < 8) {
+      addToast('Password minimal 8 karakter', 'error');
+      return;
+    }
+    try {
+      const updated = await updateAdminUser(user.id, { password: newPassword });
+      setItems((prev) => prev.map((item) => (item.id === updated.id ? updated : item)));
+      addToast('Password berhasil diperbarui', 'success');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Gagal mengatur ulang password';
+      addToast(message, 'error');
+    }
+  };
+
+  const handleChangeFilter = (patch: Partial<typeof filters>) => {
+    setFilters((prev) => {
+      const next = { ...prev, ...patch };
+      const shouldResetPage =
+        patch.page === undefined && (patch.role !== undefined || patch.status !== undefined || patch.limit !== undefined);
+      if (shouldResetPage) {
+        next.page = 1;
+      }
+      return next;
+    });
+  };
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    try {
+      await loadUsers();
+      addToast('Data pengguna diperbarui', 'success');
+    } catch (error_) {
+      const message = error_ instanceof Error ? error_.message : 'Gagal memuat ulang data';
+      addToast(message, 'error');
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  const toolbarSubtitle = useMemo(() => {
+    if (loading) return 'Memuat pengguna…';
+    if (error) return error;
+    if (!items.length) return 'Tidak ada pengguna yang cocok';
+    return `${items.length} pengguna ditampilkan`;
+  }, [loading, error, items.length]);
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Manajemen Pengguna</h1>
+          <p className="text-sm text-muted-foreground">Kelola akses pengguna aplikasi HematWoi.</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={handleRefresh}
+            disabled={refreshing}
+            className="inline-flex h-11 items-center gap-2 rounded-xl border border-border/60 bg-background px-4 text-sm font-semibold text-muted-foreground transition hover:border-primary hover:text-primary disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {refreshing ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCcw className="h-4 w-4" />}
+            Muat ulang
+          </button>
+          <button
+            type="button"
+            onClick={handleOpenCreate}
+            className="inline-flex h-11 items-center gap-2 rounded-xl bg-primary px-4 text-sm font-semibold text-white shadow-sm transition hover:bg-primary/90"
+          >
+            <Plus className="h-4 w-4" /> Tambah Pengguna
+          </button>
+        </div>
+      </header>
+
+      <div className="rounded-2xl border border-border/60 bg-card p-4 shadow-sm">
+        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <label className="flex flex-1 items-center gap-3 rounded-xl border border-border/60 bg-background px-3 py-2">
+            <Search className="h-4 w-4 text-muted-foreground" />
+            <input
+              type="search"
+              placeholder="Cari berdasarkan email, nama, atau username"
+              value={search}
+              onChange={(event) => {
+                setSearch(event.target.value);
+                setFilters((prev) => ({ ...prev, page: 1 }));
+              }}
+              className="h-10 flex-1 bg-transparent text-sm focus:outline-none"
+            />
+          </label>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="flex items-center gap-2 rounded-xl border border-border/60 bg-background px-3 py-2 text-sm">
+              <Filter className="h-4 w-4 text-muted-foreground" />
+              <select
+                value={filters.role}
+                onChange={(event) => handleChangeFilter({ role: event.target.value as typeof filters.role, page: 1 })}
+                className="bg-transparent text-sm focus:outline-none"
+              >
+                {ROLE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex items-center gap-2 rounded-xl border border-border/60 bg-background px-3 py-2 text-sm">
+              <select
+                value={filters.status}
+                onChange={(event) => handleChangeFilter({ status: event.target.value as typeof filters.status, page: 1 })}
+                className="bg-transparent text-sm focus:outline-none"
+              >
+                {STATUS_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex items-center gap-2 rounded-xl border border-border/60 bg-background px-3 py-2 text-sm">
+              <select
+                value={filters.limit}
+                onChange={(event) => handleChangeFilter({ limit: Number(event.target.value), page: 1 })}
+                className="bg-transparent text-sm focus:outline-none"
+              >
+                {LIMIT_OPTIONS.map((option) => (
+                  <option key={option} value={option}>
+                    {option} / halaman
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-4 text-xs font-medium text-muted-foreground">{toolbarSubtitle}</div>
+      </div>
+
+      {error && (
+        <div className="rounded-2xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <UserTable
+        items={items}
+        loading={loading}
+        onToggleActive={handleToggleActive}
+        onDelete={handleDelete}
+        onEdit={handleOpenEdit}
+        onResetPassword={handleResetPassword}
+      />
+
+      <div className="flex flex-col gap-2 rounded-2xl border border-border/60 bg-card px-4 py-3 text-sm md:flex-row md:items-center md:justify-between">
+        <div>
+          Halaman {pagination.page} • Menampilkan {items.length} dari {pagination.total} pengguna
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => handleChangeFilter({ page: Math.max(1, pagination.page - 1) })}
+            disabled={pagination.page <= 1 || loading}
+            className="inline-flex h-9 items-center gap-2 rounded-xl border border-border/60 px-3 text-xs font-semibold text-muted-foreground transition hover:border-primary hover:text-primary disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Sebelumnya
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              if (pagination.has_more || (pagination.total && pagination.page * pagination.limit < pagination.total)) {
+                handleChangeFilter({ page: pagination.page + 1 });
+              }
+            }}
+            disabled={!pagination.has_more && pagination.page * pagination.limit >= pagination.total}
+            className="inline-flex h-9 items-center gap-2 rounded-xl border border-border/60 px-3 text-xs font-semibold text-muted-foreground transition hover:border-primary hover:text-primary disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Berikutnya
+          </button>
+        </div>
+      </div>
+
+      <UserFormModal
+        open={showForm}
+        mode={formMode}
+        initialUser={selectedUser ?? undefined}
+        onClose={() => setShowForm(false)}
+        onSubmit={handleSubmitForm}
+        loading={formSubmitting}
+      />
+    </div>
+  );
+}
+
+export default function UsersPage() {
+  return (
+    <AdminGuard>
+      <div className="min-h-screen bg-gradient-to-b from-background via-background/95 to-background px-4 pb-16 pt-10 text-foreground md:px-8">
+        <div className="mx-auto max-w-6xl">
+          <UsersContent />
+        </div>
+      </div>
+    </AdminGuard>
+  );
+}

--- a/src/router/nav.config.tsx
+++ b/src/router/nav.config.tsx
@@ -24,6 +24,7 @@ import {
   Repeat,
   Settings as SettingsIcon,
   User as UserIcon,
+  UserCog as UserCogIcon,
   CreditCard,
 } from 'lucide-react';
 
@@ -141,6 +142,14 @@ export const NAV_ITEMS: NavItem[] = [
     icon: <SettingsIcon className="h-5 w-5" />,
     section: 'secondary',
     inSidebar: true,
+    protected: true,
+  },
+  {
+    title: 'Admin Users',
+    path: '/admin/users',
+    icon: <UserCogIcon className="h-5 w-5" />,
+    section: 'secondary',
+    inSidebar: false,
     protected: true,
   },
   {

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -36,6 +36,8 @@ function loadComponent(path: string) {
       return lazy(() => import('../pages/SettingsPage'));
     case '/profile':
       return lazy(() => import('../pages/Profile'));
+    case '/admin/users':
+      return lazy(() => import('../pages/admin/UsersPage'));
     case '/auth':
       return lazy(() => import('../pages/AuthLogin'));
     default:

--- a/supabase/functions/admin-users/index.ts
+++ b/supabase/functions/admin-users/index.ts
@@ -1,0 +1,533 @@
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.4?target=deno';
+import type { User, UserIdentity } from 'https://esm.sh/@supabase/supabase-js@2.57.4?target=deno';
+
+type HttpError = {
+  status: number;
+  body: {
+    ok: false;
+    error: {
+      code: string;
+      message: string;
+      details?: unknown;
+    };
+  };
+};
+
+type AdminProfileRow = {
+  id: string;
+  role: 'admin' | 'user';
+  is_active: boolean;
+  full_name?: string | null;
+  username?: string | null;
+  avatar_url?: string | null;
+  locale?: string | null;
+  timezone?: string | null;
+  theme?: 'system' | 'light' | 'dark' | null;
+};
+
+type AdminUserResponse = {
+  id: string;
+  email: string;
+  created_at: string;
+  last_sign_in_at: string | null;
+  identities: { provider: string }[];
+  profile: AdminProfileRow;
+};
+
+type AdminAuditAction = 'create' | 'update' | 'delete' | 'toggle_active' | 'reset_password';
+
+type ListParams = {
+  q?: string;
+  role?: 'admin' | 'user' | 'all';
+  status?: 'active' | 'inactive' | 'all';
+  order?: string;
+  page?: number;
+  limit?: number;
+};
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'GET,POST,PATCH,DELETE,OPTIONS',
+};
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL');
+const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
+const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+if (!supabaseUrl || !supabaseAnonKey || !serviceRoleKey) {
+  console.error('Missing Supabase environment variables');
+  throw new Error('Missing Supabase environment variables');
+}
+
+function jsonResponse<T>(status: number, body: T) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...corsHeaders },
+  });
+}
+
+function httpError(status: number, code: string, message: string, details?: unknown): HttpError {
+  return {
+    status,
+    body: { ok: false, error: { code, message, details } },
+  };
+}
+
+async function getAdminContext(req: Request) {
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    throw httpError(401, 'unauthorized', 'Token otorisasi tidak ditemukan');
+  }
+
+  const accessToken = authHeader.replace('Bearer ', '').trim();
+  if (!accessToken) {
+    throw httpError(401, 'unauthorized', 'Token otorisasi kosong');
+  }
+
+  const supabaseClient = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const { data: authData, error: authError } = await supabaseClient.auth.getUser(accessToken);
+  if (authError || !authData?.user) {
+    throw httpError(401, 'unauthorized', 'Session tidak valid', authError ?? undefined);
+  }
+
+  const adminClient = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const { data: profile, error: profileError } = await adminClient
+    .from('user_profiles')
+    .select('id, role, is_active')
+    .eq('id', authData.user.id)
+    .maybeSingle();
+
+  if (profileError) {
+    console.error('[admin-users] failed to load admin profile', profileError);
+    throw httpError(500, 'profile_error', 'Gagal memuat profil admin');
+  }
+
+  if (!profile || profile.role !== 'admin' || !profile.is_active) {
+    throw httpError(403, 'forbidden', 'Hanya admin aktif yang dapat mengakses endpoint ini');
+  }
+
+  return { user: authData.user, adminClient } as const;
+}
+
+function sanitizeProfile(row: Partial<AdminProfileRow> | null | undefined): AdminProfileRow {
+  return {
+    id: String(row?.id ?? ''),
+    role: row?.role === 'admin' ? 'admin' : 'user',
+    is_active: Boolean(row?.is_active ?? true),
+    full_name: row?.full_name ?? null,
+    username: row?.username ?? null,
+    avatar_url: row?.avatar_url ?? null,
+    locale: row?.locale ?? null,
+    timezone: row?.timezone ?? null,
+    theme: (row?.theme as AdminProfileRow['theme']) ?? 'system',
+  };
+}
+
+function serializeUser(user: User, profileRow: Partial<AdminProfileRow> | null | undefined): AdminUserResponse {
+  return {
+    id: user.id,
+    email: user.email ?? '',
+    created_at: user.created_at ?? new Date().toISOString(),
+    last_sign_in_at: user.last_sign_in_at ?? null,
+    identities: Array.isArray(user.identities)
+      ? (user.identities as UserIdentity[]).map((identity) => ({ provider: identity?.provider ?? 'email' }))
+      : [{ provider: 'email' }],
+    profile: sanitizeProfile({ id: user.id, ...profileRow }),
+  };
+}
+
+function validateEmail(email: unknown) {
+  if (typeof email !== 'string' || !email.trim()) {
+    throw httpError(400, 'invalid_email', 'Email wajib diisi');
+  }
+  const trimmed = email.trim();
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(trimmed)) {
+    throw httpError(400, 'invalid_email', 'Format email tidak valid');
+  }
+  return trimmed.toLowerCase();
+}
+
+function validatePassword(password: unknown) {
+  if (typeof password !== 'string' || password.length < 8) {
+    throw httpError(400, 'invalid_password', 'Password minimal 8 karakter');
+  }
+  return password;
+}
+
+function parseListParams(url: URL): ListParams {
+  const limit = Math.min(Math.max(Number.parseInt(url.searchParams.get('limit') ?? '20', 10) || 20, 1), 100);
+  const page = Math.max(Number.parseInt(url.searchParams.get('page') ?? '1', 10) || 1, 1);
+  const order = url.searchParams.get('order') ?? 'created_at.desc';
+  const q = url.searchParams.get('q')?.trim();
+  const roleParam = url.searchParams.get('role');
+  const statusParam = url.searchParams.get('status');
+
+  const role = roleParam === 'admin' || roleParam === 'user' ? roleParam : 'all';
+  const status = statusParam === 'active' || statusParam === 'inactive' ? statusParam : 'all';
+
+  return { limit, page, order, q: q || undefined, role, status };
+}
+
+async function fetchAllUsers(adminClient: ReturnType<typeof createClient>) {
+  let page = 1;
+  const users: User[] = [];
+
+  // Fetch all users in batches to support search and filters reliably
+  while (true) {
+    const response = await fetch(`${supabaseUrl}/auth/v1/admin/users?per_page=200&page=${page}`, {
+      headers: {
+        apikey: serviceRoleKey,
+        Authorization: `Bearer ${serviceRoleKey}`,
+      },
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => ({}));
+      console.error('[admin-users] list users error', errorBody);
+      throw httpError(500, 'list_failed', 'Gagal mengambil data pengguna');
+    }
+
+    const body = await response.json();
+    const batch = Array.isArray(body?.users) ? (body.users as User[]) : [];
+    users.push(...batch);
+
+    const nextPage = body?.next_page ?? null;
+    if (!nextPage || typeof nextPage !== 'number' || nextPage <= page) {
+      break;
+    }
+    page = nextPage;
+  }
+
+  const ids = users.map((user) => user.id);
+  if (ids.length === 0) {
+    return { users, profiles: new Map<string, AdminProfileRow>() };
+  }
+
+  const { data: profileRows, error: profileError } = await adminClient
+    .from('user_profiles')
+    .select('id, role, is_active, full_name, username, avatar_url, locale, timezone, theme')
+    .in('id', ids);
+
+  if (profileError) {
+    console.error('[admin-users] failed to fetch profiles', profileError);
+    throw httpError(500, 'profile_error', 'Gagal memuat profil pengguna');
+  }
+
+  const profileMap = new Map<string, AdminProfileRow>();
+  for (const row of profileRows ?? []) {
+    profileMap.set(String(row.id), sanitizeProfile(row));
+  }
+
+  return { users, profiles: profileMap };
+}
+
+async function logAdminAction(
+  adminClient: ReturnType<typeof createClient>,
+  adminId: string,
+  action: AdminAuditAction,
+  target: string,
+  details: Record<string, unknown> = {}
+) {
+  try {
+    const { error } = await adminClient.from('admin_audit_logs').insert({
+      admin_id: adminId,
+      action,
+      target_user_id: target,
+      details,
+    });
+    if (error) {
+      console.warn('[admin-users] failed to write audit log', error);
+    }
+  } catch (err) {
+    console.warn('[admin-users] audit insert exception', err);
+  }
+}
+
+async function handleList(req: Request) {
+  const { user: adminUser, adminClient } = await getAdminContext(req);
+  const params = parseListParams(new URL(req.url));
+
+  const { users, profiles } = await fetchAllUsers(adminClient);
+
+  const filtered = users
+    .filter((entry) => {
+      const profile = profiles.get(entry.id) ?? sanitizeProfile({ id: entry.id });
+      if (params.role !== 'all' && profile.role !== params.role) {
+        return false;
+      }
+      if (params.status === 'active' && !profile.is_active) {
+        return false;
+      }
+      if (params.status === 'inactive' && profile.is_active) {
+        return false;
+      }
+      if (params.q) {
+        const haystacks = [
+          entry.email ?? '',
+          profile.full_name ?? '',
+          profile.username ?? '',
+        ]
+          .filter(Boolean)
+          .map((value) => value.toLowerCase());
+        const query = params.q.toLowerCase();
+        const matched = haystacks.some((value) => value.includes(query));
+        if (!matched) {
+          return false;
+        }
+      }
+      return true;
+    })
+    .map((entry) => serializeUser(entry, profiles.get(entry.id)));
+
+  const [orderField, orderDirection] = (params.order ?? 'created_at.desc').split('.') as [keyof AdminUserResponse | string, string];
+
+  const sorted = filtered.sort((a, b) => {
+    const dir = orderDirection === 'asc' ? 1 : -1;
+    if (orderField === 'email') {
+      return a.email.localeCompare(b.email) * dir;
+    }
+    if (orderField === 'last_sign_in_at') {
+      const aTime = a.last_sign_in_at ? Date.parse(a.last_sign_in_at) : 0;
+      const bTime = b.last_sign_in_at ? Date.parse(b.last_sign_in_at) : 0;
+      return (aTime - bTime) * dir;
+    }
+    const aTime = Date.parse(a.created_at);
+    const bTime = Date.parse(b.created_at);
+    return (aTime - bTime) * dir;
+  });
+
+  const offset = (params.page - 1) * params.limit;
+  const paginated = sorted.slice(offset, offset + params.limit);
+  const hasMore = offset + params.limit < sorted.length;
+  const nextCursor = paginated.length ? paginated[paginated.length - 1].id : null;
+
+  await logAdminAction(adminClient, adminUser.id, 'update', adminUser.id, {
+    target: 'list_users',
+    query: params,
+  });
+
+  return jsonResponse(200, {
+    ok: true,
+    data: {
+      items: paginated,
+      pagination: {
+        total: sorted.length,
+        page: params.page,
+        limit: params.limit,
+        has_more: hasMore,
+        next_cursor: nextCursor,
+      },
+    },
+  });
+}
+
+async function ensureProfile(
+  adminClient: ReturnType<typeof createClient>,
+  userId: string,
+  payload: Partial<AdminProfileRow> | undefined
+) {
+  const profilePayload = {
+    id: userId,
+    role: payload?.role ?? 'user',
+    is_active: payload?.is_active ?? true,
+    full_name: payload?.full_name ?? null,
+    username: payload?.username ?? null,
+    avatar_url: payload?.avatar_url ?? null,
+    locale: payload?.locale ?? null,
+    timezone: payload?.timezone ?? null,
+    theme: payload?.theme ?? 'system',
+  };
+
+  const { error } = await adminClient.from('user_profiles').upsert(profilePayload, { onConflict: 'id' });
+  if (error) {
+    console.error('[admin-users] failed to upsert profile', error);
+    throw httpError(500, 'profile_error', 'Gagal menyimpan profil pengguna');
+  }
+}
+
+async function handleCreate(req: Request) {
+  const { user: adminUser, adminClient } = await getAdminContext(req);
+  const body = await req.json().catch(() => null);
+
+  const email = validateEmail(body?.email);
+  const sendEmailInvite = Boolean(body?.sendEmailInvite);
+  const profilePayload = body?.profile as Partial<AdminProfileRow> | undefined;
+
+  let password: string | undefined;
+  if (!sendEmailInvite) {
+    password = validatePassword(body?.password);
+  }
+
+  const adminAuth = adminClient.auth.admin;
+
+  const { data: created, error: createError } = sendEmailInvite
+    ? await adminAuth.inviteUserByEmail(email, {
+        data: {
+          full_name: profilePayload?.full_name ?? null,
+          username: profilePayload?.username ?? null,
+        },
+      })
+    : await adminAuth.createUser({
+        email,
+        password: password!,
+        email_confirm: true,
+        user_metadata: {
+          full_name: profilePayload?.full_name ?? null,
+          username: profilePayload?.username ?? null,
+        },
+      });
+
+  if (createError || !created?.user) {
+    const code = createError?.status === 422 ? 'email_exists' : 'create_failed';
+    throw httpError(409, code, createError?.message ?? 'Gagal membuat pengguna', createError ?? undefined);
+  }
+
+  await ensureProfile(adminClient, created.user.id, profilePayload);
+
+  const { data: finalUser, error: fetchError } = await adminAuth.getUserById(created.user.id);
+  if (fetchError || !finalUser?.user) {
+    throw httpError(500, 'fetch_failed', 'Gagal memuat ulang pengguna', fetchError ?? undefined);
+  }
+
+  const { data: profileRow } = await adminClient
+    .from('user_profiles')
+    .select('id, role, is_active, full_name, username, avatar_url, locale, timezone, theme')
+    .eq('id', created.user.id)
+    .maybeSingle();
+
+  await logAdminAction(adminClient, adminUser.id, 'create', created.user.id, {
+    email,
+    role: profilePayload?.role ?? 'user',
+  });
+
+  return jsonResponse(201, { ok: true, data: serializeUser(finalUser.user, profileRow ?? undefined) });
+}
+
+async function handleUpdate(req: Request, userId: string) {
+  const { user: adminUser, adminClient } = await getAdminContext(req);
+  const body = await req.json().catch(() => null);
+
+  if (!body || typeof body !== 'object') {
+    throw httpError(400, 'invalid_payload', 'Payload tidak valid');
+  }
+
+  const updatePayload: { email?: string; password?: string } = {};
+  if (body.email != null) {
+    updatePayload.email = validateEmail(body.email);
+  }
+  if (body.password) {
+    updatePayload.password = validatePassword(body.password);
+  }
+
+  const profilePayload = body.profile as Partial<AdminProfileRow> | undefined;
+
+  if (Object.keys(updatePayload).length > 0) {
+    const { error: updateError } = await adminClient.auth.admin.updateUserById(userId, updatePayload);
+    if (updateError) {
+      throw httpError(updateError.status ?? 500, 'update_failed', updateError.message ?? 'Gagal memperbarui pengguna', updateError);
+    }
+    if (updatePayload.password) {
+      await logAdminAction(adminClient, adminUser.id, 'reset_password', userId, {});
+    }
+  }
+
+  if (profilePayload) {
+    await ensureProfile(adminClient, userId, profilePayload);
+    if (profilePayload.is_active !== undefined) {
+      await logAdminAction(adminClient, adminUser.id, 'toggle_active', userId, {
+        is_active: profilePayload.is_active,
+      });
+    } else {
+      await logAdminAction(adminClient, adminUser.id, 'update', userId, profilePayload);
+    }
+  }
+
+  const { data: finalUser, error: fetchError } = await adminClient.auth.admin.getUserById(userId);
+  if (fetchError || !finalUser?.user) {
+    throw httpError(404, 'not_found', 'Pengguna tidak ditemukan', fetchError ?? undefined);
+  }
+
+  const { data: profileRow } = await adminClient
+    .from('user_profiles')
+    .select('id, role, is_active, full_name, username, avatar_url, locale, timezone, theme')
+    .eq('id', userId)
+    .maybeSingle();
+
+  return jsonResponse(200, { ok: true, data: serializeUser(finalUser.user, profileRow ?? undefined) });
+}
+
+async function handleDelete(req: Request, userId: string) {
+  const { user: adminUser, adminClient } = await getAdminContext(req);
+  const url = new URL(req.url);
+  const modeParam = url.searchParams.get('mode');
+  const mode: 'soft' | 'hard' = modeParam === 'soft' ? 'soft' : 'hard';
+
+  if (mode === 'soft') {
+    await ensureProfile(adminClient, userId, { is_active: false });
+    await logAdminAction(adminClient, adminUser.id, 'toggle_active', userId, { is_active: false, mode: 'soft' });
+    return jsonResponse(200, { ok: true, data: null });
+  }
+
+  const { error: deleteError } = await adminClient.auth.admin.deleteUser(userId);
+  if (deleteError) {
+    throw httpError(deleteError.status ?? 500, 'delete_failed', deleteError.message ?? 'Gagal menghapus pengguna', deleteError);
+  }
+
+  const { error: profileDeleteError } = await adminClient.from('user_profiles').delete().eq('id', userId);
+  if (profileDeleteError) {
+    console.warn('[admin-users] failed to delete profile row', profileDeleteError);
+  }
+
+  await logAdminAction(adminClient, adminUser.id, 'delete', userId, { mode: 'hard' });
+  return jsonResponse(200, { ok: true, data: null });
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const url = new URL(req.url);
+    const idMatch = url.pathname.match(/admin-users\/?([^/]*)$/);
+    const id = idMatch && idMatch[1] ? decodeURIComponent(idMatch[1]) : null;
+
+    if (req.method === 'GET') {
+      return await handleList(req);
+    }
+
+    if (req.method === 'POST') {
+      return await handleCreate(req);
+    }
+
+    if (req.method === 'PATCH' && id) {
+      return await handleUpdate(req, id);
+    }
+
+    if (req.method === 'DELETE' && id) {
+      return await handleDelete(req, id);
+    }
+
+    throw httpError(405, 'method_not_allowed', 'Metode tidak diizinkan');
+  } catch (error) {
+    if ('status' in (error as HttpError)) {
+      const httpErr = error as HttpError;
+      return jsonResponse(httpErr.status, httpErr.body);
+    }
+
+    console.error('[admin-users] unexpected error', error);
+    return jsonResponse(500, {
+      ok: false,
+      error: { code: 'internal_error', message: 'Terjadi kesalahan internal' },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add an admin-users Supabase Edge Function that enforces admin-only access and wraps auth.user CRUD operations
- build a new React admin users page with table, filters, modal forms, and soft/hard delete flows
- expose a client-side API wrapper and route configuration for the Users admin panel

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d921f246d08332902795c5e39a9871