### PR TITLE
feat: add admin user management

### DIFF
--- a/src/components/admin/users/DeleteUserDialog.tsx
+++ b/src/components/admin/users/DeleteUserDialog.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react';
+import Modal from '../../../components/Modal.jsx';
+import type { AdminUserItem } from '../../../lib/api/adminUsers';
+
+type DeleteMode = 'soft' | 'hard';
+
+type DeleteUserDialogProps = {
+  open: boolean;
+  user?: AdminUserItem | null;
+  deleting?: boolean;
+  onClose: () => void;
+  onConfirm: (mode: DeleteMode) => Promise<void> | void;
+};
+
+export default function DeleteUserDialog({
+  open,
+  user,
+  deleting = false,
+  onClose,
+  onConfirm,
+}: DeleteUserDialogProps) {
+  const [mode, setMode] = useState<DeleteMode>('hard');
+
+  useEffect(() => {
+    if (!open) return;
+    setMode('hard');
+  }, [open]);
+
+  if (!user) return null;
+
+  const handleConfirm = async () => {
+    await onConfirm(mode);
+  };
+
+  return (
+    <Modal open={open} title="Hapus Pengguna" onClose={onClose}>
+      <div className="space-y-4 text-sm text-text">
+        <p>
+          Tindakan ini akan {mode === 'hard' ? 'menghapus seluruh data pengguna dari sistem' : 'menonaktifkan akun sehingga pengguna tidak bisa login lagi'}.
+        </p>
+        <div className="rounded-2xl border border-border-subtle bg-surface-2 p-4 text-xs text-muted-foreground">
+          <p className="font-semibold text-text">Ringkasan akun</p>
+          <ul className="mt-2 space-y-1">
+            <li><span className="text-muted">Email:</span> {user.email}</li>
+            <li><span className="text-muted">Role:</span> {user.profile.role}</li>
+            <li><span className="text-muted">Status:</span> {user.profile.is_active ? 'Aktif' : 'Tidak aktif'}</li>
+            <li><span className="text-muted">ID:</span> <span className="font-mono">{user.id}</span></li>
+          </ul>
+        </div>
+        <fieldset className="space-y-3">
+          <legend className="text-sm font-semibold text-text">Pilih jenis penghapusan</legend>
+          <label className="flex items-start gap-3 rounded-2xl border border-border-subtle bg-surface-1 p-3">
+            <input
+              type="radio"
+              name="delete-mode"
+              className="mt-1"
+              value="hard"
+              checked={mode === 'hard'}
+              onChange={() => setMode('hard')}
+            />
+            <div>
+              <p className="font-semibold text-text">Hard delete</p>
+              <p className="text-xs text-muted-foreground">
+                Menghapus data auth dan profil secara permanen.
+              </p>
+            </div>
+          </label>
+          <label className="flex items-start gap-3 rounded-2xl border border-border-subtle bg-surface-1 p-3">
+            <input
+              type="radio"
+              name="delete-mode"
+              className="mt-1"
+              value="soft"
+              checked={mode === 'soft'}
+              onChange={() => setMode('soft')}
+            />
+            <div>
+              <p className="font-semibold text-text">Soft delete</p>
+              <p className="text-xs text-muted-foreground">
+                Hanya menonaktifkan akun tanpa menghapus data auth.
+              </p>
+            </div>
+          </label>
+        </fieldset>
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-center">
+          <button type="button" className="btn btn-ghost" onClick={onClose} disabled={deleting}>
+            Batal
+          </button>
+          <button
+            type="button"
+            className={mode === 'hard' ? 'btn btn-danger' : 'btn btn-secondary'}
+            onClick={handleConfirm}
+            disabled={deleting}
+          >
+            {deleting ? 'Memproses…' : mode === 'hard' ? 'Hapus Permanen' : 'Nonaktifkan Pengguna'}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/admin/users/UserFormModal.tsx
+++ b/src/components/admin/users/UserFormModal.tsx
@@ -1,0 +1,378 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import Modal from '../../../components/Modal.jsx';
+import type { AdminUserItem, AdminUserProfile } from '../../../lib/api/adminUsers';
+
+type UserFormMode = 'create' | 'edit';
+
+type FormState = {
+  email: string;
+  password: string;
+  profile: AdminUserProfile;
+  sendEmailInvite: boolean;
+};
+
+type ValidationErrors = Partial<Record<'email' | 'password', string>>;
+
+type SubmitPayload = {
+  email: string;
+  password?: string;
+  profile: Partial<AdminUserProfile>;
+  sendEmailInvite?: boolean;
+};
+
+type UserFormModalProps = {
+  open: boolean;
+  mode: UserFormMode;
+  user?: AdminUserItem | null;
+  submitting?: boolean;
+  forcePassword?: boolean;
+  onClose: () => void;
+  onSubmit: (payload: SubmitPayload) => Promise<void> | void;
+};
+
+const DEFAULT_PROFILE: AdminUserProfile = {
+  role: 'user',
+  is_active: true,
+  full_name: '',
+  username: '',
+  avatar_url: '',
+  locale: 'id-ID',
+  timezone: 'Asia/Jakarta',
+  theme: 'system',
+};
+
+function validateEmail(email: string) {
+  const pattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return pattern.test(email.trim().toLowerCase());
+}
+
+function validatePassword(password: string) {
+  if (!password || password.length < 8) return false;
+  if (!/[a-z]/.test(password)) return false;
+  if (!/[A-Z]/.test(password)) return false;
+  if (!/[0-9]/.test(password)) return false;
+  return true;
+}
+
+function mergeProfile(user?: AdminUserItem | null): AdminUserProfile {
+  if (!user) return { ...DEFAULT_PROFILE };
+  return {
+    role: user.profile.role,
+    is_active: Boolean(user.profile.is_active),
+    full_name: user.profile.full_name ?? '',
+    username: user.profile.username ?? '',
+    avatar_url: user.profile.avatar_url ?? '',
+    locale: user.profile.locale ?? 'id-ID',
+    timezone: user.profile.timezone ?? 'Asia/Jakarta',
+    theme: user.profile.theme ?? 'system',
+  };
+}
+
+export default function UserFormModal({
+  open,
+  mode,
+  user,
+  submitting,
+  forcePassword = false,
+  onClose,
+  onSubmit,
+}: UserFormModalProps) {
+  const [form, setForm] = useState<FormState>(() => ({
+    email: user?.email ?? '',
+    password: '',
+    profile: mergeProfile(user),
+    sendEmailInvite: false,
+  }));
+  const [errors, setErrors] = useState<ValidationErrors>({});
+  const [showPassword, setShowPassword] = useState<boolean>(mode === 'create' || forcePassword);
+
+  useEffect(() => {
+    if (!open) return;
+    setForm({
+      email: user?.email ?? '',
+      password: '',
+      profile: mergeProfile(user),
+      sendEmailInvite: false,
+    });
+    setErrors({});
+    setShowPassword(mode === 'create' || forcePassword);
+  }, [open, user, mode, forcePassword]);
+
+  const title = mode === 'create' ? 'Tambah Pengguna' : 'Edit Pengguna';
+  const submitLabel = mode === 'create' ? 'Buat Pengguna' : 'Simpan Perubahan';
+
+  const passwordRequired = useMemo(() => {
+    if (mode === 'create' && !form.sendEmailInvite) return true;
+    if (mode === 'edit' && showPassword) return true;
+    return false;
+  }, [form.sendEmailInvite, mode, showPassword]);
+
+  const handleProfileChange = <K extends keyof AdminUserProfile>(key: K, value: AdminUserProfile[K]) => {
+    setForm((prev) => ({
+      ...prev,
+      profile: {
+        ...prev.profile,
+        [key]: value,
+      },
+    }));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const nextErrors: ValidationErrors = {};
+
+    if (!validateEmail(form.email)) {
+      nextErrors.email = 'Email tidak valid';
+    }
+
+    if (passwordRequired && !validatePassword(form.password)) {
+      nextErrors.password = 'Password minimal 8 karakter dengan huruf besar, kecil, dan angka';
+    }
+
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) {
+      return;
+    }
+
+    const payload: SubmitPayload = {
+      email: form.email.trim(),
+      profile: {
+        role: form.profile.role,
+        is_active: Boolean(form.profile.is_active),
+        full_name: form.profile.full_name?.trim() || undefined,
+        username: form.profile.username?.trim() || undefined,
+        avatar_url: form.profile.avatar_url?.trim() || undefined,
+        locale: form.profile.locale?.trim() || undefined,
+        timezone: form.profile.timezone?.trim() || undefined,
+        theme: form.profile.theme ?? 'system',
+      },
+    };
+
+    if (mode === 'create' && form.sendEmailInvite) {
+      payload.sendEmailInvite = true;
+    }
+
+    if (passwordRequired && form.password) {
+      payload.password = form.password;
+    }
+
+    await onSubmit(payload);
+  };
+
+  const handleInviteToggle = (checked: boolean) => {
+    setForm((prev) => ({
+      ...prev,
+      sendEmailInvite: checked,
+    }));
+    if (checked) {
+      setShowPassword(false);
+    } else if (mode === 'create') {
+      setShowPassword(true);
+    }
+  };
+
+  const displayName = form.profile.full_name?.trim() || form.profile.username?.trim();
+  const hasDisplayName = Boolean(displayName);
+
+  return (
+    <Modal open={open} title={title} onClose={onClose}>
+      <form className="flex flex-col gap-5" onSubmit={handleSubmit}>
+        <div className="grid gap-4">
+          <label className="flex flex-col gap-2">
+            <span className="text-sm font-medium text-text">Email</span>
+            <input
+              type="email"
+              className="input"
+              value={form.email}
+              onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
+              required
+            />
+            {errors.email ? <span className="text-xs text-danger">{errors.email}</span> : null}
+          </label>
+
+          {mode === 'create' ? (
+            <label className="inline-flex items-center gap-2 text-sm text-muted">
+              <input
+                type="checkbox"
+                checked={form.sendEmailInvite}
+                onChange={(event) => handleInviteToggle(event.target.checked)}
+              />
+              Kirim undangan email (pengguna akan mengatur password sendiri)
+            </label>
+          ) : null}
+
+          {passwordRequired ? (
+            <label className="flex flex-col gap-2">
+              <div className="flex items-center justify-between text-sm font-medium text-text">
+                <span>Password {mode === 'edit' ? 'baru' : ''}</span>
+                {mode === 'edit' && !form.sendEmailInvite ? (
+                  <button
+                    type="button"
+                    className="text-xs font-semibold text-primary hover:underline"
+                    onClick={() => setShowPassword(false)}
+                  >
+                    Batalkan
+                  </button>
+                ) : null}
+              </div>
+              <input
+                type="password"
+                className="input"
+                placeholder="Minimal 8 karakter"
+                value={form.password}
+                onChange={(event) => setForm((prev) => ({ ...prev, password: event.target.value }))}
+                required={passwordRequired}
+              />
+              {errors.password ? <span className="text-xs text-danger">{errors.password}</span> : null}
+            </label>
+          ) : mode === 'edit' ? (
+            <button
+              type="button"
+              className="btn btn-secondary btn-sm w-fit"
+              onClick={() => setShowPassword(true)}
+            >
+              Setel password baru
+            </button>
+          ) : null}
+
+          <div className="grid gap-3 rounded-2xl border border-border-subtle bg-surface-2 p-4">
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-semibold text-text">Role & Status</span>
+              <p className="text-xs text-muted-foreground">
+                Tentukan hak akses dan status aktivasi pengguna.
+              </p>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="flex flex-col gap-2 text-sm">
+                <span className="font-medium text-text">Role</span>
+                <select
+                  className="input"
+                  value={form.profile.role}
+                  onChange={(event) => handleProfileChange('role', event.target.value as AdminUserProfile['role'])}
+                >
+                  <option value="user">User</option>
+                  <option value="admin">Admin</option>
+                </select>
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={form.profile.is_active}
+                  onChange={(event) => handleProfileChange('is_active', event.target.checked)}
+                />
+                <span>Aktifkan akses</span>
+              </label>
+            </div>
+          </div>
+
+          <div className="grid gap-3 rounded-2xl border border-border-subtle bg-surface-2 p-4">
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-semibold text-text">Profil Publik</span>
+              <p className="text-xs text-muted-foreground">
+                Informasi ini akan tampil pada tampilan admin dan mungkin terlihat oleh pengguna lain.
+              </p>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="flex flex-col gap-2 text-sm">
+                <span className="font-medium text-text">Nama Lengkap</span>
+                <input
+                  type="text"
+                  className="input"
+                  value={form.profile.full_name ?? ''}
+                  onChange={(event) => handleProfileChange('full_name', event.target.value)}
+                  placeholder="Misal: Andi Wijaya"
+                />
+              </label>
+              <label className="flex flex-col gap-2 text-sm">
+                <span className="font-medium text-text">Username</span>
+                <input
+                  type="text"
+                  className="input"
+                  value={form.profile.username ?? ''}
+                  onChange={(event) => handleProfileChange('username', event.target.value)}
+                  placeholder="Misal: andi.w"
+                />
+              </label>
+              <label className="flex flex-col gap-2 text-sm">
+                <span className="font-medium text-text">Avatar URL</span>
+                <input
+                  type="url"
+                  className="input"
+                  value={form.profile.avatar_url ?? ''}
+                  onChange={(event) => handleProfileChange('avatar_url', event.target.value)}
+                  placeholder="https://..."
+                />
+              </label>
+              <div className="grid gap-4 sm:grid-cols-2 sm:col-span-2">
+                <label className="flex flex-col gap-2 text-sm">
+                  <span className="font-medium text-text">Locale</span>
+                  <input
+                    type="text"
+                    className="input"
+                    value={form.profile.locale ?? ''}
+                    onChange={(event) => handleProfileChange('locale', event.target.value)}
+                    placeholder="id-ID"
+                  />
+                </label>
+                <label className="flex flex-col gap-2 text-sm">
+                  <span className="font-medium text-text">Timezone</span>
+                  <input
+                    type="text"
+                    className="input"
+                    value={form.profile.timezone ?? ''}
+                    onChange={(event) => handleProfileChange('timezone', event.target.value)}
+                    placeholder="Asia/Jakarta"
+                  />
+                </label>
+                <label className="flex flex-col gap-2 text-sm">
+                  <span className="font-medium text-text">Tema</span>
+                  <select
+                    className="input"
+                    value={form.profile.theme ?? 'system'}
+                    onChange={(event) => handleProfileChange('theme', event.target.value)}
+                  >
+                    <option value="system">System</option>
+                    <option value="light">Light</option>
+                    <option value="dark">Dark</option>
+                  </select>
+                </label>
+              </div>
+            </div>
+          </div>
+
+          {mode === 'edit' && user ? (
+            <div className="rounded-2xl border border-border-subtle bg-amber-50 p-4 text-sm text-amber-900">
+              <p className="font-semibold">Informasi akun</p>
+              <ul className="mt-2 list-disc space-y-1 pl-5">
+                <li>ID Pengguna: <span className="font-mono text-xs">{user.id}</span></li>
+                <li>Dibuat pada: {new Date(user.created_at).toLocaleString('id-ID')}</li>
+                {user.last_sign_in_at ? (
+                  <li>Login terakhir: {new Date(user.last_sign_in_at).toLocaleString('id-ID')}</li>
+                ) : null}
+                {hasDisplayName ? <li>Nama tampilan: {displayName}</li> : null}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-center">
+          <button
+            type="button"
+            className="btn btn-ghost"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Batal
+          </button>
+          <button
+            type="submit"
+            className="btn btn-primary"
+            disabled={submitting}
+          >
+            {submitting ? 'Menyimpan…' : submitLabel}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/src/components/admin/users/UserTable.tsx
+++ b/src/components/admin/users/UserTable.tsx
@@ -1,0 +1,266 @@
+import type { AdminUserItem, AdminUsersPagination } from '../../../lib/api/adminUsers';
+import { useMemo } from 'react';
+import { Mail, Chrome, ShieldCheck } from 'lucide-react';
+
+type UserTableProps = {
+  users: AdminUserItem[];
+  loading?: boolean;
+  pagination?: AdminUsersPagination;
+  onEdit: (user: AdminUserItem) => void;
+  onDelete: (user: AdminUserItem) => void;
+  onRequestPasswordReset: (user: AdminUserItem) => void;
+  onToggleActive: (user: AdminUserItem, next: boolean) => void;
+  onNextPage?: () => void;
+  onPrevPage?: () => void;
+  canNext?: boolean;
+  canPrev?: boolean;
+  togglingUserId?: string | null;
+};
+
+type ProviderIconProps = {
+  provider: string;
+};
+
+function ProviderIcon({ provider }: ProviderIconProps) {
+  const normalized = provider.toLowerCase();
+  if (normalized === 'email') {
+    return <Mail className="h-4 w-4" title="Email" />;
+  }
+  if (normalized === 'google') {
+    return <Chrome className="h-4 w-4" title="Google" />;
+  }
+  return <ShieldCheck className="h-4 w-4" title={provider} />;
+}
+
+function formatRelativeTime(value: string | null) {
+  if (!value) return 'Belum pernah';
+  const target = new Date(value);
+  if (Number.isNaN(target.getTime())) return 'Tidak diketahui';
+  const now = new Date();
+  const diff = target.getTime() - now.getTime();
+  const absDiff = Math.abs(diff);
+  const units: [Intl.RelativeTimeFormatUnit, number][] = [
+    ['year', 1000 * 60 * 60 * 24 * 365],
+    ['month', 1000 * 60 * 60 * 24 * 30],
+    ['week', 1000 * 60 * 60 * 24 * 7],
+    ['day', 1000 * 60 * 60 * 24],
+    ['hour', 1000 * 60 * 60],
+    ['minute', 1000 * 60],
+  ];
+  const formatter = new Intl.RelativeTimeFormat('id-ID', { numeric: 'auto' });
+  for (const [unit, divisor] of units) {
+    if (absDiff >= divisor || unit === 'minute') {
+      const value = Math.round(diff / divisor);
+      return formatter.format(value, unit);
+    }
+  }
+  return formatter.format(0, 'minute');
+}
+
+function getDisplayName(user: AdminUserItem) {
+  return user.profile.full_name?.trim() || user.profile.username?.trim() || user.email.split('@')[0];
+}
+
+function getAvatarFallback(user: AdminUserItem) {
+  const name = getDisplayName(user);
+  return name?.slice(0, 1).toUpperCase() ?? user.email.slice(0, 1).toUpperCase();
+}
+
+export default function UserTable({
+  users,
+  loading = false,
+  pagination,
+  onEdit,
+  onDelete,
+  onRequestPasswordReset,
+  onToggleActive,
+  onNextPage,
+  onPrevPage,
+  canNext,
+  canPrev,
+  togglingUserId,
+}: UserTableProps) {
+  const skeletonRows = useMemo(() => Array.from({ length: 5 }), []);
+
+  return (
+    <div className="overflow-hidden rounded-3xl border border-border-subtle bg-surface">
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-border-subtle">
+          <thead className="bg-surface-2/60 text-xs uppercase tracking-wide text-muted-foreground">
+            <tr>
+              <th scope="col" className="px-5 py-3 text-left">Pengguna</th>
+              <th scope="col" className="px-5 py-3 text-left">Email</th>
+              <th scope="col" className="px-5 py-3 text-left">Role</th>
+              <th scope="col" className="px-5 py-3 text-left">Status</th>
+              <th scope="col" className="px-5 py-3 text-left">Login Terakhir</th>
+              <th scope="col" className="px-5 py-3 text-left">Dibuat</th>
+              <th scope="col" className="px-5 py-3 text-left">Provider</th>
+              <th scope="col" className="px-5 py-3 text-right">Aksi</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border-subtle text-sm text-text">
+            {loading
+              ? skeletonRows.map((_, index) => (
+                  <tr key={`skeleton-${index}`} className="animate-pulse">
+                    <td className="px-5 py-4">
+                      <div className="flex items-center gap-3">
+                        <div className="h-10 w-10 rounded-full bg-border" />
+                        <div className="h-3 w-24 rounded-full bg-border" />
+                      </div>
+                    </td>
+                    <td className="px-5 py-4">
+                      <div className="h-3 w-32 rounded-full bg-border" />
+                    </td>
+                    <td className="px-5 py-4">
+                      <div className="h-3 w-16 rounded-full bg-border" />
+                    </td>
+                    <td className="px-5 py-4">
+                      <div className="h-3 w-16 rounded-full bg-border" />
+                    </td>
+                    <td className="px-5 py-4">
+                      <div className="h-3 w-20 rounded-full bg-border" />
+                    </td>
+                    <td className="px-5 py-4">
+                      <div className="h-3 w-20 rounded-full bg-border" />
+                    </td>
+                    <td className="px-5 py-4">
+                      <div className="flex gap-2">
+                        <div className="h-4 w-4 rounded-full bg-border" />
+                        <div className="h-4 w-4 rounded-full bg-border" />
+                      </div>
+                    </td>
+                    <td className="px-5 py-4 text-right">
+                      <div className="h-3 w-24 rounded-full bg-border" />
+                    </td>
+                  </tr>
+                ))
+              : null}
+
+            {!loading && users.length === 0 ? (
+              <tr>
+                <td colSpan={8} className="px-5 py-10 text-center text-sm text-muted-foreground">
+                  Tidak ada pengguna yang cocok dengan filter saat ini.
+                </td>
+              </tr>
+            ) : null}
+
+            {!loading
+              ? users.map((user) => (
+                  <tr key={user.id} className="hover:bg-surface-2/60">
+                    <td className="px-5 py-4">
+                      <div className="flex items-center gap-3">
+                        {user.profile.avatar_url ? (
+                          <img
+                            src={user.profile.avatar_url}
+                            alt={getDisplayName(user)}
+                            className="h-10 w-10 rounded-full object-cover"
+                          />
+                        ) : (
+                          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted/40 text-sm font-semibold">
+                            {getAvatarFallback(user)}
+                          </div>
+                        )}
+                        <div className="flex flex-col">
+                          <span className="font-semibold text-text">{getDisplayName(user)}</span>
+                          <span className="text-xs text-muted-foreground">ID: {user.id}</span>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-5 py-4">
+                      <div className="flex flex-col">
+                        <span className="font-medium text-text">{user.email}</span>
+                      </div>
+                    </td>
+                    <td className="px-5 py-4">
+                      <span
+                        className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold ${user.profile.role === 'admin' ? 'bg-brand/15 text-brand' : 'bg-muted/30 text-muted-foreground'}`}
+                      >
+                        {user.profile.role === 'admin' ? 'Admin' : 'User'}
+                      </span>
+                    </td>
+                    <td className="px-5 py-4">
+                      <label className="inline-flex items-center gap-2 text-xs font-medium text-text">
+                        <input
+                          type="checkbox"
+                          checked={user.profile.is_active}
+                          onChange={(event) => onToggleActive(user, event.target.checked)}
+                          disabled={togglingUserId === user.id}
+                        />
+                        <span>{user.profile.is_active ? 'Aktif' : 'Tidak aktif'}</span>
+                      </label>
+                    </td>
+                    <td className="px-5 py-4">
+                      <span className="text-xs text-muted-foreground" title={user.last_sign_in_at ?? 'Belum pernah login'}>
+                        {formatRelativeTime(user.last_sign_in_at)}
+                      </span>
+                    </td>
+                    <td className="px-5 py-4">
+                      <span className="text-xs text-muted-foreground" title={new Date(user.created_at).toLocaleString('id-ID')}>
+                        {new Date(user.created_at).toLocaleDateString('id-ID')}
+                      </span>
+                    </td>
+                    <td className="px-5 py-4">
+                      <div className="flex items-center gap-2 text-muted-foreground">
+                        {(user.identities ?? []).map((identity, index) => (
+                          <ProviderIcon key={`${identity.provider}-${index}`} provider={identity.provider} />
+                        ))}
+                        {user.identities?.length === 0 ? <Mail className="h-4 w-4" title="Email" /> : null}
+                      </div>
+                    </td>
+                    <td className="px-5 py-4 text-right">
+                      <div className="flex flex-wrap justify-end gap-2">
+                        <button
+                          type="button"
+                          className="btn btn-secondary btn-sm"
+                          onClick={() => onEdit(user)}
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          className="btn btn-ghost btn-sm"
+                          onClick={() => onRequestPasswordReset(user)}
+                        >
+                          Reset Password
+                        </button>
+                        <button
+                          type="button"
+                          className="btn btn-danger btn-sm"
+                          onClick={() => onDelete(user)}
+                        >
+                          Hapus
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              : null}
+          </tbody>
+        </table>
+      </div>
+      <div className="flex items-center justify-between border-t border-border-subtle bg-surface-1 px-5 py-3 text-xs text-muted-foreground">
+        <div>
+          Halaman {pagination?.page ?? 1}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm"
+            onClick={onPrevPage}
+            disabled={!canPrev}
+          >
+            Sebelumnya
+          </button>
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm"
+            onClick={onNextPage}
+            disabled={!canNext}
+          >
+            Selanjutnya
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -196,7 +196,27 @@ export default function Sidebar({
                 : String(row.category),
         }));
 
-        setMenuItems(normalized);
+        let finalItems = normalized;
+        if (role === 'admin' && !normalized.some((item) => item.route === '/admin/users')) {
+          const nextPosition =
+            normalized.length > 0
+              ? Math.max(...normalized.map((item) => item.position ?? 0)) + 1
+              : 900;
+          finalItems = [
+            ...normalized,
+            {
+              id: 'admin-users-fallback',
+              title: 'Users',
+              route: '/admin/users',
+              access_level: 'admin',
+              icon_name: 'users',
+              position: nextPosition,
+              category: 'Admin',
+            },
+          ];
+        }
+
+        setMenuItems(finalItems);
       } catch (error) {
         if (!cancelled) {
           setMenuItems([]);

--- a/src/lib/api/adminUsers.ts
+++ b/src/lib/api/adminUsers.ts
@@ -1,0 +1,169 @@
+import { supabase, SUPABASE_URL } from '../supabase';
+
+export type AdminUserProfile = {
+  role: 'admin' | 'user';
+  is_active: boolean;
+  full_name?: string;
+  username?: string;
+  avatar_url?: string;
+  locale?: string;
+  timezone?: string;
+  theme?: 'system' | 'light' | 'dark' | string;
+};
+
+export type AdminUserItem = {
+  id: string;
+  email: string;
+  created_at: string;
+  last_sign_in_at: string | null;
+  identities: { provider: string }[];
+  profile: AdminUserProfile;
+};
+
+export type ListUsersParams = {
+  q?: string;
+  role?: 'admin' | 'user' | 'all';
+  status?: 'active' | 'inactive' | 'all';
+  limit?: number;
+  cursor?: string | null;
+  offset?: number;
+  order?: string;
+};
+
+export type AdminUsersPagination = {
+  page: number;
+  perPage: number;
+  nextCursor: string | null;
+  prevCursor: string | null;
+  hasMore: boolean;
+};
+
+export type ListUsersResult = {
+  items: AdminUserItem[];
+  pagination: AdminUsersPagination;
+};
+
+type ApiError = {
+  code: string;
+  message: string;
+  details?: string;
+};
+
+type ApiResponse<T> = {
+  ok: boolean;
+  data?: T;
+  error?: ApiError;
+};
+
+async function getAccessToken(): Promise<string> {
+  const { data, error } = await supabase.auth.getSession();
+  if (error) {
+    throw new Error(error.message ?? 'Gagal mengambil sesi Supabase');
+  }
+  const token = data.session?.access_token;
+  if (!token) {
+    throw new Error('Sesi Supabase tidak tersedia');
+  }
+  return token;
+}
+
+function buildUrl(path: string, params?: Record<string, string | number | boolean | null | undefined>) {
+  if (!SUPABASE_URL) {
+    throw new Error('SUPABASE_URL belum dikonfigurasi');
+  }
+  const url = new URL(`/functions/v1/admin-users${path}`, SUPABASE_URL);
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined || value === null || value === '') continue;
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url;
+}
+
+async function request<T>(path: string, init?: RequestInit & { query?: Record<string, any> }) {
+  const token = await getAccessToken();
+  const { query, headers, ...rest } = init ?? {};
+  const url = buildUrl(path, query ?? undefined);
+  const response = await fetch(url.toString(), {
+    method: rest.method ?? 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...(headers as Record<string, string> | undefined),
+    },
+    body: rest.body,
+  });
+
+  const contentType = response.headers.get('content-type') ?? '';
+  const isJson = contentType.includes('application/json');
+  const payload: ApiResponse<T> | undefined = isJson ? await response.json() : undefined;
+
+  if (!response.ok || !payload) {
+    const message = payload?.error?.message ?? `Request gagal dengan status ${response.status}`;
+    throw new Error(message);
+  }
+
+  if (!payload.ok) {
+    throw new Error(payload.error?.message ?? 'Permintaan gagal');
+  }
+
+  if (!('data' in payload)) {
+    throw new Error('Respons tidak valid dari server admin-users');
+  }
+
+  return payload.data as T;
+}
+
+export async function listUsers(params: ListUsersParams = {}): Promise<ListUsersResult> {
+  const query: Record<string, string> = {};
+  if (params.q) query.q = params.q;
+  if (params.role && params.role !== 'all') query.role = params.role;
+  if (params.status && params.status !== 'all') query.status = params.status;
+  if (params.limit) query.limit = String(params.limit);
+  if (params.cursor) query.cursor = String(params.cursor);
+  if (typeof params.offset === 'number') query.offset = String(params.offset);
+  if (params.order) query.order = params.order;
+
+  return request<ListUsersResult>('/', { query });
+}
+
+export type CreateUserPayload = {
+  email: string;
+  password?: string;
+  profile?: Partial<AdminUserProfile>;
+  sendEmailInvite?: boolean;
+};
+
+export async function createUser(payload: CreateUserPayload): Promise<AdminUserItem> {
+  const body = JSON.stringify(payload);
+  return request<AdminUserItem>('/', {
+    method: 'POST',
+    body,
+  });
+}
+
+export type UpdateUserPayload = {
+  email?: string;
+  password?: string;
+  profile?: Partial<AdminUserProfile>;
+};
+
+export async function updateUser(userId: string, payload: UpdateUserPayload): Promise<AdminUserItem> {
+  const body = JSON.stringify(payload);
+  return request<AdminUserItem>(`/${userId}`, {
+    method: 'PATCH',
+    body,
+  });
+}
+
+export async function deleteUser(userId: string, options?: { mode?: 'soft' | 'hard' }) {
+  const query: Record<string, string> = {};
+  if (options?.mode) {
+    query.mode = options.mode;
+  }
+  await request<unknown>(`/${userId}`, {
+    method: 'DELETE',
+    query,
+  });
+}

--- a/src/pages/admin/UsersPage.tsx
+++ b/src/pages/admin/UsersPage.tsx
@@ -1,0 +1,302 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Page from '../../layout/Page.jsx';
+import PageHeader from '../../layout/PageHeader.jsx';
+import Section from '../../layout/Section.jsx';
+import { useToast } from '../../context/ToastContext.jsx';
+import type {
+  AdminUserItem,
+  ListUsersResult,
+  CreateUserPayload,
+  UpdateUserPayload,
+} from '../../lib/api/adminUsers';
+import { createUser, deleteUser, listUsers, updateUser } from '../../lib/api/adminUsers';
+import UserTable from '../../components/admin/users/UserTable';
+import UserFormModal from '../../components/admin/users/UserFormModal';
+import DeleteUserDialog from '../../components/admin/users/DeleteUserDialog';
+
+const DEFAULT_LIMIT = 20;
+
+type FiltersState = {
+  q: string;
+  role: 'all' | 'admin' | 'user';
+  status: 'all' | 'active' | 'inactive';
+  order: 'created_at.desc' | 'created_at.asc' | 'last_sign_in_at.desc';
+};
+
+const INITIAL_FILTERS: FiltersState = {
+  q: '',
+  role: 'all',
+  status: 'all',
+  order: 'created_at.desc',
+};
+
+type DeleteMode = 'soft' | 'hard';
+
+type ModalMode = 'create' | 'edit';
+
+type FormSubmitPayload = (CreateUserPayload & UpdateUserPayload);
+
+export default function UsersPage() {
+  const { addToast } = useToast();
+  const [users, setUsers] = useState<AdminUserItem[]>([]);
+  const [filters, setFilters] = useState<FiltersState>(INITIAL_FILTERS);
+  const [searchInput, setSearchInput] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pagination, setPagination] = useState<ListUsersResult['pagination'] | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalMode, setModalMode] = useState<ModalMode>('create');
+  const [modalSubmitting, setModalSubmitting] = useState(false);
+  const [selectedUser, setSelectedUser] = useState<AdminUserItem | null>(null);
+  const [forcePassword, setForcePassword] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [togglingUserId, setTogglingUserId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const timeout = globalThis.setTimeout(() => {
+      setDebouncedSearch(searchInput.trim());
+    }, 400);
+    return () => {
+      globalThis.clearTimeout(timeout);
+    };
+  }, [searchInput]);
+
+  useEffect(() => {
+    setFilters((prev) => {
+      if (prev.q === debouncedSearch) return prev;
+      return { ...prev, q: debouncedSearch };
+    });
+  }, [debouncedSearch]);
+
+  const queryParams = useMemo(() => {
+    return {
+      q: filters.q || undefined,
+      role: filters.role === 'all' ? undefined : filters.role,
+      status: filters.status === 'all' ? undefined : filters.status,
+      order: filters.order,
+      limit: DEFAULT_LIMIT,
+    } as const;
+  }, [filters]);
+
+  const loadUsers = useCallback(
+    async (cursor?: string | null) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await listUsers({ ...queryParams, cursor: cursor ?? undefined });
+        setUsers(result.items);
+        setPagination(result.pagination);
+      } catch (err) {
+        console.error('Failed to load admin users', err);
+        setUsers([]);
+        setPagination(null);
+        setError(err instanceof Error ? err.message : 'Gagal memuat daftar pengguna');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [queryParams]
+  );
+
+  useEffect(() => {
+    void loadUsers();
+  }, [loadUsers]);
+
+  const handleOpenCreate = () => {
+    setModalMode('create');
+    setSelectedUser(null);
+    setForcePassword(false);
+    setModalOpen(true);
+  };
+
+  const handleOpenEdit = (user: AdminUserItem, withPassword = false) => {
+    setModalMode('edit');
+    setSelectedUser(user);
+    setForcePassword(withPassword);
+    setModalOpen(true);
+  };
+
+  const handleSubmitForm = async (payload: FormSubmitPayload) => {
+    setModalSubmitting(true);
+    try {
+      if (modalMode === 'create') {
+        await createUser(payload);
+        addToast('Pengguna berhasil dibuat', 'success');
+        setModalOpen(false);
+        await loadUsers();
+      } else if (selectedUser) {
+        const updated = await updateUser(selectedUser.id, payload);
+        setUsers((prev) => prev.map((item) => (item.id === updated.id ? updated : item)));
+        setSelectedUser(updated);
+        addToast('Pengguna berhasil diperbarui', 'success');
+        setModalOpen(false);
+      }
+    } catch (err) {
+      console.error('Failed to submit admin user form', err);
+      addToast(err instanceof Error ? err.message : 'Terjadi kesalahan saat menyimpan pengguna', 'error');
+    } finally {
+      setModalSubmitting(false);
+    }
+  };
+
+  const handleToggleActive = async (user: AdminUserItem, next: boolean) => {
+    setTogglingUserId(user.id);
+    setUsers((prev) =>
+      prev.map((item) => (item.id === user.id ? { ...item, profile: { ...item.profile, is_active: next } } : item))
+    );
+    try {
+      await updateUser(user.id, { profile: { is_active: next } });
+      addToast(next ? 'Pengguna diaktifkan' : 'Pengguna dinonaktifkan', 'success');
+    } catch (err) {
+      addToast('Gagal memperbarui status pengguna', 'error');
+      setUsers((prev) =>
+        prev.map((item) =>
+          item.id === user.id ? { ...item, profile: { ...item.profile, is_active: !next } } : item
+        )
+      );
+    } finally {
+      setTogglingUserId(null);
+    }
+  };
+
+  const handleDeleteRequest = (user: AdminUserItem) => {
+    setSelectedUser(user);
+    setDeleteOpen(true);
+  };
+
+  const handleConfirmDelete = async (mode: DeleteMode) => {
+    if (!selectedUser) return;
+    setDeleting(true);
+    try {
+      await deleteUser(selectedUser.id, { mode });
+      addToast(mode === 'hard' ? 'Pengguna dihapus permanen' : 'Pengguna dinonaktifkan', 'success');
+      setDeleteOpen(false);
+      await loadUsers();
+    } catch (err) {
+      console.error('Failed to delete admin user', err);
+      addToast(err instanceof Error ? err.message : 'Gagal menghapus pengguna', 'error');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const handleFilterChange = <K extends keyof FiltersState>(key: K, value: FiltersState[K]) => {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const canNext = Boolean(pagination?.nextCursor) && !loading;
+  const canPrev = Boolean(pagination?.prevCursor) && !loading;
+
+  return (
+    <Page>
+      <PageHeader
+        title="Kelola Pengguna"
+        description="Tambah, edit, dan kelola hak akses pengguna HematWoi."
+      >
+        <button type="button" className="btn btn-primary" onClick={handleOpenCreate}>
+          Tambah Pengguna
+        </button>
+      </PageHeader>
+
+      <Section first>
+        <div className="flex flex-col gap-4 rounded-3xl border border-border-subtle bg-surface p-5">
+          <div className="grid gap-3 sm:grid-cols-4 sm:items-end">
+            <div className="sm:col-span-2">
+              <label className="flex flex-col gap-2 text-sm">
+                <span className="font-medium text-text">Cari pengguna</span>
+                <input
+                  type="search"
+                  className="input"
+                  placeholder="Cari email, nama, atau username"
+                  value={searchInput}
+                  onChange={(event) => setSearchInput(event.target.value)}
+                />
+              </label>
+            </div>
+            <label className="flex flex-col gap-2 text-sm">
+              <span className="font-medium text-text">Role</span>
+              <select
+                className="input"
+                value={filters.role}
+                onChange={(event) => handleFilterChange('role', event.target.value as FiltersState['role'])}
+              >
+                <option value="all">Semua role</option>
+                <option value="admin">Admin</option>
+                <option value="user">User</option>
+              </select>
+            </label>
+            <label className="flex flex-col gap-2 text-sm">
+              <span className="font-medium text-text">Status</span>
+              <select
+                className="input"
+                value={filters.status}
+                onChange={(event) => handleFilterChange('status', event.target.value as FiltersState['status'])}
+              >
+                <option value="all">Semua status</option>
+                <option value="active">Aktif</option>
+                <option value="inactive">Tidak aktif</option>
+              </select>
+            </label>
+            <label className="flex flex-col gap-2 text-sm sm:col-span-2">
+              <span className="font-medium text-text">Urutkan</span>
+              <select
+                className="input"
+                value={filters.order}
+                onChange={(event) => handleFilterChange('order', event.target.value as FiltersState['order'])}
+              >
+                <option value="created_at.desc">Terbaru dibuat</option>
+                <option value="created_at.asc">Terlama dibuat</option>
+                <option value="last_sign_in_at.desc">Login terbaru</option>
+              </select>
+            </label>
+          </div>
+          {error ? (
+            <div className="rounded-2xl border border-danger/40 bg-danger/10 px-4 py-3 text-sm text-danger">
+              {error}
+            </div>
+          ) : null}
+        </div>
+      </Section>
+
+      <Section>
+        <UserTable
+          users={users}
+          loading={loading}
+          pagination={pagination ?? undefined}
+          onEdit={(user) => handleOpenEdit(user, false)}
+          onRequestPasswordReset={(user) => handleOpenEdit(user, true)}
+          onToggleActive={handleToggleActive}
+          onDelete={handleDeleteRequest}
+          onNextPage={() => (pagination?.nextCursor ? loadUsers(pagination.nextCursor) : undefined)}
+          onPrevPage={() => (pagination?.prevCursor ? loadUsers(pagination.prevCursor) : undefined)}
+          canNext={canNext}
+          canPrev={canPrev}
+          togglingUserId={togglingUserId}
+        />
+      </Section>
+
+      <UserFormModal
+        open={modalOpen}
+        mode={modalMode}
+        user={selectedUser}
+        forcePassword={forcePassword}
+        submitting={modalSubmitting}
+        onClose={() => {
+          setModalOpen(false);
+          setForcePassword(false);
+        }}
+        onSubmit={handleSubmitForm}
+      />
+
+      <DeleteUserDialog
+        open={deleteOpen}
+        user={selectedUser}
+        deleting={deleting}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={handleConfirmDelete}
+      />
+    </Page>
+  );
+}

--- a/src/router/nav.config.tsx
+++ b/src/router/nav.config.tsx
@@ -25,6 +25,7 @@ import {
   Settings as SettingsIcon,
   User as UserIcon,
   CreditCard,
+  Users as UsersIcon,
 } from 'lucide-react';
 
 export const NAV_ITEMS: NavItem[] = [
@@ -142,6 +143,15 @@ export const NAV_ITEMS: NavItem[] = [
     section: 'secondary',
     inSidebar: true,
     protected: true,
+  },
+  {
+    title: 'Users',
+    path: '/admin/users',
+    icon: <UsersIcon className="h-5 w-5" />,
+    section: 'secondary',
+    inSidebar: true,
+    protected: true,
+    roles: ['admin'],
   },
   {
     title: 'Auth',

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from 'react';
 import type { RouteObject } from 'react-router-dom';
 import { NAV_ITEMS, NavItem } from './nav.config';
 import AuthGuard from '../guards/AuthGuard';
+import AdminGuard from '../components/AdminGuard';
 import { isFeatureEnabled } from '../featureFlags';
 
 function loadComponent(path: string) {
@@ -36,6 +37,8 @@ function loadComponent(path: string) {
       return lazy(() => import('../pages/SettingsPage'));
     case '/profile':
       return lazy(() => import('../pages/Profile'));
+    case '/admin/users':
+      return lazy(() => import('../pages/admin/UsersPage'));
     case '/auth':
       return lazy(() => import('../pages/AuthLogin'));
     default:
@@ -51,10 +54,13 @@ function buildRoutes(items: NavItem[]): RouteObject[] {
       const element = (
         <Suspense fallback={<div />}> <Component /> </Suspense>
       );
-      const wrapped = item.protected ? <AuthGuard>{element}</AuthGuard> : element;
+      const protectedElement = item.protected ? <AuthGuard>{element}</AuthGuard> : element;
+      const roleWrapped = item.roles?.includes('admin')
+        ? <AdminGuard>{protectedElement}</AdminGuard>
+        : protectedElement;
       return {
         path: item.path,
-        element: wrapped,
+        element: roleWrapped,
         children: item.children ? buildRoutes(item.children) : undefined,
       };
     });

--- a/supabase/functions/admin-users/index.ts
+++ b/supabase/functions/admin-users/index.ts
@@ -1,0 +1,711 @@
+// deno-lint-ignore-file no-explicit-any
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.57.4";
+import type { User } from "https://esm.sh/@supabase/supabase-js@2.57.4";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
+const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY || !SUPABASE_SERVICE_ROLE_KEY) {
+  console.error("Missing Supabase environment variables for admin-users function");
+}
+
+const corsHeaders: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
+};
+
+const adminClient = SUPABASE_URL && SUPABASE_SERVICE_ROLE_KEY
+  ? createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    })
+  : null;
+
+function jsonResponse(status: number, body: Record<string, unknown>) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      ...corsHeaders,
+    },
+  });
+}
+
+function normalizeBoolean(value: any, fallback = false): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return ["1", "true", "yes", "y"].includes(normalized);
+  }
+  return fallback;
+}
+
+function normalizeProfile(row: any | null | undefined) {
+  if (!row) {
+    return {
+      role: "user" as const,
+      is_active: false,
+    };
+  }
+
+  return {
+    role: row.role === "admin" ? "admin" : "user",
+    is_active: normalizeBoolean(row.is_active, true),
+    full_name: typeof row.full_name === "string" ? row.full_name : undefined,
+    username: typeof row.username === "string" ? row.username : undefined,
+    avatar_url: typeof row.avatar_url === "string" ? row.avatar_url : undefined,
+    locale: typeof row.locale === "string" ? row.locale : undefined,
+    timezone: typeof row.timezone === "string" ? row.timezone : undefined,
+    theme: typeof row.theme === "string" ? row.theme : undefined,
+  };
+}
+
+function sanitizeUser(user: User, profile: any | null | undefined) {
+  const normalizedProfile = normalizeProfile(profile);
+  return {
+    id: user.id,
+    email: user.email,
+    created_at: user.created_at,
+    last_sign_in_at: user.last_sign_in_at ?? null,
+    identities: Array.isArray(user.identities)
+      ? user.identities.map((identity) => ({
+          provider: typeof identity.provider === "string" ? identity.provider : "unknown",
+        }))
+      : [],
+    profile: normalizedProfile,
+  };
+}
+
+function extractPathSuffix(url: URL) {
+  const segments = url.pathname.split("/").filter(Boolean);
+  const index = segments.findIndex((segment) => segment === "admin-users");
+  if (index === -1) return "/";
+  const remaining = segments.slice(index + 1);
+  return `/${remaining.join("/")}` || "/";
+}
+
+function validateEmail(email: unknown): email is string {
+  if (typeof email !== "string") return false;
+  const normalized = email.trim();
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailPattern.test(normalized.toLowerCase());
+}
+
+function validatePassword(password: unknown): password is string {
+  if (typeof password !== "string") return false;
+  if (password.length < 8) return false;
+  if (!/[a-z]/.test(password)) return false;
+  if (!/[A-Z]/.test(password)) return false;
+  if (!/[0-9]/.test(password)) return false;
+  return true;
+}
+
+function escapeLike(value: string) {
+  return value.replace(/[%_]/g, (match) => `\\${match}`);
+}
+
+async function logAudit(
+  adminId: string,
+  action: string,
+  targetId: string,
+  details: Record<string, unknown>,
+) {
+  if (!adminClient) return;
+  try {
+    await adminClient.from("admin_audit_logs").insert({
+      admin_id: adminId,
+      action,
+      target_user_id: targetId,
+      details,
+    });
+  } catch (error) {
+    console.warn("Failed to write admin audit log", error);
+  }
+}
+
+async function getProfilesByIds(ids: string[]) {
+  if (!adminClient) return new Map<string, any>();
+  if (!ids.length) return new Map<string, any>();
+  const { data, error } = await adminClient
+    .from("user_profiles")
+    .select(
+      "id, role, is_active, full_name, username, avatar_url, locale, timezone, theme",
+    )
+    .in("id", ids);
+  if (error) throw error;
+  const map = new Map<string, any>();
+  for (const row of data ?? []) {
+    if (row?.id) {
+      map.set(String(row.id), row);
+    }
+  }
+  return map;
+}
+
+async function ensureProfile(userId: string, profilePayload: Record<string, unknown>) {
+  if (!adminClient) throw new Error("Admin client unavailable");
+  const payload: Record<string, unknown> = { id: userId };
+
+  if (Object.prototype.hasOwnProperty.call(profilePayload, "role")) {
+    payload.role = profilePayload.role === "admin" ? "admin" : "user";
+  }
+
+  if (Object.prototype.hasOwnProperty.call(profilePayload, "is_active")) {
+    payload.is_active = normalizeBoolean(profilePayload.is_active, true);
+  }
+
+  const optionalKeys = [
+    "full_name",
+    "username",
+    "avatar_url",
+    "locale",
+    "timezone",
+    "theme",
+  ] as const;
+
+  for (const key of optionalKeys) {
+    if (Object.prototype.hasOwnProperty.call(profilePayload, key)) {
+      const value = profilePayload[key];
+      payload[key] = typeof value === "string" ? value : value ?? null;
+    }
+  }
+
+  const { error } = await adminClient.from("user_profiles").upsert(payload, { onConflict: "id" });
+  if (error) throw error;
+}
+
+function parseProfilePayload(raw: any) {
+  if (!raw || typeof raw !== "object") return {} as Record<string, unknown>;
+  const allowed: Record<string, unknown> = {};
+  if (raw.role === "admin" || raw.role === "user") {
+    allowed.role = raw.role;
+  }
+  if (raw.is_active !== undefined) {
+    allowed.is_active = normalizeBoolean(raw.is_active, true);
+  }
+  const optionalFields = [
+    "full_name",
+    "username",
+    "avatar_url",
+    "locale",
+    "timezone",
+    "theme",
+  ] as const;
+  for (const key of optionalFields) {
+    if (Object.prototype.hasOwnProperty.call(raw, key)) {
+      const value = raw[key];
+      if (typeof value === "string") {
+        allowed[key] = value;
+      } else if (value == null) {
+        allowed[key] = null;
+      }
+    }
+  }
+  return allowed;
+}
+
+async function fetchUserById(id: string) {
+  if (!adminClient) throw new Error("Admin client unavailable");
+  const { data, error } = await adminClient.auth.admin.getUserById(id);
+  if (error) throw error;
+  if (!data?.user) throw new Error("User not found");
+  const profileMap = await getProfilesByIds([id]);
+  return sanitizeUser(data.user, profileMap.get(id));
+}
+
+async function listUsersHandler(url: URL) {
+  if (!adminClient) {
+    return jsonResponse(500, {
+      ok: false,
+      error: { code: "service/unavailable", message: "Admin client is not configured" },
+    });
+  }
+
+  const q = (url.searchParams.get("q") ?? "").trim();
+  const roleFilter = url.searchParams.get("role");
+  const statusFilter = url.searchParams.get("status");
+  const order = (url.searchParams.get("order") ?? "created_at.desc").toLowerCase();
+  const limitParam = Number.parseInt(url.searchParams.get("limit") ?? "20", 10);
+  const limit = Number.isFinite(limitParam) ? Math.min(Math.max(limitParam, 1), 100) : 20;
+
+  const cursorParam = url.searchParams.get("cursor");
+  const offsetParam = url.searchParams.get("offset");
+  let page = 1;
+  if (cursorParam) {
+    const parsedCursor = Number.parseInt(cursorParam, 10);
+    if (Number.isFinite(parsedCursor) && parsedCursor > 0) {
+      page = parsedCursor;
+    }
+  } else if (offsetParam) {
+    const offset = Number.parseInt(offsetParam, 10);
+    if (Number.isFinite(offset) && offset >= 0) {
+      page = Math.floor(offset / limit) + 1;
+    }
+  }
+
+  try {
+    let users: User[] = [];
+    let pagination = {
+      page,
+      perPage: limit,
+      nextCursor: null as string | null,
+      prevCursor: page > 1 ? String(page - 1) : null,
+      hasMore: false,
+    };
+
+    if (q) {
+      const matches = new Map<string, User>();
+
+      if (q.includes("@")) {
+        const { data: emailData } = await adminClient.auth.admin.getUserByEmail(q);
+        if (emailData?.user) {
+          matches.set(emailData.user.id, emailData.user);
+        }
+      }
+
+      const escaped = escapeLike(q).replace(/'/g, "''");
+      const { data: profileMatches, error: profileSearchError } = await adminClient
+        .from("user_profiles")
+        .select("id")
+        .or(`full_name.ilike.%${escaped}%,username.ilike.%${escaped}%`)
+        .limit(50);
+
+      if (profileSearchError) throw profileSearchError;
+
+      for (const row of profileMatches ?? []) {
+        if (!row?.id || matches.has(row.id)) continue;
+        try {
+          const { data: userData } = await adminClient.auth.admin.getUserById(row.id);
+          if (userData?.user) {
+            matches.set(userData.user.id, userData.user);
+          }
+        } catch (err) {
+          console.warn("Failed to fetch user while searching", err);
+        }
+      }
+
+      users = Array.from(matches.values());
+      pagination = {
+        page: 1,
+        perPage: limit,
+        nextCursor: null,
+        prevCursor: null,
+        hasMore: false,
+      };
+    } else {
+      const { data, error } = await adminClient.auth.admin.listUsers({
+        page,
+        perPage: limit,
+      });
+      if (error) throw error;
+      users = data?.users ?? [];
+      pagination = {
+        page,
+        perPage: limit,
+        nextCursor: data?.nextPage ? String(data.nextPage) : null,
+        prevCursor: page > 1 ? String(page - 1) : null,
+        hasMore: Boolean(data?.nextPage),
+      };
+    }
+
+    const ids = users.map((user) => user.id);
+    const profiles = await getProfilesByIds(ids);
+
+    let items = users.map((user) => sanitizeUser(user, profiles.get(user.id)));
+
+    if (roleFilter === "admin" || roleFilter === "user") {
+      items = items.filter((item) => item.profile.role === roleFilter);
+    }
+
+    if (statusFilter === "active") {
+      items = items.filter((item) => item.profile.is_active);
+    } else if (statusFilter === "inactive") {
+      items = items.filter((item) => !item.profile.is_active);
+    }
+
+    const orderParts = order.split(".");
+    const orderField = orderParts[0];
+    const direction = orderParts[1] === "asc" ? 1 : -1;
+    items.sort((a, b) => {
+      const valueA = orderField === "last_sign_in_at"
+        ? a.last_sign_in_at ?? ""
+        : orderField === "email"
+          ? a.email ?? ""
+          : a.created_at ?? "";
+      const valueB = orderField === "last_sign_in_at"
+        ? b.last_sign_in_at ?? ""
+        : orderField === "email"
+          ? b.email ?? ""
+          : b.created_at ?? "";
+      if (valueA < valueB) return -1 * direction;
+      if (valueA > valueB) return 1 * direction;
+      return 0;
+    });
+
+    if (items.length > limit) {
+      items = items.slice(0, limit);
+    }
+
+    return jsonResponse(200, {
+      ok: true,
+      data: {
+        items,
+        pagination,
+      },
+    });
+  } catch (error) {
+    console.error("Failed to list users", error);
+    return jsonResponse(500, {
+      ok: false,
+      error: {
+        code: "users/list_failed",
+        message: "Tidak dapat memuat daftar pengguna",
+        details: error instanceof Error ? error.message : String(error),
+      },
+    });
+  }
+}
+
+async function createUserHandler(req: Request, adminId: string) {
+  if (!adminClient) {
+    return jsonResponse(500, {
+      ok: false,
+      error: { code: "service/unavailable", message: "Admin client is not configured" },
+    });
+  }
+
+  let payload: any = null;
+  try {
+    payload = await req.json();
+  } catch {
+    return jsonResponse(400, {
+      ok: false,
+      error: { code: "request/invalid", message: "Body harus berupa JSON" },
+    });
+  }
+
+  const { email, password, profile, sendEmailInvite } = payload ?? {};
+
+  if (!validateEmail(email)) {
+    return jsonResponse(422, {
+      ok: false,
+      error: { code: "validation/invalid_email", message: "Email tidak valid" },
+    });
+  }
+
+  if (!sendEmailInvite && !validatePassword(password)) {
+    return jsonResponse(422, {
+      ok: false,
+      error: {
+        code: "validation/invalid_password",
+        message: "Password minimal 8 karakter dan mengandung huruf besar, kecil, dan angka",
+      },
+    });
+  }
+
+  const profilePayload = parseProfilePayload(profile);
+  if (profilePayload.is_active === undefined) {
+    profilePayload.is_active = true;
+  }
+  if (!profilePayload.role) {
+    profilePayload.role = "user";
+  }
+
+  try {
+    let user: User | null = null;
+    if (sendEmailInvite) {
+      const { data, error } = await adminClient.auth.admin.inviteUserByEmail(email);
+      if (error) {
+        if (error.status === 409) {
+          return jsonResponse(409, {
+            ok: false,
+            error: {
+              code: "users/email_conflict",
+              message: "Email sudah terdaftar",
+            },
+          });
+        }
+        throw error;
+      }
+      user = data?.user ?? null;
+    } else {
+      const { data, error } = await adminClient.auth.admin.createUser({
+        email,
+        password,
+        email_confirm: true,
+      });
+      if (error) {
+        if (error.status === 409) {
+          return jsonResponse(409, {
+            ok: false,
+            error: {
+              code: "users/email_conflict",
+              message: "Email sudah terdaftar",
+            },
+          });
+        }
+        throw error;
+      }
+      user = data?.user ?? null;
+    }
+
+    if (!user) {
+      throw new Error("Supabase tidak mengembalikan data pengguna baru");
+    }
+
+    await ensureProfile(user.id, profilePayload);
+
+    await logAudit(adminId, "create", user.id, {
+      email,
+      profile: profilePayload,
+      sendEmailInvite: Boolean(sendEmailInvite),
+    });
+
+    const response = await fetchUserById(user.id);
+    return jsonResponse(201, { ok: true, data: response });
+  } catch (error) {
+    console.error("Failed to create user", error);
+    return jsonResponse(500, {
+      ok: false,
+      error: {
+        code: "users/create_failed",
+        message: "Tidak dapat membuat pengguna",
+        details: error instanceof Error ? error.message : String(error),
+      },
+    });
+  }
+}
+
+async function updateUserHandler(req: Request, adminId: string, userId: string) {
+  if (!adminClient) {
+    return jsonResponse(500, {
+      ok: false,
+      error: { code: "service/unavailable", message: "Admin client is not configured" },
+    });
+  }
+
+  let payload: any = null;
+  try {
+    payload = await req.json();
+  } catch {
+    return jsonResponse(400, {
+      ok: false,
+      error: { code: "request/invalid", message: "Body harus berupa JSON" },
+    });
+  }
+
+  const updates: { email?: string; password?: string } = {};
+
+  if (payload.email !== undefined) {
+    if (!validateEmail(payload.email)) {
+      return jsonResponse(422, {
+        ok: false,
+        error: { code: "validation/invalid_email", message: "Email tidak valid" },
+      });
+    }
+    updates.email = payload.email.trim();
+  }
+
+  if (payload.password !== undefined) {
+    if (!validatePassword(payload.password)) {
+      return jsonResponse(422, {
+        ok: false,
+        error: {
+          code: "validation/invalid_password",
+          message: "Password minimal 8 karakter dan mengandung huruf besar, kecil, dan angka",
+        },
+      });
+    }
+    updates.password = payload.password;
+  }
+
+  const profilePayload = parseProfilePayload(payload.profile);
+
+  if (!updates.email && !updates.password && Object.keys(profilePayload).length === 0) {
+    return jsonResponse(400, {
+      ok: false,
+      error: {
+        code: "request/empty",
+        message: "Tidak ada perubahan yang diberikan",
+      },
+    });
+  }
+
+  try {
+    if (updates.email || updates.password) {
+      const { error: updateError } = await adminClient.auth.admin.updateUserById(userId, updates);
+      if (updateError) {
+        if (updateError.status === 409) {
+          return jsonResponse(409, {
+            ok: false,
+            error: {
+              code: "users/email_conflict",
+              message: "Email sudah terdaftar",
+            },
+          });
+        }
+        throw updateError;
+      }
+    }
+
+    if (Object.keys(profilePayload).length > 0) {
+      await ensureProfile(userId, profilePayload);
+    }
+
+    await logAudit(adminId, "update", userId, {
+      updates,
+      profile: profilePayload,
+    });
+
+    const response = await fetchUserById(userId);
+    return jsonResponse(200, { ok: true, data: response });
+  } catch (error) {
+    console.error("Failed to update user", error);
+    return jsonResponse(500, {
+      ok: false,
+      error: {
+        code: "users/update_failed",
+        message: "Tidak dapat memperbarui pengguna",
+        details: error instanceof Error ? error.message : String(error),
+      },
+    });
+  }
+}
+
+async function deleteUserHandler(req: Request, adminId: string, userId: string) {
+  if (!adminClient) {
+    return jsonResponse(500, {
+      ok: false,
+      error: { code: "service/unavailable", message: "Admin client is not configured" },
+    });
+  }
+
+  const url = new URL(req.url);
+  const mode = (url.searchParams.get("mode") ?? "hard").toLowerCase();
+
+  try {
+    if (mode === "soft") {
+      await ensureProfile(userId, { is_active: false });
+      await logAudit(adminId, "toggle_active", userId, { is_active: false, mode: "soft" });
+    } else {
+      const { error } = await adminClient.auth.admin.deleteUser(userId);
+      if (error) throw error;
+      await adminClient.from("user_profiles").delete().eq("id", userId);
+      await logAudit(adminId, "delete", userId, { mode: "hard" });
+    }
+
+    return jsonResponse(200, { ok: true });
+  } catch (error) {
+    console.error("Failed to delete user", error);
+    return jsonResponse(500, {
+      ok: false,
+      error: {
+        code: "users/delete_failed",
+        message: "Tidak dapat menghapus pengguna",
+        details: error instanceof Error ? error.message : String(error),
+      },
+    });
+  }
+}
+
+serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY || !SUPABASE_SERVICE_ROLE_KEY || !adminClient) {
+    return jsonResponse(500, {
+      ok: false,
+      error: { code: "service/unconfigured", message: "Supabase environment variables are missing" },
+    });
+  }
+
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader) {
+    return jsonResponse(401, {
+      ok: false,
+      error: { code: "auth/unauthorized", message: "Token otorisasi diperlukan" },
+    });
+  }
+
+  const supabaseClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    global: {
+      headers: { Authorization: authHeader },
+    },
+  });
+
+  try {
+    const { data: authData, error: authError } = await supabaseClient.auth.getUser();
+    if (authError || !authData?.user) {
+      return jsonResponse(401, {
+        ok: false,
+        error: { code: "auth/unauthorized", message: "Session tidak valid" },
+      });
+    }
+
+    const currentUser = authData.user;
+    const { data: profile, error: profileError } = await supabaseClient
+      .from("user_profiles")
+      .select("id, role, is_active")
+      .eq("id", currentUser.id)
+      .maybeSingle();
+
+    if (profileError) {
+      console.error("Failed to load admin profile", profileError);
+      return jsonResponse(500, {
+        ok: false,
+        error: {
+          code: "auth/profile_error",
+          message: "Tidak dapat memeriksa peran admin",
+        },
+      });
+    }
+
+    if (!profile || profile.role !== "admin" || !normalizeBoolean(profile.is_active, false)) {
+      return jsonResponse(403, {
+        ok: false,
+        error: { code: "auth/forbidden", message: "Akses admin diperlukan" },
+      });
+    }
+
+    const url = new URL(req.url);
+    const pathSuffix = extractPathSuffix(url);
+
+    if (req.method === "GET" && pathSuffix === "/") {
+      return await listUsersHandler(url);
+    }
+
+    if (req.method === "POST" && pathSuffix === "/") {
+      return await createUserHandler(req, currentUser.id);
+    }
+
+    const idMatch = pathSuffix.match(/^\/(.+)$/);
+    if (idMatch) {
+      const userId = idMatch[1];
+      if (req.method === "PATCH") {
+        return await updateUserHandler(req, currentUser.id, userId);
+      }
+      if (req.method === "DELETE") {
+        return await deleteUserHandler(req, currentUser.id, userId);
+      }
+    }
+
+    return jsonResponse(404, {
+      ok: false,
+      error: { code: "route/not_found", message: "Endpoint tidak ditemukan" },
+    });
+  } catch (error) {
+    console.error("Unexpected error in admin-users function", error);
+    return jsonResponse(500, {
+      ok: false,
+      error: {
+        code: "server/error",
+        message: "Terjadi kesalahan tidak terduga",
+        details: error instanceof Error ? error.message : String(error),
+      },
+    });
+  }
+});

--- a/supabase/migrations/20250515000000_create_admin_audit_logs.sql
+++ b/supabase/migrations/20250515000000_create_admin_audit_logs.sql
@@ -1,0 +1,30 @@
+create extension if not exists "pgcrypto";
+
+alter table public.user_profiles
+  add column if not exists role text not null default 'user' check (role in ('user','admin')),
+  add column if not exists is_active boolean not null default true;
+
+update public.user_profiles
+set role = coalesce(nullif(trim(role), ''), 'user'),
+    is_active = coalesce(is_active, true);
+
+create table if not exists public.admin_audit_logs (
+  id uuid primary key default gen_random_uuid(),
+  admin_id uuid not null references auth.users(id) on delete cascade,
+  action text not null,
+  target_user_id uuid not null,
+  details jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists admin_audit_logs_admin_id_idx on public.admin_audit_logs(admin_id);
+create index if not exists admin_audit_logs_target_user_idx on public.admin_audit_logs(target_user_id);
+
+insert into public.app_sidebar_items (title, route, access_level, icon_name, position)
+values ('Users', '/admin/users', 'admin', 'users', 900)
+on conflict (route) do update set
+  title = excluded.title,
+  access_level = excluded.access_level,
+  icon_name = excluded.icon_name,
+  position = excluded.position,
+  updated_at = timezone('utc', now());


### PR DESCRIPTION
## Summary
- add an admin-users edge function that validates admin roles, handles CRUD operations via the service role client, and writes audit logs
- expose a typed admin users API wrapper and seed the sidebar/navigation so the admin users section is discoverable
- build an admin Users page with search/filter controls, CRUD modals, soft/hard delete confirmation, and a responsive table with provider/status indicators

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d921f246d08332902795c5e39a9871