### PR TITLE
Adjust dashboard spend and transaction controls

### DIFF
--- a/src/components/TopSpendsTable.jsx
+++ b/src/components/TopSpendsTable.jsx
@@ -70,11 +70,8 @@ export default function TopSpendsTable({ data = [], onSelect }) {
         }
       />
       <CardBody className="flex-1 space-y-6">
-        <div className="flex items-end justify-between gap-3 rounded-2xl bg-surface-alt/60 px-4 py-3">
-          <div>
-            <p className="text-xs font-medium uppercase tracking-wide text-muted">Total 5 pengeluaran teratas</p>
-            <p className="text-2xl font-semibold text-text">{toRupiah(totalTopSpend)}</p>
-          </div>
+        <div className="flex items-center justify-between gap-3 rounded-2xl bg-surface-alt/60 px-4 py-3">
+          <p className="text-2xl font-semibold text-text">{toRupiah(totalTopSpend)}</p>
           <span className="inline-flex items-center gap-1 rounded-xl bg-danger/10 px-3 py-1 text-xs font-semibold text-danger">
             <ArrowDownRight className="h-4 w-4" aria-hidden="true" />
             {sort === "asc" ? "Terkecil" : "Terbesar"}
@@ -114,13 +111,6 @@ export default function TopSpendsTable({ data = [], onSelect }) {
                         </p>
                         <p className="text-xs text-muted/80">{contribution}% dari total</p>
                       </div>
-                    </div>
-                    <div className="mt-3 h-1.5 rounded-full bg-border-subtle">
-                      <div
-                        className="h-full rounded-full bg-danger transition-all"
-                        style={{ width: `${contribution}%` }}
-                        aria-hidden="true"
-                      />
                     </div>
                   </button>
                 </li>

--- a/src/components/TopSpendsTable.jsx
+++ b/src/components/TopSpendsTable.jsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from "react";
-import { ArrowDownRight } from "lucide-react";
 import Card, { CardBody, CardHeader } from "./Card";
 
 function toRupiah(n = 0) {
@@ -42,10 +41,6 @@ export default function TopSpendsTable({ data = [], onSelect }) {
   }, [expenses, sort]);
 
   const items = sorted.slice(0, 5);
-  const totalTopSpend = useMemo(
-    () => items.reduce((sum, tx) => sum + tx.amount, 0),
-    [items]
-  );
   const totalExpense = useMemo(
     () => expenses.reduce((sum, tx) => sum + tx.amount, 0),
     [expenses]
@@ -70,10 +65,8 @@ export default function TopSpendsTable({ data = [], onSelect }) {
         }
       />
       <CardBody className="flex-1 space-y-6">
-        <div className="flex items-center justify-between gap-3 rounded-2xl bg-surface-alt/60 px-4 py-3">
-          <p className="text-2xl font-semibold text-text">{toRupiah(totalTopSpend)}</p>
-          <span className="inline-flex items-center gap-1 rounded-xl bg-danger/10 px-3 py-1 text-xs font-semibold text-danger">
-            <ArrowDownRight className="h-4 w-4" aria-hidden="true" />
+        <div className="flex justify-end">
+          <span className="inline-flex items-center rounded-xl bg-danger/10 px-3 py-1 text-xs font-semibold text-danger">
             {sort === "asc" ? "Terkecil" : "Terbesar"}
           </span>
         </div>

--- a/src/components/ui/Segmented.jsx
+++ b/src/components/ui/Segmented.jsx
@@ -1,15 +1,18 @@
+import clsx from "clsx";
+
 export default function Segmented({ value, onChange, options = [] }) {
   return (
-    <div className="inline-flex rounded-xl border border-border overflow-hidden">
+    <div className="inline-flex items-stretch gap-1 rounded-xl border border-border bg-surface-alt/60 p-1">
       {options.map((opt) => (
         <button
           key={opt.value}
           type="button"
-          className={`px-3 py-2 text-sm flex-1 ${
+          className={clsx(
+            "flex-1 rounded-lg px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]",
             value === opt.value
-              ? "bg-brand-var text-brand-foreground"
-              : "bg-surface-1"
-          }`}
+              ? "bg-brand text-brand-foreground shadow-sm"
+              : "bg-transparent text-muted hover:bg-surface-alt"
+          )}
           onClick={() => onChange(opt.value)}
         >
           {opt.label}


### PR DESCRIPTION
## Summary
- remove the redundant top spend label and clean up the list layout by dropping the progress bar
- refresh the segmented control styling so active and inactive states respect theme accents and accessibility across modes

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d95f4725ec83329eefe67f1b918453