### PR TITLE
Add toast on successful transaction deletion

### DIFF
--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -576,6 +576,9 @@ export default function Transactions() {
       }
       lastSelectedIdRef.current = null;
       refresh({ keepPage: true });
+      const successMessage =
+        ids.length === 1 ? "Transaksi dihapus" : `${ids.length} transaksi dihapus`;
+      addToast(successMessage, "success");
       showUndoSnackbar({
         ids,
         records: removalRecords.map((record) => ({


### PR DESCRIPTION
## Summary
- show a success toast when transactions are deleted
- reuse existing toast messaging for both single and bulk deletions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9620827588332b069f7078cb55510