### PR TITLE
Add toast feedback for transaction deletions

### DIFF
--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -576,6 +576,11 @@ export default function Transactions() {
       }
       lastSelectedIdRef.current = null;
       refresh({ keepPage: true });
+      const deletedCount = ids.length;
+      addToast(
+        deletedCount === 1 ? 'Transaksi dihapus' : `${deletedCount} transaksi dihapus`,
+        'success',
+      );
       showUndoSnackbar({
         ids,
         records: removalRecords.map((record) => ({


### PR DESCRIPTION
## Summary
- show a success toast after transactions are deleted so users get feedback

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9620827588332b069f7078cb55510