### PR TITLE
Show toast after deleting transactions

### DIFF
--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -576,6 +576,10 @@ export default function Transactions() {
       }
       lastSelectedIdRef.current = null;
       refresh({ keepPage: true });
+      addToast(
+        ids.length === 1 ? 'Transaksi dihapus' : `${ids.length} transaksi dihapus`,
+        'success',
+      );
       showUndoSnackbar({
         ids,
         records: removalRecords.map((record) => ({


### PR DESCRIPTION
## Summary
- trigger a success toast after transactions are removed so the UI matches edit feedback

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d964528da88332be3bd6ecbfb57b88