### PR TITLE
Update sidebar logo with accent-aware icon

### DIFF
--- a/src/components/Logo.jsx
+++ b/src/components/Logo.jsx
@@ -5,13 +5,12 @@ const DEFAULT_TITLE = "HematWoi";
 
 export default function Logo({ className, title = DEFAULT_TITLE, ...props }) {
   const rawId = useId().replace(/:/g, "");
-  const gradientId = `${rawId}-gradient`;
   const titleId = `${rawId}-title`;
   const labelled = typeof title === "string" && title.length > 0;
 
   return (
     <svg
-      viewBox="0 0 64 64"
+      viewBox="0 0 512 512"
       role="img"
       className={clsx("h-10 w-10", className)}
       aria-labelledby={labelled ? titleId : undefined}
@@ -19,54 +18,38 @@ export default function Logo({ className, title = DEFAULT_TITLE, ...props }) {
       {...props}
     >
       {labelled ? <title id={titleId}>{title}</title> : null}
-      <defs>
-        <linearGradient id={gradientId} x1="0%" y1="100%" x2="100%" y2="0%">
-          <stop offset="0%" stopColor="var(--brand, #3f63f3)" />
-          <stop offset="100%" stopColor="var(--brand-ring, #1d3fc5)" />
-        </linearGradient>
-      </defs>
-
       <rect
-        width="64"
-        height="64"
-        rx="18"
-        fill="var(--brand-soft, #e6ecff)"
+        width="512"
+        height="512"
+        rx="104"
+        fill="var(--brand-soft, #e0e7ff)"
       />
-      <rect
-        x="6"
-        y="6"
-        width="52"
-        height="52"
-        rx="14"
-        fill="none"
-        stroke="var(--brand, #3f63f3)"
-        strokeOpacity="0.35"
-        strokeWidth="2.5"
-      />
-
-      <g fill={`url(#${gradientId})`}>
-        <rect x="18" y="30" width="8" height="18" rx="4" />
-        <rect x="28" y="24" width="8" height="24" rx="4" />
-        <rect x="38" y="18" width="8" height="30" rx="4" />
+      <g transform="translate(6.409 -19.23)">
+        <polygon
+          points="413.394,192.157 430.091,208.854 227.066,411.878 174.789,349.931 162.434,335.287 148.813,348.821 14.858,481.853 160.125,387.43 212.478,449.47 224.905,464.197 238.526,450.58 455.171,233.934 471.868,250.631 484.324,179.701"
+          fill="var(--brand-ring, #4f46e5)"
+        />
+        <polygon
+          points="342.179,68.606 342.179,264.18 382.825,223.534 382.825,68.606 342.179,68.606"
+          fill="var(--brand, #6366f1)"
+        />
+        <polygon
+          points="109.36,355.494 109.36,317.111 68.715,317.111 68.715,395.863 109.36,355.494"
+          fill="var(--brand, #6366f1)"
+        />
+        <polygon
+          points="177.727,318.879 177.727,197.017 137.081,197.017 137.081,327.963 163.364,301.859 177.727,318.879"
+          fill="var(--brand, #6366f1)"
+        />
+        <polygon
+          points="246.092,360.262 246.092,236.741 205.447,236.741 205.447,351.728 227.955,378.4 246.092,360.262"
+          fill="var(--brand, #6366f1)"
+        />
+        <polygon
+          points="314.459,291.896 314.459,124.033 273.813,124.033 273.813,332.542 314.459,291.896"
+          fill="var(--brand, #6366f1)"
+        />
       </g>
-
-      <circle
-        cx="46"
-        cy="22"
-        r="6"
-        fill="var(--brand, #3f63f3)"
-        fillOpacity="0.14"
-      />
-      <circle cx="46" cy="22" r="3.5" fill={`url(#${gradientId})`} />
-
-      <path
-        d="M16 42l6-8 7 5 8-14 11 9"
-        fill="none"
-        stroke="var(--brand-foreground, #ffffff)"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="3"
-      />
     </svg>
   );
 }


### PR DESCRIPTION
## Summary
- replace the existing sidebar logo with the provided SVG illustration
- map the illustration colors to the dynamic brand and accent variables so the icon follows theme accents

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d969d54104833299bf9e2448c1b86e