### PR TITLE
Handle password creation for social logins

### DIFF
--- a/src/lib/api-profile.ts
+++ b/src/lib/api-profile.ts
@@ -397,6 +397,22 @@ export async function changePassword(payload: PasswordChangePayload): Promise<Pa
   }
 }
 
+export async function createPassword(newPassword: string): Promise<void> {
+  try {
+    if (!newPassword) {
+      throw new Error('Password baru wajib diisi.');
+    }
+    if (newPassword.length < 6) {
+      throw new Error('Password baru minimal 6 karakter.');
+    }
+    await requireUser();
+    const { error } = await supabase.auth.updateUser({ password: newPassword });
+    if (error) throw error;
+  } catch (error) {
+    wrapError('createPassword', error, 'Tidak bisa membuat password.');
+  }
+}
+
 function detectDeviceLabel(agent: string | null | undefined) {
   if (!agent) return 'Perangkat tidak dikenal';
   const normalized = agent.toLowerCase();


### PR DESCRIPTION
## Summary
- show a password creation notice and form in the security tab when the account lacks a password
- allow the profile page to mark accounts as having passwords after creation
- add an API helper to create passwords without requiring the current password

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d9cd75c3a08332a061861172a94f35