### PR TITLE
Add password creation flow for social login users

### DIFF
--- a/src/components/profile/SecurityCard.tsx
+++ b/src/components/profile/SecurityCard.tsx
@@ -1,14 +1,16 @@
 import { useCallback, useMemo, useState } from 'react';
 import { AlertCircle, Laptop, Loader2, LogOut, RefreshCcw, ShieldCheck } from 'lucide-react';
-import type { PasswordChangePayload, SessionInfo } from '../../lib/api-profile';
+import type { PasswordChangePayload, PasswordCreatePayload, SessionInfo } from '../../lib/api-profile';
 
 interface SecurityCardProps {
   offline: boolean;
   sessions: SessionInfo[];
   loadingSessions: boolean;
+  hasPassword: boolean;
   onRefreshSessions: () => Promise<void>;
   onSignOutSession: (sessionId?: string) => Promise<void>;
   onChangePassword: (payload: PasswordChangePayload) => Promise<void>;
+  onCreatePassword: (payload: PasswordCreatePayload) => Promise<void>;
 }
 
 type StrengthLevel = 'weak' | 'medium' | 'strong';
@@ -46,21 +48,29 @@ export default function SecurityCard({
   offline,
   sessions,
   loadingSessions,
+  hasPassword,
   onRefreshSessions,
   onSignOutSession,
   onChangePassword,
+  onCreatePassword,
 }: SecurityCardProps) {
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
-  const [signOutOther, setSignOutOther] = useState(true);
+  const [changeSignOutOther, setChangeSignOutOther] = useState(true);
   const [changing, setChanging] = useState(false);
   const [formError, setFormError] = useState('');
+  const [createPassword, setCreatePassword] = useState('');
+  const [createConfirmPassword, setCreateConfirmPassword] = useState('');
+  const [createSignOutOther, setCreateSignOutOther] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState('');
   const [sessionMessage, setSessionMessage] = useState('');
   const [sessionError, setSessionError] = useState('');
   const [sessionBusy, setSessionBusy] = useState(false);
 
-  const strength = useMemo(() => detectStrength(newPassword), [newPassword]);
+  const changeStrength = useMemo(() => detectStrength(newPassword), [newPassword]);
+  const createStrength = useMemo(() => detectStrength(createPassword), [createPassword]);
 
   const disabledChange = useMemo(() => {
     if (!currentPassword || !newPassword || !confirmPassword) return true;
@@ -68,7 +78,13 @@ export default function SecurityCard({
     return offline;
   }, [currentPassword, newPassword, confirmPassword, offline]);
 
-  const handleSubmit = useCallback(
+  const disabledCreate = useMemo(() => {
+    if (!createPassword || !createConfirmPassword) return true;
+    if (createPassword !== createConfirmPassword) return true;
+    return offline;
+  }, [createPassword, createConfirmPassword, offline]);
+
+  const handleChangeSubmit = useCallback(
     async (event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault();
       if (disabledChange) return;
@@ -78,7 +94,7 @@ export default function SecurityCard({
         await onChangePassword({
           current_password: currentPassword,
           new_password: newPassword,
-          sign_out_other: signOutOther,
+          sign_out_other: changeSignOutOther,
         });
         setCurrentPassword('');
         setNewPassword('');
@@ -91,7 +107,32 @@ export default function SecurityCard({
         setChanging(false);
       }
     },
-    [disabledChange, onChangePassword, currentPassword, newPassword, signOutOther],
+    [disabledChange, onChangePassword, currentPassword, newPassword, changeSignOutOther],
+  );
+
+  const handleCreateSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (disabledCreate) return;
+      setCreating(true);
+      setCreateError('');
+      try {
+        await onCreatePassword({
+          new_password: createPassword,
+          sign_out_other: createSignOutOther,
+        });
+        setCreatePassword('');
+        setCreateConfirmPassword('');
+        setCreateSignOutOther(true);
+      } catch (error) {
+        setCreateError(
+          error instanceof Error ? error.message : 'Tidak bisa membuat password saat ini.',
+        );
+      } finally {
+        setCreating(false);
+      }
+    },
+    [disabledCreate, onCreatePassword, createPassword, createSignOutOther],
   );
 
   const handleRefreshSessions = useCallback(async () => {
@@ -143,101 +184,191 @@ export default function SecurityCard({
         </p>
       </div>
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-          <div className="space-y-1">
-            <label htmlFor="profile-current-password" className="text-sm font-medium text-foreground">
-              Password saat ini
-            </label>
-            <input
-              id="profile-current-password"
-              type="password"
-              autoComplete="current-password"
-              value={currentPassword}
-              onChange={(event) => setCurrentPassword(event.target.value)}
-              disabled={changing || offline}
-              className="h-11 w-full rounded-2xl border border-border-subtle bg-surface-alt/70 px-3 text-sm shadow-sm transition focus:outline-none focus:ring-2 focus:ring-ring-primary disabled:cursor-not-allowed disabled:opacity-60"
-            />
-          </div>
-          <div className="space-y-1">
-            <label htmlFor="profile-new-password" className="text-sm font-medium text-foreground">
-              Password baru
-            </label>
-            <input
-              id="profile-new-password"
-              type="password"
-              autoComplete="new-password"
-              value={newPassword}
-              onChange={(event) => setNewPassword(event.target.value)}
-              disabled={changing || offline}
-              aria-describedby="password-strength"
-              className="h-11 w-full rounded-2xl border border-border-subtle bg-surface-alt/70 px-3 text-sm shadow-sm transition focus:outline-none focus:ring-2 focus:ring-ring-primary disabled:cursor-not-allowed disabled:opacity-60"
-            />
-            <div className="mt-2 space-y-2" id="password-strength" aria-live="polite">
-              <div className="h-2 w-full overflow-hidden rounded-full bg-surface-alt">
-                <div
-                  className={
-                    strength.label === 'strong'
-                      ? 'h-full bg-success'
-                      : strength.label === 'medium'
-                        ? 'h-full bg-warning'
-                        : 'h-full bg-danger'
-                  }
-                  style={{ width: `${Math.min(strength.score * 33.33, 100)}%` }}
-                />
-              </div>
-              <p className="flex items-center gap-2 text-xs text-muted">
-                <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
-                Kekuatan: <span className="font-semibold text-foreground">{labelForStrength(strength.label)}</span>
-              </p>
+        {hasPassword ? (
+          <form onSubmit={handleChangeSubmit} className="flex flex-col gap-4">
+            <div className="space-y-1">
+              <label htmlFor="profile-current-password" className="text-sm font-medium text-foreground">
+                Password saat ini
+              </label>
+              <input
+                id="profile-current-password"
+                type="password"
+                autoComplete="current-password"
+                value={currentPassword}
+                onChange={(event) => setCurrentPassword(event.target.value)}
+                disabled={changing || offline}
+                className="h-11 w-full rounded-2xl border border-border-subtle bg-surface-alt/70 px-3 text-sm shadow-sm transition focus:outline-none focus:ring-2 focus:ring-ring-primary disabled:cursor-not-allowed disabled:opacity-60"
+              />
             </div>
-          </div>
-          <div className="space-y-1">
-            <label htmlFor="profile-confirm-password" className="text-sm font-medium text-foreground">
-              Konfirmasi password baru
+            <div className="space-y-1">
+              <label htmlFor="profile-new-password" className="text-sm font-medium text-foreground">
+                Password baru
+              </label>
+              <input
+                id="profile-new-password"
+                type="password"
+                autoComplete="new-password"
+                value={newPassword}
+                onChange={(event) => setNewPassword(event.target.value)}
+                disabled={changing || offline}
+                aria-describedby="profile-change-password-strength"
+                className="h-11 w-full rounded-2xl border border-border-subtle bg-surface-alt/70 px-3 text-sm shadow-sm transition focus:outline-none focus:ring-2 focus:ring-ring-primary disabled:cursor-not-allowed disabled:opacity-60"
+              />
+              <div className="mt-2 space-y-2" id="profile-change-password-strength" aria-live="polite">
+                <div className="h-2 w-full overflow-hidden rounded-full bg-surface-alt">
+                  <div
+                    className={
+                      changeStrength.label === 'strong'
+                        ? 'h-full bg-success'
+                        : changeStrength.label === 'medium'
+                          ? 'h-full bg-warning'
+                          : 'h-full bg-danger'
+                    }
+                    style={{ width: `${Math.min(changeStrength.score * 33.33, 100)}%` }}
+                  />
+                </div>
+                <p className="flex items-center gap-2 text-xs text-muted">
+                  <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+                  Kekuatan:{' '}
+                  <span className="font-semibold text-foreground">{labelForStrength(changeStrength.label)}</span>
+                </p>
+              </div>
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="profile-confirm-password" className="text-sm font-medium text-foreground">
+                Konfirmasi password baru
+              </label>
+              <input
+                id="profile-confirm-password"
+                type="password"
+                autoComplete="new-password"
+                value={confirmPassword}
+                onChange={(event) => setConfirmPassword(event.target.value)}
+                disabled={changing || offline}
+                aria-invalid={Boolean(confirmPassword) && confirmPassword !== newPassword}
+                className="h-11 w-full rounded-2xl border border-border-subtle bg-surface-alt/70 px-3 text-sm shadow-sm transition focus:outline-none focus:ring-2 focus:ring-ring-primary disabled:cursor-not-allowed disabled:opacity-60"
+              />
+              {confirmPassword && confirmPassword !== newPassword ? (
+                <p className="text-xs text-danger" aria-live="assertive">
+                  Konfirmasi password belum cocok.
+                </p>
+              ) : null}
+            </div>
+            <label className="inline-flex items-center gap-2 text-sm text-foreground">
+              <input
+                type="checkbox"
+                checked={changeSignOutOther}
+                onChange={(event) => setChangeSignOutOther(event.target.checked)}
+                disabled={changing || offline}
+                className="h-4 w-4 rounded border-border-subtle text-primary focus:outline-none focus:ring-2 focus:ring-ring-primary"
+              />
+              Keluar dari sesi lain setelah ganti password
             </label>
-            <input
-              id="profile-confirm-password"
-              type="password"
-              autoComplete="new-password"
-              value={confirmPassword}
-              onChange={(event) => setConfirmPassword(event.target.value)}
-              disabled={changing || offline}
-              aria-invalid={Boolean(confirmPassword) && confirmPassword !== newPassword}
-              className="h-11 w-full rounded-2xl border border-border-subtle bg-surface-alt/70 px-3 text-sm shadow-sm transition focus:outline-none focus:ring-2 focus:ring-ring-primary disabled:cursor-not-allowed disabled:opacity-60"
-            />
-            {confirmPassword && confirmPassword !== newPassword ? (
-              <p className="text-xs text-danger" aria-live="assertive">
-                Konfirmasi password belum cocok.
+            {formError ? (
+              <p className="flex items-center gap-2 text-sm text-danger" aria-live="assertive">
+                <AlertCircle className="h-4 w-4" aria-hidden="true" />
+                {formError}
               </p>
             ) : null}
-          </div>
-          <label className="inline-flex items-center gap-2 text-sm text-foreground">
-            <input
-              type="checkbox"
-              checked={signOutOther}
-              onChange={(event) => setSignOutOther(event.target.checked)}
-              disabled={changing || offline}
-              className="h-4 w-4 rounded border-border-subtle text-primary focus:outline-none focus:ring-2 focus:ring-ring-primary"
-            />
-            Keluar dari sesi lain setelah ganti password
-          </label>
-          {formError ? (
-            <p className="flex items-center gap-2 text-sm text-danger" aria-live="assertive">
-              <AlertCircle className="h-4 w-4" aria-hidden="true" />
-              {formError}
-            </p>
-          ) : null}
-          <div className="flex justify-end">
-            <button
-              type="submit"
-              disabled={disabledChange || changing}
-              className="inline-flex h-11 items-center justify-center rounded-2xl bg-primary px-6 text-sm font-semibold text-primary-foreground shadow-sm transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring-primary disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {changing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : null}
-              Ubah password
-            </button>
-          </div>
-        </form>
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                disabled={disabledChange || changing}
+                className="inline-flex h-11 items-center justify-center rounded-2xl bg-primary px-6 text-sm font-semibold text-primary-foreground shadow-sm transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring-primary disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {changing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+                Ubah password
+              </button>
+            </div>
+          </form>
+        ) : (
+          <form onSubmit={handleCreateSubmit} className="flex flex-col gap-4">
+            <div className="rounded-2xl border border-border-subtle bg-surface-alt/60 p-4 text-sm text-muted">
+              Kamu masuk menggunakan penyedia pihak ketiga. Buat password agar bisa masuk dengan email &amp;
+              password.
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="profile-create-password" className="text-sm font-medium text-foreground">
+                Password baru
+              </label>
+              <input
+                id="profile-create-password"
+                type="password"
+                autoComplete="new-password"
+                value={createPassword}
+                onChange={(event) => setCreatePassword(event.target.value)}
+                disabled={creating || offline}
+                aria-describedby="profile-create-password-strength"
+                className="h-11 w-full rounded-2xl border border-border-subtle bg-surface-alt/70 px-3 text-sm shadow-sm transition focus:outline-none focus:ring-2 focus:ring-ring-primary disabled:cursor-not-allowed disabled:opacity-60"
+              />
+              <div className="mt-2 space-y-2" id="profile-create-password-strength" aria-live="polite">
+                <div className="h-2 w-full overflow-hidden rounded-full bg-surface-alt">
+                  <div
+                    className={
+                      createStrength.label === 'strong'
+                        ? 'h-full bg-success'
+                        : createStrength.label === 'medium'
+                          ? 'h-full bg-warning'
+                          : 'h-full bg-danger'
+                    }
+                    style={{ width: `${Math.min(createStrength.score * 33.33, 100)}%` }}
+                  />
+                </div>
+                <p className="flex items-center gap-2 text-xs text-muted">
+                  <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+                  Kekuatan:{' '}
+                  <span className="font-semibold text-foreground">{labelForStrength(createStrength.label)}</span>
+                </p>
+              </div>
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="profile-create-confirm" className="text-sm font-medium text-foreground">
+                Konfirmasi password baru
+              </label>
+              <input
+                id="profile-create-confirm"
+                type="password"
+                autoComplete="new-password"
+                value={createConfirmPassword}
+                onChange={(event) => setCreateConfirmPassword(event.target.value)}
+                disabled={creating || offline}
+                aria-invalid={Boolean(createConfirmPassword) && createConfirmPassword !== createPassword}
+                className="h-11 w-full rounded-2xl border border-border-subtle bg-surface-alt/70 px-3 text-sm shadow-sm transition focus:outline-none focus:ring-2 focus:ring-ring-primary disabled:cursor-not-allowed disabled:opacity-60"
+              />
+              {createConfirmPassword && createConfirmPassword !== createPassword ? (
+                <p className="text-xs text-danger" aria-live="assertive">
+                  Konfirmasi password belum cocok.
+                </p>
+              ) : null}
+            </div>
+            <label className="inline-flex items-center gap-2 text-sm text-foreground">
+              <input
+                type="checkbox"
+                checked={createSignOutOther}
+                onChange={(event) => setCreateSignOutOther(event.target.checked)}
+                disabled={creating || offline}
+                className="h-4 w-4 rounded border-border-subtle text-primary focus:outline-none focus:ring-2 focus:ring-ring-primary"
+              />
+              Keluar dari sesi lain setelah membuat password
+            </label>
+            {createError ? (
+              <p className="flex items-center gap-2 text-sm text-danger" aria-live="assertive">
+                <AlertCircle className="h-4 w-4" aria-hidden="true" />
+                {createError}
+              </p>
+            ) : null}
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                disabled={disabledCreate || creating}
+                className="inline-flex h-11 items-center justify-center rounded-2xl bg-primary px-6 text-sm font-semibold text-primary-foreground shadow-sm transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring-primary disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {creating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+                Buat password
+              </button>
+            </div>
+          </form>
+        )}
         <div className="flex flex-col gap-4">
           <div className="flex items-center justify-between">
             <div>


### PR DESCRIPTION
## Summary
- track whether the authenticated user already has an email/password identity so the security tab can tailor its UI
- add a password creation API helper and expose a dedicated form when the user has never set a password
- keep the existing change-password flow for users with passwords while preserving session management options

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d9cd75c3a08332a061861172a94f35