### PR TITLE
Handle password creation for social logins

### DIFF
--- a/src/lib/api-profile.ts
+++ b/src/lib/api-profile.ts
@@ -397,6 +397,27 @@ export async function changePassword(payload: PasswordChangePayload): Promise<Pa
   }
 }
 
+export async function createPassword(newPassword: string): Promise<void> {
+  try {
+    if (!newPassword) {
+      throw new Error('Password baru wajib diisi.');
+    }
+    if (newPassword.length < 6) {
+      throw new Error('Password baru minimal 6 karakter.');
+    }
+    const user = await requireUser();
+    const hasEmailIdentity = user.identities?.some((identity) => identity.provider === 'email');
+    if (hasEmailIdentity) {
+      throw new Error('Akunmu sudah memiliki password.');
+    }
+    const { error } = await supabase.auth.updateUser({ password: newPassword });
+    if (error) throw error;
+    return;
+  } catch (error) {
+    wrapError('createPassword', error, 'Tidak bisa membuat password.');
+  }
+}
+
 function detectDeviceLabel(agent: string | null | undefined) {
   if (!agent) return 'Perangkat tidak dikenal';
   const normalized = agent.toLowerCase();


### PR DESCRIPTION
## Summary
- detect when a user authenticated via social login lacks an email/password identity and surface that in the profile page
- add an API helper that allows first-time password creation when no password exists yet
- update the security settings UI to render a password creation form until a password is set, falling back to the existing change password flow afterwards

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d9cd75c3a08332a061861172a94f35