### PR TITLE
feat: refresh budget page styling

### DIFF
--- a/src/pages/budgets/components/BudgetTable.tsx
+++ b/src/pages/budgets/components/BudgetTable.tsx
@@ -11,11 +11,10 @@ interface BudgetTableProps {
   onToggleCarryover: (row: BudgetWithSpent, carryover: boolean) => void;
 }
 
-const CARD_WRAPPER_CLASS =
-  'grid gap-4 md:grid-cols-2 xl:grid-cols-3';
+const CARD_WRAPPER_CLASS = 'grid gap-5 md:grid-cols-2 xl:grid-cols-3';
 
 const CARD_CLASS =
-  'flex flex-col gap-4 rounded-2xl border border-white/20 bg-gradient-to-b from-white/80 to-white/40 p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-white/5 dark:from-zinc-900/60 dark:to-zinc-900/30';
+  'group relative flex flex-col gap-6 overflow-hidden rounded-3xl border border-zinc-200/70 bg-white/85 p-6 shadow-[0_18px_60px_-28px_rgba(15,23,42,0.45)] transition-transform duration-300 hover:-translate-y-1 hover:shadow-[0_26px_90px_-32px_rgba(15,23,42,0.55)] dark:border-zinc-800/70 dark:bg-zinc-900/70';
 
 function LoadingCards() {
   return (
@@ -26,15 +25,15 @@ function LoadingCards() {
           key={index}
           className={clsx(CARD_CLASS, 'animate-pulse')}
         >
-          <div className="h-4 w-24 rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
+          <div className="h-4 w-28 rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
           <div className="space-y-3">
-            <div className="h-3 w-full rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
             <div className="h-3 w-3/4 rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
+            <div className="h-3 w-2/3 rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
           </div>
           <div className="h-2 w-full rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
           <div className="space-y-2">
-            <div className="h-3 w-1/3 rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
             <div className="h-3 w-1/2 rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
+            <div className="h-3 w-1/3 rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
           </div>
         </div>
       ))}
@@ -72,18 +71,43 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
 
         return (
           <article key={row.id} className={CARD_CLASS}>
-            <header className="flex items-start justify-between gap-3">
-              <div>
-                <p className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Kategori</p>
-                <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+            <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/40 via-white/10 to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100 dark:from-zinc-800/30 dark:via-zinc-800/20" />
+            <header className="relative flex flex-wrap items-start justify-between gap-4">
+              <div className="space-y-1">
+                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-zinc-500 dark:text-zinc-400">Kategori</p>
+                <h3 className="text-xl font-semibold text-zinc-900 dark:text-zinc-50">
                   {row.category?.name ?? 'Tanpa kategori'}
                 </h3>
               </div>
-              <div className="flex items-center gap-2">
+              <div className="flex flex-wrap items-center justify-end gap-2 sm:gap-3">
+                <div className="inline-flex items-center gap-3 rounded-2xl border border-zinc-200/80 bg-white/70 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.25em] text-zinc-500 shadow-sm transition hover:-translate-y-0.5 hover:bg-white/90 dark:border-zinc-800/70 dark:bg-zinc-900/60 dark:text-zinc-300">
+                  <span className="hidden sm:inline">Carryover</span>
+                  <label className="relative inline-flex h-6 w-12 cursor-pointer items-center">
+                    <input
+                      type="checkbox"
+                      checked={row.carryover_enabled}
+                      onChange={(event) => onToggleCarryover(row, event.target.checked)}
+                      className="peer sr-only"
+                    />
+                    <span className="absolute inset-0 rounded-full bg-zinc-200/70 transition peer-checked:bg-emerald-500/80 dark:bg-zinc-800/70 dark:peer-checked:bg-emerald-500/70" />
+                    <span className="relative ml-1 h-4 w-4 rounded-full bg-white shadow-sm transition-transform peer-checked:translate-x-6" />
+                    <span className="sr-only">Aktifkan carryover</span>
+                  </label>
+                  <span
+                    className={clsx(
+                      'hidden rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.25em] sm:inline-flex',
+                      row.carryover_enabled
+                        ? 'bg-emerald-100/70 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-300'
+                        : 'bg-zinc-200/60 text-zinc-500 dark:bg-zinc-800/60 dark:text-zinc-400',
+                    )}
+                  >
+                    {row.carryover_enabled ? 'Aktif' : 'Nonaktif'}
+                  </span>
+                </div>
                 <button
                   type="button"
                   onClick={() => onEdit(row)}
-                  className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-white/30 bg-white/60 text-zinc-600 shadow-sm transition hover:-translate-y-0.5 hover:bg-white dark:border-white/10 dark:bg-zinc-900/60 dark:text-zinc-200"
+                  className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-white/60 bg-white/80 text-zinc-600 shadow-sm transition hover:-translate-y-0.5 hover:bg-white dark:border-white/10 dark:bg-zinc-900/60 dark:text-zinc-200"
                   aria-label={`Edit ${row.category?.name ?? 'budget'}`}
                 >
                   <Pencil className="h-4 w-4" />
@@ -91,7 +115,7 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
                 <button
                   type="button"
                   onClick={() => onDelete(row)}
-                  className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-rose-200/50 bg-rose-50/60 text-rose-500 shadow-sm transition hover:-translate-y-0.5 hover:bg-rose-100 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-300"
+                  className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-rose-200/50 bg-rose-50/60 text-rose-500 shadow-sm transition hover:-translate-y-0.5 hover:bg-rose-100 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-300"
                   aria-label={`Hapus ${row.category?.name ?? 'budget'}`}
                 >
                   <Trash2 className="h-4 w-4" />
@@ -99,18 +123,18 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
               </div>
             </header>
 
-            <div className="space-y-1 text-sm text-zinc-600 dark:text-zinc-300">
-              <div className="flex items-center justify-between">
+            <div className="relative grid gap-2 text-sm text-zinc-600 dark:text-zinc-300">
+              <div className="flex items-center justify-between rounded-2xl bg-white/60 px-4 py-3 shadow-sm backdrop-blur dark:bg-zinc-900/50">
                 <span>Anggaran</span>
-                <span className="font-semibold text-zinc-900 dark:text-zinc-100">
+                <span className="text-base font-semibold text-zinc-900 dark:text-zinc-100">
                   {formatCurrency(planned, 'IDR')}
                 </span>
               </div>
-              <div className="flex items-center justify-between">
+              <div className="flex items-center justify-between rounded-2xl border border-transparent px-4 py-3">
                 <span>Terpakai</span>
                 <span>{formatCurrency(spent, 'IDR')}</span>
               </div>
-              <div className="flex items-center justify-between">
+              <div className="flex items-center justify-between rounded-2xl border border-transparent px-4 py-3">
                 <span>Sisa</span>
                 <span className={clsx('font-semibold', overBudget ? 'text-rose-500 dark:text-rose-400' : 'text-emerald-600 dark:text-emerald-400')}>
                   {formatCurrency(remaining, 'IDR')}
@@ -118,7 +142,7 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
               </div>
             </div>
 
-            <div className="space-y-2">
+            <div className="space-y-3">
               <div className="flex items-center justify-between text-xs font-medium text-zinc-500 dark:text-zinc-400">
                 <span>Progres penggunaan</span>
                 <span>{displayPercentage}%</span>
@@ -136,30 +160,9 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
               ) : null}
             </div>
 
-            <div className="flex flex-col gap-3 rounded-xl bg-white/50 p-4 text-sm shadow-sm dark:bg-zinc-900/40">
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <p className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Carryover</p>
-                  <p className="font-medium text-zinc-800 dark:text-zinc-100">
-                    {row.carryover_enabled ? 'Aktif' : 'Nonaktif'}
-                  </p>
-                </div>
-                <label className="relative inline-flex h-6 w-12 cursor-pointer items-center">
-                  <input
-                    type="checkbox"
-                    checked={row.carryover_enabled}
-                    onChange={(event) => onToggleCarryover(row, event.target.checked)}
-                    className="peer sr-only"
-                  />
-                  <span className="absolute inset-0 rounded-full bg-zinc-200/70 transition peer-checked:bg-emerald-500/80 dark:bg-zinc-800/70 dark:peer-checked:bg-emerald-500/70" />
-                  <span className="relative ml-1 h-4 w-4 rounded-full bg-white shadow-sm transition-transform peer-checked:translate-x-6" />
-                </label>
-              </div>
-
-              <div className="space-y-1 text-sm text-zinc-500 dark:text-zinc-300">
-                <p className="text-xs uppercase tracking-wide">Catatan</p>
-                <p>{row.notes?.trim() ? row.notes : 'Tidak ada catatan.'}</p>
-              </div>
+            <div className="rounded-2xl border border-zinc-200/80 bg-white/70 p-5 text-sm text-zinc-600 shadow-sm backdrop-blur dark:border-zinc-800/70 dark:bg-zinc-900/60 dark:text-zinc-300">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500 dark:text-zinc-400">Catatan</p>
+              <p className="mt-2 leading-relaxed">{row.notes?.trim() ? row.notes : 'Tidak ada catatan.'}</p>
             </div>
           </article>
         );

--- a/src/pages/budgets/components/SummaryCards.tsx
+++ b/src/pages/budgets/components/SummaryCards.tsx
@@ -8,15 +8,32 @@ interface SummaryCardsProps {
 }
 
 const CARD_BASE_CLASS =
-  'rounded-2xl border border-white/20 dark:border-white/5 bg-gradient-to-b from-white/80 to-white/50 dark:from-zinc-900/60 dark:to-zinc-900/30 backdrop-blur shadow-sm';
+  'group relative overflow-hidden rounded-3xl border border-zinc-200/70 bg-white/80 shadow-[0_18px_60px_-28px_rgba(15,23,42,0.45)] transition-transform duration-300 hover:-translate-y-1 hover:shadow-[0_26px_80px_-32px_rgba(15,23,42,0.55)] dark:border-zinc-800/60 dark:bg-zinc-900/70';
+
+const ACCENT_BACKGROUND: Record<string, string> = {
+  sky: 'from-sky-100/90 via-sky-50/50 to-transparent dark:from-sky-500/20 dark:via-sky-500/10 dark:to-transparent',
+  emerald: 'from-emerald-100/90 via-emerald-50/40 to-transparent dark:from-emerald-500/20 dark:via-emerald-500/10 dark:to-transparent',
+  purple: 'from-purple-100/90 via-purple-50/40 to-transparent dark:from-purple-500/20 dark:via-purple-500/10 dark:to-transparent',
+  orange: 'from-orange-100/90 via-orange-50/40 to-transparent dark:from-orange-500/20 dark:via-orange-500/10 dark:to-transparent',
+};
+
+const ACCENT_ICON_CLASS: Record<string, string> = {
+  sky: 'bg-sky-500/10 text-sky-600 shadow-[0_10px_30px_-16px_rgba(14,165,233,0.8)] dark:bg-sky-500/15 dark:text-sky-300',
+  emerald:
+    'bg-emerald-500/10 text-emerald-600 shadow-[0_10px_30px_-16px_rgba(5,150,105,0.75)] dark:bg-emerald-500/15 dark:text-emerald-300',
+  purple:
+    'bg-purple-500/10 text-purple-600 shadow-[0_10px_30px_-16px_rgba(147,51,234,0.7)] dark:bg-purple-500/15 dark:text-purple-300',
+  orange:
+    'bg-orange-500/10 text-orange-600 shadow-[0_10px_30px_-16px_rgba(249,115,22,0.7)] dark:bg-orange-500/15 dark:text-orange-300',
+};
 
 function SummarySkeleton() {
   return (
     <div className={CARD_BASE_CLASS}>
-      <div className="flex h-full flex-col gap-4 p-5">
+      <div className="relative flex h-full flex-col gap-5 p-6">
         <div className="h-4 w-32 animate-pulse rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
-        <div className="h-8 w-24 animate-pulse rounded-lg bg-zinc-200/70 dark:bg-zinc-700/70" />
-        <div className="h-2 w-full animate-pulse rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
+        <div className="h-9 w-28 animate-pulse rounded-2xl bg-zinc-200/70 dark:bg-zinc-700/70" />
+        <div className="mt-auto h-2 w-full animate-pulse rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
       </div>
     </div>
   );
@@ -40,25 +57,25 @@ export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
       label: 'Total Anggaran',
       value: formatCurrency(summary.planned, 'IDR'),
       icon: Wallet,
-      accent: 'text-sky-600 dark:text-sky-400',
+      accent: 'sky',
     },
     {
       label: 'Realisasi',
       value: formatCurrency(summary.spent, 'IDR'),
       icon: TrendingDown,
-      accent: 'text-emerald-600 dark:text-emerald-400',
+      accent: 'emerald',
     },
     {
       label: 'Sisa',
       value: formatCurrency(summary.remaining, 'IDR'),
       icon: PiggyBank,
-      accent: 'text-purple-600 dark:text-purple-400',
+      accent: 'purple',
     },
     {
       label: 'Persentase',
       value: `${(progress * 100).toFixed(0)}%`,
       icon: Target,
-      accent: 'text-orange-600 dark:text-orange-400',
+      accent: 'orange',
       progress,
     },
   ];
@@ -67,21 +84,30 @@ export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
     <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
       {cards.map(({ label, value, icon: Icon, accent, progress: cardProgress }) => (
         <div key={label} className={CARD_BASE_CLASS}>
-          <div className="flex h-full flex-col gap-4 p-5">
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400">{label}</span>
-              <Icon className={`h-5 w-5 ${accent}`} />
+          <div
+            className={`pointer-events-none absolute inset-0 bg-gradient-to-br opacity-0 transition-opacity duration-300 group-hover:opacity-100 ${ACCENT_BACKGROUND[accent]}`}
+          />
+          <div className="relative flex h-full flex-col gap-5 p-6">
+            <div className="flex items-start justify-between gap-4">
+              <div className="space-y-1">
+                <span className="text-xs font-semibold uppercase tracking-[0.25em] text-zinc-500 dark:text-zinc-400">
+                  {label}
+                </span>
+                <span className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">{value}</span>
+              </div>
+              <span className={`inline-flex h-12 w-12 items-center justify-center rounded-2xl ${ACCENT_ICON_CLASS[accent]}`}>
+                <Icon className="h-6 w-6" />
+              </span>
             </div>
-            <span className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">{value}</span>
             {typeof cardProgress === 'number' ? (
-              <div className="mt-auto">
+              <div className="mt-auto space-y-3">
                 <div className="flex items-center justify-between text-xs font-medium text-zinc-500 dark:text-zinc-400">
                   <span>0%</span>
                   <span>100%</span>
                 </div>
-                <div className="mt-2 h-2 rounded-full bg-zinc-200/70 dark:bg-zinc-800/70">
+                <div className="h-2 w-full overflow-hidden rounded-full bg-zinc-200/70 dark:bg-zinc-800/70">
                   <div
-                    className="h-full rounded-full bg-gradient-to-r from-sky-500 via-sky-400 to-sky-300 dark:from-sky-400 dark:via-sky-500 dark:to-sky-600 transition-all"
+                    className="h-full rounded-full bg-gradient-to-r from-orange-500 via-orange-400 to-orange-300 transition-all dark:from-orange-400 dark:via-orange-500 dark:to-orange-600"
                     style={{ width: `${cardProgress * 100}%` }}
                   />
                 </div>


### PR DESCRIPTION
## Summary
- refresh the budget summary cards with accent gradients and bolder icon treatments
- restyle the budget detail cards with elevated surfaces and align the carryover toggle beside action buttons
- refine budget stats, progress and notes sections for a more polished presentation

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d9de2b984c8332a21829620a6b77cc