### PR TITLE
Align category chart colors with category selections

### DIFF
--- a/src/components/CategoryDonut.jsx
+++ b/src/components/CategoryDonut.jsx
@@ -9,7 +9,21 @@ function toRupiah(n = 0) {
   }).format(n);
 }
 
-const COLORS = ["#dc2626", "#f97316", "#eab308", "#16a34a", "#0ea5e9", "#6366f1", "#d946ef", "#475569"];
+const FALLBACK_COLORS = [
+  "#dc2626",
+  "#f97316",
+  "#eab308",
+  "#16a34a",
+  "#0ea5e9",
+  "#6366f1",
+  "#d946ef",
+  "#475569",
+];
+
+function resolveColor(item, index) {
+  if (typeof item?.color === "string" && item.color) return item.color;
+  return FALLBACK_COLORS[index % FALLBACK_COLORS.length];
+}
 
 export default function CategoryDonut({ data = [] }) {
   const renderTooltip = ({ payload }) => {
@@ -35,7 +49,7 @@ export default function CategoryDonut({ data = [] }) {
               <li key={item.name} className="flex min-w-0 items-center gap-2">
                 <span
                   className="h-3 w-3 flex-shrink-0 rounded-full"
-                  style={{ backgroundColor: COLORS[index % COLORS.length] }}
+                  style={{ backgroundColor: resolveColor(item, index) }}
                 />
                 <span className="truncate">
                   {item.name} · {toRupiah(item.value)}
@@ -58,7 +72,7 @@ export default function CategoryDonut({ data = [] }) {
               paddingAngle={4}
             >
               {data.map((entry, i) => (
-                <Cell key={entry.name || i} fill={COLORS[i % COLORS.length]} />
+                <Cell key={entry.name || i} fill={resolveColor(entry, i)} />
               ))}
             </Pie>
             <Tooltip content={renderTooltip} />

--- a/src/hooks/useInsights.test.js
+++ b/src/hooks/useInsights.test.js
@@ -12,9 +12,33 @@ describe("aggregateInsights", () => {
 
   const txs = [
     { id: 1, date: "2024-06-01", type: "income", amount: 1000 },
-    { id: 2, date: "2024-06-02", type: "expense", amount: 200, category: "Food", note: "A" },
-    { id: 3, date: "2024-06-03", type: "expense", amount: 300, category: "Transport", note: "B" },
-    { id: 4, date: "2024-06-04", type: "expense", amount: 400, category: "Food", note: "C" },
+    {
+      id: 2,
+      date: "2024-06-02",
+      type: "expense",
+      amount: 200,
+      category: "Food",
+      category_color: "#ff0000",
+      note: "A",
+    },
+    {
+      id: 3,
+      date: "2024-06-03",
+      type: "expense",
+      amount: 300,
+      category: "Transport",
+      category_color: "#00ff00",
+      note: "B",
+    },
+    {
+      id: 4,
+      date: "2024-06-04",
+      type: "expense",
+      amount: 400,
+      category: "Food",
+      category_color: "#ff0000",
+      note: "C",
+    },
     { id: 5, date: "2024-05-10", type: "income", amount: 1000 },
     { id: 6, date: "2024-05-11", type: "expense", amount: 500 },
     { id: 7, date: "2024-04-10", type: "income", amount: 1000 },
@@ -46,7 +70,9 @@ describe("aggregateInsights", () => {
     const food = res.categories.find((c) => c.name === "Food");
     const transport = res.categories.find((c) => c.name === "Transport");
     expect(food.value).toBe(600);
+    expect(food.color).toBe("#ff0000");
     expect(transport.value).toBe(300);
+    expect(transport.color).toBe("#00ff00");
   });
 
   it("lists top spends", () => {


### PR DESCRIPTION
## Summary
- propagate category color information through dashboard insights data
- render the category distribution donut using the category-specific colors with safe fallbacks
- cover the new behavior with updated insight aggregation tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68da201823608332b387091504aeeb9a