### PR TITLE
Fix goal date parsing and savings suggestion calculations

### DIFF
--- a/src/components/goals/GoalCard.tsx
+++ b/src/components/goals/GoalCard.tsx
@@ -33,6 +33,16 @@ function calculateDailySuggestion(goal: GoalRecord) {
   if (!goal.due_date) return null;
   const remaining = Math.max(goal.target_amount - goal.saved_amount, 0);
   if (remaining <= 0) return null;
+  const start = goal.start_date ? new Date(goal.start_date) : null;
+  const due = new Date(goal.due_date);
+  if (Number.isNaN(due.getTime())) return null;
+
+  if (start && !Number.isNaN(start.getTime())) {
+    const totalDays = Math.max(1, Math.floor((due.getTime() - start.getTime()) / 86400000) + 1);
+    if (totalDays <= 0) return null;
+    return Math.ceil(remaining / totalDays);
+  }
+
   const daysLeft = calculateDaysLeft(goal.due_date);
   if (daysLeft == null) return null;
   const divisor = Math.max(daysLeft, 1);

--- a/src/lib/api-goals.ts
+++ b/src/lib/api-goals.ts
@@ -131,20 +131,34 @@ function toNum(value: unknown): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+function parseUtcDate(value: string, hour = 0, minute = 0, second = 0): Date | null {
+  const [year, month, day] = value.split('-').map(Number);
+  if (!year || !month || !day) return null;
+  const utcDate = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+  if (Number.isNaN(utcDate.getTime())) return null;
+  return utcDate;
+}
+
 function toISODate(value?: string | null): string | null {
   if (!value) return null;
-  const isoSource = value.includes('T') ? value : `${value}T00:00:00`;
-  const date = new Date(isoSource);
-  if (Number.isNaN(date.getTime())) return null;
-  return date.toISOString();
+  if (value.includes('T')) {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return null;
+    return date.toISOString();
+  }
+  const parsed = parseUtcDate(value);
+  return parsed ? parsed.toISOString() : null;
 }
 
 function toISODateEnd(value?: string | null): string | null {
   if (!value) return null;
-  const isoSource = value.includes('T') ? value : `${value}T23:59:59`;
-  const date = new Date(isoSource);
-  if (Number.isNaN(date.getTime())) return null;
-  return date.toISOString();
+  if (value.includes('T')) {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return null;
+    return date.toISOString();
+  }
+  const parsed = parseUtcDate(value, 23, 59, 59);
+  return parsed ? parsed.toISOString() : null;
 }
 
 function normalizeColor(value: unknown): string {


### PR DESCRIPTION
## Summary
- adjust goal date serialization to preserve the selected calendar day
- update savings suggestion calculations to use the goal start date window

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68da2142739883328c2e7461b2d810bb