### PR TITLE
Fix goal date timezone handling and adjust savings recommendations

### DIFF
--- a/src/components/goals/GoalCard.tsx
+++ b/src/components/goals/GoalCard.tsx
@@ -33,10 +33,33 @@ function calculateDailySuggestion(goal: GoalRecord) {
   if (!goal.due_date) return null;
   const remaining = Math.max(goal.target_amount - goal.saved_amount, 0);
   if (remaining <= 0) return null;
-  const daysLeft = calculateDaysLeft(goal.due_date);
-  if (daysLeft == null) return null;
-  const divisor = Math.max(daysLeft, 1);
-  return Math.ceil(remaining / divisor);
+
+  const due = new Date(goal.due_date);
+  if (Number.isNaN(due.getTime())) return null;
+
+  let start: Date | null = null;
+  if (goal.start_date) {
+    const parsedStart = new Date(goal.start_date);
+    if (!Number.isNaN(parsedStart.getTime())) {
+      start = parsedStart;
+    }
+  }
+
+  const startTime = start?.getTime();
+  if (startTime == null) {
+    const daysLeft = calculateDaysLeft(goal.due_date);
+    if (daysLeft == null) return null;
+    const divisor = Math.max(daysLeft, 1);
+    return Math.ceil(remaining / divisor);
+  }
+
+  const totalDuration = due.getTime() - startTime;
+  if (totalDuration <= 0) {
+    return remaining;
+  }
+
+  const totalDays = Math.max(1, Math.floor(totalDuration / 86400000) + 1);
+  return Math.ceil(remaining / totalDays);
 }
 
 function calculateAveragePerDay(goal: GoalRecord) {

--- a/src/lib/api-goals.ts
+++ b/src/lib/api-goals.ts
@@ -133,16 +133,42 @@ function toNum(value: unknown): number | undefined {
 
 function toISODate(value?: string | null): string | null {
   if (!value) return null;
-  const isoSource = value.includes('T') ? value : `${value}T00:00:00`;
-  const date = new Date(isoSource);
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const dateOnlyMatch = /^\d{4}-\d{2}-\d{2}$/.exec(trimmed);
+  if (dateOnlyMatch) {
+    const [year, month, day] = trimmed.split('-').map((part) => Number.parseInt(part, 10));
+    const utcDate = new Date(Date.UTC(year, month - 1, day));
+    if (Number.isNaN(utcDate.getTime())) return null;
+    return utcDate.toISOString();
+  }
+
+  const source = trimmed.includes('T') && /[zZ]|[+-]\d{2}:?\d{2}$/.test(trimmed)
+    ? trimmed
+    : `${trimmed}Z`;
+  const date = new Date(source);
   if (Number.isNaN(date.getTime())) return null;
   return date.toISOString();
 }
 
 function toISODateEnd(value?: string | null): string | null {
   if (!value) return null;
-  const isoSource = value.includes('T') ? value : `${value}T23:59:59`;
-  const date = new Date(isoSource);
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const dateOnlyMatch = /^\d{4}-\d{2}-\d{2}$/.exec(trimmed);
+  if (dateOnlyMatch) {
+    const [year, month, day] = trimmed.split('-').map((part) => Number.parseInt(part, 10));
+    const utcDate = new Date(Date.UTC(year, month - 1, day, 23, 59, 59, 999));
+    if (Number.isNaN(utcDate.getTime())) return null;
+    return utcDate.toISOString();
+  }
+
+  const source = trimmed.includes('T') && /[zZ]|[+-]\d{2}:?\d{2}$/.test(trimmed)
+    ? trimmed
+    : `${trimmed}Z`;
+  const date = new Date(source);
   if (Number.isNaN(date.getTime())) return null;
   return date.toISOString();
 }


### PR DESCRIPTION
## Summary
- prevent goal dates from shifting by converting date-only values to UTC before storing
- base the daily/weekly savings suggestion on the full goal period starting from the start date

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68da2142739883328c2e7461b2d810bb