### PR TITLE
Fix goal date handling and adjust savings pacing

### DIFF
--- a/src/components/goals/GoalCard.tsx
+++ b/src/components/goals/GoalCard.tsx
@@ -33,10 +33,23 @@ function calculateDailySuggestion(goal: GoalRecord) {
   if (!goal.due_date) return null;
   const remaining = Math.max(goal.target_amount - goal.saved_amount, 0);
   if (remaining <= 0) return null;
-  const daysLeft = calculateDaysLeft(goal.due_date);
-  if (daysLeft == null) return null;
-  const divisor = Math.max(daysLeft, 1);
-  return Math.ceil(remaining / divisor);
+
+  const due = new Date(goal.due_date);
+  if (Number.isNaN(due.getTime())) return null;
+
+  const start = goal.start_date ? new Date(goal.start_date) : null;
+  if (!start || Number.isNaN(start.getTime())) {
+    const daysLeft = calculateDaysLeft(goal.due_date);
+    if (daysLeft == null) return null;
+    return Math.ceil(remaining / Math.max(daysLeft, 1));
+  }
+
+  const totalDays = Math.floor((due.getTime() - start.getTime()) / 86400000) + 1;
+  if (totalDays <= 0) {
+    return Math.ceil(remaining);
+  }
+
+  return Math.ceil(remaining / Math.max(totalDays, 1));
 }
 
 function calculateAveragePerDay(goal: GoalRecord) {

--- a/src/lib/api-goals.ts
+++ b/src/lib/api-goals.ts
@@ -133,7 +133,7 @@ function toNum(value: unknown): number | undefined {
 
 function toISODate(value?: string | null): string | null {
   if (!value) return null;
-  const isoSource = value.includes('T') ? value : `${value}T00:00:00`;
+  const isoSource = value.includes('T') ? value : `${value}T00:00:00Z`;
   const date = new Date(isoSource);
   if (Number.isNaN(date.getTime())) return null;
   return date.toISOString();
@@ -141,7 +141,7 @@ function toISODate(value?: string | null): string | null {
 
 function toISODateEnd(value?: string | null): string | null {
   if (!value) return null;
-  const isoSource = value.includes('T') ? value : `${value}T23:59:59`;
+  const isoSource = value.includes('T') ? value : `${value}T23:59:59Z`;
   const date = new Date(isoSource);
   if (Number.isNaN(date.getTime())) return null;
   return date.toISOString();


### PR DESCRIPTION
## Summary
- prevent goal start and due dates from shifting when saving by normalizing them as UTC timestamps
- adjust daily and weekly savings suggestions to spread the remaining target across the entire goal duration

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68da2142739883328c2e7461b2d810bb