### PR TITLE
Add debt due reminders to daily digest

### DIFF
--- a/src/components/DailyDigestModal.tsx
+++ b/src/components/DailyDigestModal.tsx
@@ -166,7 +166,7 @@ export default function DailyDigestModal({ open, data, onClose }: DailyDigestMod
               ))}
             </ul>
           ) : (
-            <p className="mt-3 text-sm text-muted">Tidak ada tagihan atau langganan yang jatuh tempo dalam 7 hari.</p>
+            <p className="mt-3 text-sm text-muted">Tidak ada hutang, tagihan, atau langganan yang jatuh tempo dalam 7 hari.</p>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- fetch upcoming debts due within seven days and merge them into the daily digest reminder list
- keep subscription reminders as a fallback when debt data is unavailable and update the empty-state copy

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68da650c9a1c833299f0987a7d1b1558