### PR TITLE
Redesign budget overview cards

### DIFF
--- a/src/components/budgets/InlineIcons.tsx
+++ b/src/components/budgets/InlineIcons.tsx
@@ -1,0 +1,90 @@
+import type { SVGProps } from 'react';
+
+type IconProps = SVGProps<SVGSVGElement>;
+
+function createIcon(path: JSX.Element) {
+  return function Icon(props: IconProps) {
+    return (
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+        {...props}
+      >
+        {path}
+      </svg>
+    );
+  };
+}
+
+export const CalendarIcon = createIcon(
+  <>
+    <rect x="3.5" y="4.5" width="17" height="16" rx="2.5" />
+    <path d="M8 2.5v4" />
+    <path d="M16 2.5v4" />
+    <path d="M3.5 9.5h17" />
+  </>
+);
+
+export const SearchIcon = createIcon(
+  <>
+    <circle cx="11" cy="11" r="6" />
+    <path d="m20 20-3.5-3.5" />
+  </>
+);
+
+export const EyeIcon = createIcon(
+  <>
+    <path d="M2.5 12s3.5-6.5 9.5-6.5S21.5 12 21.5 12s-3.5 6.5-9.5 6.5S2.5 12 2.5 12z" />
+    <circle cx="12" cy="12" r="2.5" />
+  </>
+);
+
+export const PencilIcon = createIcon(
+  <>
+    <path d="m4 20 2.2-6.6 9.4-9.4a1.5 1.5 0 0 1 2.12 0l2.28 2.28a1.5 1.5 0 0 1 0 2.12l-9.4 9.4z" />
+    <path d="M13 5.5 18.5 11" />
+  </>
+);
+
+export const RefreshIcon = createIcon(
+  <>
+    <path d="M20 11a8 8 0 0 0-14.9-3" />
+    <path d="M4 5v3.5h3.5" />
+    <path d="M4 13a8 8 0 0 0 14.9 3" />
+    <path d="M20 19v-3.5h-3.5" />
+  </>
+);
+
+export const ToggleIcon = createIcon(
+  <>
+    <rect x="3" y="8" width="18" height="8" rx="4" />
+    <circle cx="9" cy="12" r="2.5" />
+  </>
+);
+
+export const PlusIcon = createIcon(
+  <>
+    <path d="M12 5v14" />
+    <path d="M5 12h14" />
+  </>
+);
+
+export const InfoIcon = createIcon(
+  <>
+    <circle cx="12" cy="12" r="9" />
+    <path d="M12 8.5h.01" />
+    <path d="M11 11.5h1v5" />
+  </>
+);
+
+export const ArrowRightIcon = createIcon(
+  <>
+    <path d="M5 12h14" />
+    <path d="m13 6 6 6-6 6" />
+  </>
+);

--- a/src/components/dashboard/BudgetHighlights.tsx
+++ b/src/components/dashboard/BudgetHighlights.tsx
@@ -3,7 +3,7 @@ import { AlertTriangle, ArrowRight, Sparkles } from "lucide-react"
 import { Link } from "react-router-dom"
 import { useBudgets } from "../../hooks/useBudgets"
 import { formatCurrency } from "../../lib/format.js"
-import type { BudgetWithSpent } from "../../lib/budgetApi"
+import type { BudgetWithActual } from "../../lib/budgetsApi"
 import type { PeriodRange } from "./PeriodPicker"
 
 interface BudgetHighlightsProps {
@@ -33,12 +33,12 @@ function formatPercent(progress: number) {
   return `${Math.round(progress * 100)}%`
 }
 
-function createHighlights(rows: BudgetWithSpent[]): HighlightBudget[] {
+function createHighlights(rows: BudgetWithActual[]): HighlightBudget[] {
   return rows
     .map((row) => {
-      const planned = Number(row.amount_planned ?? 0)
+      const planned = Number(row.planned ?? row.amount_planned ?? 0)
       if (planned <= 0) return null
-      const spent = Number(row.spent ?? 0)
+      const spent = Number(row.actual ?? 0)
       const progress = planned > 0 ? spent / planned : 0
       const distance = Math.abs(1 - progress)
       return {

--- a/src/lib/budgetsApi.ts
+++ b/src/lib/budgetsApi.ts
@@ -1,0 +1,429 @@
+import { supabase } from './supabase';
+import { getCurrentUserId, getUserToken } from './session';
+import type { CategoryRecord } from './api-categories';
+
+export type BudgetType = 'income' | 'expense';
+
+export interface BudgetCategoryInfo {
+  id: string;
+  name: string;
+  type: BudgetType;
+  group_name: string | null;
+}
+
+export interface BudgetRecord {
+  id: string;
+  user_id: string;
+  category_id: string;
+  amount_planned: number | null;
+  carryover_enabled: boolean | null;
+  notes: string | null;
+  period_month: string;
+  created_at: string;
+  updated_at: string;
+  category: BudgetCategoryInfo | null;
+}
+
+export interface BudgetWithActual extends BudgetRecord {
+  planned: number;
+  actual: number;
+  remaining: number;
+  progress: number;
+}
+
+export interface BudgetSummary {
+  planned: number;
+  actual: number;
+  remaining: number;
+  progress: number;
+}
+
+export interface ListBudgetsOptions {
+  period: string; // YYYY-MM
+  signal?: AbortSignal;
+  force?: boolean;
+}
+
+export interface CreateBudgetPayload {
+  period: string; // YYYY-MM
+  category_id: string;
+  amount: number;
+  carryover_enabled?: boolean;
+  notes?: string | null;
+}
+
+export interface UpdateBudgetPayload {
+  amount?: number;
+  carryover_enabled?: boolean;
+  notes?: string | null;
+}
+
+const CACHE_TTL = 90_000; // 90 seconds
+const budgetCache = new Map<string, { timestamp: number; data: BudgetWithActual[] }>();
+let budgetsViewAvailable: boolean | null = null;
+
+function now(): number {
+  return Date.now();
+}
+
+function clampMonth(value: number): number {
+  if (value < 1) return 1;
+  if (value > 12) return 12;
+  return value;
+}
+
+export function toMonthStart(period: string): string {
+  const [yearStr, monthStr] = (period ?? '').split('-');
+  const year = Number.parseInt(yearStr ?? '', 10);
+  const month = Number.parseInt(monthStr ?? '', 10);
+  if (!Number.isFinite(year) || !Number.isFinite(month)) {
+    throw new Error('Periode harus dalam format YYYY-MM');
+  }
+  const normalizedMonth = clampMonth(month);
+  return `${year.toString().padStart(4, '0')}-${normalizedMonth.toString().padStart(2, '0')}-01`;
+}
+
+export function getMonthRange(period: string): { start: string; end: string } {
+  const startDate = new Date(`${toMonthStart(period)}T00:00:00.000Z`);
+  const endDate = new Date(startDate);
+  endDate.setUTCMonth(endDate.getUTCMonth() + 1);
+  const format = (date: Date) => {
+    const year = date.getUTCFullYear();
+    const month = (date.getUTCMonth() + 1).toString().padStart(2, '0');
+    const day = date.getUTCDate().toString().padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  };
+  return {
+    start: format(startDate),
+    end: format(endDate),
+  };
+}
+
+function normaliseNumber(value: unknown): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return 0;
+  return parsed;
+}
+
+function computeProgress(actual: number, planned: number): number {
+  if (planned <= 0) return actual > 0 ? 1 : 0;
+  return actual / planned;
+}
+
+function shouldFallbackView(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const message = (error as { message?: unknown }).message;
+  const code = (error as { code?: unknown }).code;
+  if (code === '42P01' || code === 'PGRST201' || code === 'PGRST204') {
+    return true;
+  }
+  if (typeof message === 'string') {
+    const normalised = message.toLowerCase();
+    if (normalised.includes('budgets_v') && normalised.includes('does not exist')) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function fetchBudgetsBase(
+  userId: string,
+  period: string,
+  signal?: AbortSignal
+): Promise<BudgetRecord[]> {
+  const monthStart = toMonthStart(period);
+
+  if (budgetsViewAvailable !== false) {
+    try {
+      let query = supabase
+        .from('budgets_v')
+        .select(
+          'id,user_id,category_id,amount_planned,carryover_enabled,notes,period_month,created_at,updated_at,category_name,category_type,group_name'
+        )
+        .eq('user_id', userId)
+        .eq('period_month', monthStart)
+        .order('category_name', { ascending: true });
+
+      if (signal) {
+        query = query.abortSignal(signal);
+      }
+
+        const { data, error } = await query;
+        if (error) throw error;
+        budgetsViewAvailable = true;
+        return (data ?? []).map((row: any) => ({
+        id: row.id,
+        user_id: row.user_id,
+        category_id: row.category_id,
+        amount_planned: row.amount_planned,
+        carryover_enabled: row.carryover_enabled,
+        notes: row.notes ?? null,
+        period_month: row.period_month,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+        category: {
+          id: row.category_id,
+          name: row.category_name,
+          type: row.category_type ?? 'expense',
+          group_name: row.group_name ?? null,
+        },
+      }));
+    } catch (error) {
+      if (shouldFallbackView(error)) {
+        budgetsViewAvailable = false;
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  let query = supabase
+    .from('budgets')
+    .select(
+      'id,user_id,category_id,amount_planned,carryover_enabled,notes,period_month,created_at,updated_at,categories(id,name,type,group_name)'
+    )
+    .eq('user_id', userId)
+    .eq('period_month', monthStart)
+    .order('created_at', { ascending: true });
+
+  if (signal) {
+    query = query.abortSignal(signal);
+  }
+
+  const { data, error } = await query;
+  if (error) throw error;
+  return (data ?? []).map((row: any) => ({
+    id: row.id,
+    user_id: row.user_id,
+    category_id: row.category_id,
+    amount_planned: row.amount_planned,
+    carryover_enabled: row.carryover_enabled,
+    notes: row.notes ?? null,
+    period_month: row.period_month,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    category: row.categories
+      ? {
+          id: row.categories.id,
+          name: row.categories.name,
+          type: (row.categories.type as BudgetType) ?? 'expense',
+          group_name: row.categories.group_name ?? null,
+        }
+      : null,
+  }));
+}
+
+async function fetchActualMap(
+  userId: string,
+  period: string,
+  signal?: AbortSignal
+): Promise<Record<string, number>> {
+  const { start, end } = getMonthRange(period);
+  let query = supabase
+    .from('transactions')
+    .select('category_id, amount, to_account_id, type, deleted_at, date')
+    .eq('user_id', userId)
+    .eq('type', 'expense')
+    .is('deleted_at', null)
+    .is('to_account_id', null)
+    .gte('date', start)
+    .lt('date', end);
+
+  if (signal) {
+    query = query.abortSignal(signal);
+  }
+
+  const { data, error } = await query;
+  if (error) throw error;
+  const result: Record<string, number> = {};
+  for (const row of data ?? []) {
+    const categoryId = (row as { category_id?: string | null }).category_id;
+    if (!categoryId) continue;
+    const amount = normaliseNumber((row as { amount?: unknown }).amount);
+    result[categoryId] = (result[categoryId] ?? 0) + amount;
+  }
+  return result;
+}
+
+export function buildBudgetSummary(rows: BudgetWithActual[]): BudgetSummary {
+  const summary = rows.reduce(
+    (acc, row) => {
+      acc.planned += row.planned;
+      acc.actual += row.actual;
+      acc.remaining += row.remaining;
+      return acc;
+    },
+    { planned: 0, actual: 0, remaining: 0, progress: 0 }
+  );
+  summary.progress = summary.planned > 0 ? summary.actual / summary.planned : 0;
+  return summary;
+}
+
+function mapToWithActual(
+  budgets: BudgetRecord[],
+  actualMap: Record<string, number>
+): BudgetWithActual[] {
+  return budgets.map((budget) => {
+    const planned = normaliseNumber(budget.amount_planned);
+    const actual = normaliseNumber(actualMap[budget.category_id]);
+    const remaining = planned - actual;
+    return {
+      ...budget,
+      planned,
+      actual,
+      remaining,
+      progress: computeProgress(actual, planned),
+    };
+  });
+}
+
+export async function listBudgetsWithActual({
+  period,
+  signal,
+  force = false,
+}: ListBudgetsOptions): Promise<BudgetWithActual[]> {
+  const cacheKey = period;
+  if (!force) {
+    const cached = budgetCache.get(cacheKey);
+    if (cached && now() - cached.timestamp < CACHE_TTL) {
+      return cached.data;
+    }
+  }
+
+  const userId = await getCurrentUserId();
+  if (!userId) {
+    throw new Error('Pengguna belum masuk');
+  }
+
+  const [budgets, actualMap] = await Promise.all([
+    fetchBudgetsBase(userId, period, signal),
+    fetchActualMap(userId, period, signal),
+  ]);
+
+  const merged = mapToWithActual(budgets, actualMap);
+  budgetCache.set(cacheKey, { timestamp: now(), data: merged });
+  return merged;
+}
+
+export function invalidateBudgetsCache(period?: string) {
+  if (!period) {
+    budgetCache.clear();
+    return;
+  }
+  budgetCache.delete(period);
+}
+
+function ensureNumber(value: unknown, fallback = 0): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return parsed;
+}
+
+export async function createBudget(payload: CreateBudgetPayload): Promise<BudgetWithActual> {
+  const userId = await getCurrentUserId();
+  if (!userId) throw new Error('Pengguna belum masuk');
+  await getUserToken();
+
+  const insertPayload = {
+    user_id: userId,
+    category_id: payload.category_id,
+    amount_planned: ensureNumber(payload.amount),
+    carryover_enabled: payload.carryover_enabled ?? false,
+    notes: payload.notes ?? null,
+    period_month: toMonthStart(payload.period),
+  };
+
+  const { data, error } = await supabase
+    .from('budgets')
+    .insert(insertPayload)
+    .select(
+      'id,user_id,category_id,amount_planned,carryover_enabled,notes,period_month,created_at,updated_at,categories(id,name,type,group_name)'
+    )
+    .single();
+
+  if (error) {
+    throw new Error(error.message || 'Gagal menyimpan anggaran');
+  }
+
+  invalidateBudgetsCache(payload.period);
+
+  const record: BudgetRecord = {
+    id: data.id,
+    user_id: data.user_id,
+    category_id: data.category_id,
+    amount_planned: ensureNumber(data.amount_planned),
+    carryover_enabled: Boolean(data.carryover_enabled),
+    notes: data.notes ?? null,
+    period_month: data.period_month,
+    created_at: data.created_at,
+    updated_at: data.updated_at,
+    category: data.categories
+      ? {
+          id: data.categories.id,
+          name: data.categories.name,
+          type: (data.categories.type as BudgetType) ?? 'expense',
+          group_name: data.categories.group_name ?? null,
+        }
+      : null,
+  };
+
+  return {
+    ...record,
+    planned: ensureNumber(record.amount_planned),
+    actual: 0,
+    remaining: ensureNumber(record.amount_planned),
+    progress: 0,
+  };
+}
+
+export async function updateBudget(id: string, payload: UpdateBudgetPayload, period: string): Promise<void> {
+  const userId = await getCurrentUserId();
+  if (!userId) throw new Error('Pengguna belum masuk');
+  await getUserToken();
+
+  const updatePayload: Record<string, unknown> = {};
+  if (payload.amount !== undefined) {
+    updatePayload.amount_planned = ensureNumber(payload.amount);
+  }
+  if (payload.carryover_enabled !== undefined) {
+    updatePayload.carryover_enabled = payload.carryover_enabled;
+  }
+  if (payload.notes !== undefined) {
+    updatePayload.notes = payload.notes ?? null;
+  }
+
+  if (Object.keys(updatePayload).length === 0) return;
+
+  const { error } = await supabase
+    .from('budgets')
+    .update(updatePayload)
+    .eq('user_id', userId)
+    .eq('id', id);
+
+  if (error) {
+    throw new Error(error.message || 'Gagal memperbarui anggaran');
+  }
+
+  invalidateBudgetsCache(period);
+}
+
+export async function deleteBudget(id: string, period: string): Promise<void> {
+  const userId = await getCurrentUserId();
+  if (!userId) throw new Error('Pengguna belum masuk');
+  await getUserToken();
+
+  const { error } = await supabase.from('budgets').delete().eq('user_id', userId).eq('id', id);
+  if (error) {
+    throw new Error(error.message || 'Gagal menghapus anggaran');
+  }
+  invalidateBudgetsCache(period);
+}
+
+export function mapCategoryRecordToInfo(category: CategoryRecord): BudgetCategoryInfo {
+  return {
+    id: category.id,
+    name: category.name,
+    type: category.type,
+    group_name: (category as { group_name?: string | null }).group_name ?? null,
+  };
+}

--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -1,193 +1,285 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
-import { Calendar, Plus, RefreshCw } from 'lucide-react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import Page from '../../layout/Page';
-import Section from '../../layout/Section';
-import PageHeader from '../../layout/PageHeader';
-import { useToast } from '../../context/ToastContext';
-import SummaryCards from './components/SummaryCards';
-import BudgetTable from './components/BudgetTable';
-import BudgetFormModal, { type BudgetFormValues } from './components/BudgetFormModal';
+import Breadcrumbs from '../../layout/Breadcrumbs';
 import { useBudgets } from '../../hooks/useBudgets';
+import { useToast } from '../../context/ToastContext';
 import {
-  deleteBudget,
-  listCategoriesExpense,
-  upsertBudget,
-  type BudgetWithSpent,
-  type ExpenseCategory,
-} from '../../lib/budgetApi';
+  createBudget,
+  getMonthRange,
+  invalidateBudgetsCache,
+  toMonthStart,
+  updateBudget,
+  type BudgetWithActual,
+} from '../../lib/budgetsApi';
+import { listCategories, type CategoryRecord } from '../../lib/api-categories';
+import { formatCurrency } from '../../lib/format.js';
+import BudgetFilters from './components/BudgetFilters';
+import BudgetCard from './components/BudgetCard';
+import BudgetFormDialog, {
+  type BudgetCategoryOption,
+  type BudgetFormValues,
+} from './components/BudgetFormDialog';
+import {
+  ArrowRightIcon,
+  InfoIcon,
+  PlusIcon,
+  RefreshIcon,
+} from '../../components/budgets/InlineIcons';
 
-const SEGMENTS = [
-  { value: 'current', label: 'Bulan ini' },
-  { value: 'previous', label: 'Bulan lalu' },
-  { value: 'custom', label: 'Custom' },
-] as const;
+const SKELETON_COUNT = 8;
 
-type SegmentValue = (typeof SEGMENTS)[number]['value'];
-
-function formatPeriod(date: Date): string {
-  const year = date.getFullYear();
-  const month = `${date.getMonth() + 1}`.padStart(2, '0');
-  return `${year}-${month}`;
-}
-
-function getCurrentPeriod() {
-  return formatPeriod(new Date());
-}
-
-function getPreviousPeriod() {
+function getCurrentPeriod(): string {
   const now = new Date();
-  const previous = new Date(now.getFullYear(), now.getMonth() - 1, 1);
-  return formatPeriod(previous);
+  const month = `${now.getMonth() + 1}`.padStart(2, '0');
+  return `${now.getFullYear()}-${month}`;
 }
 
 function toHumanReadable(period: string): string {
   const [year, month] = period.split('-').map((value) => Number.parseInt(value, 10));
   if (!year || !month) return period;
-  const formatter = new Intl.DateTimeFormat('id-ID', { month: 'long', year: 'numeric' });
-  return formatter.format(new Date(year, month - 1, 1));
+  return new Intl.DateTimeFormat('id-ID', { month: 'long', year: 'numeric' }).format(
+    new Date(year, month - 1, 1)
+  );
 }
 
-function isoToPeriod(isoDate: string | null | undefined): string {
-  if (!isoDate) return getCurrentPeriod();
-  return isoDate.slice(0, 7);
+function clampPeriod(period: string | null | undefined): string {
+  if (!period) return getCurrentPeriod();
+  if (/^\d{4}-\d{2}$/.test(period)) return period;
+  return getCurrentPeriod();
+}
+
+function toNextPeriod(period: string): string {
+  const [year, month] = period.split('-').map((value) => Number.parseInt(value, 10));
+  const date = new Date(year, (month ?? 1) - 1, 1);
+  date.setMonth(date.getMonth() + 1);
+  const nextMonth = `${date.getMonth() + 1}`.padStart(2, '0');
+  return `${date.getFullYear()}-${nextMonth}`;
+}
+
+function formatDateISO(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function resolveEndOfMonth(period: string): string {
+  const { end } = getMonthRange(period);
+  const endDate = new Date(`${end}T00:00:00`);
+  endDate.setDate(endDate.getDate() - 1);
+  return formatDateISO(endDate);
+}
+
+function mapCategoryRecord(category: CategoryRecord): BudgetCategoryOption {
+  return {
+    id: category.id,
+    name: category.name,
+    type: category.type === 'income' ? 'income' : 'expense',
+    group_name: (category as { group_name?: string | null }).group_name ?? null,
+  };
 }
 
 const DEFAULT_FORM_VALUES: BudgetFormValues = {
   period: getCurrentPeriod(),
-  category_id: '',
-  amount_planned: 0,
-  carryover_enabled: false,
+  categoryId: '',
+  amount: 0,
+  carryover: false,
   notes: '',
 };
 
+type BudgetTypeFilter = 'all' | 'expense' | 'income';
+
+type GroupedBudgets = {
+  group: string;
+  items: BudgetWithActual[];
+};
+
+function buildInitialValues(period: string, editing?: BudgetWithActual | null): BudgetFormValues {
+  if (!editing) {
+    return { ...DEFAULT_FORM_VALUES, period };
+  }
+  return {
+    period: editing.period_month?.slice(0, 7) ?? period,
+    categoryId: editing.category_id,
+    amount: Number(editing.planned ?? editing.amount_planned ?? 0),
+    carryover: Boolean(editing.carryover_enabled),
+    notes: editing.notes ?? '',
+  };
+}
+
 export default function BudgetsPage() {
+  const navigate = useNavigate();
   const { addToast } = useToast();
-  const [segment, setSegment] = useState<SegmentValue>('current');
-  const [customPeriod, setCustomPeriod] = useState<string>(getCurrentPeriod());
-  const [period, setPeriod] = useState<string>(getCurrentPeriod());
-  const [modalOpen, setModalOpen] = useState(false);
-  const [editing, setEditing] = useState<BudgetWithSpent | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const period = clampPeriod(searchParams.get('period'));
+  const typeFilter = (searchParams.get('type') as BudgetTypeFilter) ?? 'expense';
+  const searchQuery = searchParams.get('q') ?? '';
+  const groupBy = searchParams.get('group') === 'true';
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<BudgetWithActual | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [categories, setCategories] = useState<ExpenseCategory[]>([]);
+  const [categories, setCategories] = useState<BudgetCategoryOption[]>([]);
   const [categoriesLoading, setCategoriesLoading] = useState(true);
+  const [autoRollover, setAutoRollover] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.localStorage?.getItem('hw-auto-rollover') === '1';
+  });
 
   const { rows, summary, loading, error, refresh } = useBudgets(period);
 
+  const updateParams = useCallback(
+    (updates: Record<string, string | boolean | null | undefined>) => {
+      const next = new URLSearchParams(searchParams);
+      Object.entries(updates).forEach(([key, value]) => {
+        if (value === undefined || value === null || value === '') {
+          next.delete(key);
+        } else {
+          next.set(key, String(value));
+        }
+      });
+      setSearchParams(next, { replace: true });
+    },
+    [searchParams, setSearchParams]
+  );
+
   useEffect(() => {
-    let active = true;
     setCategoriesLoading(true);
-    listCategoriesExpense()
+    const controller = new AbortController();
+    listCategories(controller.signal)
       .then((data) => {
-        if (!active) return;
-        setCategories(data);
+        if (controller.signal.aborted) return;
+        setCategories(data.map(mapCategoryRecord));
       })
       .catch((err) => {
-        if (!active) return;
+        if (controller.signal.aborted) return;
         const message = err instanceof Error ? err.message : 'Gagal memuat kategori';
         addToast(message, 'error');
       })
       .finally(() => {
-        if (!active) return;
+        if (controller.signal.aborted) return;
         setCategoriesLoading(false);
       });
-    return () => {
-      active = false;
-    };
+    return () => controller.abort();
   }, [addToast]);
 
   useEffect(() => {
-    if (!error) return;
-    addToast(error, 'error');
-  }, [error, addToast]);
-
-  useEffect(() => {
-    if (segment === 'current') {
-      setPeriod(getCurrentPeriod());
-    } else if (segment === 'previous') {
-      setPeriod(getPreviousPeriod());
-    } else {
-      setPeriod(customPeriod || getCurrentPeriod());
+    if (typeof window !== 'undefined') {
+      window.localStorage?.setItem('hw-auto-rollover', autoRollover ? '1' : '0');
     }
-  }, [segment, customPeriod]);
+  }, [autoRollover]);
 
-  const initialFormValues = useMemo<BudgetFormValues>(() => {
-    if (editing) {
-      return {
-        period: isoToPeriod(editing.period_month),
-        category_id: editing.category_id ?? '',
-        amount_planned: Number(editing.amount_planned ?? 0),
-        carryover_enabled: editing.carryover_enabled,
-        notes: editing.notes ?? '',
-      };
-    }
-    return { ...DEFAULT_FORM_VALUES, period };
-  }, [editing, period]);
+  const handlePeriodChange = useCallback(
+    (value: string) => {
+      updateParams({ period: value || getCurrentPeriod() });
+    },
+    [updateParams]
+  );
 
-  const handleSegmentChange = (value: SegmentValue) => {
-    setSegment(value);
-  };
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      updateParams({ q: value || null });
+    },
+    [updateParams]
+  );
 
-  const handleCustomPeriodChange = (value: string) => {
-    setCustomPeriod(value);
-    setPeriod(value || getCurrentPeriod());
-  };
+  const handleTypeChange = useCallback(
+    (value: BudgetTypeFilter) => {
+      updateParams({ type: value === 'expense' ? 'expense' : value === 'income' ? 'income' : 'all' });
+    },
+    [updateParams]
+  );
 
-  const handleOpenCreate = () => {
-    setEditing(null);
-    setModalOpen(true);
-  };
+  const handleGroupToggle = useCallback(
+    (value: boolean) => {
+      updateParams({ group: value ? 'true' : null });
+    },
+    [updateParams]
+  );
 
-  const handleEdit = (row: BudgetWithSpent) => {
-    setEditing(row);
-    setModalOpen(true);
-  };
-
-  const handleDelete = async (row: BudgetWithSpent) => {
-    const confirmed = window.confirm(`Hapus anggaran untuk ${row.category?.name ?? 'kategori ini'}?`);
-    if (!confirmed) return;
-    try {
-      setSubmitting(true);
-      await deleteBudget(row.id);
-      await refresh();
-      addToast('Anggaran dihapus', 'success');
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Gagal menghapus anggaran';
-      addToast(message, 'error');
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  const handleToggleCarryover = async (row: BudgetWithSpent, carryover: boolean) => {
-    try {
-      await upsertBudget({
-        category_id: row.category_id,
-        period: isoToPeriod(row.period_month),
-        amount_planned: Number(row.amount_planned ?? 0),
-        carryover_enabled: carryover,
-        notes: row.notes ?? undefined,
+  const filteredBudgets = useMemo(() => {
+    const normalizedQuery = searchQuery.trim().toLowerCase();
+    return rows
+      .filter((budget) => {
+        if (typeFilter === 'all') return true;
+        const categoryType = budget.category?.type ?? 'expense';
+        return categoryType === typeFilter;
+      })
+      .filter((budget) => {
+        if (!normalizedQuery) return true;
+        const source = `${budget.category?.name ?? ''} ${budget.category?.group_name ?? ''}`.toLowerCase();
+        return source.includes(normalizedQuery);
+      })
+      .sort((a, b) => {
+        const aName = a.category?.name ?? '';
+        const bName = b.category?.name ?? '';
+        return aName.localeCompare(bName, 'id-ID', { sensitivity: 'base' });
       });
-      await refresh();
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Gagal memperbarui carryover';
-      addToast(message, 'error');
-    }
+  }, [rows, searchQuery, typeFilter]);
+
+  const groupedBudgets = useMemo<GroupedBudgets[]>(() => {
+    if (!groupBy) return [];
+    const groups = new Map<string, BudgetWithActual[]>();
+    filteredBudgets.forEach((budget) => {
+      const key = budget.category?.group_name?.trim() || 'Tanpa grup';
+      const groupItems = groups.get(key) ?? [];
+      groupItems.push(budget);
+      groups.set(key, groupItems);
+    });
+    return Array.from(groups.entries())
+      .map(([group, items]) => ({ group, items }))
+      .sort((a, b) => {
+        if (a.group === 'Tanpa grup') return 1;
+        if (b.group === 'Tanpa grup') return -1;
+        return a.group.localeCompare(b.group, 'id-ID', { sensitivity: 'base' });
+      });
+  }, [filteredBudgets, groupBy]);
+
+  const initialFormValues = useMemo(() => buildInitialValues(period, editing), [period, editing]);
+
+  const openCreate = () => {
+    setEditing(null);
+    setFormOpen(true);
+  };
+
+  const openEdit = (budget: BudgetWithActual) => {
+    setEditing(budget);
+    setFormOpen(true);
+  };
+
+  const closeForm = () => {
+    setFormOpen(false);
+    setEditing(null);
   };
 
   const handleSubmit = async (values: BudgetFormValues) => {
     try {
       setSubmitting(true);
-      await upsertBudget({
-        category_id: values.category_id,
-        period: values.period,
-        amount_planned: Number(values.amount_planned),
-        carryover_enabled: values.carryover_enabled,
-        notes: values.notes ? values.notes : undefined,
-      });
-      setModalOpen(false);
-      setEditing(null);
-      addToast('Anggaran tersimpan', 'success');
+      if (editing) {
+        await updateBudget(
+          editing.id,
+          {
+            amount: values.amount,
+            carryover_enabled: values.carryover,
+            notes: values.notes.trim() ? values.notes : null,
+          },
+          values.period
+        );
+        addToast('Anggaran diperbarui', 'success');
+      } else {
+        await createBudget({
+          category_id: values.categoryId,
+          amount: values.amount,
+          carryover_enabled: values.carryover,
+          notes: values.notes.trim() ? values.notes : null,
+          period: values.period,
+        });
+        addToast('Anggaran ditambahkan', 'success');
+      }
+      invalidateBudgetsCache(values.period);
+      closeForm();
       await refresh();
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Gagal menyimpan anggaran';
@@ -197,106 +289,242 @@ export default function BudgetsPage() {
     }
   };
 
+  const handleToggleCarryover = async (budget: BudgetWithActual, next: boolean) => {
+    try {
+      await updateBudget(
+        budget.id,
+        {
+          carryover_enabled: next,
+        },
+        budget.period_month?.slice(0, 7) ?? period
+      );
+      invalidateBudgetsCache(period);
+      addToast(next ? 'Carryover diaktifkan' : 'Carryover dinonaktifkan', 'success');
+      await refresh();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Gagal mengubah carryover';
+      addToast(message, 'error');
+    }
+  };
+
+  const handleRollover = async (budget: BudgetWithActual) => {
+    if (budget.remaining <= 0) {
+      addToast('Tidak ada sisa anggaran untuk di-rollover', 'info');
+      return;
+    }
+    const nextPeriod = toNextPeriod(budget.period_month?.slice(0, 7) ?? period);
+    try {
+      await createBudget({
+        category_id: budget.category_id,
+        period: nextPeriod,
+        amount: Math.max(budget.planned, 0) + Math.max(budget.remaining, 0),
+        carryover_enabled: Boolean(budget.carryover_enabled),
+        notes: budget.notes ?? null,
+      });
+      invalidateBudgetsCache(nextPeriod);
+      addToast('Rollover ke bulan berikutnya dibuat', 'success');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Gagal membuat rollover';
+      addToast(message, 'error');
+    }
+  };
+
+  const handleViewTransactions = (budget: BudgetWithActual) => {
+    const basePeriod = budget.period_month?.slice(0, 7) ?? period;
+    const start = toMonthStart(basePeriod);
+    const end = resolveEndOfMonth(basePeriod);
+    navigate(`/transactions?category=${budget.category_id}&start=${start}&end=${end}`);
+  };
+
+  const toggleAutoRollover = () => {
+    const next = !autoRollover;
+    setAutoRollover(next);
+    addToast(next ? 'Rollover otomatis akan diterapkan (simulasi)' : 'Rollover otomatis dimatikan', 'info');
+  };
+
+  const renderSkeletons = () => (
+    <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {Array.from({ length: SKELETON_COUNT }).map((_, index) => (
+        <div
+          key={index}
+          className="h-48 animate-pulse rounded-2xl bg-slate-900/80 ring-1 ring-slate-800"
+        />
+      ))}
+    </div>
+  );
+
+  const renderEmptyState = () => (
+    <div className="flex flex-col items-center justify-center gap-4 rounded-3xl bg-slate-900/80 px-10 py-14 text-center ring-1 ring-slate-800">
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--accent)]/10 text-[var(--accent)]">
+        <InfoIcon className="h-8 w-8" />
+      </div>
+      <div className="space-y-2">
+        <h3 className="text-lg font-semibold text-slate-100">Belum ada anggaran untuk filter ini</h3>
+        <p className="text-sm text-slate-400">
+          Tambahkan anggaran baru atau ubah filter pencarian untuk melihat daftar anggaran.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={openCreate}
+        className="inline-flex items-center gap-2 rounded-full bg-[var(--accent)] px-5 py-2 text-sm font-semibold text-slate-950 shadow hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+      >
+        <PlusIcon className="h-4 w-4" />
+        Tambah anggaran
+      </button>
+    </div>
+  );
+
+  const canShowGrouped = groupBy && groupedBudgets.length > 0;
+
   return (
     <Page>
-      <PageHeader
-        title="Anggaran"
-        description="Atur dan pantau alokasi pengeluaranmu tiap bulan."
-      >
-        <button
-          type="button"
-          onClick={refresh}
-          className="hidden h-11 items-center gap-2 rounded-2xl border border-border bg-surface px-4 text-sm font-semibold text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 md:inline-flex"
-        >
-          <RefreshCw className="h-4 w-4" />
-          Segarkan
-        </button>
-        <button
-          type="button"
-          disabled={categoriesLoading}
-          onClick={handleOpenCreate}
-          className="inline-flex h-11 items-center gap-2 rounded-2xl bg-brand px-5 text-sm font-semibold text-brand-foreground shadow transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)] disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          <Plus className="h-4 w-4" />
-          Tambah anggaran
-        </button>
-      </PageHeader>
-
-      <Section first>
-        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div className="flex flex-wrap gap-2">
-            {SEGMENTS.map(({ value, label }) => {
-              const active = value === segment;
-              return (
-                <button
-                  key={value}
-                  type="button"
-                  onClick={() => handleSegmentChange(value)}
-                  className={clsx(
-                    'h-11 rounded-2xl px-5 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
-                    active
-                      ? 'bg-brand text-brand-foreground shadow'
-                      : 'border border-border bg-surface px-5 text-muted hover:border-brand/40 hover:bg-brand/5 hover:text-text'
-                  )}
-                >
-                  {label}
-                </button>
-              );
-            })}
-          </div>
-
-          {segment === 'custom' ? (
-            <input
-              type="month"
-              value={customPeriod}
-              onChange={(event) => handleCustomPeriodChange(event.target.value)}
-              className="h-11 rounded-2xl border border-border bg-surface px-4 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-              aria-label="Pilih periode custom"
-            />
-          ) : (
-            <div className="flex items-center gap-2 rounded-2xl border border-border bg-surface px-4 py-2 text-sm font-medium text-muted">
-              <Calendar className="h-4 w-4" />
-              <span>{toHumanReadable(period)}</span>
+      <div className="space-y-8">
+        <div className="space-y-6">
+          <Breadcrumbs />
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-2">
+              <span className="inline-flex items-center gap-2 rounded-full bg-[var(--accent)]/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-[var(--accent)]">
+                Anggaran Bulan Ini
+              </span>
+              <div>
+                <h1 className="text-2xl font-semibold text-slate-100 md:text-3xl">
+                  {toHumanReadable(period)}
+                </h1>
+                <p className="text-sm text-slate-400">
+                  Pantau pemakaian anggaran dan ambil tindakan cepat sebelum terlambat.
+                </p>
+              </div>
             </div>
-          )}
-        </div>
-      </Section>
-
-      <Section>
-        <SummaryCards summary={summary} loading={loading} />
-      </Section>
-
-      {error ? (
-        <Section>
-          <div className="rounded-2xl border border-rose-200/70 bg-rose-50/70 p-4 text-sm text-rose-600 shadow-sm dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-300">
-            Terjadi kesalahan saat memuat data anggaran. Silakan coba lagi.
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={toggleAutoRollover}
+                className={clsx(
+                  'inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60',
+                  autoRollover
+                    ? 'bg-[var(--accent)]/20 text-[var(--accent)]'
+                    : 'bg-slate-900/80 text-slate-200 hover:bg-slate-800'
+                )}
+              >
+                <ArrowRightIcon className="h-4 w-4" />
+                Rollover Otomatis
+              </button>
+              <button
+                type="button"
+                onClick={openCreate}
+                disabled={categoriesLoading}
+                className="inline-flex items-center gap-2 rounded-full bg-[var(--accent)] px-5 py-2 text-sm font-semibold text-slate-950 shadow transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <PlusIcon className="h-4 w-4" />
+                Tambah Anggaran
+              </button>
+            </div>
           </div>
-        </Section>
-      ) : null}
 
-      <Section>
-        <BudgetTable
-          rows={rows}
-          loading={loading || submitting}
-          onEdit={handleEdit}
-          onDelete={handleDelete}
-          onToggleCarryover={handleToggleCarryover}
-        />
-      </Section>
+          <BudgetFilters
+            period={period}
+            search={searchQuery}
+            type={typeFilter}
+            groupBy={groupBy}
+            onPeriodChange={handlePeriodChange}
+            onSearchChange={handleSearchChange}
+            onTypeChange={handleTypeChange}
+            onGroupByChange={handleGroupToggle}
+          />
 
-      <BudgetFormModal
-        open={modalOpen}
-        title={editing ? 'Edit anggaran' : 'Tambah anggaran'}
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="rounded-2xl bg-slate-900/80 p-4 ring-1 ring-slate-800">
+              <p className="text-xs uppercase tracking-wide text-slate-500">Planned</p>
+              <p className="mt-1 font-mono text-lg text-slate-100">{formatCurrency(summary.planned, 'IDR')}</p>
+            </div>
+            <div className="rounded-2xl bg-slate-900/80 p-4 ring-1 ring-slate-800">
+              <p className="text-xs uppercase tracking-wide text-slate-500">Actual MTD</p>
+              <p className="mt-1 font-mono text-lg text-slate-100">{formatCurrency(summary.actual, 'IDR')}</p>
+            </div>
+            <div className="rounded-2xl bg-slate-900/80 p-4 ring-1 ring-slate-800">
+              <p className="text-xs uppercase tracking-wide text-slate-500">Remaining</p>
+              <p
+                className={clsx(
+                  'mt-1 font-mono text-lg',
+                  summary.remaining < 0 ? 'text-rose-300' : 'text-emerald-300'
+                )}
+              >
+                {formatCurrency(summary.remaining, 'IDR')}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {error ? (
+          <div className="flex items-center justify-between gap-4 rounded-2xl bg-red-500/10 px-4 py-3 text-sm text-red-200 ring-1 ring-red-500/30">
+            <span>Terjadi kesalahan saat memuat data anggaran.</span>
+            <button
+              type="button"
+              onClick={refresh}
+              className="inline-flex items-center gap-2 rounded-full border border-red-400/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-red-200 transition hover:bg-red-500/10"
+            >
+              <RefreshIcon className="h-4 w-4" /> Retry
+            </button>
+          </div>
+        ) : null}
+
+        {loading && !rows.length ? (
+          renderSkeletons()
+        ) : filteredBudgets.length === 0 ? (
+          renderEmptyState()
+        ) : canShowGrouped ? (
+          <div className="space-y-8">
+            {groupedBudgets.map((group) => (
+              <section key={group.group} className="space-y-3">
+                <header className="flex items-center justify-between">
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    {group.group}
+                  </h3>
+                  <span className="text-xs text-slate-500">{group.items.length} kategori</span>
+                </header>
+                <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                  {group.items.map((budget) => (
+                    <BudgetCard
+                      key={budget.id}
+                      budget={budget}
+                      onEdit={openEdit}
+                      onViewTransactions={handleViewTransactions}
+                      onToggleCarryover={handleToggleCarryover}
+                      onRollover={handleRollover}
+                      rolloverEnabled={autoRollover}
+                    />
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {filteredBudgets.map((budget) => (
+              <BudgetCard
+                key={budget.id}
+                budget={budget}
+                onEdit={openEdit}
+                onViewTransactions={handleViewTransactions}
+                onToggleCarryover={handleToggleCarryover}
+                onRollover={handleRollover}
+                rolloverEnabled={autoRollover}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <BudgetFormDialog
+        open={formOpen}
+        title={editing ? 'Edit Anggaran' : 'Tambah Anggaran'}
         categories={categories}
         initialValues={initialFormValues}
         submitting={submitting}
-        onClose={() => {
-          setModalOpen(false);
-          setEditing(null);
-        }}
+        onClose={closeForm}
         onSubmit={handleSubmit}
       />
     </Page>
   );
 }
-

--- a/src/pages/budgets/components/BudgetCard.tsx
+++ b/src/pages/budgets/components/BudgetCard.tsx
@@ -1,0 +1,212 @@
+import clsx from 'clsx';
+import type { BudgetWithActual } from '../../../lib/budgetsApi';
+import { formatCurrency } from '../../../lib/format.js';
+import {
+  EyeIcon,
+  PencilIcon,
+  RefreshIcon,
+  ToggleIcon,
+} from '../../../components/budgets/InlineIcons';
+
+interface BudgetCardProps {
+  budget: BudgetWithActual;
+  onViewTransactions: (budget: BudgetWithActual) => void;
+  onEdit: (budget: BudgetWithActual) => void;
+  onToggleCarryover: (budget: BudgetWithActual, nextValue: boolean) => void;
+  onRollover?: (budget: BudgetWithActual) => void;
+  rolloverEnabled?: boolean;
+}
+
+function formatPercent(value: number): string {
+  if (!Number.isFinite(value)) return '0%';
+  return `${Math.round(value * 100)}%`;
+}
+
+function getStatus(progress: number, planned: number) {
+  if (planned <= 0) {
+    return {
+      label: 'Belum disetel',
+      className: 'bg-slate-700/60 text-slate-200',
+      bar: 'bg-slate-600',
+    };
+  }
+  if (progress > 1) {
+    return {
+      label: 'Over',
+      className: 'bg-rose-500/20 text-rose-200 ring-1 ring-rose-500/40',
+      bar: 'bg-rose-500/90',
+    };
+  }
+  if (progress >= 0.9) {
+    return {
+      label: '90%+',
+      className: 'bg-orange-500/20 text-orange-200 ring-1 ring-orange-500/40',
+      bar: 'bg-orange-500/80',
+    };
+  }
+  if (progress >= 0.75) {
+    return {
+      label: '75%+',
+      className: 'bg-amber-400/20 text-amber-200 ring-1 ring-amber-400/40',
+      bar: 'bg-amber-400/80',
+    };
+  }
+  return {
+    label: 'Aman',
+    className: 'bg-[var(--accent)]/20 text-[var(--accent)] ring-1 ring-[var(--accent)]/30',
+    bar: 'bg-[var(--accent)]',
+  };
+}
+
+function getTypeChip(type: string | undefined) {
+  if (type === 'income') {
+    return 'bg-emerald-500/15 text-emerald-200';
+  }
+  return 'bg-rose-500/15 text-rose-200';
+}
+
+export default function BudgetCard({
+  budget,
+  onEdit,
+  onViewTransactions,
+  onToggleCarryover,
+  onRollover,
+  rolloverEnabled = true,
+}: BudgetCardProps) {
+  const planned = Number(budget.planned ?? budget.amount_planned ?? 0);
+  const actual = Number(budget.actual ?? 0);
+  const remaining = planned - actual;
+  const progress = planned > 0 ? actual / planned : actual > 0 ? 1 : 0;
+  const status = getStatus(progress, planned);
+  const width = `${Math.min(Math.max(progress, 0), 1) * 100}%`;
+  const percentLabel = planned > 0 ? formatPercent(progress) : '0%';
+  const remainingLabel = formatCurrency(Math.abs(remaining), 'IDR');
+  const remainingNegative = remaining < 0;
+
+  const canRollover = typeof onRollover === 'function';
+  const rolloverDisabled = !canRollover || !rolloverEnabled;
+
+  return (
+    <article className="relative flex flex-col gap-4 rounded-2xl bg-slate-900/90 p-4 ring-1 ring-slate-800 transition hover:ring-slate-700 focus-within:ring-[var(--accent)]/60">
+      <header className="flex items-start justify-between gap-3">
+        <div className="min-w-0 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="truncate text-base font-semibold text-slate-100" title={budget.category?.name ?? 'Tanpa kategori'}>
+              {budget.category?.name ?? 'Tanpa kategori'}
+            </h3>
+            <span
+              className={clsx(
+                'rounded-full px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide',
+                getTypeChip(budget.category?.type)
+              )}
+            >
+              {budget.category?.type === 'income' ? 'Income' : 'Expense'}
+            </span>
+          </div>
+          {budget.category?.group_name ? (
+            <p className="text-xs text-slate-400">{budget.category.group_name}</p>
+          ) : null}
+        </div>
+        <span className={clsx('rounded-full px-2 py-1 text-[10px] font-semibold uppercase tracking-wide', status.className)}>
+          {status.label}
+        </span>
+      </header>
+
+      <dl className="grid grid-cols-2 gap-3 text-sm text-slate-200 sm:grid-cols-3">
+        <div className="space-y-1">
+          <dt className="text-xs uppercase tracking-wide text-slate-500">Planned</dt>
+          <dd className="font-mono text-sm text-slate-100">
+            {planned > 0 ? formatCurrency(planned, 'IDR') : <span className="text-slate-500">Belum disetel</span>}
+          </dd>
+        </div>
+        <div className="space-y-1">
+          <dt className="text-xs uppercase tracking-wide text-slate-500">Actual MTD</dt>
+          <dd className="font-mono text-sm text-slate-100">{formatCurrency(actual, 'IDR')}</dd>
+        </div>
+        <div className="space-y-1">
+          <dt className="text-xs uppercase tracking-wide text-slate-500">Remaining</dt>
+          <dd
+            className={clsx(
+              'font-mono text-sm',
+              remainingNegative ? 'text-rose-300' : 'text-emerald-300'
+            )}
+          >
+            {remainingNegative ? `- ${remainingLabel}` : remainingLabel}
+          </dd>
+        </div>
+      </dl>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between text-xs text-slate-400">
+          <span>Progress</span>
+          <span className="font-mono text-slate-200">{percentLabel}</span>
+        </div>
+        <div className="h-2 w-full overflow-hidden rounded-full bg-slate-800">
+          <div className={clsx('h-full rounded-full transition-all duration-300', status.bar)} style={{ width }} />
+        </div>
+        {progress > 1 ? (
+          <p className="text-xs text-rose-300">Pengeluaran melebihi anggaran sebesar {formatCurrency(actual - planned, 'IDR')}.</p>
+        ) : null}
+        {budget.carryover_enabled ? (
+          <p className="text-xs text-slate-400">Carryover aktif untuk kategori ini.</p>
+        ) : null}
+      </div>
+
+      <footer className="mt-auto flex items-center justify-between gap-2 pt-1">
+        <div className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-slate-500">
+          <span>Bulan</span>
+          <span className="font-mono text-slate-300">{budget.period_month?.slice(0, 7)}</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            title="Lihat transaksi"
+            aria-label="Lihat transaksi"
+            onClick={() => onViewTransactions(budget)}
+            className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-800/80 text-slate-200 transition hover:bg-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+          >
+            <EyeIcon className="h-5 w-5" />
+          </button>
+          <button
+            type="button"
+            title="Edit anggaran"
+            aria-label="Edit anggaran"
+            onClick={() => onEdit(budget)}
+            className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-800/80 text-slate-200 transition hover:bg-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+          >
+            <PencilIcon className="h-5 w-5" />
+          </button>
+          <button
+            type="button"
+            title={budget.carryover_enabled ? 'Nonaktifkan carryover' : 'Aktifkan carryover'}
+            aria-label={budget.carryover_enabled ? 'Nonaktifkan carryover' : 'Aktifkan carryover'}
+            onClick={() => onToggleCarryover(budget, !budget.carryover_enabled)}
+            className={clsx(
+              'flex h-10 w-10 items-center justify-center rounded-full transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60',
+              budget.carryover_enabled
+                ? 'bg-[var(--accent)]/20 text-[var(--accent)] hover:bg-[var(--accent)]/30'
+                : 'bg-slate-800/80 text-slate-200 hover:bg-slate-700'
+            )}
+          >
+            <ToggleIcon className="h-5 w-5" />
+          </button>
+          <button
+            type="button"
+            title="Rollover ke bulan berikutnya"
+            aria-label="Rollover ke bulan berikutnya"
+            disabled={rolloverDisabled}
+            onClick={() => onRollover?.(budget)}
+            className={clsx(
+              'flex h-10 w-10 items-center justify-center rounded-full transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60',
+              rolloverDisabled
+                ? 'cursor-not-allowed bg-slate-800/40 text-slate-600'
+                : 'bg-slate-800/80 text-slate-200 hover:bg-slate-700'
+            )}
+          >
+            <RefreshIcon className="h-5 w-5" />
+          </button>
+        </div>
+      </footer>
+    </article>
+  );
+}

--- a/src/pages/budgets/components/BudgetFilters.tsx
+++ b/src/pages/budgets/components/BudgetFilters.tsx
@@ -1,0 +1,92 @@
+import clsx from 'clsx';
+import { CalendarIcon, SearchIcon, ToggleIcon } from '../../../components/budgets/InlineIcons';
+
+type BudgetTypeFilter = 'all' | 'expense' | 'income';
+
+interface BudgetFiltersProps {
+  period: string;
+  onPeriodChange: (value: string) => void;
+  search: string;
+  onSearchChange: (value: string) => void;
+  type: BudgetTypeFilter;
+  onTypeChange: (value: BudgetTypeFilter) => void;
+  groupBy: boolean;
+  onGroupByChange: (value: boolean) => void;
+}
+
+export default function BudgetFilters({
+  period,
+  onPeriodChange,
+  search,
+  onSearchChange,
+  type,
+  onTypeChange,
+  groupBy,
+  onGroupByChange,
+}: BudgetFiltersProps) {
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <label className="flex flex-col gap-2 text-sm text-slate-300">
+          <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Bulan</span>
+          <div className="flex items-center gap-2 rounded-xl bg-slate-900/80 px-3 py-2 ring-1 ring-slate-800 focus-within:ring-[var(--accent)]/60">
+            <CalendarIcon className="h-4 w-4 text-slate-500" />
+            <input
+              type="month"
+              value={period}
+              onChange={(event) => onPeriodChange(event.target.value)}
+              className="w-full bg-transparent text-sm text-slate-100 outline-none"
+              aria-label="Pilih bulan"
+            />
+          </div>
+        </label>
+
+        <label className="flex flex-col gap-2 text-sm text-slate-300">
+          <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Cari kategori</span>
+          <div className="flex items-center gap-2 rounded-xl bg-slate-900/80 px-3 py-2 ring-1 ring-slate-800 focus-within:ring-[var(--accent)]/60">
+            <SearchIcon className="h-4 w-4 text-slate-500" />
+            <input
+              type="search"
+              value={search}
+              onChange={(event) => onSearchChange(event.target.value)}
+              placeholder="Nama kategori atau grup"
+              className="w-full bg-transparent text-sm text-slate-100 placeholder:text-slate-600 outline-none"
+              aria-label="Cari kategori"
+            />
+          </div>
+        </label>
+
+        <label className="flex flex-col gap-2 text-sm text-slate-300">
+          <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Tipe</span>
+          <div className="rounded-xl bg-slate-900/80 px-3 py-2 ring-1 ring-slate-800 focus-within:ring-[var(--accent)]/60">
+            <select
+              value={type}
+              onChange={(event) => onTypeChange(event.target.value as BudgetTypeFilter)}
+              className="w-full bg-transparent text-sm text-slate-100 outline-none"
+              aria-label="Filter tipe kategori"
+            >
+              <option value="all">Semua tipe</option>
+              <option value="expense">Expense saja</option>
+              <option value="income">Income saja</option>
+            </select>
+          </div>
+        </label>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => onGroupByChange(!groupBy)}
+          className={clsx(
+            'inline-flex items-center gap-2 rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-wide transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60',
+            groupBy ? 'bg-[var(--accent)]/20 text-[var(--accent)]' : 'bg-slate-900/80 text-slate-300'
+          )}
+          aria-pressed={groupBy}
+        >
+          <ToggleIcon className="h-4 w-4" />
+          Group by grup kategori
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/budgets/components/BudgetFormDialog.tsx
+++ b/src/pages/budgets/components/BudgetFormDialog.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { FormEvent } from 'react';
+import clsx from 'clsx';
+
+export interface BudgetFormValues {
+  period: string;
+  categoryId: string;
+  amount: number;
+  carryover: boolean;
+  notes: string;
+}
+
+export interface BudgetCategoryOption {
+  id: string;
+  name: string;
+  type: 'income' | 'expense';
+  group_name?: string | null;
+}
+
+interface BudgetFormDialogProps {
+  open: boolean;
+  title: string;
+  categories: BudgetCategoryOption[];
+  initialValues: BudgetFormValues;
+  submitting?: boolean;
+  onClose: () => void;
+  onSubmit: (values: BudgetFormValues) => Promise<void> | void;
+}
+
+const defaultValues: BudgetFormValues = {
+  period: '',
+  categoryId: '',
+  amount: 0,
+  carryover: false,
+  notes: '',
+};
+
+type FormErrors = Partial<Record<keyof BudgetFormValues, string>>;
+
+export default function BudgetFormDialog({
+  open,
+  title,
+  categories,
+  initialValues,
+  submitting = false,
+  onClose,
+  onSubmit,
+}: BudgetFormDialogProps) {
+  const [values, setValues] = useState<BudgetFormValues>(initialValues ?? defaultValues);
+  const [errors, setErrors] = useState<FormErrors>({});
+
+  useEffect(() => {
+    if (open) {
+      setValues(initialValues ?? defaultValues);
+      setErrors({});
+    }
+  }, [open, initialValues]);
+
+  const groupedOptions = useMemo(() => {
+    return categories.reduce(
+      (acc, category) => {
+        acc[category.type].push(category);
+        return acc;
+      },
+      {
+        expense: [] as BudgetCategoryOption[],
+        income: [] as BudgetCategoryOption[],
+      }
+    );
+  }, [categories]);
+
+  const handleChange = <T extends keyof BudgetFormValues>(field: T, value: BudgetFormValues[T]) => {
+    setValues((prev) => ({ ...prev, [field]: value }));
+    setErrors((prev) => ({ ...prev, [field]: undefined }));
+  };
+
+  const validate = (): boolean => {
+    const nextErrors: FormErrors = {};
+    if (!values.categoryId) {
+      nextErrors.categoryId = 'Kategori wajib dipilih.';
+    }
+    if (!values.period) {
+      nextErrors.period = 'Periode wajib diisi.';
+    }
+    if (Number.isNaN(values.amount) || values.amount < 0) {
+      nextErrors.amount = 'Nominal tidak boleh negatif.';
+    }
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!validate()) return;
+    await onSubmit(values);
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-slate-950/70 px-4 py-6"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="budget-form-title"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-lg overflow-hidden rounded-3xl bg-slate-900/95 ring-1 ring-slate-800"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="flex items-start justify-between gap-3 border-b border-slate-800/60 px-6 py-4">
+          <div>
+            <h2 id="budget-form-title" className="text-lg font-semibold text-slate-100">
+              {title}
+            </h2>
+            <p className="text-xs text-slate-400">Atur anggaran untuk kategori pilihanmu.</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full bg-slate-800/80 px-3 py-1 text-sm text-slate-300 transition hover:bg-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+          >
+            Tutup
+          </button>
+        </header>
+
+        <form onSubmit={handleSubmit} className="space-y-5 px-6 py-6">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="flex flex-col gap-1 text-sm text-slate-300">
+              <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Bulan</span>
+              <input
+                type="month"
+                value={values.period}
+                onChange={(event) => handleChange('period', event.target.value)}
+                className={clsx(
+                  'rounded-xl border border-transparent bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none ring-1 ring-slate-800 focus:ring-[var(--accent)]/60',
+                  errors.period ? 'ring-rose-500/60' : 'focus:ring-2'
+                )}
+              />
+              {errors.period ? <span className="text-xs text-rose-400">{errors.period}</span> : null}
+            </label>
+
+            <label className="flex flex-col gap-1 text-sm text-slate-300">
+              <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Nominal</span>
+              <input
+                type="number"
+                min={0}
+                step={1}
+                value={values.amount}
+                onChange={(event) => handleChange('amount', Number(event.target.value))}
+                className={clsx(
+                  'rounded-xl border border-transparent bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none ring-1 ring-slate-800 focus:ring-[var(--accent)]/60',
+                  errors.amount ? 'ring-rose-500/60' : 'focus:ring-2'
+                )}
+              />
+              {errors.amount ? <span className="text-xs text-rose-400">{errors.amount}</span> : null}
+            </label>
+          </div>
+
+          <label className="flex flex-col gap-1 text-sm text-slate-300">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Kategori</span>
+            <select
+              value={values.categoryId}
+              onChange={(event) => handleChange('categoryId', event.target.value)}
+              className={clsx(
+                'rounded-xl border border-transparent bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none ring-1 ring-slate-800 focus:ring-[var(--accent)]/60',
+                errors.categoryId ? 'ring-rose-500/60' : 'focus:ring-2'
+              )}
+            >
+              <option value="">Pilih kategori…</option>
+              {groupedOptions.expense.length ? (
+                <optgroup label="Expense">
+                  {groupedOptions.expense.map((category) => (
+                    <option key={category.id} value={category.id}>
+                      {category.name}
+                      {category.group_name ? ` — ${category.group_name}` : ''}
+                    </option>
+                  ))}
+                </optgroup>
+              ) : null}
+              {groupedOptions.income.length ? (
+                <optgroup label="Income">
+                  {groupedOptions.income.map((category) => (
+                    <option key={category.id} value={category.id}>
+                      {category.name}
+                      {category.group_name ? ` — ${category.group_name}` : ''}
+                    </option>
+                  ))}
+                </optgroup>
+              ) : null}
+            </select>
+            {errors.categoryId ? <span className="text-xs text-rose-400">{errors.categoryId}</span> : null}
+          </label>
+
+          <label className="flex items-center gap-3 rounded-2xl bg-slate-900/60 px-4 py-3 text-sm text-slate-200 ring-1 ring-slate-800">
+            <input
+              type="checkbox"
+              checked={values.carryover}
+              onChange={(event) => handleChange('carryover', event.target.checked)}
+              className="h-4 w-4 rounded border-slate-700 bg-slate-800 text-[var(--accent)] focus:ring-[var(--accent)]/40"
+            />
+            Aktifkan carryover bulan berikutnya
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm text-slate-300">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Catatan</span>
+            <textarea
+              value={values.notes}
+              onChange={(event) => handleChange('notes', event.target.value)}
+              rows={3}
+              className="rounded-xl border border-transparent bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none ring-1 ring-slate-800 focus:ring-[var(--accent)]/60"
+              placeholder="Opsional"
+            />
+          </label>
+
+          <div className="flex items-center justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-full px-4 py-2 text-sm font-semibold text-slate-300 transition hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60"
+            >
+              Batal
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="rounded-full bg-[var(--accent)] px-5 py-2 text-sm font-semibold text-slate-950 transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/60 disabled:opacity-60"
+            >
+              {submitting ? 'Menyimpan…' : 'Simpan anggaran'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated budgets API that merges planned amounts and MTD actuals with caching helpers
- replace the /budget page with a modern card grid, filters, grouped sections, and refreshed interactions
- introduce reusable budget UI pieces (cards, filters, dialog, inline icons) and update hooks/highlights to the new data model

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68da6a6412bc8332b5cfb84dd09de9c2