### PR TITLE
Revamp budget page UI

### DIFF
--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
-import { Calendar, Plus, RefreshCw } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import { Calendar, CalendarClock, History, Plus, RefreshCw, Wand2 } from 'lucide-react';
 import Page from '../../layout/Page';
 import Section from '../../layout/Section';
 import PageHeader from '../../layout/PageHeader';
@@ -24,6 +25,12 @@ const SEGMENTS = [
 ] as const;
 
 type SegmentValue = (typeof SEGMENTS)[number]['value'];
+
+const SEGMENT_ICONS: Record<SegmentValue, LucideIcon> = {
+  current: CalendarClock,
+  previous: History,
+  custom: Wand2,
+};
 
 function formatPeriod(date: Date): string {
   const year = date.getFullYear();
@@ -223,42 +230,78 @@ export default function BudgetsPage() {
       </PageHeader>
 
       <Section first>
-        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div className="flex flex-wrap gap-2">
-            {SEGMENTS.map(({ value, label }) => {
-              const active = value === segment;
-              return (
-                <button
-                  key={value}
-                  type="button"
-                  onClick={() => handleSegmentChange(value)}
-                  className={clsx(
-                    'h-11 rounded-2xl px-5 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
-                    active
-                      ? 'bg-brand text-brand-foreground shadow'
-                      : 'border border-border bg-surface px-5 text-muted hover:border-brand/40 hover:bg-brand/5 hover:text-text'
-                  )}
-                >
-                  {label}
-                </button>
-              );
-            })}
-          </div>
+        <div className="relative overflow-hidden rounded-3xl border border-zinc-200/60 bg-gradient-to-br from-brand/5 via-white to-white p-6 shadow-lg ring-1 ring-black/5 dark:border-zinc-800/60 dark:from-brand/10 dark:via-zinc-950 dark:to-zinc-900/60 dark:ring-white/5">
+          <div className="absolute -right-12 top-0 h-36 w-36 rounded-full bg-brand/20 opacity-60 blur-3xl dark:bg-brand/30" />
+          <div className="absolute -bottom-14 left-6 h-32 w-32 rounded-full bg-sky-200/40 blur-3xl dark:bg-sky-500/20" />
+          <div className="relative grid gap-6 lg:grid-cols-[1.25fr,0.75fr] lg:items-center">
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <p className="inline-flex items-center gap-2 rounded-full border border-white/70 bg-white/80 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-brand shadow-sm backdrop-blur dark:border-white/10 dark:bg-zinc-900/60 dark:text-brand-foreground">
+                  <span className="h-1.5 w-1.5 rounded-full bg-current" />
+                  Kontrol anggaran bulanan
+                </p>
+                <h2 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">
+                  Kelola alokasi dan pantau progres keuanganmu dengan mudah.
+                </h2>
+                <p className="text-sm text-zinc-600 dark:text-zinc-400">
+                  Pilih periode yang ingin kamu evaluasi, lalu cek insight detail di bawah untuk mengambil keputusan lebih cepat.
+                </p>
+              </div>
 
-          {segment === 'custom' ? (
-            <input
-              type="month"
-              value={customPeriod}
-              onChange={(event) => handleCustomPeriodChange(event.target.value)}
-              className="h-11 rounded-2xl border border-border bg-surface px-4 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-              aria-label="Pilih periode custom"
-            />
-          ) : (
-            <div className="flex items-center gap-2 rounded-2xl border border-border bg-surface px-4 py-2 text-sm font-medium text-muted">
-              <Calendar className="h-4 w-4" />
-              <span>{toHumanReadable(period)}</span>
+              <div className="flex flex-wrap items-center gap-2">
+                {SEGMENTS.map(({ value, label }) => {
+                  const active = value === segment;
+                  const Icon = SEGMENT_ICONS[value];
+                  return (
+                    <button
+                      key={value}
+                      type="button"
+                      onClick={() => handleSegmentChange(value)}
+                      className={clsx(
+                        'inline-flex h-12 items-center gap-2 rounded-full border px-5 text-sm font-semibold shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
+                        active
+                          ? 'border-transparent bg-brand text-brand-foreground shadow-md'
+                          : 'border-white/70 bg-white/80 text-zinc-500 hover:border-brand/40 hover:bg-brand/10 hover:text-brand dark:border-white/10 dark:bg-zinc-900/60 dark:text-zinc-300',
+                      )}
+                    >
+                      <Icon className="h-4 w-4" />
+                      {label}
+                    </button>
+                  );
+                })}
+              </div>
             </div>
-          )}
+
+            <div className="flex flex-col gap-4 rounded-3xl border border-white/70 bg-white/80 p-5 text-sm text-zinc-600 shadow-sm backdrop-blur dark:border-white/10 dark:bg-zinc-900/60 dark:text-zinc-200">
+              <span className="text-xs font-semibold uppercase tracking-wide text-zinc-400 dark:text-zinc-500">
+                Periode aktif
+              </span>
+              {segment === 'custom' ? (
+                <label className="flex flex-col gap-2 text-sm text-zinc-500 dark:text-zinc-400">
+                  <span>Pilih bulan yang ingin dianalisis</span>
+                  <input
+                    type="month"
+                    value={customPeriod}
+                    onChange={(event) => handleCustomPeriodChange(event.target.value)}
+                    className="h-12 rounded-2xl border border-zinc-200 bg-white px-4 text-sm font-medium text-zinc-700 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+                    aria-label="Pilih periode custom"
+                  />
+                </label>
+              ) : (
+                <div className="flex items-start gap-3">
+                  <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-brand/10 text-brand dark:bg-brand/20">
+                    <Calendar className="h-5 w-5" />
+                  </span>
+                  <div className="space-y-1">
+                    <p className="text-base font-semibold text-zinc-900 dark:text-zinc-50">{toHumanReadable(period)}</p>
+                    <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                      Data ditampilkan berdasarkan transaksi pada periode tersebut.
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
         </div>
       </Section>
 

--- a/src/pages/budgets/components/BudgetTable.tsx
+++ b/src/pages/budgets/components/BudgetTable.tsx
@@ -1,5 +1,12 @@
 import clsx from 'clsx';
-import { Pencil, Trash2 } from 'lucide-react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Flame,
+  NotebookPen,
+  Pencil,
+  Trash2,
+} from 'lucide-react';
 import { formatCurrency } from '../../../lib/format';
 import type { BudgetWithSpent } from '../../../lib/budgetApi';
 
@@ -11,29 +18,27 @@ interface BudgetTableProps {
   onToggleCarryover: (row: BudgetWithSpent, carryover: boolean) => void;
 }
 
-const CARD_WRAPPER_CLASS = 'grid gap-4 md:grid-cols-2 xl:grid-cols-3';
+const CARD_WRAPPER_CLASS = 'grid gap-6 md:grid-cols-2 xl:grid-cols-3';
 
 const CARD_CLASS =
-  'flex flex-col gap-5 rounded-3xl border border-white/30 bg-gradient-to-br from-white/95 via-white/75 to-white/50 p-6 shadow-xl ring-1 ring-black/5 transition hover:-translate-y-1 hover:shadow-2xl dark:border-white/5 dark:from-zinc-900/70 dark:via-zinc-900/40 dark:to-zinc-900/20 dark:ring-white/5';
+  'group relative overflow-hidden rounded-3xl border border-zinc-200/70 bg-gradient-to-br from-white via-white/95 to-zinc-50 shadow-lg ring-1 ring-black/5 transition-all hover:-translate-y-1 hover:shadow-2xl dark:border-zinc-800/60 dark:from-zinc-950 dark:via-zinc-900/60 dark:to-zinc-900/30 dark:ring-white/5';
 
 function LoadingCards() {
   return (
     <div className={clsx(CARD_WRAPPER_CLASS)}>
       {Array.from({ length: 6 }).map((_, index) => (
-        <div
-          // eslint-disable-next-line react/no-array-index-key
-          key={index}
-          className={clsx(CARD_CLASS, 'animate-pulse')}
-        >
-          <div className="h-4 w-24 rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
-          <div className="space-y-3">
-            <div className="h-3 w-full rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
-            <div className="h-3 w-3/4 rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
-          </div>
-          <div className="h-2 w-full rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
-          <div className="space-y-2">
-            <div className="h-3 w-1/3 rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
-            <div className="h-3 w-1/2 rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
+        // eslint-disable-next-line react/no-array-index-key
+        <div key={index} className={clsx(CARD_CLASS, 'animate-pulse')}>
+          <div className="relative flex h-full flex-col gap-5 p-6">
+            <div className="h-10 w-3/4 rounded-2xl bg-zinc-200/70 dark:bg-zinc-800/60" />
+            <div className="h-6 w-1/2 rounded-xl bg-zinc-200/70 dark:bg-zinc-800/60" />
+            <div className="h-3 w-full rounded-full bg-zinc-200/70 dark:bg-zinc-800/60" />
+            <div className="h-3 w-3/4 rounded-full bg-zinc-200/70 dark:bg-zinc-800/60" />
+            <div className="mt-auto grid grid-cols-3 gap-3">
+              <div className="h-12 rounded-2xl bg-zinc-200/60 dark:bg-zinc-800/60" />
+              <div className="h-12 rounded-2xl bg-zinc-200/60 dark:bg-zinc-800/60" />
+              <div className="h-12 rounded-2xl bg-zinc-200/60 dark:bg-zinc-800/60" />
+            </div>
           </div>
         </div>
       ))}
@@ -43,11 +48,51 @@ function LoadingCards() {
 
 function EmptyState() {
   return (
-    <div className="rounded-2xl border border-dashed border-zinc-200 bg-white/60 p-8 text-center text-sm text-zinc-500 shadow-sm dark:border-zinc-700 dark:bg-zinc-900/40 dark:text-zinc-400">
-      Belum ada anggaran untuk periode ini. Tambahkan kategori agar pengeluaran lebih terkontrol.
+    <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border border-dashed border-zinc-200/70 bg-white/70 p-12 text-center text-sm text-zinc-500 shadow-sm dark:border-zinc-700/70 dark:bg-zinc-900/40 dark:text-zinc-400">
+      <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-brand/10 text-brand dark:bg-brand/20">
+        <NotebookPen className="h-6 w-6" />
+      </div>
+      <div className="space-y-2">
+        <h3 className="text-base font-semibold text-zinc-800 dark:text-zinc-100">Belum ada anggaran</h3>
+        <p className="max-w-sm text-sm text-zinc-500 dark:text-zinc-400">
+          Buat kategori anggaran untuk membantu kamu mengatur prioritas pengeluaran dan mencapai tujuan finansial.
+        </p>
+      </div>
     </div>
   );
 }
+
+const STATUS_PRESET = {
+  over: {
+    label: 'Melebihi batas',
+    description: 'Pengeluaran melampaui rencana. Cek kembali prioritasmu.',
+    icon: Flame,
+    chipClass:
+      'bg-rose-50 text-rose-600 ring-rose-500/30 dark:bg-rose-500/10 dark:text-rose-200',
+    iconBadge: 'bg-rose-500/10 text-rose-500 dark:bg-rose-400/10 dark:text-rose-300',
+    gradient: 'from-rose-500/10 via-rose-500/5 to-transparent',
+  },
+  warning: {
+    label: 'Hampir habis',
+    description: 'Pengeluaran mendekati batas. Jaga ritme pengeluaranmu.',
+    icon: AlertTriangle,
+    chipClass:
+      'bg-amber-50 text-amber-600 ring-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200',
+    iconBadge: 'bg-amber-500/10 text-amber-600 dark:bg-amber-400/10 dark:text-amber-300',
+    gradient: 'from-amber-500/10 via-amber-500/5 to-transparent',
+  },
+  safe: {
+    label: 'Sehat',
+    description: 'Pengeluaran masih sesuai dengan rencana.',
+    icon: CheckCircle2,
+    chipClass:
+      'bg-emerald-50 text-emerald-600 ring-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-200',
+    iconBadge: 'bg-emerald-500/10 text-emerald-600 dark:bg-emerald-400/10 dark:text-emerald-300',
+    gradient: 'from-emerald-500/10 via-emerald-500/5 to-transparent',
+  },
+} as const;
+
+type StatusKey = keyof typeof STATUS_PRESET;
 
 export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleCarryover }: BudgetTableProps) {
   if (loading) {
@@ -67,127 +112,132 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
         const percentage = planned > 0 ? Math.min(200, Math.round((spent / planned) * 100)) : spent > 0 ? 200 : 0;
         const displayPercentage = Math.min(100, percentage);
         const overBudget = remaining < 0;
-        const progressColor = overBudget ? 'bg-rose-500 dark:bg-rose-400' : 'bg-brand dark:bg-brand';
+        const status: StatusKey = overBudget ? 'over' : percentage >= 90 ? 'warning' : 'safe';
+        const statusPreset = STATUS_PRESET[status];
         const categoryName = row.category?.name ?? 'Tanpa kategori';
         const categoryInitial = categoryName.trim().charAt(0).toUpperCase() || 'B';
-        const statusLabel = overBudget ? 'Melebihi batas' : percentage >= 90 ? 'Hampir habis' : 'Sehat';
-        const statusClass = clsx(
-          'inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium shadow-sm ring-1 ring-inset',
-          overBudget
-            ? 'bg-rose-50 text-rose-600 ring-rose-500/30 dark:bg-rose-500/10 dark:text-rose-200'
-            : percentage >= 90
-              ? 'bg-amber-50 text-amber-600 ring-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200'
-              : 'bg-emerald-50 text-emerald-600 ring-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-200',
-        );
+        const StatusIcon = statusPreset.icon;
 
         return (
           <article key={row.id} className={CARD_CLASS}>
-            <header className="flex items-start justify-between gap-4">
-              <div className="flex items-start gap-3">
-                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-brand/10 text-base font-semibold uppercase text-brand shadow-sm dark:bg-brand/20 dark:text-brand">
-                  {categoryInitial}
-                </div>
-                <div className="space-y-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">{categoryName}</h3>
-                    <span className={statusClass}>
-                      <span className="h-1.5 w-1.5 rounded-full bg-current opacity-60" />
-                      {statusLabel}
-                    </span>
+            <div className={`absolute inset-0 ${statusPreset.gradient}`} />
+            <div className="absolute -right-10 top-0 h-32 w-32 rounded-full bg-white/50 blur-3xl dark:bg-white/10" />
+            <div className="absolute -bottom-8 -left-6 h-32 w-32 rounded-full bg-brand/5 blur-3xl dark:bg-brand/20" />
+
+            <div className="relative flex h-full flex-col gap-6 p-6">
+              <header className="flex flex-col gap-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex items-start gap-4">
+                    <div className={clsx('flex h-14 w-14 shrink-0 items-center justify-center rounded-3xl text-lg font-semibold uppercase shadow-inner backdrop-blur', statusPreset.iconBadge)}>
+                      {categoryInitial}
+                    </div>
+                    <div className="space-y-2">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h3 className="text-xl font-semibold text-zinc-900 dark:text-zinc-50">{categoryName}</h3>
+                        <span className={clsx('inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium shadow-sm ring-1 ring-inset', statusPreset.chipClass)}>
+                          <StatusIcon className="h-3.5 w-3.5" />
+                          {statusPreset.label}
+                        </span>
+                      </div>
+                      <p className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                        Anggaran periode {row.period_month?.slice(0, 7) ?? '-'}
+                      </p>
+                      <p className="text-sm text-zinc-500 dark:text-zinc-400">{statusPreset.description}</p>
+                    </div>
                   </div>
-                  <p className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                    Anggaran periode {row.period_month?.slice(0, 7) ?? '-'}
-                  </p>
-                </div>
-              </div>
 
-              <div className="flex flex-wrap items-center justify-end gap-2">
-                <div className="flex items-center gap-2 rounded-full border border-white/40 bg-white/70 px-3 py-1.5 text-xs font-medium text-zinc-600 shadow-sm dark:border-white/10 dark:bg-zinc-900/50 dark:text-zinc-200">
-                  <span className="hidden text-xs sm:inline">Carryover</span>
-                  <span className="sm:hidden">CO</span>
-                  <span className="text-[0.7rem] uppercase tracking-wide text-zinc-400 dark:text-zinc-500">
-                    {row.carryover_enabled ? 'Aktif' : 'Nonaktif'}
-                  </span>
-                  <label className="relative inline-flex h-6 w-12 cursor-pointer items-center">
-                    <input
-                      type="checkbox"
-                      checked={row.carryover_enabled}
-                      onChange={(event) => onToggleCarryover(row, event.target.checked)}
-                      className="peer sr-only"
-                      aria-label={`Atur carryover untuk ${categoryName}`}
+                  <div className="flex flex-wrap items-center justify-end gap-2">
+                    <div className="flex items-center gap-3 rounded-2xl border border-white/50 bg-white/80 px-3 py-2 text-xs font-medium text-zinc-600 shadow-sm backdrop-blur dark:border-white/10 dark:bg-zinc-900/50 dark:text-zinc-200">
+                      <span className="hidden text-xs sm:inline">Carryover</span>
+                      <span className="sm:hidden">CO</span>
+                      <span className="text-[0.7rem] uppercase tracking-wide text-zinc-400 dark:text-zinc-500">
+                        {row.carryover_enabled ? 'Aktif' : 'Nonaktif'}
+                      </span>
+                      <label className="relative inline-flex h-6 w-12 cursor-pointer items-center">
+                        <input
+                          type="checkbox"
+                          checked={row.carryover_enabled}
+                          onChange={(event) => onToggleCarryover(row, event.target.checked)}
+                          className="peer sr-only"
+                          aria-label={`Atur carryover untuk ${categoryName}`}
+                        />
+                        <span className="absolute inset-0 rounded-full bg-zinc-200/80 transition peer-checked:bg-emerald-500/80 dark:bg-zinc-700/70 dark:peer-checked:bg-emerald-500/60" />
+                        <span className="relative ml-1 h-4 w-4 rounded-full bg-white shadow-sm transition-transform peer-checked:translate-x-6" />
+                      </label>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => onEdit(row)}
+                      className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-white/60 bg-white/90 text-zinc-600 shadow-sm transition hover:-translate-y-0.5 hover:bg-white dark:border-white/10 dark:bg-zinc-900/60 dark:text-zinc-200"
+                      aria-label={`Edit ${categoryName}`}
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onDelete(row)}
+                      className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-rose-200/60 bg-rose-50/80 text-rose-500 shadow-sm transition hover:-translate-y-0.5 hover:bg-rose-100 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-300"
+                      aria-label={`Hapus ${categoryName}`}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </div>
+                </div>
+              </header>
+
+              <section className="rounded-2xl border border-white/60 bg-white/80 p-5 text-sm text-zinc-600 shadow-sm backdrop-blur dark:border-white/10 dark:bg-zinc-900/40 dark:text-zinc-300">
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                  <div className="space-y-1">
+                    <span className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Anggaran</span>
+                    <p className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">{formatCurrency(planned, 'IDR')}</p>
+                  </div>
+                  <div className="space-y-1">
+                    <span className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Terpakai</span>
+                    <p className="text-lg font-semibold text-zinc-800 dark:text-zinc-200">{formatCurrency(spent, 'IDR')}</p>
+                  </div>
+                  <div className="space-y-1">
+                    <span className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Sisa</span>
+                    <p
+                      className={clsx(
+                        'text-lg font-semibold',
+                        remaining >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-rose-500 dark:text-rose-400',
+                      )}
+                    >
+                      {formatCurrency(remaining, 'IDR')}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="mt-5 space-y-3">
+                  <div className="flex flex-wrap items-center justify-between gap-2 text-xs font-medium text-zinc-500 dark:text-zinc-400">
+                    <span>Progres penggunaan</span>
+                    <span>{displayPercentage}%</span>
+                  </div>
+                  <div className="h-3 w-full overflow-hidden rounded-full bg-zinc-200/80 dark:bg-zinc-800/70">
+                    <div
+                      className={clsx(
+                        'h-full rounded-full transition-all',
+                        overBudget
+                          ? 'bg-gradient-to-r from-rose-500 via-rose-500 to-rose-600'
+                          : 'bg-gradient-to-r from-brand via-brand/90 to-brand/60',
+                      )}
+                      style={{ width: `${displayPercentage}%` }}
                     />
-                    <span className="absolute inset-0 rounded-full bg-zinc-200/80 transition peer-checked:bg-emerald-500/80 dark:bg-zinc-700/70 dark:peer-checked:bg-emerald-500/70" />
-                    <span className="relative ml-1 h-4 w-4 rounded-full bg-white shadow-sm transition-transform peer-checked:translate-x-6" />
-                  </label>
+                  </div>
+                  {percentage > 100 ? (
+                    <p className="text-xs font-medium text-rose-500 dark:text-rose-400">
+                      Pengeluaran sudah melebihi anggaran sebesar {formatCurrency(Math.abs(remaining), 'IDR')}.
+                    </p>
+                  ) : null}
                 </div>
-                <button
-                  type="button"
-                  onClick={() => onEdit(row)}
-                  className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-white/40 bg-white/70 text-zinc-600 shadow-sm transition hover:-translate-y-0.5 hover:bg-white dark:border-white/10 dark:bg-zinc-900/60 dark:text-zinc-200"
-                  aria-label={`Edit ${categoryName}`}
-                >
-                  <Pencil className="h-4 w-4" />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => onDelete(row)}
-                  className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-rose-200/60 bg-rose-50/80 text-rose-500 shadow-sm transition hover:-translate-y-0.5 hover:bg-rose-100 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-300"
-                  aria-label={`Hapus ${categoryName}`}
-                >
-                  <Trash2 className="h-4 w-4" />
-                </button>
-              </div>
-            </header>
+              </section>
 
-            <div className="rounded-2xl border border-white/40 bg-white/70 p-4 text-sm text-zinc-600 shadow-sm dark:border-white/5 dark:bg-zinc-900/40 dark:text-zinc-300">
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-                <div className="space-y-1">
-                  <span className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Anggaran</span>
-                  <p className="text-base font-semibold text-zinc-900 dark:text-zinc-100">
-                    {formatCurrency(planned, 'IDR')}
-                  </p>
-                </div>
-                <div className="space-y-1">
-                  <span className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Terpakai</span>
-                  <p className="text-base font-semibold text-zinc-800 dark:text-zinc-200">{formatCurrency(spent, 'IDR')}</p>
-                </div>
-                <div className="space-y-1">
-                  <span className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Sisa</span>
-                  <p
-                    className={clsx(
-                      'text-base font-semibold',
-                      overBudget ? 'text-rose-500 dark:text-rose-400' : 'text-emerald-600 dark:text-emerald-400',
-                    )}
-                  >
-                    {formatCurrency(remaining, 'IDR')}
-                  </p>
-                </div>
-              </div>
-
-              <div className="mt-4 space-y-2">
-                <div className="flex flex-wrap items-center justify-between gap-2 text-xs font-medium text-zinc-500 dark:text-zinc-400">
-                  <span>Progres penggunaan</span>
-                  <span>{displayPercentage}%</span>
-                </div>
-                <div className="h-2 w-full overflow-hidden rounded-full bg-zinc-200/80 dark:bg-zinc-800/70">
-                  <div
-                    className={clsx('h-full rounded-full transition-all', progressColor)}
-                    style={{ width: `${displayPercentage}%` }}
-                  />
-                </div>
-                {percentage > 100 ? (
-                  <p className="text-xs font-medium text-rose-500 dark:text-rose-400">
-                    Pengeluaran sudah melebihi anggaran sebesar {formatCurrency(Math.abs(remaining), 'IDR')}.
-                  </p>
-                ) : null}
-              </div>
-            </div>
-
-            <div className="rounded-2xl border border-dashed border-zinc-200/70 bg-white/50 p-4 text-sm text-zinc-500 shadow-sm dark:border-zinc-700/70 dark:bg-zinc-900/30 dark:text-zinc-300">
-              <p className="text-xs uppercase tracking-wide text-zinc-400 dark:text-zinc-500">Catatan</p>
-              <p className="mt-1 leading-relaxed">
-                {row.notes?.trim() ? row.notes : 'Tidak ada catatan.'}
-              </p>
+              <footer className="rounded-2xl border border-dashed border-zinc-200/70 bg-white/70 p-5 text-sm text-zinc-600 shadow-sm backdrop-blur dark:border-zinc-700/70 dark:bg-zinc-900/40 dark:text-zinc-300">
+                <p className="text-xs uppercase tracking-wide text-zinc-400 dark:text-zinc-500">Catatan</p>
+                <p className="mt-2 leading-relaxed">
+                  {row.notes?.trim() ? row.notes : 'Tidak ada catatan. Tambahkan insight singkat agar keputusan berikutnya lebih mudah.'}
+                </p>
+              </footer>
             </div>
           </article>
         );
@@ -195,4 +245,3 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
     </div>
   );
 }
-

--- a/src/pages/budgets/components/SummaryCards.tsx
+++ b/src/pages/budgets/components/SummaryCards.tsx
@@ -1,4 +1,12 @@
-import { PiggyBank, Target, TrendingDown, Wallet } from 'lucide-react';
+import {
+  ArrowDownRight,
+  ArrowUpRight,
+  FlagTriangleRight,
+  PiggyBank,
+  Sparkles,
+  Target,
+  Wallet,
+} from 'lucide-react';
 import { formatCurrency } from '../../../lib/format';
 import type { BudgetSummary } from '../../../lib/budgetApi';
 
@@ -8,15 +16,16 @@ interface SummaryCardsProps {
 }
 
 const CARD_BASE_CLASS =
-  'rounded-2xl border border-white/20 dark:border-white/5 bg-gradient-to-b from-white/80 to-white/50 dark:from-zinc-900/60 dark:to-zinc-900/30 backdrop-blur shadow-sm';
+  'relative overflow-hidden rounded-3xl border border-zinc-200/60 bg-gradient-to-br from-white via-white/90 to-zinc-50 shadow-lg ring-1 ring-black/5 transition-all hover:-translate-y-0.5 hover:shadow-xl dark:border-zinc-800/70 dark:from-zinc-950 dark:via-zinc-900/60 dark:to-zinc-900/30 dark:ring-white/5';
 
 function SummarySkeleton() {
   return (
     <div className={CARD_BASE_CLASS}>
-      <div className="flex h-full flex-col gap-4 p-5">
+      <div className="absolute inset-0 bg-gradient-to-br from-brand/5 via-transparent to-transparent opacity-70" />
+      <div className="relative flex h-full flex-col gap-4 p-6">
         <div className="h-4 w-32 animate-pulse rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
-        <div className="h-8 w-24 animate-pulse rounded-lg bg-zinc-200/70 dark:bg-zinc-700/70" />
-        <div className="h-2 w-full animate-pulse rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
+        <div className="h-10 w-28 animate-pulse rounded-xl bg-zinc-200/70 dark:bg-zinc-700/70" />
+        <div className="mt-auto h-2 w-full animate-pulse rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
       </div>
     </div>
   );
@@ -25,8 +34,9 @@ function SummarySkeleton() {
 export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
   if (loading) {
     return (
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
         {Array.from({ length: 4 }).map((_, index) => (
+          // eslint-disable-next-line react/no-array-index-key
           <SummarySkeleton key={index} />
         ))}
       </div>
@@ -34,63 +44,108 @@ export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
   }
 
   const progress = Math.min(Math.max(summary.percentage, 0), 1);
+  const spentRatio = summary.planned > 0 ? summary.spent / summary.planned : 0;
+  const remainingPositive = summary.remaining >= 0;
 
   const cards = [
     {
       label: 'Total Anggaran',
       value: formatCurrency(summary.planned, 'IDR'),
       icon: Wallet,
-      accent: 'text-sky-600 dark:text-sky-400',
+      accent: 'from-sky-500/15 via-sky-500/5 to-transparent',
+      iconAccent: 'bg-sky-500/15 text-sky-600 dark:bg-sky-400/15 dark:text-sky-300',
+      helper: 'Dana yang sudah kamu siapkan untuk periode ini.',
+      footerIcon: Sparkles,
+      footerLabel: 'Siap digunakan secara strategis',
     },
     {
       label: 'Realisasi',
       value: formatCurrency(summary.spent, 'IDR'),
-      icon: TrendingDown,
-      accent: 'text-emerald-600 dark:text-emerald-400',
+      icon: ArrowUpRight,
+      accent: 'from-emerald-500/15 via-emerald-500/5 to-transparent',
+      iconAccent: 'bg-emerald-500/15 text-emerald-600 dark:bg-emerald-400/10 dark:text-emerald-300',
+      helper: `${Math.min(100, Math.max(0, spentRatio * 100)).toFixed(0)}% dari anggaran sudah dipakai.`,
+      footerIcon: ArrowUpRight,
+      footerLabel: spentRatio > 1 ? 'Perhatikan laju pengeluaranmu' : 'Masih dalam batas wajar',
     },
     {
-      label: 'Sisa',
+      label: 'Sisa Dana',
       value: formatCurrency(summary.remaining, 'IDR'),
       icon: PiggyBank,
-      accent: 'text-purple-600 dark:text-purple-400',
+      accent: 'from-purple-500/15 via-purple-500/5 to-transparent',
+      iconAccent: 'bg-purple-500/15 text-purple-600 dark:bg-purple-400/10 dark:text-purple-300',
+      helper: remainingPositive
+        ? 'Masih ada ruang untuk kebutuhan penting.'
+        : 'Pengeluaran melampaui alokasi yang tersedia.',
+      footerIcon: remainingPositive ? ArrowDownRight : ArrowUpRight,
+      footerLabel: remainingPositive ? 'Tetap jaga pengeluaran tetap efisien' : 'Pertimbangkan penyesuaian anggaran',
     },
     {
-      label: 'Persentase',
+      label: 'Persentase Terpakai',
       value: `${(progress * 100).toFixed(0)}%`,
       icon: Target,
-      accent: 'text-orange-600 dark:text-orange-400',
+      accent: 'from-amber-500/15 via-amber-500/5 to-transparent',
+      iconAccent: 'bg-amber-500/15 text-amber-600 dark:bg-amber-400/10 dark:text-amber-300',
+      helper: progress >= 1 ? 'Anggaran telah habis digunakan.' : 'Pantau batas agar tetap terkendali.',
+      footerIcon: FlagTriangleRight,
+      footerLabel: progress >= 1 ? 'Saatnya evaluasi prioritas' : 'Masih ada ruang untuk dioptimalkan',
       progress,
     },
-  ];
+  ] as const;
 
   return (
-    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-      {cards.map(({ label, value, icon: Icon, accent, progress: cardProgress }) => (
+    <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
+      {cards.map(({
+        label,
+        value,
+        icon: Icon,
+        accent,
+        iconAccent,
+        helper,
+        footerIcon: FooterIcon,
+        footerLabel,
+        progress: cardProgress,
+      }) => (
         <div key={label} className={CARD_BASE_CLASS}>
-          <div className="flex h-full flex-col gap-4 p-5">
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400">{label}</span>
-              <Icon className={`h-5 w-5 ${accent}`} />
+          <div className={`absolute inset-0 ${accent}`} />
+          <div className="absolute -right-6 -top-6 h-24 w-24 rounded-full bg-white/40 blur-2xl dark:bg-white/5" />
+          <div className="relative flex h-full flex-col gap-5 p-6">
+            <div className="flex items-center justify-between gap-3">
+              <div className="space-y-1">
+                <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                  {label}
+                </span>
+                <span className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">{value}</span>
+              </div>
+              <span className={`flex h-12 w-12 items-center justify-center rounded-2xl backdrop-blur ${iconAccent}`}>
+                <Icon className="h-5 w-5" />
+              </span>
             </div>
-            <span className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">{value}</span>
+
             {typeof cardProgress === 'number' ? (
-              <div className="mt-auto">
-                <div className="flex items-center justify-between text-xs font-medium text-zinc-500 dark:text-zinc-400">
+              <div className="space-y-2 rounded-2xl border border-white/60 bg-white/70 p-4 text-xs font-medium text-zinc-500 shadow-sm dark:border-white/10 dark:bg-zinc-900/40 dark:text-zinc-400">
+                <div className="flex items-center justify-between">
                   <span>0%</span>
-                  <span>100%</span>
+                  <span>{`${(cardProgress * 100).toFixed(0)}%`}</span>
                 </div>
-                <div className="mt-2 h-2 rounded-full bg-zinc-200/70 dark:bg-zinc-800/70">
+                <div className="h-2 w-full overflow-hidden rounded-full bg-zinc-200/70 dark:bg-zinc-800/70">
                   <div
-                    className="h-full rounded-full bg-gradient-to-r from-sky-500 via-sky-400 to-sky-300 dark:from-sky-400 dark:via-sky-500 dark:to-sky-600 transition-all"
-                    style={{ width: `${cardProgress * 100}%` }}
+                    className="h-full rounded-full bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 transition-all dark:from-amber-400 dark:via-orange-400 dark:to-rose-400"
+                    style={{ width: `${Math.min(cardProgress * 100, 100)}%` }}
                   />
                 </div>
               </div>
-            ) : null}
+            ) : (
+              <p className="text-sm text-zinc-600 dark:text-zinc-300">{helper}</p>
+            )}
+
+            <div className="mt-auto flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-zinc-400 dark:text-zinc-500">
+              <FooterIcon className="h-3.5 w-3.5" />
+              {footerLabel}
+            </div>
           </div>
         </div>
       ))}
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- refresh the budgets period selector with a hero card, iconography, and richer context copy
- redesign the budget summary cards with gradients, helper text, and progress styling updates
- modernize each budget detail card with status presets, improved empty/loading states, and polished controls

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68da7387a06483328cf682176cfa34ac