### PR TITLE
Revamp budgets page visuals

### DIFF
--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
-import { Calendar, Plus, RefreshCw } from 'lucide-react';
+import { Calendar, Plus, RefreshCw, Sparkles } from 'lucide-react';
 import Page from '../../layout/Page';
 import Section from '../../layout/Section';
 import PageHeader from '../../layout/PageHeader';
@@ -201,12 +201,12 @@ export default function BudgetsPage() {
     <Page>
       <PageHeader
         title="Anggaran"
-        description="Atur dan pantau alokasi pengeluaranmu tiap bulan."
+        description="Atur strategi pengeluaranmu dengan tampilan yang lebih intuitif dan inspiratif."
       >
         <button
           type="button"
           onClick={refresh}
-          className="hidden h-11 items-center gap-2 rounded-2xl border border-border bg-surface px-4 text-sm font-semibold text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 md:inline-flex"
+          className="hidden h-11 items-center gap-2 rounded-2xl border border-border/70 bg-background/80 px-4 text-sm font-semibold text-muted shadow-sm transition hover:-translate-y-0.5 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 md:inline-flex"
         >
           <RefreshCw className="h-4 w-4" />
           Segarkan
@@ -215,7 +215,7 @@ export default function BudgetsPage() {
           type="button"
           disabled={categoriesLoading}
           onClick={handleOpenCreate}
-          className="inline-flex h-11 items-center gap-2 rounded-2xl bg-brand px-5 text-sm font-semibold text-brand-foreground shadow transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)] disabled:cursor-not-allowed disabled:opacity-60"
+          className="inline-flex h-11 items-center gap-2 rounded-2xl bg-brand px-5 text-sm font-semibold text-brand-foreground shadow transition hover:-translate-y-0.5 hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)] disabled:cursor-not-allowed disabled:opacity-60"
         >
           <Plus className="h-4 w-4" />
           Tambah anggaran
@@ -223,42 +223,59 @@ export default function BudgetsPage() {
       </PageHeader>
 
       <Section first>
-        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div className="flex flex-wrap gap-2">
-            {SEGMENTS.map(({ value, label }) => {
-              const active = value === segment;
-              return (
-                <button
-                  key={value}
-                  type="button"
-                  onClick={() => handleSegmentChange(value)}
-                  className={clsx(
-                    'h-11 rounded-2xl px-5 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
-                    active
-                      ? 'bg-brand text-brand-foreground shadow'
-                      : 'border border-border bg-surface px-5 text-muted hover:border-brand/40 hover:bg-brand/5 hover:text-text'
-                  )}
-                >
-                  {label}
-                </button>
-              );
-            })}
-          </div>
-
-          {segment === 'custom' ? (
-            <input
-              type="month"
-              value={customPeriod}
-              onChange={(event) => handleCustomPeriodChange(event.target.value)}
-              className="h-11 rounded-2xl border border-border bg-surface px-4 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-              aria-label="Pilih periode custom"
-            />
-          ) : (
-            <div className="flex items-center gap-2 rounded-2xl border border-border bg-surface px-4 py-2 text-sm font-medium text-muted">
-              <Calendar className="h-4 w-4" />
-              <span>{toHumanReadable(period)}</span>
+        <div className="relative overflow-hidden rounded-3xl border border-border/70 bg-gradient-to-br from-brand/10 via-background to-background/40 p-6 shadow-lg">
+          <div className="absolute right-0 top-0 h-32 w-32 translate-x-8 -translate-y-8 rounded-full bg-brand/20 blur-3xl" aria-hidden />
+          <div className="relative flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+            <div className="max-w-xl space-y-3">
+              <span className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-muted">
+                <Sparkles className="h-3.5 w-3.5" />
+                Snapshot periode
+              </span>
+              <h2 className="text-2xl font-semibold text-text">{toHumanReadable(period)}</h2>
+              <p className="text-sm leading-relaxed text-muted">
+                Pilih periode yang ingin kamu evaluasi dan kami akan menampilkan ringkasan anggaran lengkap beserta status setiap kategori.
+              </p>
             </div>
-          )}
+
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-end">
+              <div className="inline-flex items-center gap-2 rounded-2xl border border-border/70 bg-background/80 p-1 shadow-inner shadow-black/5">
+                {SEGMENTS.map(({ value, label }) => {
+                  const active = value === segment;
+                  return (
+                    <button
+                      key={value}
+                      type="button"
+                      onClick={() => handleSegmentChange(value)}
+                      className={clsx(
+                        'relative inline-flex h-10 items-center justify-center rounded-2xl px-4 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
+                        active
+                          ? 'bg-brand text-brand-foreground shadow'
+                          : 'text-muted hover:text-text',
+                      )}
+                      aria-pressed={active}
+                    >
+                      {label}
+                    </button>
+                  );
+                })}
+              </div>
+
+              {segment === 'custom' ? (
+                <input
+                  type="month"
+                  value={customPeriod}
+                  onChange={(event) => handleCustomPeriodChange(event.target.value)}
+                  className="h-11 rounded-2xl border border-border/70 bg-background/80 px-4 text-sm font-semibold text-text shadow-inner shadow-black/5 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+                  aria-label="Pilih periode custom"
+                />
+              ) : (
+                <div className="flex items-center gap-2 rounded-2xl border border-border/70 bg-background/80 px-4 py-2 text-sm font-semibold text-text shadow-inner shadow-black/5">
+                  <Calendar className="h-4 w-4" />
+                  <span>{toHumanReadable(period)}</span>
+                </div>
+              )}
+            </div>
+          </div>
         </div>
       </Section>
 

--- a/src/pages/budgets/components/BudgetTable.tsx
+++ b/src/pages/budgets/components/BudgetTable.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { Pencil, Trash2 } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, Flame, LineChart, Pencil, Trash2 } from 'lucide-react';
 import { formatCurrency } from '../../../lib/format';
 import type { BudgetWithSpent } from '../../../lib/budgetApi';
 
@@ -11,10 +11,37 @@ interface BudgetTableProps {
   onToggleCarryover: (row: BudgetWithSpent, carryover: boolean) => void;
 }
 
-const CARD_WRAPPER_CLASS = 'grid gap-4 md:grid-cols-2 xl:grid-cols-3';
+const CARD_WRAPPER_CLASS = 'grid gap-5 md:grid-cols-2 xl:grid-cols-3';
 
 const CARD_CLASS =
-  'flex flex-col gap-5 rounded-3xl border border-white/30 bg-gradient-to-br from-white/95 via-white/75 to-white/50 p-6 shadow-xl ring-1 ring-black/5 transition hover:-translate-y-1 hover:shadow-2xl dark:border-white/5 dark:from-zinc-900/70 dark:via-zinc-900/40 dark:to-zinc-900/20 dark:ring-white/5';
+  'relative flex h-full flex-col gap-6 overflow-hidden rounded-3xl border border-border/60 bg-surface/90 p-6 shadow-lg ring-1 ring-inset ring-border/70 transition duration-200 hover:-translate-y-1 hover:shadow-2xl dark:bg-surface-2/80';
+
+const STATUS_CONFIG = {
+  danger: {
+    label: 'Melebihi batas',
+    icon: Flame,
+    badgeClass:
+      'bg-rose-500/10 text-rose-500 ring-rose-400/40 dark:bg-rose-500/10 dark:text-rose-200 dark:ring-rose-300/40',
+    halo: 'from-rose-500/20 via-rose-400/10 to-transparent',
+    progress: 'from-rose-500 via-rose-400 to-rose-300',
+  },
+  warning: {
+    label: 'Hampir habis',
+    icon: AlertTriangle,
+    badgeClass:
+      'bg-amber-500/10 text-amber-500 ring-amber-400/40 dark:bg-amber-500/10 dark:text-amber-200 dark:ring-amber-300/40',
+    halo: 'from-amber-500/20 via-amber-400/10 to-transparent',
+    progress: 'from-amber-500 via-amber-400 to-amber-300',
+  },
+  good: {
+    label: 'Sehat',
+    icon: CheckCircle2,
+    badgeClass:
+      'bg-emerald-500/10 text-emerald-500 ring-emerald-400/40 dark:bg-emerald-500/10 dark:text-emerald-200 dark:ring-emerald-300/40',
+    halo: 'from-emerald-500/20 via-emerald-400/10 to-transparent',
+    progress: 'from-emerald-500 via-emerald-400 to-emerald-300',
+  },
+} as const;
 
 function LoadingCards() {
   return (
@@ -43,8 +70,11 @@ function LoadingCards() {
 
 function EmptyState() {
   return (
-    <div className="rounded-2xl border border-dashed border-zinc-200 bg-white/60 p-8 text-center text-sm text-zinc-500 shadow-sm dark:border-zinc-700 dark:bg-zinc-900/40 dark:text-zinc-400">
-      Belum ada anggaran untuk periode ini. Tambahkan kategori agar pengeluaran lebih terkontrol.
+    <div className="rounded-3xl border border-dashed border-border bg-surface-1/70 p-10 text-center text-sm text-muted shadow-sm">
+      <p className="text-base font-semibold text-text">Belum ada anggaran</p>
+      <p className="mt-2 leading-relaxed">
+        Mulai tambahkan kategori anggaran untuk memetakan rencana belanja dan memantau sisa dana setiap bulan.
+      </p>
     </div>
   );
 }
@@ -67,96 +97,95 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
         const percentage = planned > 0 ? Math.min(200, Math.round((spent / planned) * 100)) : spent > 0 ? 200 : 0;
         const displayPercentage = Math.min(100, percentage);
         const overBudget = remaining < 0;
-        const progressColor = overBudget ? 'bg-rose-500 dark:bg-rose-400' : 'bg-brand dark:bg-brand';
         const categoryName = row.category?.name ?? 'Tanpa kategori';
         const categoryInitial = categoryName.trim().charAt(0).toUpperCase() || 'B';
-        const statusLabel = overBudget ? 'Melebihi batas' : percentage >= 90 ? 'Hampir habis' : 'Sehat';
-        const statusClass = clsx(
-          'inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium shadow-sm ring-1 ring-inset',
-          overBudget
-            ? 'bg-rose-50 text-rose-600 ring-rose-500/30 dark:bg-rose-500/10 dark:text-rose-200'
-            : percentage >= 90
-              ? 'bg-amber-50 text-amber-600 ring-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200'
-              : 'bg-emerald-50 text-emerald-600 ring-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-200',
-        );
+        const statusKey = overBudget ? 'danger' : percentage >= 90 ? 'warning' : 'good';
+        const status = STATUS_CONFIG[statusKey];
+        const StatusIcon = status.icon;
 
         return (
           <article key={row.id} className={CARD_CLASS}>
-            <header className="flex items-start justify-between gap-4">
-              <div className="flex items-start gap-3">
-                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-brand/10 text-base font-semibold uppercase text-brand shadow-sm dark:bg-brand/20 dark:text-brand">
-                  {categoryInitial}
-                </div>
-                <div className="space-y-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">{categoryName}</h3>
-                    <span className={statusClass}>
-                      <span className="h-1.5 w-1.5 rounded-full bg-current opacity-60" />
-                      {statusLabel}
-                    </span>
+            <div className={clsx('pointer-events-none absolute inset-0 bg-gradient-to-br opacity-90', status.halo)} aria-hidden />
+            <header className="relative flex flex-col gap-5">
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex items-start gap-3">
+                  <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-brand/10 via-brand/5 to-transparent text-lg font-semibold uppercase text-brand shadow-inner shadow-brand/10">
+                    {categoryInitial}
                   </div>
-                  <p className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                    Anggaran periode {row.period_month?.slice(0, 7) ?? '-'}
-                  </p>
+                  <div className="space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h3 className="text-lg font-semibold text-text">{categoryName}</h3>
+                      <span
+                        className={clsx(
+                          'inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold ring-1 ring-inset backdrop-blur',
+                          status.badgeClass,
+                        )}
+                      >
+                        <StatusIcon className="h-3.5 w-3.5" />
+                        {status.label}
+                      </span>
+                    </div>
+                    <p className="text-xs uppercase tracking-[0.2em] text-muted">
+                      {row.period_month?.slice(0, 7) ? `Periode ${row.period_month.slice(0, 7)}` : 'Periode tidak diketahui'}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap items-center justify-end gap-2">
+                  <div className="inline-flex items-center gap-2 rounded-2xl border border-border/70 bg-background/70 px-3 py-2 text-xs font-medium text-muted shadow-sm">
+                    <span className="inline-flex items-center gap-1 text-[0.7rem] uppercase tracking-wide">
+                      <LineChart className="h-3 w-3" />
+                      Carryover
+                    </span>
+                    <span className="text-[0.7rem] font-semibold text-text">
+                      {row.carryover_enabled ? 'Aktif' : 'Nonaktif'}
+                    </span>
+                    <label className="relative inline-flex h-6 w-11 cursor-pointer items-center">
+                      <input
+                        type="checkbox"
+                        checked={row.carryover_enabled}
+                        onChange={(event) => onToggleCarryover(row, event.target.checked)}
+                        className="peer sr-only"
+                        aria-label={`Atur carryover untuk ${categoryName}`}
+                      />
+                      <span className="absolute inset-0 rounded-full bg-muted/60 transition peer-checked:bg-brand/70" />
+                      <span className="relative ml-1 h-4 w-4 rounded-full bg-background shadow transition-transform peer-checked:translate-x-5" />
+                    </label>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => onEdit(row)}
+                    className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-border/60 bg-background/80 text-muted shadow-sm transition hover:-translate-y-0.5 hover:text-text"
+                    aria-label={`Edit ${categoryName}`}
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onDelete(row)}
+                    className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-rose-400/40 bg-rose-500/10 text-rose-500 shadow-sm transition hover:-translate-y-0.5 hover:bg-rose-500/20"
+                    aria-label={`Hapus ${categoryName}`}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
                 </div>
               </div>
 
-              <div className="flex flex-wrap items-center justify-end gap-2">
-                <div className="flex items-center gap-2 rounded-full border border-white/40 bg-white/70 px-3 py-1.5 text-xs font-medium text-zinc-600 shadow-sm dark:border-white/10 dark:bg-zinc-900/50 dark:text-zinc-200">
-                  <span className="hidden text-xs sm:inline">Carryover</span>
-                  <span className="sm:hidden">CO</span>
-                  <span className="text-[0.7rem] uppercase tracking-wide text-zinc-400 dark:text-zinc-500">
-                    {row.carryover_enabled ? 'Aktif' : 'Nonaktif'}
-                  </span>
-                  <label className="relative inline-flex h-6 w-12 cursor-pointer items-center">
-                    <input
-                      type="checkbox"
-                      checked={row.carryover_enabled}
-                      onChange={(event) => onToggleCarryover(row, event.target.checked)}
-                      className="peer sr-only"
-                      aria-label={`Atur carryover untuk ${categoryName}`}
-                    />
-                    <span className="absolute inset-0 rounded-full bg-zinc-200/80 transition peer-checked:bg-emerald-500/80 dark:bg-zinc-700/70 dark:peer-checked:bg-emerald-500/70" />
-                    <span className="relative ml-1 h-4 w-4 rounded-full bg-white shadow-sm transition-transform peer-checked:translate-x-6" />
-                  </label>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => onEdit(row)}
-                  className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-white/40 bg-white/70 text-zinc-600 shadow-sm transition hover:-translate-y-0.5 hover:bg-white dark:border-white/10 dark:bg-zinc-900/60 dark:text-zinc-200"
-                  aria-label={`Edit ${categoryName}`}
-                >
-                  <Pencil className="h-4 w-4" />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => onDelete(row)}
-                  className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-rose-200/60 bg-rose-50/80 text-rose-500 shadow-sm transition hover:-translate-y-0.5 hover:bg-rose-100 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-300"
-                  aria-label={`Hapus ${categoryName}`}
-                >
-                  <Trash2 className="h-4 w-4" />
-                </button>
-              </div>
-            </header>
-
-            <div className="rounded-2xl border border-white/40 bg-white/70 p-4 text-sm text-zinc-600 shadow-sm dark:border-white/5 dark:bg-zinc-900/40 dark:text-zinc-300">
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <div className="grid gap-4 rounded-2xl border border-border/60 bg-background/70 p-4 shadow-inner shadow-black/5 sm:grid-cols-3">
                 <div className="space-y-1">
-                  <span className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Anggaran</span>
-                  <p className="text-base font-semibold text-zinc-900 dark:text-zinc-100">
-                    {formatCurrency(planned, 'IDR')}
-                  </p>
+                  <span className="text-xs font-semibold uppercase tracking-[0.18em] text-muted">Anggaran</span>
+                  <p className="text-xl font-semibold text-text">{formatCurrency(planned, 'IDR')}</p>
                 </div>
                 <div className="space-y-1">
-                  <span className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Terpakai</span>
-                  <p className="text-base font-semibold text-zinc-800 dark:text-zinc-200">{formatCurrency(spent, 'IDR')}</p>
+                  <span className="text-xs font-semibold uppercase tracking-[0.18em] text-muted">Terpakai</span>
+                  <p className="text-xl font-semibold text-text/90">{formatCurrency(spent, 'IDR')}</p>
                 </div>
                 <div className="space-y-1">
-                  <span className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Sisa</span>
+                  <span className="text-xs font-semibold uppercase tracking-[0.18em] text-muted">Sisa</span>
                   <p
                     className={clsx(
-                      'text-base font-semibold',
-                      overBudget ? 'text-rose-500 dark:text-rose-400' : 'text-emerald-600 dark:text-emerald-400',
+                      'text-xl font-semibold',
+                      overBudget ? 'text-rose-500' : 'text-emerald-500',
                     )}
                   >
                     {formatCurrency(remaining, 'IDR')}
@@ -164,31 +193,33 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
                 </div>
               </div>
 
-              <div className="mt-4 space-y-2">
-                <div className="flex flex-wrap items-center justify-between gap-2 text-xs font-medium text-zinc-500 dark:text-zinc-400">
+              <div className="space-y-3 rounded-2xl border border-border/60 bg-background/60 p-4 shadow-inner shadow-black/5">
+                <div className="flex flex-wrap items-center justify-between gap-2 text-xs font-medium text-muted">
                   <span>Progres penggunaan</span>
-                  <span>{displayPercentage}%</span>
+                  <span className="inline-flex items-center gap-1 rounded-full bg-background px-2 py-0.5 text-[11px] font-semibold text-text">
+                    {displayPercentage}%
+                  </span>
                 </div>
-                <div className="h-2 w-full overflow-hidden rounded-full bg-zinc-200/80 dark:bg-zinc-800/70">
+                <div className="relative h-2 w-full overflow-hidden rounded-full bg-muted/60">
                   <div
-                    className={clsx('h-full rounded-full transition-all', progressColor)}
+                    className={clsx('absolute inset-y-0 left-0 rounded-full bg-gradient-to-r transition-all', status.progress)}
                     style={{ width: `${displayPercentage}%` }}
                   />
                 </div>
                 {percentage > 100 ? (
-                  <p className="text-xs font-medium text-rose-500 dark:text-rose-400">
+                  <p className="text-xs font-semibold text-rose-500">
                     Pengeluaran sudah melebihi anggaran sebesar {formatCurrency(Math.abs(remaining), 'IDR')}.
                   </p>
                 ) : null}
               </div>
-            </div>
+            </header>
 
-            <div className="rounded-2xl border border-dashed border-zinc-200/70 bg-white/50 p-4 text-sm text-zinc-500 shadow-sm dark:border-zinc-700/70 dark:bg-zinc-900/30 dark:text-zinc-300">
-              <p className="text-xs uppercase tracking-wide text-zinc-400 dark:text-zinc-500">Catatan</p>
-              <p className="mt-1 leading-relaxed">
-                {row.notes?.trim() ? row.notes : 'Tidak ada catatan.'}
+            <footer className="relative rounded-2xl border border-dashed border-border/60 bg-background/60 p-4 text-sm text-muted">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted">Catatan</p>
+              <p className="mt-2 leading-relaxed text-text/80">
+                {row.notes?.trim() ? row.notes : 'Tidak ada catatan khusus.'}
               </p>
-            </div>
+            </footer>
           </article>
         );
       })}

--- a/src/pages/budgets/components/SummaryCards.tsx
+++ b/src/pages/budgets/components/SummaryCards.tsx
@@ -1,4 +1,5 @@
-import { PiggyBank, Target, TrendingDown, Wallet } from 'lucide-react';
+import clsx from 'clsx';
+import { Gauge, PiggyBank, Target, TrendingDown, Wallet } from 'lucide-react';
 import { formatCurrency } from '../../../lib/format';
 import type { BudgetSummary } from '../../../lib/budgetApi';
 
@@ -8,15 +9,15 @@ interface SummaryCardsProps {
 }
 
 const CARD_BASE_CLASS =
-  'rounded-2xl border border-white/20 dark:border-white/5 bg-gradient-to-b from-white/80 to-white/50 dark:from-zinc-900/60 dark:to-zinc-900/30 backdrop-blur shadow-sm';
+  'relative overflow-hidden rounded-3xl border border-border/60 bg-surface/80 shadow-lg ring-1 ring-inset ring-border/60 transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-xl dark:bg-surface-2/80';
 
 function SummarySkeleton() {
   return (
     <div className={CARD_BASE_CLASS}>
-      <div className="flex h-full flex-col gap-4 p-5">
-        <div className="h-4 w-32 animate-pulse rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
-        <div className="h-8 w-24 animate-pulse rounded-lg bg-zinc-200/70 dark:bg-zinc-700/70" />
-        <div className="h-2 w-full animate-pulse rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
+      <div className="flex h-full flex-col gap-4 p-6">
+        <div className="h-4 w-32 animate-pulse rounded-full bg-muted/60" />
+        <div className="h-8 w-24 animate-pulse rounded-lg bg-muted/60" />
+        <div className="h-2 w-full animate-pulse rounded-full bg-muted/60" />
       </div>
     </div>
   );
@@ -41,48 +42,65 @@ export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
       value: formatCurrency(summary.planned, 'IDR'),
       icon: Wallet,
       accent: 'text-sky-600 dark:text-sky-400',
+      gradient: 'from-sky-500/20 via-sky-400/10 to-transparent',
+      iconBg: 'bg-sky-500/10 text-sky-600 dark:bg-sky-500/20 dark:text-sky-300',
     },
     {
       label: 'Realisasi',
       value: formatCurrency(summary.spent, 'IDR'),
       icon: TrendingDown,
       accent: 'text-emerald-600 dark:text-emerald-400',
+      gradient: 'from-emerald-500/20 via-emerald-400/10 to-transparent',
+      iconBg: 'bg-emerald-500/10 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-300',
     },
     {
       label: 'Sisa',
       value: formatCurrency(summary.remaining, 'IDR'),
       icon: PiggyBank,
       accent: 'text-purple-600 dark:text-purple-400',
+      gradient: 'from-purple-500/20 via-purple-400/10 to-transparent',
+      iconBg: 'bg-purple-500/10 text-purple-600 dark:bg-purple-500/20 dark:text-purple-300',
     },
     {
       label: 'Persentase',
       value: `${(progress * 100).toFixed(0)}%`,
       icon: Target,
       accent: 'text-orange-600 dark:text-orange-400',
+      gradient: 'from-orange-500/20 via-orange-400/10 to-transparent',
+      iconBg: 'bg-orange-500/10 text-orange-600 dark:bg-orange-500/20 dark:text-orange-300',
       progress,
     },
   ];
 
   return (
     <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-      {cards.map(({ label, value, icon: Icon, accent, progress: cardProgress }) => (
+      {cards.map(({ label, value, icon: Icon, accent, gradient, iconBg, progress: cardProgress }) => (
         <div key={label} className={CARD_BASE_CLASS}>
-          <div className="flex h-full flex-col gap-4 p-5">
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400">{label}</span>
-              <Icon className={`h-5 w-5 ${accent}`} />
+          <div className={clsx('absolute inset-0 bg-gradient-to-br opacity-90', gradient)} aria-hidden />
+          <div className="relative flex h-full flex-col gap-5 p-6">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted">{label}</p>
+                <p className="mt-2 text-3xl font-bold text-text">{value}</p>
+              </div>
+              <div className={clsx('flex h-12 w-12 items-center justify-center rounded-2xl shadow-inner shadow-black/5', iconBg)}>
+                <Icon className={clsx('h-6 w-6', accent)} />
+              </div>
             </div>
-            <span className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">{value}</span>
+
             {typeof cardProgress === 'number' ? (
-              <div className="mt-auto">
-                <div className="flex items-center justify-between text-xs font-medium text-zinc-500 dark:text-zinc-400">
-                  <span>0%</span>
-                  <span>100%</span>
+              <div className="mt-auto space-y-3">
+                <div className="flex items-center justify-between text-xs font-medium text-muted">
+                  <span>Penggunaan</span>
+                  <span className="inline-flex items-center gap-1 rounded-full bg-background/60 px-2 py-0.5 font-semibold text-text">
+                    <Gauge className="h-3 w-3" />
+                    {(cardProgress * 100).toFixed(0)}%
+                  </span>
                 </div>
-                <div className="mt-2 h-2 rounded-full bg-zinc-200/70 dark:bg-zinc-800/70">
+                <div className="relative h-2 overflow-hidden rounded-full bg-muted/40">
                   <div
-                    className="h-full rounded-full bg-gradient-to-r from-sky-500 via-sky-400 to-sky-300 dark:from-sky-400 dark:via-sky-500 dark:to-sky-600 transition-all"
-                    style={{ width: `${cardProgress * 100}%` }}
+                    className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-brand via-brand/80 to-brand/60 transition-all"
+                    style={{ width: `${Math.max(6, cardProgress * 100)}%` }}
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- polish the budgets hero filter area with a gradient snapshot block and refreshed action buttons
- redesign summary metric cards with glassmorphism accents, icon chips, and progress gauge styling
- overhaul individual budget cards to highlight status, carryover controls, and progress with richer visuals

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68da7387a06483328cf682176cfa34ac