### PR TITLE
Revamp budgets page styling

### DIFF
--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
-import { Calendar, Plus, RefreshCw } from 'lucide-react';
+import { CalendarRange, CalendarDays, History, Plus, RefreshCw } from 'lucide-react';
 import Page from '../../layout/Page';
 import Section from '../../layout/Section';
 import PageHeader from '../../layout/PageHeader';
@@ -18,9 +18,9 @@ import {
 } from '../../lib/budgetApi';
 
 const SEGMENTS = [
-  { value: 'current', label: 'Bulan ini' },
-  { value: 'previous', label: 'Bulan lalu' },
-  { value: 'custom', label: 'Custom' },
+  { value: 'current', label: 'Bulan ini', icon: CalendarDays },
+  { value: 'previous', label: 'Bulan lalu', icon: History },
+  { value: 'custom', label: 'Custom', icon: CalendarRange },
 ] as const;
 
 type SegmentValue = (typeof SEGMENTS)[number]['value'];
@@ -225,7 +225,7 @@ export default function BudgetsPage() {
       <Section first>
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div className="flex flex-wrap gap-2">
-            {SEGMENTS.map(({ value, label }) => {
+            {SEGMENTS.map(({ value, label, icon: Icon }) => {
               const active = value === segment;
               return (
                 <button
@@ -233,12 +233,20 @@ export default function BudgetsPage() {
                   type="button"
                   onClick={() => handleSegmentChange(value)}
                   className={clsx(
-                    'h-11 rounded-2xl px-5 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
+                    'group inline-flex h-11 items-center gap-2 rounded-2xl border px-5 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
                     active
-                      ? 'bg-brand text-brand-foreground shadow'
-                      : 'border border-border bg-surface px-5 text-muted hover:border-brand/40 hover:bg-brand/5 hover:text-text'
+                      ? 'border-transparent bg-brand text-brand-foreground shadow-lg shadow-brand/30'
+                      : 'border-border bg-surface/80 text-muted hover:border-brand/40 hover:bg-brand/5 hover:text-text'
                   )}
                 >
+                  <span
+                    className={clsx(
+                      'flex h-8 w-8 items-center justify-center rounded-xl bg-white/60 text-brand shadow-inner transition group-hover:scale-105 dark:bg-white/10',
+                      active ? 'bg-white/90 text-brand' : 'text-brand',
+                    )}
+                  >
+                    <Icon className="h-4 w-4" />
+                  </span>
                   {label}
                 </button>
               );
@@ -250,12 +258,12 @@ export default function BudgetsPage() {
               type="month"
               value={customPeriod}
               onChange={(event) => handleCustomPeriodChange(event.target.value)}
-              className="h-11 rounded-2xl border border-border bg-surface px-4 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+              className="h-11 rounded-2xl border border-border/60 bg-surface/80 px-4 text-sm font-medium text-text shadow-inner transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
               aria-label="Pilih periode custom"
             />
           ) : (
-            <div className="flex items-center gap-2 rounded-2xl border border-border bg-surface px-4 py-2 text-sm font-medium text-muted">
-              <Calendar className="h-4 w-4" />
+            <div className="flex items-center gap-2 rounded-2xl border border-border/60 bg-surface/80 px-4 py-2 text-sm font-medium text-muted shadow-inner">
+              <CalendarRange className="h-4 w-4" />
               <span>{toHumanReadable(period)}</span>
             </div>
           )}

--- a/src/pages/budgets/components/BudgetTable.tsx
+++ b/src/pages/budgets/components/BudgetTable.tsx
@@ -1,5 +1,14 @@
 import clsx from 'clsx';
-import { Pencil, Trash2 } from 'lucide-react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Flame,
+  NotebookPen,
+  Pencil,
+  RefreshCcw,
+  Sparkles,
+  Trash2,
+} from 'lucide-react';
 import { formatCurrency } from '../../../lib/format';
 import type { BudgetWithSpent } from '../../../lib/budgetApi';
 
@@ -11,10 +20,10 @@ interface BudgetTableProps {
   onToggleCarryover: (row: BudgetWithSpent, carryover: boolean) => void;
 }
 
-const CARD_WRAPPER_CLASS = 'grid gap-4 md:grid-cols-2 xl:grid-cols-3';
+const CARD_WRAPPER_CLASS = 'grid gap-5 md:grid-cols-2 xl:grid-cols-3';
 
 const CARD_CLASS =
-  'flex flex-col gap-5 rounded-3xl border border-white/30 bg-gradient-to-br from-white/95 via-white/75 to-white/50 p-6 shadow-xl ring-1 ring-black/5 transition hover:-translate-y-1 hover:shadow-2xl dark:border-white/5 dark:from-zinc-900/70 dark:via-zinc-900/40 dark:to-zinc-900/20 dark:ring-white/5';
+  'relative flex flex-col gap-6 overflow-hidden rounded-3xl border border-border/60 bg-surface/80 p-6 shadow-[0_28px_50px_-28px_rgba(15,23,42,0.5)] transition duration-300 ease-out hover:-translate-y-1 hover:shadow-[0_35px_70px_-35px_rgba(15,23,42,0.55)] backdrop-blur supports-[backdrop-filter]:bg-surface/60';
 
 function LoadingCards() {
   return (
@@ -23,18 +32,15 @@ function LoadingCards() {
         <div
           // eslint-disable-next-line react/no-array-index-key
           key={index}
-          className={clsx(CARD_CLASS, 'animate-pulse')}
+          className={clsx(CARD_CLASS, 'animate-pulse border-dashed')}
         >
-          <div className="h-4 w-24 rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
+          <div className="h-4 w-24 rounded-full bg-zinc-200/70 dark:bg-zinc-700/60" />
           <div className="space-y-3">
-            <div className="h-3 w-full rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
-            <div className="h-3 w-3/4 rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
+            <div className="h-3 w-3/4 rounded-full bg-zinc-200/70 dark:bg-zinc-700/60" />
+            <div className="h-3 w-2/4 rounded-full bg-zinc-200/70 dark:bg-zinc-700/60" />
           </div>
-          <div className="h-2 w-full rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
-          <div className="space-y-2">
-            <div className="h-3 w-1/3 rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
-            <div className="h-3 w-1/2 rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
-          </div>
+          <div className="h-32 rounded-2xl bg-zinc-200/50 dark:bg-zinc-800/50" />
+          <div className="h-20 rounded-2xl border border-dashed border-zinc-200/70 dark:border-zinc-700/70" />
         </div>
       ))}
     </div>
@@ -43,8 +49,16 @@ function LoadingCards() {
 
 function EmptyState() {
   return (
-    <div className="rounded-2xl border border-dashed border-zinc-200 bg-white/60 p-8 text-center text-sm text-zinc-500 shadow-sm dark:border-zinc-700 dark:bg-zinc-900/40 dark:text-zinc-400">
-      Belum ada anggaran untuk periode ini. Tambahkan kategori agar pengeluaran lebih terkontrol.
+    <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border border-dashed border-border/60 bg-surface/70 p-10 text-center text-sm text-muted shadow-inner">
+      <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-brand/10 text-brand">
+        <Sparkles className="h-5 w-5" />
+      </span>
+      <div className="space-y-1">
+        <p className="text-base font-semibold text-text">Belum ada anggaran</p>
+        <p className="text-sm text-muted">
+          Tambahkan kategori anggaran untuk mulai mengontrol pengeluaranmu.
+        </p>
+      </div>
     </div>
   );
 }
@@ -67,132 +81,173 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
         const percentage = planned > 0 ? Math.min(200, Math.round((spent / planned) * 100)) : spent > 0 ? 200 : 0;
         const displayPercentage = Math.min(100, percentage);
         const overBudget = remaining < 0;
-        const progressColor = overBudget ? 'bg-rose-500 dark:bg-rose-400' : 'bg-brand dark:bg-brand';
+
+        const status = overBudget
+          ? {
+              label: 'Melebihi batas',
+              icon: Flame,
+              badgeClass:
+                'bg-rose-500/10 text-rose-600 ring-rose-500/40 dark:bg-rose-500/15 dark:text-rose-200 dark:ring-rose-500/30',
+              highlight: 'rgba(244, 63, 94, 0.18)',
+              progressGradient: 'linear-gradient(90deg, rgba(244,63,94,0.95), rgba(248,113,113,0.7))',
+              insight: `Pengeluaran sudah melebihi anggaran sebesar ${formatCurrency(Math.abs(remaining), 'IDR')}.`,
+            }
+          : percentage >= 90
+            ? {
+                label: 'Hampir habis',
+                icon: AlertTriangle,
+                badgeClass:
+                  'bg-amber-500/10 text-amber-600 ring-amber-500/40 dark:bg-amber-500/15 dark:text-amber-200 dark:ring-amber-500/30',
+                highlight: 'rgba(245, 158, 11, 0.18)',
+                progressGradient: 'linear-gradient(90deg, rgba(245,158,11,0.9), rgba(253,186,116,0.7))',
+                insight: `Sisa dana tinggal ${formatCurrency(remaining, 'IDR')} — waktunya rem pengeluaran.`,
+              }
+            : {
+                label: 'Sehat',
+                icon: CheckCircle2,
+                badgeClass:
+                  'bg-emerald-500/10 text-emerald-600 ring-emerald-500/40 dark:bg-emerald-500/15 dark:text-emerald-200 dark:ring-emerald-500/30',
+                highlight: 'rgba(16, 185, 129, 0.18)',
+                progressGradient: 'linear-gradient(90deg, rgba(16,185,129,0.9), rgba(52,211,153,0.7))',
+                insight: `Masih tersedia ${formatCurrency(remaining, 'IDR')} dari anggaran ini.`,
+              };
+
         const categoryName = row.category?.name ?? 'Tanpa kategori';
         const categoryInitial = categoryName.trim().charAt(0).toUpperCase() || 'B';
-        const statusLabel = overBudget ? 'Melebihi batas' : percentage >= 90 ? 'Hampir habis' : 'Sehat';
-        const statusClass = clsx(
-          'inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium shadow-sm ring-1 ring-inset',
-          overBudget
-            ? 'bg-rose-50 text-rose-600 ring-rose-500/30 dark:bg-rose-500/10 dark:text-rose-200'
-            : percentage >= 90
-              ? 'bg-amber-50 text-amber-600 ring-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200'
-              : 'bg-emerald-50 text-emerald-600 ring-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-200',
-        );
+        const StatusIcon = status.icon;
 
         return (
           <article key={row.id} className={CARD_CLASS}>
-            <header className="flex items-start justify-between gap-4">
-              <div className="flex items-start gap-3">
-                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-brand/10 text-base font-semibold uppercase text-brand shadow-sm dark:bg-brand/20 dark:text-brand">
-                  {categoryInitial}
-                </div>
-                <div className="space-y-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">{categoryName}</h3>
-                    <span className={statusClass}>
-                      <span className="h-1.5 w-1.5 rounded-full bg-current opacity-60" />
-                      {statusLabel}
-                    </span>
-                  </div>
-                  <p className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                    Anggaran periode {row.period_month?.slice(0, 7) ?? '-'}
-                  </p>
-                </div>
-              </div>
+            <div
+              aria-hidden
+              className="pointer-events-none absolute -right-20 -top-16 h-52 w-52 rounded-full blur-3xl"
+              style={{ background: `radial-gradient(circle at center, ${status.highlight} 0%, rgba(255,255,255,0) 70%)` }}
+            />
 
-              <div className="flex flex-wrap items-center justify-end gap-2">
-                <div className="flex items-center gap-2 rounded-full border border-white/40 bg-white/70 px-3 py-1.5 text-xs font-medium text-zinc-600 shadow-sm dark:border-white/10 dark:bg-zinc-900/50 dark:text-zinc-200">
-                  <span className="hidden text-xs sm:inline">Carryover</span>
-                  <span className="sm:hidden">CO</span>
-                  <span className="text-[0.7rem] uppercase tracking-wide text-zinc-400 dark:text-zinc-500">
-                    {row.carryover_enabled ? 'Aktif' : 'Nonaktif'}
-                  </span>
-                  <label className="relative inline-flex h-6 w-12 cursor-pointer items-center">
-                    <input
-                      type="checkbox"
-                      checked={row.carryover_enabled}
-                      onChange={(event) => onToggleCarryover(row, event.target.checked)}
-                      className="peer sr-only"
-                      aria-label={`Atur carryover untuk ${categoryName}`}
-                    />
-                    <span className="absolute inset-0 rounded-full bg-zinc-200/80 transition peer-checked:bg-emerald-500/80 dark:bg-zinc-700/70 dark:peer-checked:bg-emerald-500/70" />
-                    <span className="relative ml-1 h-4 w-4 rounded-full bg-white shadow-sm transition-transform peer-checked:translate-x-6" />
-                  </label>
+            <header className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="flex items-start gap-3">
+                  <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-brand/10 text-base font-semibold uppercase text-brand shadow-inner">
+                    {categoryInitial}
+                  </div>
+                  <div className="space-y-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h3 className="text-lg font-semibold text-text dark:text-white">{categoryName}</h3>
+                      <span
+                        className={clsx(
+                          'inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold ring-1 ring-inset shadow-sm backdrop-blur',
+                          status.badgeClass,
+                        )}
+                      >
+                        <StatusIcon className="h-3.5 w-3.5" />
+                        {status.label}
+                      </span>
+                    </div>
+                    <p className="text-xs uppercase tracking-[0.2em] text-muted">Periode {row.period_month?.slice(0, 7) ?? '-'}</p>
+                  </div>
                 </div>
-                <button
-                  type="button"
-                  onClick={() => onEdit(row)}
-                  className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-white/40 bg-white/70 text-zinc-600 shadow-sm transition hover:-translate-y-0.5 hover:bg-white dark:border-white/10 dark:bg-zinc-900/60 dark:text-zinc-200"
-                  aria-label={`Edit ${categoryName}`}
-                >
-                  <Pencil className="h-4 w-4" />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => onDelete(row)}
-                  className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-rose-200/60 bg-rose-50/80 text-rose-500 shadow-sm transition hover:-translate-y-0.5 hover:bg-rose-100 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-300"
-                  aria-label={`Hapus ${categoryName}`}
-                >
-                  <Trash2 className="h-4 w-4" />
-                </button>
+
+                <div className="flex flex-wrap items-center justify-end gap-2">
+                  <div className="flex items-center gap-2 rounded-full border border-border/60 bg-surface/70 px-3 py-1.5 text-xs font-medium text-muted shadow-inner">
+                    <RefreshCcw className="h-3.5 w-3.5" />
+                    <span className="hidden sm:inline">Carryover</span>
+                    <span className="sm:hidden">CO</span>
+                    <span className="text-[0.7rem] uppercase tracking-widest text-muted/80">
+                      {row.carryover_enabled ? 'Aktif' : 'Nonaktif'}
+                    </span>
+                    <label className="relative inline-flex h-6 w-12 cursor-pointer items-center">
+                      <input
+                        type="checkbox"
+                        checked={row.carryover_enabled}
+                        onChange={(event) => onToggleCarryover(row, event.target.checked)}
+                        className="peer sr-only"
+                        aria-label={`Atur carryover untuk ${categoryName}`}
+                      />
+                      <span className="absolute inset-0 rounded-full bg-muted/30 transition peer-checked:bg-emerald-500/70 dark:bg-muted/40 dark:peer-checked:bg-emerald-500/60" />
+                      <span className="relative ml-1 h-4 w-4 rounded-full bg-white shadow transition-transform peer-checked:translate-x-6 dark:bg-zinc-900" />
+                    </label>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => onEdit(row)}
+                    className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-border/60 bg-surface/80 text-muted shadow-sm transition hover:-translate-y-0.5 hover:text-text"
+                    aria-label={`Edit ${categoryName}`}
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onDelete(row)}
+                    className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-rose-200/70 bg-rose-50/70 text-rose-500 shadow-sm transition hover:-translate-y-0.5 hover:bg-rose-100 dark:border-rose-500/30 dark:bg-rose-500/15 dark:text-rose-200"
+                    aria-label={`Hapus ${categoryName}`}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
               </div>
             </header>
 
-            <div className="rounded-2xl border border-white/40 bg-white/70 p-4 text-sm text-zinc-600 shadow-sm dark:border-white/5 dark:bg-zinc-900/40 dark:text-zinc-300">
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-                <div className="space-y-1">
-                  <span className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Anggaran</span>
-                  <p className="text-base font-semibold text-zinc-900 dark:text-zinc-100">
-                    {formatCurrency(planned, 'IDR')}
-                  </p>
+            <section className="space-y-5">
+              <div className="rounded-2xl border border-border/50 bg-surface/70 p-4 shadow-inner">
+                <div className="grid gap-4 sm:grid-cols-3">
+                  <div className="space-y-1">
+                    <span className="text-xs uppercase tracking-[0.2em] text-muted">Anggaran</span>
+                    <p className="text-lg font-semibold text-text">{formatCurrency(planned, 'IDR')}</p>
+                    <p className="text-xs text-muted">Dialokasikan</p>
+                  </div>
+                  <div className="space-y-1">
+                    <span className="text-xs uppercase tracking-[0.2em] text-muted">Terpakai</span>
+                    <p className="text-lg font-semibold text-text/90 dark:text-zinc-200">{formatCurrency(spent, 'IDR')}</p>
+                    <p className="text-xs text-muted">{planned > 0 ? `${Math.min(100, Math.round((spent / planned) * 100))}% dari anggaran` : 'Tidak ada batas'}</p>
+                  </div>
+                  <div className="space-y-1">
+                    <span className="text-xs uppercase tracking-[0.2em] text-muted">Sisa</span>
+                    <p
+                      className={clsx(
+                        'text-lg font-semibold',
+                        overBudget ? 'text-rose-500 dark:text-rose-300' : 'text-emerald-600 dark:text-emerald-300',
+                      )}
+                    >
+                      {formatCurrency(remaining, 'IDR')}
+                    </p>
+                    <p className="text-xs text-muted">{overBudget ? 'Perlu tindakan' : 'Masih tersedia'}</p>
+                  </div>
                 </div>
-                <div className="space-y-1">
-                  <span className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Terpakai</span>
-                  <p className="text-base font-semibold text-zinc-800 dark:text-zinc-200">{formatCurrency(spent, 'IDR')}</p>
-                </div>
-                <div className="space-y-1">
-                  <span className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Sisa</span>
-                  <p
-                    className={clsx(
-                      'text-base font-semibold',
-                      overBudget ? 'text-rose-500 dark:text-rose-400' : 'text-emerald-600 dark:text-emerald-400',
-                    )}
-                  >
-                    {formatCurrency(remaining, 'IDR')}
+
+                <div className="mt-5 space-y-3">
+                  <div className="flex flex-wrap items-center justify-between gap-2 text-xs font-semibold text-muted">
+                    <span>Progres penggunaan</span>
+                    <span>{displayPercentage}%</span>
+                  </div>
+                  <div className="h-2 w-full overflow-hidden rounded-full bg-muted/20 dark:bg-muted/30">
+                    <div
+                      className="h-full rounded-full transition-all"
+                      style={{ width: `${displayPercentage}%`, background: status.progressGradient }}
+                    />
+                  </div>
+                  <p className={clsx('text-xs', overBudget ? 'text-rose-500 dark:text-rose-300' : 'text-muted')}>
+                    {status.insight}
                   </p>
                 </div>
               </div>
 
-              <div className="mt-4 space-y-2">
-                <div className="flex flex-wrap items-center justify-between gap-2 text-xs font-medium text-zinc-500 dark:text-zinc-400">
-                  <span>Progres penggunaan</span>
-                  <span>{displayPercentage}%</span>
+              <div className="rounded-2xl border border-dashed border-border/60 bg-surface/70 p-4 text-sm shadow-inner">
+                <div className="flex items-start gap-3">
+                  <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-muted/20 text-muted">
+                    <NotebookPen className="h-4 w-4" />
+                  </span>
+                  <div className="space-y-1">
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted">Catatan</p>
+                    <p className="leading-relaxed text-text dark:text-zinc-100">
+                      {row.notes?.trim() ? row.notes : 'Tidak ada catatan.'}
+                    </p>
+                  </div>
                 </div>
-                <div className="h-2 w-full overflow-hidden rounded-full bg-zinc-200/80 dark:bg-zinc-800/70">
-                  <div
-                    className={clsx('h-full rounded-full transition-all', progressColor)}
-                    style={{ width: `${displayPercentage}%` }}
-                  />
-                </div>
-                {percentage > 100 ? (
-                  <p className="text-xs font-medium text-rose-500 dark:text-rose-400">
-                    Pengeluaran sudah melebihi anggaran sebesar {formatCurrency(Math.abs(remaining), 'IDR')}.
-                  </p>
-                ) : null}
               </div>
-            </div>
-
-            <div className="rounded-2xl border border-dashed border-zinc-200/70 bg-white/50 p-4 text-sm text-zinc-500 shadow-sm dark:border-zinc-700/70 dark:bg-zinc-900/30 dark:text-zinc-300">
-              <p className="text-xs uppercase tracking-wide text-zinc-400 dark:text-zinc-500">Catatan</p>
-              <p className="mt-1 leading-relaxed">
-                {row.notes?.trim() ? row.notes : 'Tidak ada catatan.'}
-              </p>
-            </div>
+            </section>
           </article>
         );
       })}
     </div>
   );
 }
-

--- a/src/pages/budgets/components/SummaryCards.tsx
+++ b/src/pages/budgets/components/SummaryCards.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { PiggyBank, Target, TrendingDown, Wallet } from 'lucide-react';
 import { formatCurrency } from '../../../lib/format';
 import type { BudgetSummary } from '../../../lib/budgetApi';
@@ -7,16 +8,14 @@ interface SummaryCardsProps {
   loading?: boolean;
 }
 
-const CARD_BASE_CLASS =
-  'rounded-2xl border border-white/20 dark:border-white/5 bg-gradient-to-b from-white/80 to-white/50 dark:from-zinc-900/60 dark:to-zinc-900/30 backdrop-blur shadow-sm';
-
 function SummarySkeleton() {
   return (
-    <div className={CARD_BASE_CLASS}>
-      <div className="flex h-full flex-col gap-4 p-5">
-        <div className="h-4 w-32 animate-pulse rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
-        <div className="h-8 w-24 animate-pulse rounded-lg bg-zinc-200/70 dark:bg-zinc-700/70" />
-        <div className="h-2 w-full animate-pulse rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
+    <div className="relative overflow-hidden rounded-3xl border border-border/60 bg-surface/70 p-6 shadow-sm">
+      <div className="absolute inset-0 bg-gradient-to-br from-white/70 via-white/40 to-white/10 opacity-80 dark:from-zinc-900/80 dark:via-zinc-900/50 dark:to-zinc-900/20" />
+      <div className="relative flex h-full flex-col gap-4">
+        <div className="h-3 w-24 animate-pulse rounded-full bg-zinc-200/70 dark:bg-zinc-700/60" />
+        <div className="h-8 w-28 animate-pulse rounded-full bg-zinc-200/80 dark:bg-zinc-700/70" />
+        <div className="mt-auto h-2 w-full animate-pulse rounded-full bg-zinc-200/70 dark:bg-zinc-800/60" />
       </div>
     </div>
   );
@@ -25,7 +24,7 @@ function SummarySkeleton() {
 export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
   if (loading) {
     return (
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
         {Array.from({ length: 4 }).map((_, index) => (
           <SummarySkeleton key={index} />
         ))}
@@ -38,52 +37,107 @@ export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
   const cards = [
     {
       label: 'Total Anggaran',
+      description: 'Jumlah dialokasikan untuk periode ini',
       value: formatCurrency(summary.planned, 'IDR'),
       icon: Wallet,
-      accent: 'text-sky-600 dark:text-sky-400',
+      accent: 'text-sky-600 dark:text-sky-300',
+      iconBg: 'bg-sky-500/10 text-sky-500 dark:text-sky-300',
+      glow: 'rgba(14, 165, 233, 0.35)',
     },
     {
       label: 'Realisasi',
+      description: 'Pengeluaran yang sudah terjadi',
       value: formatCurrency(summary.spent, 'IDR'),
       icon: TrendingDown,
-      accent: 'text-emerald-600 dark:text-emerald-400',
+      accent: 'text-emerald-600 dark:text-emerald-300',
+      iconBg: 'bg-emerald-500/10 text-emerald-500 dark:text-emerald-300',
+      glow: 'rgba(16, 185, 129, 0.32)',
     },
     {
-      label: 'Sisa',
+      label: 'Sisa Anggaran',
+      description: 'Dana yang masih bisa digunakan',
       value: formatCurrency(summary.remaining, 'IDR'),
       icon: PiggyBank,
-      accent: 'text-purple-600 dark:text-purple-400',
+      accent: 'text-purple-600 dark:text-purple-300',
+      iconBg: 'bg-purple-500/10 text-purple-500 dark:text-purple-300',
+      glow: 'rgba(168, 85, 247, 0.28)',
     },
     {
-      label: 'Persentase',
+      label: 'Persentase Terpakai',
+      description: 'Proporsi penggunaan terhadap anggaran',
       value: `${(progress * 100).toFixed(0)}%`,
       icon: Target,
-      accent: 'text-orange-600 dark:text-orange-400',
+      accent: 'text-orange-500 dark:text-orange-300',
+      iconBg: 'bg-orange-500/10 text-orange-500 dark:text-orange-300',
+      glow: 'rgba(249, 115, 22, 0.28)',
+      accentColor: 'rgb(249, 115, 22)',
       progress,
     },
-  ];
+  ] as const;
 
   return (
-    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-      {cards.map(({ label, value, icon: Icon, accent, progress: cardProgress }) => (
-        <div key={label} className={CARD_BASE_CLASS}>
-          <div className="flex h-full flex-col gap-4 p-5">
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400">{label}</span>
-              <Icon className={`h-5 w-5 ${accent}`} />
+    <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
+      {cards.map(({
+        label,
+        description,
+        value,
+        icon: Icon,
+        accent,
+        iconBg,
+        glow,
+        accentColor,
+        progress: cardProgress,
+      }) => (
+        <div
+          key={label}
+          className={clsx(
+            'relative overflow-hidden rounded-3xl border border-border/60 bg-surface/80 p-6 shadow-[0_25px_45px_-25px_rgba(15,23,42,0.45)] transition duration-300 ease-out hover:-translate-y-1 hover:shadow-[0_32px_65px_-30px_rgba(15,23,42,0.55)]',
+            'backdrop-blur supports-[backdrop-filter]:bg-surface/60',
+          )}
+        >
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -right-16 -top-12 h-48 w-48 rounded-full blur-3xl"
+            style={{ background: `radial-gradient(circle at center, ${glow} 0%, rgba(255,255,255,0) 70%)` }}
+          />
+
+          <div className="relative flex h-full flex-col gap-5">
+            <div className="flex items-start justify-between gap-4">
+              <div className="space-y-1">
+                <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-muted">{label}</p>
+                <p className="text-xs text-muted/80 dark:text-muted/60">{description}</p>
+              </div>
+              <span
+                className={clsx(
+                  'flex h-11 w-11 items-center justify-center rounded-2xl shadow-inner ring-1 ring-inset ring-border/40 dark:ring-white/10',
+                  iconBg,
+                )}
+              >
+                <Icon className={clsx('h-5 w-5', accent)} />
+              </span>
             </div>
-            <span className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">{value}</span>
+
+            <span className="text-3xl font-semibold text-text dark:text-white">{value}</span>
+
             {typeof cardProgress === 'number' ? (
-              <div className="mt-auto">
-                <div className="flex items-center justify-between text-xs font-medium text-zinc-500 dark:text-zinc-400">
-                  <span>0%</span>
-                  <span>100%</span>
+              <div className="mt-auto flex items-end justify-between gap-4">
+                <div className="flex flex-col gap-1 text-xs text-muted">
+                  <span className="font-semibold text-text">Tingkat penggunaan</span>
+                  <span>{(cardProgress * 100).toFixed(0)}% dari total anggaran</span>
                 </div>
-                <div className="mt-2 h-2 rounded-full bg-zinc-200/70 dark:bg-zinc-800/70">
+                <div className="relative flex h-16 w-16 items-center justify-center">
                   <div
-                    className="h-full rounded-full bg-gradient-to-r from-sky-500 via-sky-400 to-sky-300 dark:from-sky-400 dark:via-sky-500 dark:to-sky-600 transition-all"
-                    style={{ width: `${cardProgress * 100}%` }}
+                    className="absolute inset-0 rounded-full opacity-80"
+                    style={{ background: `radial-gradient(circle at center, ${glow} 0%, rgba(255,255,255,0) 72%)` }}
                   />
+                  <div
+                    className="absolute inset-0 rounded-full"
+                    style={{
+                      background: `conic-gradient(${accentColor ?? glow} ${cardProgress * 360}deg, rgba(148,163,184,0.25) 0deg)`,
+                    }}
+                  />
+                  <div className="absolute inset-[6px] rounded-full border border-white/50 bg-gradient-to-br from-white/90 to-white/70 shadow-inner dark:border-white/10 dark:from-zinc-900/90 dark:to-zinc-900/60" />
+                  <span className="relative text-sm font-semibold text-text dark:text-white">{(cardProgress * 100).toFixed(0)}%</span>
                 </div>
               </div>
             ) : null}
@@ -93,4 +147,3 @@ export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- refresh the budget period segment controls with icon chips and updated surface styling
- redesign the budget summary cards with gradient highlights, icon badges, and a circular usage gauge
- restyle budget detail cards with richer status indicators, progress insights, and improved empty/loading states

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68da7387a06483328cf682176cfa34ac