### PR TITLE
Revamp budgets page layout and visuals

### DIFF
--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -1,13 +1,21 @@
 import { useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
-import { Calendar, Plus, RefreshCw } from 'lucide-react';
+import {
+  Calendar,
+  CalendarCheck2,
+  CalendarClock,
+  History,
+  PiggyBank,
+  Plus,
+  RefreshCw,
+  Sparkles,
+  TrendingUp,
+  Wallet,
+} from 'lucide-react';
 import Page from '../../layout/Page';
 import Section from '../../layout/Section';
 import PageHeader from '../../layout/PageHeader';
 import { useToast } from '../../context/ToastContext';
-import SummaryCards from './components/SummaryCards';
-import BudgetTable from './components/BudgetTable';
-import BudgetFormModal, { type BudgetFormValues } from './components/BudgetFormModal';
 import { useBudgets } from '../../hooks/useBudgets';
 import {
   deleteBudget,
@@ -16,11 +24,30 @@ import {
   type BudgetWithSpent,
   type ExpenseCategory,
 } from '../../lib/budgetApi';
+import { formatCurrency } from '../../lib/format';
+import SummaryCards from './components/SummaryCards';
+import BudgetTable from './components/BudgetTable';
+import BudgetFormModal, { type BudgetFormValues } from './components/BudgetFormModal';
 
 const SEGMENTS = [
-  { value: 'current', label: 'Bulan ini' },
-  { value: 'previous', label: 'Bulan lalu' },
-  { value: 'custom', label: 'Custom' },
+  {
+    value: 'current',
+    label: 'Bulan ini',
+    description: 'Pantau pengeluaran aktif',
+    icon: CalendarCheck2,
+  },
+  {
+    value: 'previous',
+    label: 'Bulan lalu',
+    description: 'Bandingkan dengan periode lalu',
+    icon: History,
+  },
+  {
+    value: 'custom',
+    label: 'Custom',
+    description: 'Pilih periode sendiri',
+    icon: CalendarClock,
+  },
 ] as const;
 
 type SegmentValue = (typeof SEGMENTS)[number]['value'];
@@ -197,6 +224,38 @@ export default function BudgetsPage() {
     }
   };
 
+  const normalizedPercentage = Math.min(Math.max(summary.percentage, 0), 1);
+  const progressPercent = Math.round(normalizedPercentage * 100);
+  const overspent = summary.remaining < 0;
+  const highlightMessage = overspent
+    ? 'Pengeluaran sudah melampaui batas anggaran. Tinjau kategori terbesar untuk kembali aman.'
+    : progressPercent >= 80
+      ? 'Anggaran tinggal sedikit. Fokus pada kebutuhan prioritas agar tetap terkontrol.'
+      : 'Pengeluaranmu masih stabil. Pertahankan ritme baik ini sampai akhir periode.';
+
+  const heroStats = [
+    {
+      label: 'Dialokasikan',
+      value: formatCurrency(summary.planned, 'IDR'),
+      hint: 'Total batas belanja periode ini.',
+      icon: Wallet,
+    },
+    {
+      label: 'Terpakai',
+      value: formatCurrency(summary.spent, 'IDR'),
+      hint: `${progressPercent}% dari anggaran telah digunakan.`,
+      icon: TrendingUp,
+    },
+    {
+      label: 'Sisa anggaran',
+      value: formatCurrency(summary.remaining, 'IDR'),
+      hint: overspent
+        ? 'Belanja melebihi anggaran, segera atur ulang pos pengeluaran.'
+        : 'Masih ada ruang untuk kebutuhan prioritas.',
+      icon: PiggyBank,
+    },
+  ];
+
   return (
     <Page>
       <PageHeader
@@ -206,7 +265,7 @@ export default function BudgetsPage() {
         <button
           type="button"
           onClick={refresh}
-          className="hidden h-11 items-center gap-2 rounded-2xl border border-border bg-surface px-4 text-sm font-semibold text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 md:inline-flex"
+          className="hidden h-11 items-center gap-2 rounded-full border border-white/40 bg-white/70 px-5 text-sm font-semibold text-zinc-600 shadow-sm transition hover:-translate-y-0.5 hover:border-brand/40 hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 md:inline-flex dark:border-white/10 dark:bg-zinc-900/70 dark:text-zinc-200"
         >
           <RefreshCw className="h-4 w-4" />
           Segarkan
@@ -215,7 +274,7 @@ export default function BudgetsPage() {
           type="button"
           disabled={categoriesLoading}
           onClick={handleOpenCreate}
-          className="inline-flex h-11 items-center gap-2 rounded-2xl bg-brand px-5 text-sm font-semibold text-brand-foreground shadow transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)] disabled:cursor-not-allowed disabled:opacity-60"
+          className="inline-flex h-11 items-center gap-2 rounded-full bg-gradient-to-r from-brand via-sky-500 to-emerald-500 px-6 text-sm font-semibold text-brand-foreground shadow-lg transition hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)] disabled:cursor-not-allowed disabled:opacity-60 dark:from-brand dark:via-sky-500 dark:to-emerald-500"
         >
           <Plus className="h-4 w-4" />
           Tambah anggaran
@@ -223,42 +282,153 @@ export default function BudgetsPage() {
       </PageHeader>
 
       <Section first>
-        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div className="flex flex-wrap gap-2">
-            {SEGMENTS.map(({ value, label }) => {
-              const active = value === segment;
-              return (
-                <button
-                  key={value}
-                  type="button"
-                  onClick={() => handleSegmentChange(value)}
-                  className={clsx(
-                    'h-11 rounded-2xl px-5 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
-                    active
-                      ? 'bg-brand text-brand-foreground shadow'
-                      : 'border border-border bg-surface px-5 text-muted hover:border-brand/40 hover:bg-brand/5 hover:text-text'
-                  )}
-                >
-                  {label}
-                </button>
-              );
-            })}
-          </div>
+        <div className="relative overflow-hidden rounded-[32px] border border-white/30 bg-gradient-to-br from-brand/10 via-sky-50 to-emerald-50 shadow-xl ring-1 ring-black/5 dark:border-white/10 dark:from-brand/20 dark:via-zinc-950/60 dark:to-emerald-500/10 dark:ring-white/10">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -left-24 top-[-120px] h-72 w-72 rounded-full bg-brand/20 blur-3xl dark:bg-brand/30"
+          />
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -right-20 bottom-[-140px] h-80 w-80 rounded-full bg-emerald-200/40 blur-3xl dark:bg-emerald-500/20"
+          />
+          <div className="relative flex flex-col gap-8 rounded-[30px] bg-white/70 p-6 backdrop-blur-md dark:bg-zinc-950/70 md:p-10">
+            <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
+              <div className="space-y-6">
+                <div className="inline-flex items-center gap-2 rounded-full border border-white/40 bg-white/70 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-brand shadow-sm dark:border-white/10 dark:bg-zinc-900/60 dark:text-brand">
+                  <Sparkles className="h-3.5 w-3.5" />
+                  Mode anggaran pintar
+                </div>
+                <div className="space-y-4">
+                  <h2 className="text-3xl font-semibold leading-tight text-zinc-900 dark:text-zinc-50 md:text-4xl">
+                    Kontrol pengeluaranmu lebih mudah dan cantik.
+                  </h2>
+                  <p className="max-w-xl text-sm text-zinc-600 dark:text-zinc-300">
+                    Rencanakan batas belanja, pantau progres, dan dapatkan insight setiap periode untuk membantu kamu tetap di jalur mencapai tujuan finansial.
+                  </p>
+                </div>
+                <div className="grid gap-4 sm:grid-cols-3">
+                  {heroStats.map(({ label, value, hint, icon: StatIcon }) => (
+                    <div
+                      key={label}
+                      className="relative overflow-hidden rounded-2xl border border-white/40 bg-white/80 p-4 text-left shadow-md transition hover:-translate-y-0.5 hover:border-brand/40 hover:bg-white/90 dark:border-white/10 dark:bg-zinc-900/70 dark:hover:border-brand/30"
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">{label}</span>
+                        <span className="flex h-8 w-8 items-center justify-center rounded-2xl bg-brand/10 text-brand dark:bg-brand/20">
+                          <StatIcon className="h-4 w-4" />
+                        </span>
+                      </div>
+                      <p className="mt-2 text-xl font-semibold text-zinc-900 dark:text-zinc-50">{value}</p>
+                      <p className="mt-2 text-xs text-zinc-500 dark:text-zinc-400">{hint}</p>
+                    </div>
+                  ))}
+                </div>
+                <div className="flex items-center gap-3 rounded-2xl border border-white/40 bg-white/70 px-4 py-3 text-sm text-zinc-600 shadow-sm dark:border-white/10 dark:bg-zinc-900/70 dark:text-zinc-300">
+                  <div className="flex h-9 w-9 items-center justify-center rounded-2xl bg-brand/10 text-brand dark:bg-brand/20">
+                    <TrendingUp className="h-4 w-4" />
+                  </div>
+                  <p className="leading-relaxed">{highlightMessage}</p>
+                </div>
+              </div>
 
-          {segment === 'custom' ? (
-            <input
-              type="month"
-              value={customPeriod}
-              onChange={(event) => handleCustomPeriodChange(event.target.value)}
-              className="h-11 rounded-2xl border border-border bg-surface px-4 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-              aria-label="Pilih periode custom"
-            />
-          ) : (
-            <div className="flex items-center gap-2 rounded-2xl border border-border bg-surface px-4 py-2 text-sm font-medium text-muted">
-              <Calendar className="h-4 w-4" />
-              <span>{toHumanReadable(period)}</span>
+              <div className="flex flex-col gap-5 rounded-[28px] border border-white/40 bg-white/80 p-6 text-sm text-zinc-600 shadow-lg backdrop-blur md:max-w-sm dark:border-white/10 dark:bg-zinc-900/70 dark:text-zinc-200">
+                <div className="flex items-center justify-between gap-4">
+                  <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Periode aktif</span>
+                  <span className="rounded-full border border-brand/30 bg-brand/10 px-3 py-1 text-xs font-semibold text-brand dark:border-brand/40 dark:bg-brand/20">
+                    {toHumanReadable(period)}
+                  </span>
+                </div>
+                <div className="flex items-center gap-4">
+                  <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-brand/15 text-brand shadow-sm dark:bg-brand/25">
+                    <Calendar className="h-5 w-5" />
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Total anggaran periode</p>
+                    <p className="text-xl font-semibold text-zinc-900 dark:text-zinc-50">
+                      {formatCurrency(summary.planned, 'IDR')}
+                    </p>
+                  </div>
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="rounded-2xl border border-white/40 bg-white/70 p-3 shadow-sm dark:border-white/10 dark:bg-zinc-950/60">
+                    <p className="text-[0.7rem] uppercase tracking-wide text-zinc-400 dark:text-zinc-500">Terpakai</p>
+                    <p className="mt-1 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                      {formatCurrency(summary.spent, 'IDR')}
+                    </p>
+                  </div>
+                  <div className="rounded-2xl border border-white/40 bg-white/70 p-3 shadow-sm dark:border-white/10 dark:bg-zinc-950/60">
+                    <p className="text-[0.7rem] uppercase tracking-wide text-zinc-400 dark:text-zinc-500">Sisa</p>
+                    <p
+                      className={clsx(
+                        'mt-1 text-sm font-semibold',
+                        overspent ? 'text-rose-500 dark:text-rose-300' : 'text-emerald-600 dark:text-emerald-400',
+                      )}
+                    >
+                      {formatCurrency(summary.remaining, 'IDR')}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex flex-col gap-3">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Pilih periode</p>
+                  <div className="flex flex-col gap-3">
+                    <div className="flex flex-wrap gap-2">
+                      {SEGMENTS.map(({ value, label, description, icon: SegmentIcon }) => {
+                        const active = value === segment;
+                        return (
+                          <button
+                            key={value}
+                            type="button"
+                            onClick={() => handleSegmentChange(value)}
+                            className={clsx(
+                              'group relative flex min-w-[150px] flex-1 items-start gap-3 rounded-2xl border px-4 py-3 text-left text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50',
+                              active
+                                ? 'border-brand/60 bg-white/90 shadow-md dark:border-brand/40 dark:bg-zinc-900/80'
+                                : 'border-white/40 bg-white/60 hover:border-brand/40 hover:bg-white/80 dark:border-white/10 dark:bg-zinc-900/70 dark:hover:border-brand/30',
+                            )}
+                          >
+                            <span
+                              className={clsx(
+                                'flex h-10 w-10 items-center justify-center rounded-2xl bg-brand/10 text-brand transition-all dark:bg-brand/20',
+                                active ? 'scale-105 shadow-sm' : 'opacity-80',
+                              )}
+                            >
+                              <SegmentIcon className="h-4 w-4" />
+                            </span>
+                            <span className="flex flex-col gap-1">
+                              <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">{label}</span>
+                              <span className="text-xs text-zinc-500 dark:text-zinc-400">{description}</span>
+                            </span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                    {segment === 'custom' ? (
+                      <label className="flex w-full items-center gap-3 rounded-2xl border border-brand/40 bg-brand/5 px-4 py-3 text-xs font-medium uppercase tracking-wide text-brand shadow-sm dark:border-brand/30 dark:bg-brand/10">
+                        <span className="flex h-8 w-8 items-center justify-center rounded-xl bg-white/80 text-brand dark:bg-zinc-900/60">
+                          <CalendarClock className="h-4 w-4" />
+                        </span>
+                        <span className="flex flex-1 flex-col gap-1 text-left text-[0.7rem] text-brand/80 dark:text-brand/70">
+                          Periode custom
+                          <input
+                            type="month"
+                            value={customPeriod}
+                            onChange={(event) => handleCustomPeriodChange(event.target.value)}
+                            className="h-9 rounded-xl border border-transparent bg-white/90 px-3 text-sm font-semibold text-zinc-900 shadow-sm outline-none transition focus:border-brand/40 focus:ring-2 focus:ring-brand/30 dark:bg-zinc-950/80 dark:text-zinc-100"
+                            aria-label="Pilih periode custom"
+                          />
+                        </span>
+                      </label>
+                    ) : (
+                      <div className="flex w-full items-center gap-3 rounded-2xl border border-white/40 bg-white/70 px-4 py-3 text-sm font-medium text-zinc-600 shadow-sm dark:border-white/10 dark:bg-zinc-900/70 dark:text-zinc-200">
+                        <Calendar className="h-4 w-4" />
+                        <span>{toHumanReadable(period)}</span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
             </div>
-          )}
+          </div>
         </div>
       </Section>
 

--- a/src/pages/budgets/components/SummaryCards.tsx
+++ b/src/pages/budgets/components/SummaryCards.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { PiggyBank, Target, TrendingDown, Wallet } from 'lucide-react';
 import { formatCurrency } from '../../../lib/format';
 import type { BudgetSummary } from '../../../lib/budgetApi';
@@ -8,82 +9,178 @@ interface SummaryCardsProps {
 }
 
 const CARD_BASE_CLASS =
-  'rounded-2xl border border-white/20 dark:border-white/5 bg-gradient-to-b from-white/80 to-white/50 dark:from-zinc-900/60 dark:to-zinc-900/30 backdrop-blur shadow-sm';
+  'group relative overflow-hidden rounded-3xl border border-white/20 bg-white/80 p-6 shadow-lg ring-1 ring-black/5 transition hover:-translate-y-1 hover:shadow-2xl dark:border-white/5 dark:bg-zinc-900/70 dark:ring-white/5';
 
 function SummarySkeleton() {
   return (
-    <div className={CARD_BASE_CLASS}>
-      <div className="flex h-full flex-col gap-4 p-5">
-        <div className="h-4 w-32 animate-pulse rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
-        <div className="h-8 w-24 animate-pulse rounded-lg bg-zinc-200/70 dark:bg-zinc-700/70" />
-        <div className="h-2 w-full animate-pulse rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
-      </div>
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      {['one', 'two', 'three', 'four'].map((key) => (
+        <div key={key} className={clsx(CARD_BASE_CLASS, 'animate-pulse')}>
+          <div className="flex h-full flex-col gap-4">
+            <div className="flex items-center gap-3">
+              <div className="h-12 w-12 rounded-2xl bg-zinc-200/70 dark:bg-zinc-700/60" />
+              <div className="space-y-2">
+                <div className="h-3 w-24 rounded-full bg-zinc-200/70 dark:bg-zinc-700/60" />
+                <div className="h-5 w-36 rounded-full bg-zinc-200/70 dark:bg-zinc-700/60" />
+              </div>
+            </div>
+            <div className="h-3 w-full rounded-full bg-zinc-200/60 dark:bg-zinc-700/60" />
+            <div className="h-2 w-full rounded-full bg-zinc-200/50 dark:bg-zinc-800/50" />
+          </div>
+        </div>
+      ))}
     </div>
   );
 }
 
 export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
   if (loading) {
-    return (
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        {Array.from({ length: 4 }).map((_, index) => (
-          <SummarySkeleton key={index} />
-        ))}
-      </div>
-    );
+    return <SummarySkeleton />;
   }
 
-  const progress = Math.min(Math.max(summary.percentage, 0), 1);
+  const rawPercentage = Math.max(summary.percentage, 0);
+  const progress = Math.min(rawPercentage, 1);
+  const displayPercent = Math.round(rawPercentage * 100);
+  const overspent = summary.remaining < 0;
+
+  const statusBadge = overspent
+    ? {
+        label: 'Butuh perhatian',
+        className: 'bg-rose-500/10 text-rose-600 dark:bg-rose-500/20 dark:text-rose-200',
+      }
+    : displayPercent >= 80
+      ? {
+          label: 'Waspada',
+          className: 'bg-amber-500/10 text-amber-600 dark:bg-amber-500/20 dark:text-amber-200',
+        }
+      : {
+          label: 'Stabil',
+          className: 'bg-emerald-500/10 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-200',
+        };
+
+  const remainingBadge = overspent
+    ? {
+        label: 'Defisit',
+        className: 'bg-rose-500/10 text-rose-600 dark:bg-rose-500/20 dark:text-rose-200',
+      }
+    : {
+        label: 'Surplus',
+        className: 'bg-purple-500/10 text-purple-600 dark:bg-purple-500/20 dark:text-purple-200',
+      };
+
+  const remainingHelper = overspent
+    ? `Terlewat batas sebesar ${formatCurrency(Math.abs(summary.remaining), 'IDR')}.`
+    : 'Masih tersisa ruang belanja untuk kebutuhan prioritas.';
+
+  const progressHelper = overspent
+    ? 'Anggaran sudah melampaui batas — periksa kategori pengeluaran terbesar.'
+    : displayPercent >= 80
+      ? 'Perlambat pengeluaran agar tetap on track.'
+      : 'Belanja masih aman dalam batas anggaran.';
 
   const cards = [
     {
       label: 'Total Anggaran',
       value: formatCurrency(summary.planned, 'IDR'),
       icon: Wallet,
-      accent: 'text-sky-600 dark:text-sky-400',
+      iconClass: 'bg-sky-500/15 text-sky-600 dark:bg-sky-500/20 dark:text-sky-300',
+      glow: 'from-sky-400/25 via-sky-400/10 to-transparent',
+      helper: 'Dialokasikan untuk periode ini.',
     },
     {
       label: 'Realisasi',
       value: formatCurrency(summary.spent, 'IDR'),
       icon: TrendingDown,
-      accent: 'text-emerald-600 dark:text-emerald-400',
+      iconClass: 'bg-emerald-500/15 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-200',
+      glow: 'from-emerald-400/25 via-emerald-400/10 to-transparent',
+      helper: `${displayPercent}% dari anggaran telah digunakan.`,
+      badge: statusBadge.label,
+      badgeClass: statusBadge.className,
     },
     {
       label: 'Sisa',
       value: formatCurrency(summary.remaining, 'IDR'),
       icon: PiggyBank,
-      accent: 'text-purple-600 dark:text-purple-400',
+      iconClass: overspent
+        ? 'bg-rose-500/15 text-rose-600 dark:bg-rose-500/20 dark:text-rose-200'
+        : 'bg-purple-500/15 text-purple-600 dark:bg-purple-500/20 dark:text-purple-200',
+      glow: overspent
+        ? 'from-rose-400/25 via-rose-400/10 to-transparent'
+        : 'from-purple-400/25 via-purple-400/10 to-transparent',
+      helper: remainingHelper,
+      badge: remainingBadge.label,
+      badgeClass: remainingBadge.className,
     },
     {
       label: 'Persentase',
-      value: `${(progress * 100).toFixed(0)}%`,
+      value: `${displayPercent}%`,
       icon: Target,
-      accent: 'text-orange-600 dark:text-orange-400',
+      iconClass: overspent
+        ? 'bg-rose-500/15 text-rose-600 dark:bg-rose-500/20 dark:text-rose-200'
+        : 'bg-amber-400/15 text-amber-500 dark:bg-amber-400/20 dark:text-amber-200',
+      glow: overspent
+        ? 'from-rose-400/30 via-rose-400/10 to-transparent'
+        : 'from-amber-400/30 via-amber-400/10 to-transparent',
+      helper: progressHelper,
+      badge: statusBadge.label,
+      badgeClass: statusBadge.className,
       progress,
     },
   ];
 
   return (
     <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-      {cards.map(({ label, value, icon: Icon, accent, progress: cardProgress }) => (
+      {cards.map(({ label, value, icon: Icon, iconClass, glow, helper, badge, badgeClass, progress: cardProgress }) => (
         <div key={label} className={CARD_BASE_CLASS}>
-          <div className="flex h-full flex-col gap-4 p-5">
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400">{label}</span>
-              <Icon className={`h-5 w-5 ${accent}`} />
+          <div
+            aria-hidden
+            className={clsx('pointer-events-none absolute inset-0 bg-gradient-to-br opacity-90 blur-xl', glow)}
+          />
+          <div className="relative flex h-full flex-col gap-5">
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <span className={clsx('flex h-12 w-12 items-center justify-center rounded-2xl', iconClass)}>
+                  <Icon className="h-5 w-5" />
+                </span>
+                <div className="space-y-1">
+                  <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">{label}</span>
+                  <span className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">{value}</span>
+                </div>
+              </div>
+              {badge ? (
+                <span className={clsx('rounded-full px-3 py-1 text-xs font-semibold shadow-sm', badgeClass)}>{badge}</span>
+              ) : null}
             </div>
-            <span className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">{value}</span>
+            <p className="text-sm leading-relaxed text-zinc-500 dark:text-zinc-400">{helper}</p>
             {typeof cardProgress === 'number' ? (
-              <div className="mt-auto">
+              <div className="mt-auto space-y-3">
                 <div className="flex items-center justify-between text-xs font-medium text-zinc-500 dark:text-zinc-400">
                   <span>0%</span>
                   <span>100%</span>
                 </div>
-                <div className="mt-2 h-2 rounded-full bg-zinc-200/70 dark:bg-zinc-800/70">
+                <div className="relative h-2 w-full overflow-hidden rounded-full bg-zinc-200/70 dark:bg-zinc-800/70">
                   <div
-                    className="h-full rounded-full bg-gradient-to-r from-sky-500 via-sky-400 to-sky-300 dark:from-sky-400 dark:via-sky-500 dark:to-sky-600 transition-all"
-                    style={{ width: `${cardProgress * 100}%` }}
+                    className={clsx(
+                      'absolute inset-y-0 left-0 rounded-full transition-all duration-500',
+                      overspent
+                        ? 'bg-gradient-to-r from-rose-500 via-rose-400 to-rose-500'
+                        : 'bg-gradient-to-r from-brand via-sky-400 to-emerald-400',
+                    )}
+                    style={{ width: `${Math.min(cardProgress * 100, 100)}%` }}
                   />
+                </div>
+                <div className="flex items-center justify-between text-xs font-medium">
+                  <span className="text-zinc-500 dark:text-zinc-400">Progress anggaran</span>
+                  <span
+                    className={clsx(
+                      'rounded-full px-2 py-0.5 text-[0.7rem] font-semibold',
+                      overspent
+                        ? 'bg-rose-500/10 text-rose-600 dark:bg-rose-500/20 dark:text-rose-200'
+                        : 'bg-emerald-500/10 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-200',
+                    )}
+                  >
+                    {displayPercent}%
+                  </span>
                 </div>
               </div>
             ) : null}


### PR DESCRIPTION
## Summary
- redesign the budgets landing section with a new hero, richer statistics, and updated segment controls
- refresh summary cards with gradient styling, contextual messaging, and clearer progress feedback

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68da7387a06483328cf682176cfa34ac