### PR TITLE
Tweak budgets page spacing for consistency

### DIFF
--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -206,7 +206,7 @@ export default function BudgetsPage() {
         <button
           type="button"
           onClick={refresh}
-          className="hidden h-11 items-center gap-2 rounded-2xl border border-border bg-surface px-4 text-sm font-semibold text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 md:inline-flex"
+          className="hidden md:inline-flex btn btn-secondary btn-sm gap-2"
         >
           <RefreshCw className="h-4 w-4" />
           Segarkan
@@ -215,7 +215,7 @@ export default function BudgetsPage() {
           type="button"
           disabled={categoriesLoading}
           onClick={handleOpenCreate}
-          className="inline-flex h-11 items-center gap-2 rounded-2xl bg-brand px-5 text-sm font-semibold text-brand-foreground shadow transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)] disabled:cursor-not-allowed disabled:opacity-60"
+          className="btn btn-primary btn-sm gap-2"
         >
           <Plus className="h-4 w-4" />
           Tambah anggaran
@@ -233,19 +233,19 @@ export default function BudgetsPage() {
                   type="button"
                   onClick={() => handleSegmentChange(value)}
                   className={clsx(
-                    'group inline-flex h-11 items-center gap-2 rounded-2xl border px-5 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
+                    'inline-flex items-center gap-2 rounded-full border px-4 py-2 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
                     active
-                      ? 'border-transparent bg-brand text-brand-foreground shadow-lg shadow-brand/30'
-                      : 'border-border bg-surface/80 text-muted hover:border-brand/40 hover:bg-brand/5 hover:text-text'
+                      ? 'border-transparent bg-brand text-brand-foreground shadow-sm'
+                      : 'border-border-subtle text-muted hover:border-brand/40 hover:text-text'
                   )}
                 >
                   <span
                     className={clsx(
-                      'flex h-8 w-8 items-center justify-center rounded-xl bg-white/60 text-brand shadow-inner transition group-hover:scale-105 dark:bg-white/10',
+                      'flex h-6 w-6 items-center justify-center rounded-full bg-white/70 text-brand shadow-sm dark:bg-white/10',
                       active ? 'bg-white/90 text-brand' : 'text-brand',
                     )}
                   >
-                    <Icon className="h-4 w-4" />
+                    <Icon className="h-3.5 w-3.5" />
                   </span>
                   {label}
                 </button>
@@ -258,13 +258,13 @@ export default function BudgetsPage() {
               type="month"
               value={customPeriod}
               onChange={(event) => handleCustomPeriodChange(event.target.value)}
-              className="h-11 rounded-2xl border border-border/60 bg-surface/80 px-4 text-sm font-medium text-text shadow-inner transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+              className="form-control h-10 w-full max-w-[180px] rounded-xl border-border-subtle bg-surface-alt px-3 text-sm"
               aria-label="Pilih periode custom"
             />
           ) : (
-            <div className="flex items-center gap-2 rounded-2xl border border-border/60 bg-surface/80 px-4 py-2 text-sm font-medium text-muted shadow-inner">
-              <CalendarRange className="h-4 w-4" />
-              <span>{toHumanReadable(period)}</span>
+            <div className="flex items-center gap-2 rounded-xl border border-border-subtle bg-surface-alt px-3 py-2 text-sm font-medium text-muted">
+              <CalendarRange className="h-3.5 w-3.5" />
+              <span className="text-text">{toHumanReadable(period)}</span>
             </div>
           )}
         </div>

--- a/src/pages/budgets/components/BudgetTable.tsx
+++ b/src/pages/budgets/components/BudgetTable.tsx
@@ -20,10 +20,10 @@ interface BudgetTableProps {
   onToggleCarryover: (row: BudgetWithSpent, carryover: boolean) => void;
 }
 
-const CARD_WRAPPER_CLASS = 'grid gap-5 md:grid-cols-2 xl:grid-cols-3';
+const CARD_WRAPPER_CLASS = 'grid gap-4 md:grid-cols-2 xl:grid-cols-3';
 
 const CARD_CLASS =
-  'relative flex flex-col gap-6 overflow-hidden rounded-3xl border border-border/60 bg-surface/80 p-6 shadow-[0_28px_50px_-28px_rgba(15,23,42,0.5)] transition duration-300 ease-out hover:-translate-y-1 hover:shadow-[0_35px_70px_-35px_rgba(15,23,42,0.55)] backdrop-blur supports-[backdrop-filter]:bg-surface/60';
+  'relative flex flex-col gap-5 overflow-hidden rounded-2xl border border-border/60 bg-surface/70 p-5 shadow-[0_22px_40px_-26px_rgba(15,23,42,0.45)] transition duration-200 ease-out hover:-translate-y-0.5 hover:shadow-[0_28px_55px_-30px_rgba(15,23,42,0.5)] backdrop-blur supports-[backdrop-filter]:bg-surface/60';
 
 function LoadingCards() {
   return (
@@ -34,13 +34,13 @@ function LoadingCards() {
           key={index}
           className={clsx(CARD_CLASS, 'animate-pulse border-dashed')}
         >
-          <div className="h-4 w-24 rounded-full bg-zinc-200/70 dark:bg-zinc-700/60" />
-          <div className="space-y-3">
-            <div className="h-3 w-3/4 rounded-full bg-zinc-200/70 dark:bg-zinc-700/60" />
-            <div className="h-3 w-2/4 rounded-full bg-zinc-200/70 dark:bg-zinc-700/60" />
+          <div className="h-3 w-20 rounded-full bg-zinc-200/70 dark:bg-zinc-700/60" />
+          <div className="space-y-2.5">
+            <div className="h-2.5 w-3/4 rounded-full bg-zinc-200/70 dark:bg-zinc-700/60" />
+            <div className="h-2.5 w-2/4 rounded-full bg-zinc-200/70 dark:bg-zinc-700/60" />
           </div>
-          <div className="h-32 rounded-2xl bg-zinc-200/50 dark:bg-zinc-800/50" />
-          <div className="h-20 rounded-2xl border border-dashed border-zinc-200/70 dark:border-zinc-700/70" />
+          <div className="h-28 rounded-xl bg-zinc-200/50 dark:bg-zinc-800/50" />
+          <div className="h-16 rounded-xl border border-dashed border-zinc-200/70 dark:border-zinc-700/70" />
         </div>
       ))}
     </div>
@@ -49,13 +49,13 @@ function LoadingCards() {
 
 function EmptyState() {
   return (
-    <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border border-dashed border-border/60 bg-surface/70 p-10 text-center text-sm text-muted shadow-inner">
-      <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-brand/10 text-brand">
-        <Sparkles className="h-5 w-5" />
+    <div className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-border/60 bg-surface/70 p-8 text-center text-sm text-muted shadow-inner">
+      <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-brand/10 text-brand">
+        <Sparkles className="h-4 w-4" />
       </span>
       <div className="space-y-1">
-        <p className="text-base font-semibold text-text">Belum ada anggaran</p>
-        <p className="text-sm text-muted">
+        <p className="text-sm font-semibold text-text">Belum ada anggaran</p>
+        <p className="text-xs text-muted">
           Tambahkan kategori anggaran untuk mulai mengontrol pengeluaranmu.
         </p>
       </div>
@@ -127,12 +127,12 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
             <header className="flex flex-col gap-4">
               <div className="flex flex-wrap items-start justify-between gap-4">
                 <div className="flex items-start gap-3">
-                  <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-brand/10 text-base font-semibold uppercase text-brand shadow-inner">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-brand/10 text-sm font-semibold uppercase text-brand shadow-inner">
                     {categoryInitial}
                   </div>
                   <div className="space-y-2">
                     <div className="flex flex-wrap items-center gap-2">
-                      <h3 className="text-lg font-semibold text-text dark:text-white">{categoryName}</h3>
+                      <h3 className="text-base font-semibold text-text dark:text-white">{categoryName}</h3>
                       <span
                         className={clsx(
                           'inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold ring-1 ring-inset shadow-sm backdrop-blur',
@@ -147,12 +147,12 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
                   </div>
                 </div>
 
-                <div className="flex flex-wrap items-center justify-end gap-2">
-                  <div className="flex items-center gap-2 rounded-full border border-border/60 bg-surface/70 px-3 py-1.5 text-xs font-medium text-muted shadow-inner">
+                <div className="flex flex-wrap items-center justify-end gap-1.5">
+                  <div className="flex items-center gap-2 rounded-full border border-border/60 bg-surface/70 px-3 py-1.5 text-[0.7rem] font-medium text-muted">
                     <RefreshCcw className="h-3.5 w-3.5" />
                     <span className="hidden sm:inline">Carryover</span>
                     <span className="sm:hidden">CO</span>
-                    <span className="text-[0.7rem] uppercase tracking-widest text-muted/80">
+                    <span className="text-[0.65rem] uppercase tracking-[0.3em] text-muted/80">
                       {row.carryover_enabled ? 'Aktif' : 'Nonaktif'}
                     </span>
                     <label className="relative inline-flex h-6 w-12 cursor-pointer items-center">
@@ -170,25 +170,25 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
                   <button
                     type="button"
                     onClick={() => onEdit(row)}
-                    className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-border/60 bg-surface/80 text-muted shadow-sm transition hover:-translate-y-0.5 hover:text-text"
+                    className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-border/60 bg-surface/70 text-muted transition hover:-translate-y-0.5 hover:text-text"
                     aria-label={`Edit ${categoryName}`}
                   >
-                    <Pencil className="h-4 w-4" />
+                    <Pencil className="h-3.5 w-3.5" />
                   </button>
                   <button
                     type="button"
                     onClick={() => onDelete(row)}
-                    className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-rose-200/70 bg-rose-50/70 text-rose-500 shadow-sm transition hover:-translate-y-0.5 hover:bg-rose-100 dark:border-rose-500/30 dark:bg-rose-500/15 dark:text-rose-200"
+                    className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-rose-200/70 bg-rose-50/70 text-rose-500 transition hover:-translate-y-0.5 hover:bg-rose-100 dark:border-rose-500/30 dark:bg-rose-500/15 dark:text-rose-200"
                     aria-label={`Hapus ${categoryName}`}
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="h-3.5 w-3.5" />
                   </button>
                 </div>
               </div>
             </header>
 
             <section className="space-y-5">
-              <div className="rounded-2xl border border-border/50 bg-surface/70 p-4 shadow-inner">
+              <div className="rounded-xl border border-border/50 bg-surface/70 p-4 shadow-inner">
                 <div className="grid gap-4 sm:grid-cols-3">
                   <div className="space-y-1">
                     <span className="text-xs uppercase tracking-[0.2em] text-muted">Anggaran</span>
@@ -214,7 +214,7 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
                   </div>
                 </div>
 
-                <div className="mt-5 space-y-3">
+                <div className="mt-4 space-y-3">
                   <div className="flex flex-wrap items-center justify-between gap-2 text-xs font-semibold text-muted">
                     <span>Progres penggunaan</span>
                     <span>{displayPercentage}%</span>
@@ -231,10 +231,10 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
                 </div>
               </div>
 
-              <div className="rounded-2xl border border-dashed border-border/60 bg-surface/70 p-4 text-sm shadow-inner">
+              <div className="rounded-xl border border-dashed border-border/60 bg-surface/70 p-4 text-sm shadow-inner">
                 <div className="flex items-start gap-3">
-                  <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-muted/20 text-muted">
-                    <NotebookPen className="h-4 w-4" />
+                  <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-muted/20 text-muted">
+                    <NotebookPen className="h-3.5 w-3.5" />
                   </span>
                   <div className="space-y-1">
                     <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted">Catatan</p>

--- a/src/pages/budgets/components/SummaryCards.tsx
+++ b/src/pages/budgets/components/SummaryCards.tsx
@@ -10,12 +10,12 @@ interface SummaryCardsProps {
 
 function SummarySkeleton() {
   return (
-    <div className="relative overflow-hidden rounded-3xl border border-border/60 bg-surface/70 p-6 shadow-sm">
+    <div className="relative overflow-hidden rounded-2xl border border-border/60 bg-surface/60 p-5 shadow-sm">
       <div className="absolute inset-0 bg-gradient-to-br from-white/70 via-white/40 to-white/10 opacity-80 dark:from-zinc-900/80 dark:via-zinc-900/50 dark:to-zinc-900/20" />
-      <div className="relative flex h-full flex-col gap-4">
-        <div className="h-3 w-24 animate-pulse rounded-full bg-zinc-200/70 dark:bg-zinc-700/60" />
-        <div className="h-8 w-28 animate-pulse rounded-full bg-zinc-200/80 dark:bg-zinc-700/70" />
-        <div className="mt-auto h-2 w-full animate-pulse rounded-full bg-zinc-200/70 dark:bg-zinc-800/60" />
+      <div className="relative flex h-full flex-col gap-3">
+        <div className="h-2.5 w-20 animate-pulse rounded-full bg-zinc-200/70 dark:bg-zinc-700/60" />
+        <div className="h-6 w-24 animate-pulse rounded-full bg-zinc-200/80 dark:bg-zinc-700/70" />
+        <div className="mt-auto h-1.5 w-full animate-pulse rounded-full bg-zinc-200/70 dark:bg-zinc-800/60" />
       </div>
     </div>
   );
@@ -24,12 +24,12 @@ function SummarySkeleton() {
 export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
   if (loading) {
     return (
-      <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
-        {Array.from({ length: 4 }).map((_, index) => (
-          <SummarySkeleton key={index} />
-        ))}
-      </div>
-    );
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <SummarySkeleton key={index} />
+      ))}
+    </div>
+  );
   }
 
   const progress = Math.min(Math.max(summary.percentage, 0), 1);
@@ -76,7 +76,7 @@ export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
   ] as const;
 
   return (
-    <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
       {cards.map(({
         label,
         description,
@@ -91,41 +91,41 @@ export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
         <div
           key={label}
           className={clsx(
-            'relative overflow-hidden rounded-3xl border border-border/60 bg-surface/80 p-6 shadow-[0_25px_45px_-25px_rgba(15,23,42,0.45)] transition duration-300 ease-out hover:-translate-y-1 hover:shadow-[0_32px_65px_-30px_rgba(15,23,42,0.55)]',
+            'relative overflow-hidden rounded-2xl border border-border/60 bg-surface/70 p-5 shadow-[0_18px_35px_-22px_rgba(15,23,42,0.4)] transition duration-200 ease-out hover:-translate-y-0.5 hover:shadow-[0_24px_50px_-28px_rgba(15,23,42,0.5)]',
             'backdrop-blur supports-[backdrop-filter]:bg-surface/60',
           )}
         >
           <div
             aria-hidden
-            className="pointer-events-none absolute -right-16 -top-12 h-48 w-48 rounded-full blur-3xl"
+            className="pointer-events-none absolute -right-14 -top-12 h-40 w-40 rounded-full blur-3xl"
             style={{ background: `radial-gradient(circle at center, ${glow} 0%, rgba(255,255,255,0) 70%)` }}
           />
 
-          <div className="relative flex h-full flex-col gap-5">
+          <div className="relative flex h-full flex-col gap-4">
             <div className="flex items-start justify-between gap-4">
               <div className="space-y-1">
-                <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-muted">{label}</p>
-                <p className="text-xs text-muted/80 dark:text-muted/60">{description}</p>
+                <p className="text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-muted">{label}</p>
+                <p className="text-[0.7rem] text-muted/80 dark:text-muted/60">{description}</p>
               </div>
               <span
                 className={clsx(
-                  'flex h-11 w-11 items-center justify-center rounded-2xl shadow-inner ring-1 ring-inset ring-border/40 dark:ring-white/10',
+                  'flex h-10 w-10 items-center justify-center rounded-xl shadow-inner ring-1 ring-inset ring-border/40 dark:ring-white/10',
                   iconBg,
                 )}
               >
-                <Icon className={clsx('h-5 w-5', accent)} />
+                <Icon className={clsx('h-4 w-4', accent)} />
               </span>
             </div>
 
-            <span className="text-3xl font-semibold text-text dark:text-white">{value}</span>
+            <span className="text-2xl font-semibold text-text dark:text-white">{value}</span>
 
             {typeof cardProgress === 'number' ? (
               <div className="mt-auto flex items-end justify-between gap-4">
-                <div className="flex flex-col gap-1 text-xs text-muted">
+                <div className="flex flex-col gap-1 text-[0.7rem] text-muted">
                   <span className="font-semibold text-text">Tingkat penggunaan</span>
                   <span>{(cardProgress * 100).toFixed(0)}% dari total anggaran</span>
                 </div>
-                <div className="relative flex h-16 w-16 items-center justify-center">
+                <div className="relative flex h-14 w-14 items-center justify-center">
                   <div
                     className="absolute inset-0 rounded-full opacity-80"
                     style={{ background: `radial-gradient(circle at center, ${glow} 0%, rgba(255,255,255,0) 72%)` }}
@@ -136,8 +136,8 @@ export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
                       background: `conic-gradient(${accentColor ?? glow} ${cardProgress * 360}deg, rgba(148,163,184,0.25) 0deg)`,
                     }}
                   />
-                  <div className="absolute inset-[6px] rounded-full border border-white/50 bg-gradient-to-br from-white/90 to-white/70 shadow-inner dark:border-white/10 dark:from-zinc-900/90 dark:to-zinc-900/60" />
-                  <span className="relative text-sm font-semibold text-text dark:text-white">{(cardProgress * 100).toFixed(0)}%</span>
+                  <div className="absolute inset-[5px] rounded-full border border-white/40 bg-gradient-to-br from-white/90 to-white/70 shadow-inner dark:border-white/10 dark:from-zinc-900/90 dark:to-zinc-900/60" />
+                  <span className="relative text-xs font-semibold text-text dark:text-white">{(cardProgress * 100).toFixed(0)}%</span>
                 </div>
               </div>
             ) : null}


### PR DESCRIPTION
## Summary
- adjust budgets page header controls and period selector to match shared button sizing
- refine summary card spacing and typography for a more compact presentation
- tighten budget card spacing, badges, and empty state sizing for consistency with other pages

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68da79fbfe1c833293f552dad5334eaf