### PR TITLE
Adjust budgets page control sizing and styling

### DIFF
--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -233,7 +233,7 @@ export default function BudgetsPage() {
                   type="button"
                   onClick={() => handleSegmentChange(value)}
                   className={clsx(
-                    'group inline-flex h-11 items-center gap-2 rounded-2xl border px-5 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
+                    'group inline-flex h-10 items-center gap-2 rounded-xl border px-4 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
                     active
                       ? 'border-transparent bg-brand text-brand-foreground shadow-lg shadow-brand/30'
                       : 'border-border bg-surface/80 text-muted hover:border-brand/40 hover:bg-brand/5 hover:text-text'
@@ -241,7 +241,7 @@ export default function BudgetsPage() {
                 >
                   <span
                     className={clsx(
-                      'flex h-8 w-8 items-center justify-center rounded-xl bg-white/60 text-brand shadow-inner transition group-hover:scale-105 dark:bg-white/10',
+                      'flex h-8 w-8 items-center justify-center rounded-lg bg-white/60 text-brand shadow-inner transition group-hover:scale-105 dark:bg-white/10',
                       active ? 'bg-white/90 text-brand' : 'text-brand',
                     )}
                   >
@@ -254,15 +254,18 @@ export default function BudgetsPage() {
           </div>
 
           {segment === 'custom' ? (
-            <input
-              type="month"
-              value={customPeriod}
-              onChange={(event) => handleCustomPeriodChange(event.target.value)}
-              className="h-11 rounded-2xl border border-border/60 bg-surface/80 px-4 text-sm font-medium text-text shadow-inner transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-              aria-label="Pilih periode custom"
-            />
+            <label className="flex h-10 items-center gap-2 rounded-xl border border-border/60 bg-surface/80 px-3 text-sm font-medium text-text shadow-inner transition focus-within:border-brand/40 focus-within:bg-brand/5 focus-within:text-text focus-within:outline-none focus-within:ring-2 focus-within:ring-brand/40">
+              <CalendarRange className="h-4 w-4 text-muted" aria-hidden="true" />
+              <input
+                type="month"
+                value={customPeriod}
+                onChange={(event) => handleCustomPeriodChange(event.target.value)}
+                className="w-full appearance-none bg-transparent text-sm font-medium text-text outline-none"
+                aria-label="Pilih periode custom"
+              />
+            </label>
           ) : (
-            <div className="flex items-center gap-2 rounded-2xl border border-border/60 bg-surface/80 px-4 py-2 text-sm font-medium text-muted shadow-inner">
+            <div className="flex items-center gap-2 rounded-xl border border-border/60 bg-surface/80 px-3 py-1.5 text-sm font-medium text-muted shadow-inner">
               <CalendarRange className="h-4 w-4" />
               <span>{toHumanReadable(period)}</span>
             </div>

--- a/src/pages/budgets/components/BudgetTable.tsx
+++ b/src/pages/budgets/components/BudgetTable.tsx
@@ -20,10 +20,10 @@ interface BudgetTableProps {
   onToggleCarryover: (row: BudgetWithSpent, carryover: boolean) => void;
 }
 
-const CARD_WRAPPER_CLASS = 'grid gap-5 md:grid-cols-2 xl:grid-cols-3';
+const CARD_WRAPPER_CLASS = 'grid gap-4 md:grid-cols-2 xl:grid-cols-3';
 
 const CARD_CLASS =
-  'relative flex flex-col gap-6 overflow-hidden rounded-3xl border border-border/60 bg-surface/80 p-6 shadow-[0_28px_50px_-28px_rgba(15,23,42,0.5)] transition duration-300 ease-out hover:-translate-y-1 hover:shadow-[0_35px_70px_-35px_rgba(15,23,42,0.55)] backdrop-blur supports-[backdrop-filter]:bg-surface/60';
+  'relative flex flex-col gap-5 overflow-hidden rounded-2xl border border-border/60 bg-surface/80 p-5 shadow-[0_24px_45px_-28px_rgba(15,23,42,0.5)] transition duration-300 ease-out hover:-translate-y-1 hover:shadow-[0_30px_60px_-32px_rgba(15,23,42,0.55)] backdrop-blur supports-[backdrop-filter]:bg-surface/60';
 
 function LoadingCards() {
   return (
@@ -49,12 +49,12 @@ function LoadingCards() {
 
 function EmptyState() {
   return (
-    <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border border-dashed border-border/60 bg-surface/70 p-10 text-center text-sm text-muted shadow-inner">
-      <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-brand/10 text-brand">
+    <div className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-border/60 bg-surface/70 p-8 text-center text-sm text-muted shadow-inner">
+      <span className="flex h-11 w-11 items-center justify-center rounded-xl bg-brand/10 text-brand">
         <Sparkles className="h-5 w-5" />
       </span>
       <div className="space-y-1">
-        <p className="text-base font-semibold text-text">Belum ada anggaran</p>
+        <p className="text-sm font-semibold text-text">Belum ada anggaran</p>
         <p className="text-sm text-muted">
           Tambahkan kategori anggaran untuk mulai mengontrol pengeluaranmu.
         </p>
@@ -127,12 +127,12 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
             <header className="flex flex-col gap-4">
               <div className="flex flex-wrap items-start justify-between gap-4">
                 <div className="flex items-start gap-3">
-                  <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-brand/10 text-base font-semibold uppercase text-brand shadow-inner">
+                  <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-brand/10 text-sm font-semibold uppercase text-brand shadow-inner">
                     {categoryInitial}
                   </div>
                   <div className="space-y-2">
                     <div className="flex flex-wrap items-center gap-2">
-                      <h3 className="text-lg font-semibold text-text dark:text-white">{categoryName}</h3>
+                      <h3 className="text-base font-semibold text-text dark:text-white">{categoryName}</h3>
                       <span
                         className={clsx(
                           'inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold ring-1 ring-inset shadow-sm backdrop-blur',
@@ -143,19 +143,19 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
                         {status.label}
                       </span>
                     </div>
-                    <p className="text-xs uppercase tracking-[0.2em] text-muted">Periode {row.period_month?.slice(0, 7) ?? '-'}</p>
+                    <p className="text-[0.68rem] uppercase tracking-[0.18em] text-muted">Periode {row.period_month?.slice(0, 7) ?? '-'}</p>
                   </div>
                 </div>
 
                 <div className="flex flex-wrap items-center justify-end gap-2">
-                  <div className="flex items-center gap-2 rounded-full border border-border/60 bg-surface/70 px-3 py-1.5 text-xs font-medium text-muted shadow-inner">
+                  <div className="flex items-center gap-2 rounded-full border border-border/60 bg-surface/70 px-3 py-1.5 text-[0.7rem] font-medium text-muted shadow-inner">
                     <RefreshCcw className="h-3.5 w-3.5" />
                     <span className="hidden sm:inline">Carryover</span>
                     <span className="sm:hidden">CO</span>
                     <span className="text-[0.7rem] uppercase tracking-widest text-muted/80">
                       {row.carryover_enabled ? 'Aktif' : 'Nonaktif'}
                     </span>
-                    <label className="relative inline-flex h-6 w-12 cursor-pointer items-center">
+                    <label className="relative inline-flex h-5 w-10 cursor-pointer items-center">
                       <input
                         type="checkbox"
                         checked={row.carryover_enabled}
@@ -164,13 +164,13 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
                         aria-label={`Atur carryover untuk ${categoryName}`}
                       />
                       <span className="absolute inset-0 rounded-full bg-muted/30 transition peer-checked:bg-emerald-500/70 dark:bg-muted/40 dark:peer-checked:bg-emerald-500/60" />
-                      <span className="relative ml-1 h-4 w-4 rounded-full bg-white shadow transition-transform peer-checked:translate-x-6 dark:bg-zinc-900" />
+                      <span className="relative ml-[3px] h-3.5 w-3.5 rounded-full bg-white shadow transition-transform peer-checked:translate-x-5 dark:bg-zinc-900" />
                     </label>
                   </div>
                   <button
                     type="button"
                     onClick={() => onEdit(row)}
-                    className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-border/60 bg-surface/80 text-muted shadow-sm transition hover:-translate-y-0.5 hover:text-text"
+                    className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-border/60 bg-surface/80 text-muted shadow-sm transition hover:-translate-y-0.5 hover:text-text"
                     aria-label={`Edit ${categoryName}`}
                   >
                     <Pencil className="h-4 w-4" />
@@ -178,7 +178,7 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
                   <button
                     type="button"
                     onClick={() => onDelete(row)}
-                    className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-rose-200/70 bg-rose-50/70 text-rose-500 shadow-sm transition hover:-translate-y-0.5 hover:bg-rose-100 dark:border-rose-500/30 dark:bg-rose-500/15 dark:text-rose-200"
+                    className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-rose-200/70 bg-rose-50/70 text-rose-500 shadow-sm transition hover:-translate-y-0.5 hover:bg-rose-100 dark:border-rose-500/30 dark:bg-rose-500/15 dark:text-rose-200"
                     aria-label={`Hapus ${categoryName}`}
                   >
                     <Trash2 className="h-4 w-4" />
@@ -188,23 +188,23 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
             </header>
 
             <section className="space-y-5">
-              <div className="rounded-2xl border border-border/50 bg-surface/70 p-4 shadow-inner">
+              <div className="rounded-xl border border-border/50 bg-surface/70 p-4 shadow-inner">
                 <div className="grid gap-4 sm:grid-cols-3">
                   <div className="space-y-1">
-                    <span className="text-xs uppercase tracking-[0.2em] text-muted">Anggaran</span>
-                    <p className="text-lg font-semibold text-text">{formatCurrency(planned, 'IDR')}</p>
+                    <span className="text-[0.68rem] uppercase tracking-[0.18em] text-muted">Anggaran</span>
+                    <p className="text-base font-semibold text-text">{formatCurrency(planned, 'IDR')}</p>
                     <p className="text-xs text-muted">Dialokasikan</p>
                   </div>
                   <div className="space-y-1">
-                    <span className="text-xs uppercase tracking-[0.2em] text-muted">Terpakai</span>
-                    <p className="text-lg font-semibold text-text/90 dark:text-zinc-200">{formatCurrency(spent, 'IDR')}</p>
+                    <span className="text-[0.68rem] uppercase tracking-[0.18em] text-muted">Terpakai</span>
+                    <p className="text-base font-semibold text-text/90 dark:text-zinc-200">{formatCurrency(spent, 'IDR')}</p>
                     <p className="text-xs text-muted">{planned > 0 ? `${Math.min(100, Math.round((spent / planned) * 100))}% dari anggaran` : 'Tidak ada batas'}</p>
                   </div>
                   <div className="space-y-1">
-                    <span className="text-xs uppercase tracking-[0.2em] text-muted">Sisa</span>
+                    <span className="text-[0.68rem] uppercase tracking-[0.18em] text-muted">Sisa</span>
                     <p
                       className={clsx(
-                        'text-lg font-semibold',
+                        'text-base font-semibold',
                         overBudget ? 'text-rose-500 dark:text-rose-300' : 'text-emerald-600 dark:text-emerald-300',
                       )}
                     >
@@ -214,7 +214,7 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
                   </div>
                 </div>
 
-                <div className="mt-5 space-y-3">
+                <div className="mt-4 space-y-3">
                   <div className="flex flex-wrap items-center justify-between gap-2 text-xs font-semibold text-muted">
                     <span>Progres penggunaan</span>
                     <span>{displayPercentage}%</span>
@@ -231,13 +231,13 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
                 </div>
               </div>
 
-              <div className="rounded-2xl border border-dashed border-border/60 bg-surface/70 p-4 text-sm shadow-inner">
+              <div className="rounded-xl border border-dashed border-border/60 bg-surface/70 p-4 text-sm shadow-inner">
                 <div className="flex items-start gap-3">
-                  <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-muted/20 text-muted">
+                  <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-muted/20 text-muted">
                     <NotebookPen className="h-4 w-4" />
                   </span>
                   <div className="space-y-1">
-                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted">Catatan</p>
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-muted">Catatan</p>
                     <p className="leading-relaxed text-text dark:text-zinc-100">
                       {row.notes?.trim() ? row.notes : 'Tidak ada catatan.'}
                     </p>

--- a/src/pages/budgets/components/SummaryCards.tsx
+++ b/src/pages/budgets/components/SummaryCards.tsx
@@ -10,11 +10,11 @@ interface SummaryCardsProps {
 
 function SummarySkeleton() {
   return (
-    <div className="relative overflow-hidden rounded-3xl border border-border/60 bg-surface/70 p-6 shadow-sm">
+    <div className="relative overflow-hidden rounded-2xl border border-border/60 bg-surface/70 p-5 shadow-sm">
       <div className="absolute inset-0 bg-gradient-to-br from-white/70 via-white/40 to-white/10 opacity-80 dark:from-zinc-900/80 dark:via-zinc-900/50 dark:to-zinc-900/20" />
       <div className="relative flex h-full flex-col gap-4">
         <div className="h-3 w-24 animate-pulse rounded-full bg-zinc-200/70 dark:bg-zinc-700/60" />
-        <div className="h-8 w-28 animate-pulse rounded-full bg-zinc-200/80 dark:bg-zinc-700/70" />
+        <div className="h-7 w-24 animate-pulse rounded-full bg-zinc-200/80 dark:bg-zinc-700/70" />
         <div className="mt-auto h-2 w-full animate-pulse rounded-full bg-zinc-200/70 dark:bg-zinc-800/60" />
       </div>
     </div>
@@ -24,7 +24,7 @@ function SummarySkeleton() {
 export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
   if (loading) {
     return (
-      <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         {Array.from({ length: 4 }).map((_, index) => (
           <SummarySkeleton key={index} />
         ))}
@@ -76,7 +76,7 @@ export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
   ] as const;
 
   return (
-    <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
       {cards.map(({
         label,
         description,
@@ -91,7 +91,7 @@ export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
         <div
           key={label}
           className={clsx(
-            'relative overflow-hidden rounded-3xl border border-border/60 bg-surface/80 p-6 shadow-[0_25px_45px_-25px_rgba(15,23,42,0.45)] transition duration-300 ease-out hover:-translate-y-1 hover:shadow-[0_32px_65px_-30px_rgba(15,23,42,0.55)]',
+            'relative overflow-hidden rounded-2xl border border-border/60 bg-surface/80 p-5 shadow-[0_20px_35px_-20px_rgba(15,23,42,0.45)] transition duration-300 ease-out hover:-translate-y-1 hover:shadow-[0_28px_55px_-28px_rgba(15,23,42,0.55)]',
             'backdrop-blur supports-[backdrop-filter]:bg-surface/60',
           )}
         >
@@ -104,12 +104,12 @@ export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
           <div className="relative flex h-full flex-col gap-5">
             <div className="flex items-start justify-between gap-4">
               <div className="space-y-1">
-                <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-muted">{label}</p>
+                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-muted">{label}</p>
                 <p className="text-xs text-muted/80 dark:text-muted/60">{description}</p>
               </div>
               <span
                 className={clsx(
-                  'flex h-11 w-11 items-center justify-center rounded-2xl shadow-inner ring-1 ring-inset ring-border/40 dark:ring-white/10',
+                  'flex h-10 w-10 items-center justify-center rounded-xl shadow-inner ring-1 ring-inset ring-border/40 dark:ring-white/10',
                   iconBg,
                 )}
               >
@@ -117,7 +117,7 @@ export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
               </span>
             </div>
 
-            <span className="text-3xl font-semibold text-text dark:text-white">{value}</span>
+            <span className="text-2xl font-semibold text-text dark:text-white">{value}</span>
 
             {typeof cardProgress === 'number' ? (
               <div className="mt-auto flex items-end justify-between gap-4">


### PR DESCRIPTION
## Summary
- tighten the budget period controls with a refined custom month selector
- reduce spacing and icon sizing on the summary cards to better match other screens
- slim down budget detail cards, actions, and empty state styling for a more compact layout

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68da79fbfe1c833293f552dad5334eaf