### PR TITLE
Adjust budget filters layout and icon styling

### DIFF
--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -224,7 +224,7 @@ export default function BudgetsPage() {
 
       <Section first>
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div className="flex flex-wrap gap-2">
+          <div className="grid w-full grid-cols-3 gap-2 md:w-auto">
             {SEGMENTS.map(({ value, label, icon: Icon }) => {
               const active = value === segment;
               return (
@@ -233,7 +233,7 @@ export default function BudgetsPage() {
                   type="button"
                   onClick={() => handleSegmentChange(value)}
                   className={clsx(
-                    'group inline-flex h-10 items-center gap-2 rounded-xl border px-4 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
+                    'group inline-flex h-10 w-full items-center justify-center gap-2 rounded-xl border px-4 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 md:w-auto md:justify-start',
                     active
                       ? 'border-transparent bg-brand text-brand-foreground shadow-lg shadow-brand/30'
                       : 'border-border bg-surface/80 text-muted hover:border-brand/40 hover:bg-brand/5 hover:text-text'
@@ -241,8 +241,10 @@ export default function BudgetsPage() {
                 >
                   <span
                     className={clsx(
-                      'flex h-8 w-8 items-center justify-center rounded-lg bg-white/60 text-brand shadow-inner transition group-hover:scale-105 dark:bg-white/10',
-                      active ? 'bg-white/90 text-brand' : 'text-brand',
+                      'flex h-8 w-8 items-center justify-center rounded-lg text-white transition group-hover:scale-105',
+                      active
+                        ? 'bg-white/20 text-white dark:bg-white/10'
+                        : 'bg-brand/80 text-white/90 shadow-inner group-hover:bg-brand dark:bg-brand/60 dark:text-white'
                     )}
                   >
                     <Icon className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- arrange the budget period filters into a three-column layout so they always appear on a single row
- update the period filter icons to use a consistent white foreground for better contrast

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68da810337e48332ae94b86d1a988130