### PR TITLE
feat: add household management page and context

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,7 @@ import useChallenges from "./hooks/useChallenges.js";
 import AuthGuard from "./components/AuthGuard";
 import AdminGuard from "./components/AdminGuard";
 import { DataProvider } from "./context/DataContext";
+import FamilyPage from "./pages/FamilyPage";
 
 import { supabase } from "./lib/supabase";
 import { syncGuestToCloud } from "./lib/sync";
@@ -51,6 +52,7 @@ import { removeTransaction as apiDelete } from "./lib/api-transactions";
 import CategoryProvider from "./context/CategoryContext";
 import ToastProvider, { useToast } from "./context/ToastContext";
 import UserProfileProvider from "./context/UserProfileContext.jsx";
+import { HouseholdProvider } from "./context/HouseholdContext";
 import { loadSubscriptions, findUpcoming } from "./lib/subscriptions";
 import { allocateIncome } from "./lib/goals";
 import MoneyTalkProvider, {
@@ -1063,8 +1065,9 @@ function AppShell({ prefs, setPrefs }) {
 
   return (
     <CategoryProvider catMeta={catMeta}>
-      <BootGate>
-        <>
+      <HouseholdProvider>
+        <BootGate>
+          <>
           <Routes>
             <Route path="/auth" element={<AuthLogin />} />
             <Route path="/auth/callback" element={<AuthCallback />} />
@@ -1140,6 +1143,7 @@ function AppShell({ prefs, setPrefs }) {
                   element={<Subscriptions categories={data.cat} />}
                 />
                 <Route path="data" element={<DataPage />} />
+                <Route path="family" element={<FamilyPage />} />
                 <Route
                   path="import"
                   element={
@@ -1218,8 +1222,9 @@ function AppShell({ prefs, setPrefs }) {
               });
             }}
           />
-        </>
-      </BootGate>
+          </>
+        </BootGate>
+      </HouseholdProvider>
     </CategoryProvider>
   );
 }

--- a/src/context/HouseholdContext.tsx
+++ b/src/context/HouseholdContext.tsx
@@ -1,0 +1,242 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import {
+  deleteHousehold,
+  getHouseholdContext,
+  inviteByUsername,
+  leaveHousehold,
+  listMembers,
+  removeMember,
+  updateMemberRole,
+  type HouseholdContextInfo,
+  type HouseholdMember,
+  type HouseholdMemberStatus,
+  type HouseholdRole,
+} from '../lib/householdApi';
+import { setHouseholdScopeRuntime } from '../lib/householdScope';
+
+const STORAGE_KEY = 'hw:household-view';
+
+type HouseholdState = {
+  context: HouseholdContextInfo | null;
+  members: HouseholdMember[];
+  loading: boolean;
+  error: Error | null;
+  householdViewEnabled: boolean;
+};
+
+type InvitePayload = {
+  username: string;
+  role: HouseholdRole;
+};
+
+type HouseholdContextValue = {
+  householdId: string | null;
+  householdName: string | null;
+  role: HouseholdRole | null;
+  members: HouseholdMember[];
+  memberUserIds: string[];
+  memberCount: number;
+  loading: boolean;
+  error: Error | null;
+  refresh: () => Promise<void>;
+  invite: (payload: InvitePayload) => Promise<HouseholdMemberStatus>;
+  updateRole: (memberId: string, role: HouseholdRole) => Promise<void>;
+  remove: (memberId: string) => Promise<void>;
+  leave: () => Promise<void>;
+  destroy: () => Promise<void>;
+  householdViewEnabled: boolean;
+  setHouseholdViewEnabled: (value: boolean) => void;
+  isOwner: boolean;
+  isEditor: boolean;
+};
+
+const defaultContextValue: HouseholdContextValue = {
+  householdId: null,
+  householdName: null,
+  role: null,
+  members: [],
+  memberUserIds: [],
+  memberCount: 0,
+  loading: false,
+  error: null,
+  refresh: async () => {},
+  invite: async () => 'pending',
+  updateRole: async () => {},
+  remove: async () => {},
+  leave: async () => {},
+  destroy: async () => {},
+  householdViewEnabled: false,
+  setHouseholdViewEnabled: () => {},
+  isOwner: false,
+  isEditor: false,
+};
+
+const HouseholdContext = createContext<HouseholdContextValue>(defaultContextValue);
+
+export function HouseholdProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<HouseholdState>(() => ({
+    context: null,
+    members: [],
+    loading: true,
+    error: null,
+    householdViewEnabled: (() => {
+      if (typeof window === 'undefined') return false;
+      try {
+        return window.localStorage.getItem(STORAGE_KEY) === '1';
+      } catch {
+        return false;
+      }
+    })(),
+  }));
+  const fetchingRef = useRef(false);
+
+  const load = useCallback(async () => {
+    if (fetchingRef.current) return;
+    fetchingRef.current = true;
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+    try {
+      const context = await getHouseholdContext();
+      if (!context) {
+        setState((prev) => ({
+          ...prev,
+          context: null,
+          members: [],
+          loading: false,
+          error: null,
+        }));
+        return;
+      }
+      const members = await listMembers(context.householdId);
+      setState((prev) => ({
+        ...prev,
+        context,
+        members,
+        loading: false,
+        error: null,
+      }));
+    } catch (error) {
+      setState((prev) => ({
+        ...prev,
+        loading: false,
+        error: error instanceof Error ? error : new Error('Gagal memuat household'),
+      }));
+    } finally {
+      fetchingRef.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    const context = state.context;
+    setHouseholdScopeRuntime({
+      enabled: state.householdViewEnabled,
+      memberUserIds: context?.memberUserIds ?? [],
+      householdId: context?.householdId ?? null,
+      role: context?.role ?? null,
+    });
+  }, [state.context, state.householdViewEnabled]);
+
+  const refresh = useCallback(async () => {
+    await load();
+  }, [load]);
+
+  const setHouseholdViewEnabled = useCallback((value: boolean) => {
+    setState((prev) => ({ ...prev, householdViewEnabled: value }));
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, value ? '1' : '0');
+      } catch {
+        /* ignore */
+      }
+    }
+  }, []);
+
+  const invite = useCallback<HouseholdContextValue['invite']>(
+    async ({ username, role }) => {
+      if (!state.context?.householdId) {
+        throw new Error('Household belum siap.');
+      }
+      const result = await inviteByUsername(state.context.householdId, username, role);
+      await refresh();
+      return result.status;
+    },
+    [refresh, state.context?.householdId],
+  );
+
+  const updateRole = useCallback<HouseholdContextValue['updateRole']>(
+    async (memberId, role) => {
+      await updateMemberRole(memberId, role);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const remove = useCallback<HouseholdContextValue['remove']>(
+    async (memberId) => {
+      await removeMember(memberId);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const leave = useCallback(async () => {
+    await leaveHousehold();
+    await refresh();
+  }, [refresh]);
+
+  const destroy = useCallback(async () => {
+    if (!state.context?.householdId) return;
+    await deleteHousehold(state.context.householdId);
+    await refresh();
+  }, [refresh, state.context?.householdId]);
+
+  const value = useMemo<HouseholdContextValue>(() => {
+    const context = state.context;
+    const role = context?.role ?? null;
+    const memberUserIds = context?.memberUserIds ?? [];
+    const memberCount = context?.memberCount ?? state.members.length;
+    const isOwner = role === 'owner';
+    const isEditor = role === 'editor' || role === 'owner';
+
+    return {
+      householdId: context?.householdId ?? null,
+      householdName: context?.householdName ?? null,
+      role,
+      members: state.members,
+      memberUserIds,
+      memberCount,
+      loading: state.loading,
+      error: state.error,
+      refresh,
+      invite,
+      updateRole,
+      remove,
+      leave,
+      destroy,
+      householdViewEnabled: state.householdViewEnabled,
+      setHouseholdViewEnabled,
+      isOwner,
+      isEditor,
+    };
+  }, [invite, refresh, remove, updateRole, leave, destroy, setHouseholdViewEnabled, state]);
+
+  return <HouseholdContext.Provider value={value}>{children}</HouseholdContext.Provider>;
+}
+
+export function useHousehold(): HouseholdContextValue {
+  return useContext(HouseholdContext);
+}
+
+export { withHouseholdScope } from '../lib/householdScope';

--- a/src/layout/AppTopbar.jsx
+++ b/src/layout/AppTopbar.jsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from "react";
-import { Bell, LogIn, LogOut, Menu, Settings, UserRound } from "lucide-react";
+import clsx from "clsx";
+import { Bell, LogIn, LogOut, Menu, Settings, UserRound, Users } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "../lib/supabase";
+import { useHousehold } from "../context/HouseholdContext";
 
 function getDisplayName(user) {
   if (!user) return "Masuk";
@@ -20,6 +22,12 @@ export default function AppTopbar() {
   const profileButtonRef = useRef(null);
   const navigate = useNavigate();
   const isAuthenticated = Boolean(user);
+  const {
+    householdViewEnabled,
+    setHouseholdViewEnabled,
+    memberCount,
+    householdName,
+  } = useHousehold();
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data }) => {
@@ -87,6 +95,10 @@ export default function AppTopbar() {
     }
   };
 
+  const handleToggleHouseholdView = () => {
+    setHouseholdViewEnabled(!householdViewEnabled);
+  };
+
   return (
     <header className="sticky top-0 z-[65] border-b border-border/70 bg-surface-1/80 backdrop-blur">
       <div className="mx-auto flex h-16 w-full max-w-[1280px] items-center justify-between px-4 sm:px-6 lg:px-8">
@@ -104,6 +116,31 @@ export default function AppTopbar() {
           <span className="text-base font-semibold text-text">HematWoi</span>
         </div>
         <div className="flex items-center gap-2 sm:gap-3">
+          <button
+            type="button"
+            onClick={handleToggleHouseholdView}
+            className={clsx(
+              "inline-flex h-11 items-center justify-center gap-2 rounded-2xl border px-3 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)]",
+              householdViewEnabled
+                ? "border-[color:var(--accent)] bg-[color:var(--accent)]/10 text-[color:var(--accent)]"
+                : "border-border bg-surface-1 text-muted hover:text-text",
+            )}
+            aria-pressed={householdViewEnabled}
+            aria-label="Toggle Household View"
+            title={
+              householdViewEnabled
+                ? `Menampilkan data keluarga${householdName ? ` · ${householdName}` : ''}`
+                : 'Menampilkan data pribadi'
+            }
+          >
+            <Users className="h-4 w-4" />
+            <span className="hidden sm:inline">{householdViewEnabled ? "Keluarga Aktif" : "Data Pribadi"}</span>
+            {householdViewEnabled && (
+              <span className="ml-2 hidden rounded-full bg-[color:var(--accent)] px-2 py-0.5 text-[10px] font-semibold text-white sm:inline">
+                {memberCount}
+              </span>
+            )}
+          </button>
           <button
             type="button"
             className="relative inline-flex h-11 w-11 items-center justify-center rounded-2xl border border-border/70 bg-surface-1 text-text transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background active:scale-95"
@@ -141,6 +178,15 @@ export default function AppTopbar() {
                     >
                       <UserRound className="h-4 w-4" />
                       Profil Saya
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleNavigate("/family")}
+                      className="flex w-full items-center gap-2 px-4 py-2 text-left text-text transition hover:bg-surface-2 focus-visible:outline-none focus-visible:bg-surface-2"
+                      role="menuitem"
+                    >
+                      <Users className="h-4 w-4" />
+                      Keluarga
                     </button>
                     <button
                       type="button"

--- a/src/lib/householdApi.ts
+++ b/src/lib/householdApi.ts
@@ -1,0 +1,261 @@
+import type { PostgrestError } from '@supabase/supabase-js';
+import { supabase } from './supabase';
+
+export type HouseholdRole = 'owner' | 'editor' | 'viewer';
+export type HouseholdMemberStatus = 'pending' | 'accepted';
+
+export interface HouseholdContextInfo {
+  householdId: string;
+  householdName: string | null;
+  role: HouseholdRole;
+  memberUserIds: string[];
+  memberCount: number;
+}
+
+export interface HouseholdMember {
+  id: string;
+  householdId: string;
+  userId: string | null;
+  username: string | null;
+  role: HouseholdRole;
+  status: HouseholdMemberStatus;
+  createdAt: string | null;
+}
+
+interface InviteResult {
+  status: HouseholdMemberStatus;
+  member?: HouseholdMember | null;
+}
+
+function normalizeRole(value: unknown): HouseholdRole {
+  if (value === 'owner' || value === 'editor' || value === 'viewer') {
+    return value;
+  }
+  return 'viewer';
+}
+
+function normalizeStatus(value: unknown): HouseholdMemberStatus {
+  if (value === 'accepted') return 'accepted';
+  return 'pending';
+}
+
+function normalizeUuid(value: unknown): string | null {
+  if (typeof value === 'string' && value) {
+    return value;
+  }
+  return null;
+}
+
+function normalizeUsername(value: unknown): string | null {
+  if (typeof value === 'string' && value.trim()) {
+    return value.trim();
+  }
+  return null;
+}
+
+function toFriendlyError(error: PostgrestError | Error | unknown, fallback: string): Error {
+  if (error && typeof error === 'object') {
+    const postgrest = error as Partial<PostgrestError>;
+    if (typeof postgrest.message === 'string' && postgrest.message.trim()) {
+      return new Error(postgrest.message);
+    }
+    if (typeof postgrest.hint === 'string' && postgrest.hint.trim()) {
+      return new Error(postgrest.hint);
+    }
+    if (typeof postgrest.details === 'string' && postgrest.details.trim()) {
+      return new Error(postgrest.details);
+    }
+  }
+  if (error instanceof Error && error.message) {
+    return error;
+  }
+  return new Error(fallback);
+}
+
+export async function getHouseholdContext(): Promise<HouseholdContextInfo | null> {
+  try {
+    const { data, error } = await supabase.rpc('get_household_context');
+    if (error) throw error;
+    if (!data) return null;
+
+    const payload = Array.isArray(data) ? data[0] : data;
+    if (!payload) return null;
+
+    const householdId = normalizeUuid(payload.household_id ?? payload.householdId ?? payload.id);
+    if (!householdId) return null;
+
+    const memberUserIds: string[] = Array.isArray(payload.member_user_ids ?? payload.memberUserIds)
+      ? (payload.member_user_ids ?? payload.memberUserIds).map((item: unknown) =>
+          typeof item === 'string' ? item : item ? String(item) : '',
+        )
+      : [];
+
+    const cleanedMemberIds = memberUserIds.filter(Boolean);
+
+    return {
+      householdId,
+      householdName:
+        typeof payload.household_name === 'string'
+          ? payload.household_name
+          : typeof payload.householdName === 'string'
+            ? payload.householdName
+            : typeof payload.name === 'string'
+              ? payload.name
+              : null,
+      role: normalizeRole(payload.role),
+      memberUserIds: cleanedMemberIds,
+      memberCount:
+        typeof payload.member_count === 'number' && Number.isFinite(payload.member_count)
+          ? payload.member_count
+          : cleanedMemberIds.length,
+    };
+  } catch (error) {
+    throw toFriendlyError(error, 'Gagal memuat data household.');
+  }
+}
+
+async function fetchMembersFrom(table: string, householdId: string) {
+  const { data, error } = await supabase
+    .from(table)
+    .select('id, household_id, user_id, username, role, status, created_at')
+    .eq('household_id', householdId)
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw error;
+  }
+
+  if (!data) return [];
+
+  return data.map((row: any) => ({
+    id: String(row.id ?? row.member_id ?? crypto.randomUUID?.() ?? Math.random().toString(36).slice(2)),
+    householdId: String(row.household_id ?? householdId),
+    userId: normalizeUuid(row.user_id ?? row.member_user_id ?? row.userId),
+    username: normalizeUsername(row.username ?? row.member_username),
+    role: normalizeRole(row.role),
+    status: normalizeStatus(row.status),
+    createdAt: typeof row.created_at === 'string' ? row.created_at : null,
+  }));
+}
+
+export async function listMembers(householdId: string): Promise<HouseholdMember[]> {
+  if (!householdId) return [];
+  try {
+    const fromView = await fetchMembersFrom('household_members_view', householdId);
+    if (fromView) {
+      return fromView;
+    }
+  } catch (error) {
+    if ((error as PostgrestError)?.code !== 'PGRST116') {
+      throw toFriendlyError(error, 'Gagal memuat anggota household.');
+    }
+  }
+
+  try {
+    const fallback = await fetchMembersFrom('household_members', householdId);
+    if (fallback) {
+      return fallback;
+    }
+  } catch (error) {
+    throw toFriendlyError(error, 'Gagal memuat anggota household.');
+  }
+
+  return [];
+}
+
+export async function inviteByUsername(
+  householdId: string,
+  username: string,
+  role: HouseholdRole,
+): Promise<InviteResult> {
+  if (!householdId) {
+    throw new Error('Household belum dipilih.');
+  }
+  if (!username) {
+    throw new Error('Username wajib diisi.');
+  }
+  try {
+    const normalizedUsername = username.trim().toLowerCase();
+    const { data, error } = await supabase.rpc('create_or_invite_member_by_username', {
+      household_id: householdId,
+      username: normalizedUsername,
+      role,
+    });
+    if (error) throw error;
+
+    const payload = Array.isArray(data) ? data[0] : data;
+    const status = normalizeStatus(payload?.status);
+    let member: HouseholdMember | null = null;
+    if (payload) {
+      member = {
+        id: normalizeUuid(payload.id) ?? crypto.randomUUID?.() ?? Math.random().toString(36).slice(2),
+        householdId,
+        userId: normalizeUuid(payload.user_id),
+        username: normalizeUsername(payload.username) ?? normalizedUsername,
+        role: normalizeRole(payload.role ?? role),
+        status,
+        createdAt: typeof payload.created_at === 'string' ? payload.created_at : null,
+      };
+    }
+
+    return { status, member };
+  } catch (error) {
+    throw toFriendlyError(error, 'Gagal mengundang anggota.');
+  }
+}
+
+export async function updateMemberRole(memberId: string, role: HouseholdRole): Promise<void> {
+  if (!memberId) {
+    throw new Error('Anggota tidak ditemukan.');
+  }
+  try {
+    const { error } = await supabase
+      .from('household_members')
+      .update({ role })
+      .eq('id', memberId);
+    if (error) throw error;
+  } catch (error) {
+    throw toFriendlyError(error, 'Gagal memperbarui peran anggota.');
+  }
+}
+
+export async function removeMember(memberId: string): Promise<void> {
+  if (!memberId) {
+    throw new Error('Anggota tidak ditemukan.');
+  }
+  try {
+    const { error } = await supabase
+      .from('household_members')
+      .delete()
+      .eq('id', memberId);
+    if (error) throw error;
+  } catch (error) {
+    throw toFriendlyError(error, 'Gagal menghapus anggota.');
+  }
+}
+
+export async function leaveHousehold(): Promise<void> {
+  try {
+    const { error } = await supabase.rpc('leave_household');
+    if (error) throw error;
+  } catch (error) {
+    throw toFriendlyError(error, 'Gagal keluar dari household.');
+  }
+}
+
+export async function deleteHousehold(householdId: string): Promise<void> {
+  if (!householdId) {
+    throw new Error('Household tidak ditemukan.');
+  }
+  try {
+    const { error } = await supabase.rpc('delete_household', {
+      household_id: householdId,
+    });
+    if (error) throw error;
+  } catch (error) {
+    throw toFriendlyError(error, 'Gagal menghapus household.');
+  }
+}

--- a/src/lib/householdScope.ts
+++ b/src/lib/householdScope.ts
@@ -1,0 +1,47 @@
+import type { PostgrestFilterBuilder } from '@supabase/supabase-js';
+import type { HouseholdRole } from './householdApi';
+
+export type HouseholdScopeRuntime = {
+  enabled: boolean;
+  memberUserIds: string[];
+  householdId: string | null;
+  role: HouseholdRole | null;
+};
+
+let runtimeState: HouseholdScopeRuntime = {
+  enabled: false,
+  memberUserIds: [],
+  householdId: null,
+  role: null,
+};
+
+export function setHouseholdScopeRuntime(next: HouseholdScopeRuntime) {
+  runtimeState = {
+    enabled: Boolean(next.enabled),
+    memberUserIds: Array.from(new Set(next.memberUserIds ?? [])).filter(Boolean),
+    householdId: next.householdId ?? null,
+    role: next.role ?? null,
+  };
+}
+
+export function getHouseholdScopeRuntime(): HouseholdScopeRuntime {
+  return runtimeState;
+}
+
+export function withHouseholdScope<T extends PostgrestFilterBuilder<any, any, any>>(
+  query: T,
+  memberUserIds: string[],
+  enabled: boolean,
+  currentUserId?: string | null,
+): T {
+  if (!enabled || memberUserIds.length === 0) {
+    if (currentUserId) {
+      return query.eq('user_id', currentUserId) as T;
+    }
+    return query;
+  }
+  const scopedIds = currentUserId
+    ? Array.from(new Set([...memberUserIds, currentUserId])).filter(Boolean)
+    : memberUserIds;
+  return query.in('user_id', scopedIds) as T;
+}

--- a/src/pages/FamilyPage.tsx
+++ b/src/pages/FamilyPage.tsx
@@ -1,0 +1,493 @@
+import { FormEvent, useMemo, useState } from 'react';
+import clsx from 'clsx';
+import { useHousehold } from '../context/HouseholdContext';
+import { useToast } from '../context/ToastContext';
+
+const ROLE_OPTIONS = [
+  { value: 'owner', label: 'Pemilik' },
+  { value: 'editor', label: 'Editor' },
+  { value: 'viewer', label: 'Viewer' },
+] as const;
+
+type RoleValue = (typeof ROLE_OPTIONS)[number]['value'];
+
+type SubmitState = 'idle' | 'loading' | 'success' | 'error';
+
+function IconPlus({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth={1.75}
+      className={className}
+      aria-hidden="true"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 5v14M5 12h14" />
+    </svg>
+  );
+}
+
+function IconUsers({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth={1.75}
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M16 11c1.657 0 3-1.79 3-4s-1.343-4-3-4-3 1.79-3 4 1.343 4 3 4Zm-8 0c1.657 0 3-1.79 3-4S9.657 3 8 3 5 4.79 5 7s1.343 4 3 4Z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3 21v-1a5 5 0 0 1 5-5h0a5 5 0 0 1 5 5v1m3 0v-1c0-1.657 1.79-3 4-3h0c2.21 0 4 1.343 4 3v1"
+      />
+    </svg>
+  );
+}
+
+function IconCrown({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth={1.75}
+      className={className}
+      aria-hidden="true"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="m3 9 3 3 3-6 3 6 3-6 3 6 3-3v12H3z" />
+    </svg>
+  );
+}
+
+function IconShield({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth={1.75}
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 3 4.5 6v6c0 5.25 3.75 8.4 7.5 9 3.75-.6 7.5-3.75 7.5-9V6L12 3Z"
+      />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9.5 12.25 11 14l3.5-4" />
+    </svg>
+  );
+}
+
+function IconTrash({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth={1.75}
+      className={className}
+      aria-hidden="true"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M5 7h14M10 3h4a1 1 0 0 1 1 1v2H9V4a1 1 0 0 1 1-1Zm9 4-1 13a1 1 0 0 1-1 .9H8a1 1 0 0 1-1-.9L6 7m5 4v6m4-6v6" />
+    </svg>
+  );
+}
+
+function IconPencil({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth={1.75}
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m4 17 4 4 13-13-4-4L4 17Zm0 0v4h4"
+      />
+    </svg>
+  );
+}
+
+function formatStatus(status: string) {
+  if (status === 'accepted') return 'Aktif';
+  if (status === 'pending') return 'Menunggu';
+  return status;
+}
+
+function validateUsername(value: string): string | null {
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed.length < 3 || trimmed.length > 20) {
+    return 'Username harus 3-20 karakter.';
+  }
+  if (!/^[a-z0-9_]+$/.test(trimmed)) {
+    return 'Gunakan huruf kecil, angka, atau underscore.';
+  }
+  return null;
+}
+
+export default function FamilyPage() {
+  const {
+    members,
+    memberCount,
+    householdId,
+    householdName,
+    loading,
+    error,
+    invite,
+    updateRole,
+    remove,
+    leave,
+    destroy,
+    isOwner,
+    isEditor,
+  } = useHousehold();
+  const { addToast } = useToast();
+  const [username, setUsername] = useState('');
+  const [role, setRole] = useState<RoleValue>('viewer');
+  const [usernameError, setUsernameError] = useState<string | null>(null);
+  const [submitState, setSubmitState] = useState<SubmitState>('idle');
+
+  const canInvite = Boolean(householdId) && isOwner;
+  const canManageRoles = isOwner;
+  const canRemoveMembers = isOwner;
+  const canLeave = Boolean(householdId) && !isOwner;
+
+  const acceptedMembers = useMemo(() => members.filter((member) => member.status === 'accepted'), [members]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canInvite) return;
+    const validationMessage = validateUsername(username);
+    if (validationMessage) {
+      setUsernameError(validationMessage);
+      return;
+    }
+    setUsernameError(null);
+    setSubmitState('loading');
+    try {
+      const status = await invite({ username: username.trim().toLowerCase(), role });
+      setSubmitState('success');
+      setUsername('');
+      setRole('viewer');
+      addToast({
+        id: 'invite-success',
+        type: 'success',
+        message:
+          status === 'accepted'
+            ? 'Undangan berhasil. Anggota langsung bergabung.'
+            : 'Undangan dikirim. Menunggu pengguna membuat username tersebut.',
+      });
+    } catch (submitError) {
+      setSubmitState('error');
+      const message =
+        submitError instanceof Error ? submitError.message : 'Gagal mengirim undangan. Coba lagi.';
+      addToast({ id: 'invite-error', type: 'error', message });
+    } finally {
+      setTimeout(() => setSubmitState('idle'), 1200);
+    }
+  };
+
+  const handleRoleChange = async (memberId: string, nextRole: RoleValue) => {
+    if (!canManageRoles) return;
+    try {
+      await updateRole(memberId, nextRole);
+      addToast({ id: `role-${memberId}`, type: 'success', message: 'Peran anggota diperbarui.' });
+    } catch (updateError) {
+      const message =
+        updateError instanceof Error ? updateError.message : 'Gagal memperbarui peran. Coba lagi.';
+      addToast({ id: `role-error-${memberId}`, type: 'error', message });
+    }
+  };
+
+  const handleRemove = async (memberId: string) => {
+    if (!canRemoveMembers) return;
+    try {
+      await remove(memberId);
+      addToast({ id: `remove-${memberId}`, type: 'success', message: 'Anggota dihapus.' });
+    } catch (removeError) {
+      const message =
+        removeError instanceof Error ? removeError.message : 'Gagal menghapus anggota. Coba lagi.';
+      addToast({ id: `remove-error-${memberId}`, type: 'error', message });
+    }
+  };
+
+  const handleLeave = async () => {
+    if (!canLeave) return;
+    try {
+      await leave();
+      addToast({ id: 'leave-household', type: 'success', message: 'Berhasil keluar dari household.' });
+    } catch (leaveError) {
+      const message =
+        leaveError instanceof Error ? leaveError.message : 'Gagal keluar household. Coba lagi.';
+      addToast({ id: 'leave-household-error', type: 'error', message });
+    }
+  };
+
+  const handleDeleteHousehold = async () => {
+    if (!isOwner || !householdId) return;
+    const confirmed = window.confirm('Hapus household ini? Semua anggota akan diputus.');
+    if (!confirmed) return;
+    try {
+      await destroy();
+      addToast({ id: 'delete-household', type: 'success', message: 'Household dihapus.' });
+    } catch (deleteError) {
+      const message =
+        deleteError instanceof Error ? deleteError.message : 'Gagal menghapus household. Coba lagi.';
+      addToast({ id: 'delete-household-error', type: 'error', message });
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <div className="inline-flex items-center gap-2">
+            <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Keluarga</h1>
+            <span className="inline-flex items-center rounded-full border border-brand/50 bg-brand/10 px-3 py-1 text-xs font-medium text-brand">
+              Household Aktif
+            </span>
+          </div>
+          <p className="mt-2 max-w-2xl text-sm text-muted">
+            Kelola anggota yang dapat berbagi data keuanganmu. Undang anggota baru menggunakan username mereka.
+          </p>
+        </div>
+        {canLeave && (
+          <button
+            type="button"
+            onClick={handleLeave}
+            className="inline-flex h-11 items-center justify-center rounded-2xl border border-border bg-surface-2 px-4 text-sm font-semibold text-text transition hover:bg-surface-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)]"
+          >
+            Keluar Household
+          </button>
+        )}
+      </header>
+
+      <section className="grid gap-6 rounded-3xl border border-border/60 bg-surface-1 p-6 shadow-sm sm:grid-cols-[1.2fr_1fr]">
+        <div className="space-y-6">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <p className="text-sm font-medium text-muted">Nama household</p>
+              <p className="text-lg font-semibold text-text">{householdName ?? 'Tanpa nama'}</p>
+            </div>
+            <div className="flex items-center gap-2 rounded-2xl border border-border bg-surface-2 px-4 py-2 text-sm text-muted">
+              <IconUsers className="h-5 w-5" />
+              <span>{memberCount} anggota</span>
+            </div>
+          </div>
+          <div className="rounded-3xl border border-dashed border-border/60 bg-surface-2 p-5">
+            <div className="flex items-center gap-3">
+              <IconPlus className="h-5 w-5 text-accent" />
+              <h2 className="text-base font-semibold text-text">Undang via Username</h2>
+            </div>
+            <p className="mt-2 text-sm text-muted">
+              Masukkan username HematWoi (huruf kecil, angka, underscore) untuk mengundang anggota baru.
+            </p>
+            <form className="mt-5 space-y-4" onSubmit={handleSubmit}>
+              <div className="space-y-2">
+                <label htmlFor="invite-username" className="text-sm font-medium text-text">
+                  Username
+                </label>
+                <input
+                  id="invite-username"
+                  type="text"
+                  inputMode="latin"
+                  autoCapitalize="none"
+                  autoCorrect="off"
+                  spellCheck={false}
+                  className="h-11 w-full rounded-2xl border-0 bg-surface-1 px-4 text-sm text-text shadow-inner ring-2 ring-slate-800 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+                  value={username}
+                  onChange={(event) => {
+                    setUsername(event.target.value.toLowerCase());
+                    if (usernameError) {
+                      setUsernameError(null);
+                    }
+                  }}
+                  disabled={!canInvite || submitState === 'loading'}
+                  aria-invalid={Boolean(usernameError)}
+                  aria-describedby={usernameError ? 'invite-username-error' : undefined}
+                  placeholder="contoh: hematwoi_user"
+                />
+                {usernameError && (
+                  <p id="invite-username-error" className="text-sm text-danger">
+                    {usernameError}
+                  </p>
+                )}
+              </div>
+              <div className="space-y-2">
+                <span className="text-sm font-medium text-text">Peran</span>
+                <div className="flex flex-wrap gap-2">
+                  {ROLE_OPTIONS.map((option) => {
+                    const active = role === option.value;
+                    return (
+                      <button
+                        key={option.value}
+                        type="button"
+                        className={clsx(
+                          'inline-flex min-h-[44px] min-w-[88px] items-center justify-center rounded-2xl border px-4 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)]',
+                          active
+                            ? 'border-[color:var(--accent)] bg-[color:var(--accent)]/10 text-[color:var(--accent)]'
+                            : 'border-border bg-surface-1 text-muted hover:border-[color:var(--accent)]/60 hover:text-text',
+                        )}
+                        onClick={() => setRole(option.value)}
+                        disabled={!canInvite || submitState === 'loading'}
+                      >
+                        {option.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+              <button
+                type="submit"
+                className="inline-flex min-h-[44px] min-w-[120px] items-center justify-center gap-2 rounded-2xl bg-[color:var(--accent)] px-5 text-sm font-semibold text-white shadow transition hover:bg-[color:var(--accent)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-1"
+                disabled={!canInvite || submitState === 'loading'}
+                aria-disabled={!canInvite || submitState === 'loading'}
+              >
+                <IconPlus className="h-4 w-4" />
+                Undang
+              </button>
+              {!canInvite && (
+                <p className="text-sm text-muted">
+                  Hanya pemilik household yang dapat mengirim undangan.
+                </p>
+              )}
+            </form>
+          </div>
+        </div>
+        <aside className="space-y-4 rounded-3xl border border-border/60 bg-surface-2 p-5">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-muted">Status Household</h3>
+          <dl className="grid gap-3 text-sm text-muted">
+            <div className="flex items-center justify-between">
+              <dt>Anggota aktif</dt>
+              <dd className="font-semibold text-text">{acceptedMembers.length}</dd>
+            </div>
+            <div className="flex items-center justify-between">
+              <dt>Undangan pending</dt>
+              <dd className="font-semibold text-text">{memberCount - acceptedMembers.length}</dd>
+            </div>
+          </dl>
+          {isOwner && (
+            <button
+              type="button"
+              onClick={handleDeleteHousehold}
+              className="mt-4 inline-flex h-11 w-full items-center justify-center gap-2 rounded-2xl border border-danger/30 bg-danger/10 text-sm font-semibold text-danger transition hover:border-danger/50 hover:bg-danger/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger/40"
+            >
+              <IconTrash className="h-4 w-4" /> Hapus Household
+            </button>
+          )}
+        </aside>
+      </section>
+
+      <section className="rounded-3xl border border-border/60 bg-surface-1 p-6 shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold text-text">Anggota</h2>
+            <p className="text-sm text-muted">Kelola peran dan status anggota household.</p>
+          </div>
+        </div>
+        {loading ? (
+          <div className="mt-6 space-y-3">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <div key={index} className="h-14 w-full animate-pulse rounded-2xl bg-border/50" />
+            ))}
+          </div>
+        ) : members.length === 0 ? (
+          <div className="mt-6 rounded-3xl border border-dashed border-border/60 bg-surface-2 p-6 text-center text-sm text-muted">
+            Belum ada anggota lain. Undang anggota via username.
+          </div>
+        ) : (
+          <div className="mt-6 overflow-x-auto">
+            <table className="min-w-full divide-y divide-border/60 text-sm">
+              <thead className="text-left text-xs uppercase tracking-wide text-muted">
+                <tr>
+                  <th className="px-3 py-2">Username</th>
+                  <th className="px-3 py-2">Peran</th>
+                  <th className="px-3 py-2">Status</th>
+                  <th className="px-3 py-2 text-right">Aksi</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/60">
+                {members.map((member) => {
+                  const roleLabel = ROLE_OPTIONS.find((item) => item.value === member.role)?.label ?? member.role;
+                  return (
+                    <tr key={member.id} className="transition hover:bg-surface-2">
+                      <td className="px-3 py-3 font-medium text-text">{member.username ?? 'Belum tersedia'}</td>
+                      <td className="px-3 py-3">
+                        {canManageRoles ? (
+                          <div className="relative inline-flex items-center">
+                            <select
+                              className="h-10 rounded-2xl border border-border bg-surface-1 px-3 pr-9 text-sm text-text focus:outline-none focus:ring-2 focus:ring-[color:var(--accent)]"
+                              value={member.role}
+                              onChange={(event) => handleRoleChange(member.id, event.target.value as RoleValue)}
+                              disabled={!isOwner || member.status !== 'accepted'}
+                              aria-label={`Ubah peran ${member.username ?? 'anggota'}`}
+                            >
+                              {ROLE_OPTIONS.map((option) => (
+                                <option key={option.value} value={option.value}>
+                                  {option.label}
+                                </option>
+                              ))}
+                            </select>
+                            <span className="pointer-events-none absolute right-3 text-muted">▾</span>
+                          </div>
+                        ) : (
+                          <span className="inline-flex items-center gap-2 rounded-full border border-border px-3 py-1 text-xs font-medium text-text">
+                            {member.role === 'owner' ? <IconCrown className="h-4 w-4" /> : <IconShield className="h-4 w-4" />}
+                            {roleLabel}
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-3 py-3 text-muted">{formatStatus(member.status)}</td>
+                      <td className="px-3 py-3">
+                        <div className="flex items-center justify-end gap-2">
+                          {canManageRoles && member.status === 'accepted' && (
+                            <button
+                              type="button"
+                              onClick={() => handleRoleChange(member.id, member.role)}
+                              className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-border bg-surface-1 text-muted transition hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)]"
+                              aria-label={`Segarkan peran ${member.username ?? 'anggota'}`}
+                            >
+                              <IconPencil className="h-4 w-4" />
+                            </button>
+                          )}
+                          {canRemoveMembers && member.role !== 'owner' && (
+                            <button
+                              type="button"
+                              onClick={() => handleRemove(member.id)}
+                              className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-danger/40 bg-danger/10 text-danger transition hover:border-danger/60 hover:bg-danger/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger/40"
+                              aria-label={`Hapus ${member.username ?? 'anggota'}`}
+                            >
+                              <IconTrash className="h-4 w-4" />
+                            </button>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+        {error && (
+          <div className="mt-6 rounded-2xl border border-danger/40 bg-danger/10 p-4 text-sm text-danger">
+            {error.message}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add front-end household API helpers and runtime scope state for username-based invites
- add household provider, navbar toggle, and routing to new family management page
- implement family page UI with invite form, member table, and ownership actions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da8bd248588332911c450cb98bd6ae