### PR TITLE
Add router entry for mobile Google auth callback

### DIFF
--- a/src/router/nav.config.tsx
+++ b/src/router/nav.config.tsx
@@ -149,4 +149,10 @@ export const NAV_ITEMS: NavItem[] = [
     inSidebar: false,
     protected: false,
   },
+  {
+    title: 'Auth Mobile Google',
+    path: '/auth/mobile/google',
+    inSidebar: false,
+    protected: false,
+  },
 ];

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -38,6 +38,8 @@ function loadComponent(path: string) {
       return lazy(() => import('../pages/Profile'));
     case '/auth':
       return lazy(() => import('../pages/AuthLogin'));
+    case '/auth/mobile/google':
+      return lazy(() => import('../pages/mobile/google'));
     default:
       return lazy(() => import('../pages/Dashboard'));
   }


### PR DESCRIPTION
## Summary
- register the /auth/mobile/google path in the router so it loads the mobile callback component
- add a nav configuration entry to ensure the route is recognized without appearing in the sidebar

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68da976486ec833284eaf912aa8f6093