### PR TITLE
feat: add household sharing management

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,10 +31,12 @@ import AuthLogin from "./pages/AuthLogin";
 import AdminPage from "./pages/AdminPage";
 import ChallengesPage from "./pages/Challenges.jsx";
 import WishlistPage from "./pages/WishlistPage";
+import FamilyPage from "./pages/FamilyPage";
 import useChallenges from "./hooks/useChallenges.js";
 import AuthGuard from "./components/AuthGuard";
 import AdminGuard from "./components/AdminGuard";
 import { DataProvider } from "./context/DataContext";
+import { HouseholdProvider } from "./context/HouseholdContext";
 
 import { supabase } from "./lib/supabase";
 import { syncGuestToCloud } from "./lib/sync";
@@ -1162,6 +1164,7 @@ function AppShell({ prefs, setPrefs }) {
                   element={<Navigate to="/transaction/add" replace />}
                 />
                 <Route path="settings" element={<SettingsPage />} />
+                <Route path="family" element={<FamilyPage />} />
                 <Route
                   path="admin"
                   element={
@@ -1261,9 +1264,11 @@ export default function App() {
     <ModeProvider>
       <UserProfileProvider>
         <ToastProvider>
-          <DataProvider>
-            <AppContent />
-          </DataProvider>
+          <HouseholdProvider>
+            <DataProvider>
+              <AppContent />
+            </DataProvider>
+          </HouseholdProvider>
         </ToastProvider>
       </UserProfileProvider>
     </ModeProvider>

--- a/src/context/HouseholdContext.tsx
+++ b/src/context/HouseholdContext.tsx
@@ -1,0 +1,117 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  getHouseholdContext,
+  type HouseholdMember,
+  type HouseholdRole,
+  type HouseholdSummary,
+} from '../lib/householdApi';
+import { setHouseholdScopeSnapshot } from '../lib/householdScope';
+
+interface HouseholdCtx {
+  loading: boolean;
+  error: Error | null;
+  householdId: string | null;
+  householdName: string | null;
+  role: HouseholdRole | null;
+  members: HouseholdMember[];
+  householdViewEnabled: boolean;
+  toggleHouseholdView(enabled: boolean): void;
+  refresh(): void;
+  memberUserIds: string[];
+  currentUserId: string | null;
+}
+
+const STORAGE_KEY = 'hw:household:view';
+
+const HouseholdContext = createContext<HouseholdCtx | undefined>(undefined);
+
+interface ProviderProps {
+  children: ReactNode;
+}
+
+export function HouseholdProvider({ children }: ProviderProps) {
+  const queryClient = useQueryClient();
+  const [storedEnabled, setStoredEnabled] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      return raw === 'true';
+    } catch {
+      return false;
+    }
+  });
+
+  const { data, isLoading, error, refetch, isFetching } = useQuery<HouseholdSummary>({
+    queryKey: ['household-context'],
+    queryFn: getHouseholdContext,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const householdId = data?.householdId ?? null;
+  const memberUserIds = data?.memberUserIds ?? [];
+  const currentUserId = data?.currentUserId ?? null;
+
+  const enableToggle = storedEnabled && Boolean(householdId);
+
+  useEffect(() => {
+    setHouseholdScopeSnapshot(data, enableToggle);
+  }, [data, enableToggle]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, String(storedEnabled));
+    } catch {
+      /* ignore */
+    }
+  }, [storedEnabled]);
+
+  const toggleHouseholdView = useCallback(
+    (enabled: boolean) => {
+      setStoredEnabled(enabled);
+      queryClient.invalidateQueries({ queryKey: ['household-context'] }).catch(() => {
+        /* noop */
+      });
+    },
+    [queryClient],
+  );
+
+  const value = useMemo<HouseholdCtx>(() => ({
+    loading: isLoading || isFetching,
+    error: error instanceof Error ? error : null,
+    householdId,
+    householdName: data?.householdName ?? null,
+    role: data?.role ?? null,
+    members: data?.members ?? [],
+    householdViewEnabled: enableToggle,
+    toggleHouseholdView,
+    refresh: () => {
+      void refetch();
+    },
+    memberUserIds,
+    currentUserId,
+  }), [
+    isLoading,
+    isFetching,
+    error,
+    householdId,
+    data?.householdName,
+    data?.role,
+    data?.members,
+    enableToggle,
+    toggleHouseholdView,
+    refetch,
+    memberUserIds,
+    currentUserId,
+  ]);
+
+  return <HouseholdContext.Provider value={value}>{children}</HouseholdContext.Provider>;
+}
+
+export function useHousehold() {
+  const ctx = useContext(HouseholdContext);
+  if (!ctx) throw new Error('useHousehold must be used within HouseholdProvider');
+  return ctx;
+}

--- a/src/layout/AppTopbar.jsx
+++ b/src/layout/AppTopbar.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { Bell, LogIn, LogOut, Menu, Settings, UserRound } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "../lib/supabase";
+import { useHousehold } from "../context/HouseholdContext";
 
 function getDisplayName(user) {
   if (!user) return "Masuk";
@@ -20,6 +21,13 @@ export default function AppTopbar() {
   const profileButtonRef = useRef(null);
   const navigate = useNavigate();
   const isAuthenticated = Boolean(user);
+  const {
+    householdViewEnabled,
+    toggleHouseholdView,
+    householdId,
+    householdName,
+  } = useHousehold();
+  const householdToggleAvailable = Boolean(householdId);
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data }) => {
@@ -104,6 +112,38 @@ export default function AppTopbar() {
           <span className="text-base font-semibold text-text">HematWoi</span>
         </div>
         <div className="flex items-center gap-2 sm:gap-3">
+          {householdToggleAvailable && (
+            <button
+              type="button"
+              onClick={() => toggleHouseholdView(!householdViewEnabled)}
+              role="switch"
+              aria-checked={householdViewEnabled}
+              aria-label={
+                householdViewEnabled
+                  ? "Matikan tampilan data keluarga"
+                  : "Tampilkan data keluarga"
+              }
+              className="group inline-flex h-11 items-center gap-2 rounded-2xl border border-border/70 bg-surface-1 px-3 text-sm font-medium text-text shadow-sm transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background active:scale-95"
+            >
+              <span className="hidden text-xs font-semibold uppercase tracking-wide text-muted sm:inline">
+                {householdName ? `Keluarga • ${householdName}` : "Data Keluarga"}
+              </span>
+              <span className="inline-flex items-center gap-1 text-xs font-semibold text-muted sm:hidden">
+                Keluarga
+              </span>
+              <span
+                className={`relative inline-flex h-6 w-11 items-center rounded-full border border-border/70 transition-colors duration-200 ${
+                  householdViewEnabled ? 'bg-brand/80' : 'bg-surface-2'
+                }`}
+              >
+                <span
+                  className={`ml-1 inline-flex h-4 w-4 transform rounded-full bg-background transition-transform duration-200 ${
+                    householdViewEnabled ? 'translate-x-5' : 'translate-x-0'
+                  }`}
+                />
+              </span>
+            </button>
+          )}
           <button
             type="button"
             className="relative inline-flex h-11 w-11 items-center justify-center rounded-2xl border border-border/70 bg-surface-1 text-text transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background active:scale-95"

--- a/src/layout/PageHeader.jsx
+++ b/src/layout/PageHeader.jsx
@@ -1,6 +1,8 @@
 import Breadcrumbs from "./Breadcrumbs";
+import { useHousehold } from "../context/HouseholdContext";
 
 export default function PageHeader({ title, description, children }) {
+  const { householdViewEnabled } = useHousehold();
   return (
     <div className="mb-[var(--section-y)] min-w-0">
       <Breadcrumbs />
@@ -9,6 +11,12 @@ export default function PageHeader({ title, description, children }) {
           <h1 className="text-xl font-bold text-text">
             {title}
           </h1>
+          {householdViewEnabled && (
+            <span className="mt-1 inline-flex items-center gap-1 rounded-full border border-brand/40 bg-brand/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-brand">
+              <span className="h-2 w-2 rounded-full bg-brand" aria-hidden="true" />
+              Keluarga Aktif
+            </span>
+          )}
           {description && (
             <p className="text-sm text-muted">
               {description}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,6 @@
 import type { PostgrestError } from '@supabase/supabase-js';
 import { supabase } from './supabase';
+import { applyHouseholdScope } from './householdApi';
 
 export type AccountType = 'cash' | 'bank' | 'ewallet' | 'other';
 
@@ -79,11 +80,13 @@ function toUserMessage(error: unknown, fallback: string): string {
 }
 
 export async function listAccounts(userId: string): Promise<AccountRecord[]> {
-  const { data, error } = await supabase
+  let query = supabase
     .from('accounts')
     .select('id,name,type,currency,created_at,user_id')
-    .eq('user_id', userId)
     .order('created_at', { ascending: false });
+  query = applyHouseholdScope(query, userId);
+
+  const { data, error } = await query;
 
   if (error) {
     throw new Error(toUserMessage(error, 'Gagal memuat akun.'));

--- a/src/lib/householdApi.ts
+++ b/src/lib/householdApi.ts
@@ -1,0 +1,236 @@
+import type { PostgrestError } from '@supabase/supabase-js';
+import type { PostgrestFilterBuilder } from '@supabase/postgrest-js';
+import { supabase } from './supabase';
+import { getCurrentUserId } from './session';
+import { getHouseholdScopeSnapshot } from './householdScope';
+
+export type HouseholdRole = 'owner' | 'editor' | 'viewer';
+export type HouseholdStatus = 'accepted' | 'pending' | 'revoked';
+
+export interface HouseholdMember {
+  id: string;
+  userId: string | null;
+  username: string | null;
+  role: HouseholdRole;
+  status: HouseholdStatus;
+  invitedAt: string | null;
+  joinedAt: string | null;
+}
+
+export interface HouseholdSummary {
+  householdId: string | null;
+  householdName: string | null;
+  role: HouseholdRole | null;
+  members: HouseholdMember[];
+  memberUserIds: string[];
+  currentUserId: string | null;
+}
+
+function toFriendlyError(error: unknown, fallback: string): Error {
+  if (error instanceof Error) {
+    return new Error(error.message);
+  }
+  if (error && typeof error === 'object') {
+    const typed = error as Partial<PostgrestError>;
+    if (typed.message) {
+      return new Error(typed.message);
+    }
+  }
+  return new Error(fallback);
+}
+
+async function fetchHouseholdMembers(householdId: string): Promise<HouseholdMember[]> {
+  if (!householdId) return [];
+  const { data, error } = await supabase
+    .from('household_members')
+    .select('id, household_id, user_id, username, role, status, created_at, accepted_at, updated_at')
+    .eq('household_id', householdId)
+    .order('created_at', { ascending: true });
+  if (error) {
+    throw toFriendlyError(error, 'Gagal memuat anggota rumah tangga.');
+  }
+
+  const rows = data ?? [];
+  const userIds = rows
+    .map((row) => row.user_id as string | null)
+    .filter((value): value is string => Boolean(value));
+
+  let profileMap = new Map<string, string | null>();
+  if (userIds.length > 0) {
+    const { data: profileRows, error: profileError } = await supabase
+      .from('user_profiles')
+      .select('id, username')
+      .in('id', userIds);
+    if (!profileError && Array.isArray(profileRows)) {
+      profileMap = new Map(
+        profileRows.map((row) => [String(row.id), row.username ? String(row.username) : null]),
+      );
+    }
+  }
+
+  return rows.map((row) => ({
+    id: String(row.id),
+    userId: row.user_id ? String(row.user_id) : null,
+    username:
+      typeof row.username === 'string' && row.username.trim()
+        ? row.username.trim()
+        : row.user_id && profileMap.get(String(row.user_id))
+          ? profileMap.get(String(row.user_id)) ?? null
+          : null,
+    role: (row.role as HouseholdRole) ?? 'viewer',
+    status: (row.status as HouseholdStatus) ?? 'pending',
+    invitedAt: row.created_at ?? null,
+    joinedAt: row.accepted_at ?? row.updated_at ?? null,
+  }));
+}
+
+export async function getHouseholdContext(): Promise<HouseholdSummary> {
+  const userId = await getCurrentUserId();
+  if (!userId) {
+    return {
+      householdId: null,
+      householdName: null,
+      role: null,
+      members: [],
+      memberUserIds: [],
+      currentUserId: null,
+    };
+  }
+
+  const { data: membership, error: membershipError } = await supabase
+    .from('household_members')
+    .select('household_id, role, status')
+    .eq('user_id', userId)
+    .order('accepted_at', { ascending: false, nullsFirst: false })
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (membershipError && membershipError.code !== 'PGRST116') {
+    throw toFriendlyError(membershipError, 'Gagal memuat data household.');
+  }
+
+  const householdId = membership?.household_id ? String(membership.household_id) : null;
+  if (!householdId) {
+    return {
+      householdId: null,
+      householdName: null,
+      role: null,
+      members: [],
+      memberUserIds: [userId],
+      currentUserId: userId,
+    };
+  }
+
+  const [householdRow, members] = await Promise.all([
+    supabase.from('households').select('id, name').eq('id', householdId).maybeSingle(),
+    fetchHouseholdMembers(householdId),
+  ]);
+
+  if (householdRow.error && householdRow.error.code !== 'PGRST116') {
+    throw toFriendlyError(householdRow.error, 'Gagal memuat household aktif.');
+  }
+
+  const memberUserIds = Array.from(
+    new Set(
+      members
+        .map((member) => member.userId)
+        .filter((value): value is string => Boolean(value)),
+    ),
+  );
+  if (!memberUserIds.includes(userId)) {
+    memberUserIds.push(userId);
+  }
+
+  return {
+    householdId,
+    householdName: householdRow.data?.name ?? null,
+    role: (membership?.role as HouseholdRole) ?? null,
+    members,
+    memberUserIds,
+    currentUserId: userId,
+  };
+}
+
+export async function listMembers(householdId: string): Promise<HouseholdMember[]> {
+  if (!householdId) return [];
+  return fetchHouseholdMembers(householdId);
+}
+
+export async function inviteByUsername(
+  householdId: string,
+  username: string,
+  role: HouseholdRole,
+) {
+  if (!householdId) throw new Error('Household tidak ditemukan.');
+  const normalized = username.trim().toLowerCase();
+  if (!normalized) throw new Error('Username wajib diisi.');
+
+  const { data, error } = await supabase.rpc('create_or_invite_member_by_username', {
+    household_id: householdId,
+    username: normalized,
+    role,
+  });
+  if (error) {
+    throw toFriendlyError(error, 'Gagal mengundang anggota.');
+  }
+  return data;
+}
+
+export async function updateMemberRole(memberId: string, role: HouseholdRole) {
+  if (!memberId) throw new Error('Anggota tidak ditemukan.');
+  const { error } = await supabase
+    .from('household_members')
+    .update({ role })
+    .eq('id', memberId);
+  if (error) {
+    throw toFriendlyError(error, 'Gagal memperbarui peran.');
+  }
+}
+
+export async function removeMember(memberId: string) {
+  if (!memberId) throw new Error('Anggota tidak ditemukan.');
+  const { error } = await supabase.from('household_members').delete().eq('id', memberId);
+  if (error) {
+    throw toFriendlyError(error, 'Gagal menghapus anggota.');
+  }
+}
+
+export async function leaveHousehold(householdId?: string) {
+  const userId = await getCurrentUserId();
+  if (!userId) throw new Error('Tidak bisa keluar household tanpa login.');
+  let query = supabase.from('household_members').delete().eq('user_id', userId);
+  if (householdId) {
+    query = query.eq('household_id', householdId);
+  }
+  const { error } = await query;
+  if (error) {
+    throw toFriendlyError(error, 'Gagal keluar dari household.');
+  }
+}
+
+export function withHouseholdScope<T extends PostgrestFilterBuilder<any, any, any>>(
+  query: T,
+  memberUserIds: string[],
+  enabled: boolean,
+  fallbackUserId?: string | null,
+): T {
+  if (enabled && Array.isArray(memberUserIds) && memberUserIds.length > 0) {
+    return query.in('user_id', memberUserIds) as T;
+  }
+  if (fallbackUserId) {
+    return query.eq('user_id', fallbackUserId) as T;
+  }
+  return query;
+}
+
+export function applyHouseholdScope<T extends PostgrestFilterBuilder<any, any, any>>(
+  query: T,
+  fallbackUserId?: string | null,
+  overrideEnabled?: boolean,
+): T {
+  const snapshot = getHouseholdScopeSnapshot();
+  const enabled = overrideEnabled ?? snapshot.enabled;
+  const fallback = fallbackUserId ?? snapshot.currentUserId ?? null;
+  return withHouseholdScope(query, snapshot.memberUserIds, enabled, fallback);
+}

--- a/src/lib/householdScope.ts
+++ b/src/lib/householdScope.ts
@@ -1,0 +1,44 @@
+export interface HouseholdScopeBase {
+  householdId: string | null;
+  householdName: string | null;
+  role: string | null;
+  members: any[];
+  memberUserIds: string[];
+  currentUserId: string | null;
+}
+
+export interface HouseholdScopeSnapshot extends HouseholdScopeBase {
+  enabled: boolean;
+}
+
+const defaultSnapshot: HouseholdScopeSnapshot = {
+  householdId: null,
+  householdName: null,
+  role: null,
+  members: [],
+  memberUserIds: [],
+  currentUserId: null,
+  enabled: false,
+};
+
+let latestSnapshot: HouseholdScopeSnapshot = { ...defaultSnapshot };
+
+export function setHouseholdScopeSnapshot(summary: HouseholdScopeBase | null | undefined, enabled: boolean) {
+  if (!summary) {
+    latestSnapshot = { ...defaultSnapshot, enabled: false };
+    return;
+  }
+  latestSnapshot = {
+    householdId: summary.householdId,
+    householdName: summary.householdName,
+    role: summary.role,
+    members: summary.members,
+    memberUserIds: summary.memberUserIds,
+    currentUserId: summary.currentUserId,
+    enabled,
+  };
+}
+
+export function getHouseholdScopeSnapshot(): HouseholdScopeSnapshot {
+  return { ...latestSnapshot, members: [...latestSnapshot.members] };
+}

--- a/src/pages/FamilyPage.tsx
+++ b/src/pages/FamilyPage.tsx
@@ -1,0 +1,480 @@
+import { FormEvent, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import PageHeader from '../layout/PageHeader';
+import { useHousehold } from '../context/HouseholdContext';
+import { useToast } from '../context/ToastContext';
+import {
+  inviteByUsername,
+  leaveHousehold,
+  listMembers,
+  removeMember,
+  updateMemberRole,
+  type HouseholdMember,
+  type HouseholdRole,
+} from '../lib/householdApi';
+
+const ROLE_OPTIONS: Array<{ value: HouseholdRole; label: string; description: string }> = [
+  { value: 'owner', label: 'Owner', description: 'Semua hak & kelola household' },
+  { value: 'editor', label: 'Editor', description: 'Baca & ubah data keuangan' },
+  { value: 'viewer', label: 'Viewer', description: 'Hanya baca data keuangan' },
+];
+
+function normalizeUsername(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function validateUsername(value: string) {
+  const normalized = normalizeUsername(value);
+  if (!normalized) return 'Username wajib diisi.';
+  if (normalized.length < 3 || normalized.length > 20) {
+    return 'Username harus 3-20 karakter.';
+  }
+  if (!/^[_a-z0-9]+$/.test(normalized)) {
+    return 'Gunakan huruf kecil, angka, atau underscore.';
+  }
+  return null;
+}
+
+function StatusBadge({ status }: { status: HouseholdMember['status'] }) {
+  if (status === 'accepted') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/40 bg-emerald-500/15 px-2.5 py-1 text-xs font-medium text-emerald-400">
+        <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" aria-hidden="true" />
+        Accepted
+      </span>
+    );
+  }
+  if (status === 'pending') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border border-amber-500/40 bg-amber-500/15 px-2.5 py-1 text-xs font-medium text-amber-300">
+        <span className="h-1.5 w-1.5 rounded-full bg-amber-300" aria-hidden="true" />
+        Pending
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-slate-500/40 bg-slate-500/15 px-2.5 py-1 text-xs font-medium text-slate-300">
+      <span className="h-1.5 w-1.5 rounded-full bg-slate-300" aria-hidden="true" />
+      {status ?? 'Unknown'}
+    </span>
+  );
+}
+
+function RoleSelect({
+  value,
+  disabled,
+  onChange,
+}: {
+  value: HouseholdRole;
+  disabled?: boolean;
+  onChange: (next: HouseholdRole) => void;
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(event) => onChange(event.target.value as HouseholdRole)}
+      disabled={disabled}
+      className="w-full min-w-[140px] rounded-xl border border-border/70 bg-surface-1 px-2.5 py-2 text-sm text-text shadow-sm transition-colors focus:border-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60"
+    >
+      {ROLE_OPTIONS.map((role) => (
+        <option key={role.value} value={role.value}>
+          {role.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function InviteIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth="1.75"
+      className="h-4 w-4"
+      aria-hidden="true"
+    >
+      <path d="M12 5v14" strokeLinecap="round" />
+      <path d="M5 12h14" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function TrashIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth="1.75"
+      className="h-4 w-4"
+      aria-hidden="true"
+    >
+      <path d="M4 7h16" strokeLinecap="round" />
+      <path d="M10 11v6" strokeLinecap="round" />
+      <path d="M14 11v6" strokeLinecap="round" />
+      <path d="M6 7l1 12h10l1-12" strokeLinejoin="round" />
+      <path d="M9 7V5h6v2" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function PencilIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth="1.75"
+      className="h-4 w-4"
+      aria-hidden="true"
+    >
+      <path d="M4 20h4l10.5-10.5a2.121 2.121 0 0 0-3-3L5 17v3z" strokeLinejoin="round" />
+      <path d="M13.5 6.5l3 3" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function CrownIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth="1.75"
+      className="h-4 w-4"
+      aria-hidden="true"
+    >
+      <path d="M4 17h16" strokeLinecap="round" />
+      <path d="M5 17l1-9 5 4 5-4 3 9" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+const MEMBERS_QUERY_KEY = 'household-members';
+
+export default function FamilyPage() {
+  const {
+    householdId,
+    householdName,
+    role,
+    members: initialMembers,
+    refresh: refreshHousehold,
+    currentUserId,
+  } = useHousehold();
+  const { addToast } = useToast();
+  const queryClient = useQueryClient();
+  const [username, setUsername] = useState('');
+  const [inviteRole, setInviteRole] = useState<HouseholdRole>('viewer');
+  const [usernameError, setUsernameError] = useState<string | null>(null);
+
+  const canManage = role === 'owner';
+
+  const membersQuery = useQuery<HouseholdMember[]>({
+    queryKey: [MEMBERS_QUERY_KEY, householdId],
+    queryFn: () => listMembers(householdId ?? ''),
+    enabled: Boolean(householdId),
+    initialData: initialMembers,
+  });
+
+  const inviteMutation = useMutation({
+    mutationFn: async () => {
+      if (!householdId) throw new Error('Household belum tersedia.');
+      const errorMessage = validateUsername(username);
+      if (errorMessage) {
+        setUsernameError(errorMessage);
+        throw new Error(errorMessage);
+      }
+      setUsernameError(null);
+      const normalized = normalizeUsername(username);
+      await inviteByUsername(householdId, normalized, inviteRole);
+    },
+    onSuccess: () => {
+      setUsername('');
+      setInviteRole('viewer');
+      addToast('Undangan terkirim.', 'success');
+      void queryClient.invalidateQueries({ queryKey: [MEMBERS_QUERY_KEY, householdId] });
+      refreshHousehold();
+    },
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : 'Gagal mengundang anggota.';
+      addToast(message, 'error');
+    },
+  });
+
+  const updateRoleMutation = useMutation({
+    mutationFn: async ({ id, role: nextRole }: { id: string; role: HouseholdRole }) => {
+      await updateMemberRole(id, nextRole);
+    },
+    onSuccess: () => {
+      addToast('Peran anggota diperbarui.', 'success');
+      void queryClient.invalidateQueries({ queryKey: [MEMBERS_QUERY_KEY, householdId] });
+      refreshHousehold();
+    },
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : 'Gagal memperbarui peran.';
+      addToast(message, 'error');
+    },
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: async (memberId: string) => {
+      await removeMember(memberId);
+    },
+    onSuccess: () => {
+      addToast('Anggota dihapus.', 'success');
+      void queryClient.invalidateQueries({ queryKey: [MEMBERS_QUERY_KEY, householdId] });
+      refreshHousehold();
+    },
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : 'Gagal menghapus anggota.';
+      addToast(message, 'error');
+    },
+  });
+
+  const leaveMutation = useMutation({
+    mutationFn: async () => {
+      await leaveHousehold(householdId ?? undefined);
+    },
+    onSuccess: () => {
+      addToast('Kamu keluar dari household.', 'info');
+      setTimeout(() => {
+        refreshHousehold();
+        void queryClient.invalidateQueries({ queryKey: [MEMBERS_QUERY_KEY, householdId] });
+      }, 150);
+    },
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : 'Gagal keluar dari household.';
+      addToast(message, 'error');
+    },
+  });
+
+  const members = membersQuery.data ?? [];
+  const isLoadingMembers = membersQuery.isLoading || membersQuery.isFetching;
+
+  const acceptedCount = useMemo(
+    () => members.filter((member) => member.status === 'accepted').length,
+    [members],
+  );
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canManage) return;
+    inviteMutation.mutate();
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Keluarga"
+        description="Kelola anggota household dan undangan berbagi data."
+      />
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr),minmax(0,420px)]">
+        <section className="rounded-3xl border border-border/70 bg-surface-1 p-6 shadow-lg shadow-background/30">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-wide text-muted">
+                Household Aktif
+              </p>
+              <h2 className="mt-1 text-2xl font-bold text-text">
+                {householdName ?? 'Belum ada household'}
+              </h2>
+              <p className="mt-2 text-sm text-muted">
+                {acceptedCount} anggota aktif • peran kamu: {role ?? 'N/A'}
+              </p>
+            </div>
+            <div className="flex flex-col items-start gap-2 sm:items-end">
+              {canManage ? (
+                <p className="text-xs text-muted">
+                  Kamu dapat mengundang anggota baru dan mengubah peran.
+                </p>
+              ) : (
+                <p className="text-xs text-muted">
+                  Hubungi owner untuk mengelola anggota household.
+                </p>
+              )}
+              <button
+                type="button"
+                onClick={() => inviteMutation.reset()}
+                className="inline-flex items-center gap-2 rounded-2xl border border-brand/50 bg-brand/15 px-4 py-2 text-sm font-semibold text-brand transition hover:border-brand/60 hover:bg-brand/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                disabled={!canManage}
+              >
+                <InviteIcon />
+                Undang Anggota
+              </button>
+            </div>
+          </div>
+
+          <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <div className="flex-1">
+                <label htmlFor="invite-username" className="block text-xs font-semibold uppercase tracking-wide text-muted">
+                  Username
+                </label>
+                <input
+                  id="invite-username"
+                  name="username"
+                  value={username}
+                  onChange={(event) => setUsername(event.target.value)}
+                  placeholder="contoh: hematfam"
+                  className="mt-1 h-11 w-full rounded-2xl border-0 bg-surface-2 px-4 text-sm text-text ring-2 ring-slate-800 transition focus:ring-[var(--accent)]"
+                  autoComplete="off"
+                  inputMode="text"
+                  pattern="[_a-z0-9]+"
+                  disabled={!canManage || inviteMutation.isPending}
+                />
+                {usernameError && (
+                  <p className="mt-1 text-xs text-danger">{usernameError}</p>
+                )}
+              </div>
+              <div className="sm:w-48">
+                <label htmlFor="invite-role" className="block text-xs font-semibold uppercase tracking-wide text-muted">
+                  Peran
+                </label>
+                <div className="mt-1 rounded-2xl bg-surface-2 ring-2 ring-slate-800 focus-within:ring-[var(--accent)]">
+                  <select
+                    id="invite-role"
+                    value={inviteRole}
+                    onChange={(event) => setInviteRole(event.target.value as HouseholdRole)}
+                    className="h-11 w-full rounded-2xl bg-transparent px-4 text-sm text-text focus:outline-none"
+                    disabled={!canManage || inviteMutation.isPending}
+                  >
+                    {ROLE_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <p className="text-xs text-muted">
+                Username bersifat unik & tidak peka huruf besar kecil. Undangan akan otomatis aktif saat username tersedia.
+              </p>
+              <button
+                type="submit"
+                className="inline-flex h-11 items-center gap-2 rounded-2xl bg-brand px-5 text-sm font-semibold text-brand-foreground shadow-sm transition hover:bg-[var(--color-primary-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={!canManage || inviteMutation.isPending}
+              >
+                <InviteIcon />
+                {inviteMutation.isPending ? 'Mengundang…' : 'Undang'}
+              </button>
+            </div>
+          </form>
+        </section>
+
+        <aside className="flex flex-col gap-4 rounded-3xl border border-border/70 bg-surface-1 p-6 shadow-lg shadow-background/30">
+          <h3 className="text-base font-semibold text-text">Info Peran</h3>
+          <ul className="space-y-3 text-sm text-muted">
+            {ROLE_OPTIONS.map((option) => (
+              <li key={option.value} className="flex items-start gap-2">
+                <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full border border-border/60 bg-surface-2 text-xs font-semibold text-text">
+                  {option.value === 'owner' ? <CrownIcon /> : option.label.charAt(0)}
+                </span>
+                <div>
+                  <p className="font-semibold text-text">{option.label}</p>
+                  <p>{option.description}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+          <button
+            type="button"
+            onClick={() => leaveMutation.mutate()}
+            className="mt-auto inline-flex items-center gap-2 rounded-2xl border border-border/70 bg-surface-2 px-4 py-2 text-sm font-semibold text-danger transition hover:border-danger/60 hover:bg-danger/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            disabled={leaveMutation.isPending}
+          >
+            <TrashIcon /> Keluar Household
+          </button>
+        </aside>
+      </div>
+
+      <section className="overflow-hidden rounded-3xl border border-border/70 bg-surface-1 shadow-lg shadow-background/30">
+        <div className="border-b border-border/60 bg-surface-2 px-6 py-4">
+          <h3 className="text-base font-semibold text-text">Daftar Anggota</h3>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-border/60 text-sm">
+            <thead className="bg-surface-2 text-xs uppercase tracking-wide text-muted">
+              <tr>
+                <th scope="col" className="px-6 py-3 text-left">Username</th>
+                <th scope="col" className="px-6 py-3 text-left">Peran</th>
+                <th scope="col" className="px-6 py-3 text-left">Status</th>
+                <th scope="col" className="px-6 py-3 text-right">Aksi</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border/60">
+              {isLoadingMembers && (
+                <tr>
+                  <td className="px-6 py-5" colSpan={4}>
+                    <div className="flex items-center gap-3 text-muted">
+                      <span className="h-2 w-2 animate-pulse rounded-full bg-muted" />
+                      Memuat anggota…
+                    </div>
+                  </td>
+                </tr>
+              )}
+              {!isLoadingMembers && members.length === 0 && (
+                <tr>
+                  <td className="px-6 py-6 text-center text-muted" colSpan={4}>
+                    Belum ada anggota. Undang anggota via username di atas.
+                  </td>
+                </tr>
+              )}
+              {!isLoadingMembers &&
+                members.map((member) => {
+                  const isSelf = Boolean(member.userId && currentUserId && member.userId === currentUserId);
+                  const disableRoleChange = !canManage || member.status !== 'accepted' || isSelf;
+                  const allowRemove = canManage && !isSelf;
+                  return (
+                    <tr key={member.id} className="transition hover:bg-surface-2/60">
+                      <td className="px-6 py-4 font-medium text-text">
+                        {member.username ?? '• Pending username'}
+                      </td>
+                      <td className="px-6 py-4">
+                        <RoleSelect
+                          value={member.role}
+                          disabled={disableRoleChange}
+                          onChange={(nextRole) => {
+                            if (nextRole === member.role) return;
+                            updateRoleMutation.mutate({ id: member.id, role: nextRole });
+                          }}
+                        />
+                      </td>
+                      <td className="px-6 py-4">
+                        <StatusBadge status={member.status} />
+                      </td>
+                      <td className="px-6 py-4">
+                        <div className="flex justify-end gap-2">
+                          <button
+                            type="button"
+                            className="inline-flex h-9 items-center gap-1 rounded-2xl border border-border/70 px-3 text-xs font-semibold text-muted transition hover:border-border hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                            disabled
+                          >
+                            <PencilIcon />
+                            Ubah
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => removeMutation.mutate(member.id)}
+                            className="inline-flex h-9 items-center gap-1 rounded-2xl border border-border/70 px-3 text-xs font-semibold text-danger transition hover:border-danger/60 hover:text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-60"
+                            disabled={!allowRemove}
+                            aria-label="Hapus anggota"
+                          >
+                            <TrashIcon /> Hapus
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/router/nav.config.tsx
+++ b/src/router/nav.config.tsx
@@ -24,6 +24,7 @@ import {
   Repeat,
   Settings as SettingsIcon,
   User as UserIcon,
+  Users as UsersIcon,
   CreditCard,
 } from 'lucide-react';
 
@@ -124,6 +125,14 @@ export const NAV_ITEMS: NavItem[] = [
     path: '/subscriptions',
     icon: <Repeat className="h-5 w-5" />,
     section: 'primary',
+    inSidebar: true,
+    protected: true,
+  },
+  {
+    title: 'Keluarga',
+    path: '/family',
+    icon: <UsersIcon className="h-5 w-5" />,
+    section: 'secondary',
     inSidebar: true,
     protected: true,
   },

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -32,6 +32,8 @@ function loadComponent(path: string) {
       return lazy(() => import('../pages/DataPage'));
     case '/subscriptions':
       return lazy(() => import('../pages/Subscriptions'));
+    case '/family':
+      return lazy(() => import('../pages/FamilyPage'));
     case '/settings':
       return lazy(() => import('../pages/SettingsPage'));
     case '/profile':


### PR DESCRIPTION
## Summary
- add HouseholdProvider, scope helpers, and shared data toggle wiring across the app
- implement the Family management page with invite-by-username form, member table, and role controls
- surface the household view toggle in the top bar and badge active pages while updating key Supabase queries for household scope

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68da8bd248588332911c450cb98bd6ae