### PR TITLE
Add mobile Google auth callback route

### DIFF
--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -4,6 +4,8 @@ import { NAV_ITEMS, NavItem } from './nav.config';
 import AuthGuard from '../guards/AuthGuard';
 import { isFeatureEnabled } from '../featureFlags';
 
+const MobileGoogleCallback = lazy(() => import('../routes/MobileGoogleCallback'));
+
 function loadComponent(path: string) {
   switch (path) {
     case '/':
@@ -60,4 +62,14 @@ function buildRoutes(items: NavItem[]): RouteObject[] {
     });
 }
 
-export const ROUTES: RouteObject[] = buildRoutes(NAV_ITEMS);
+export const ROUTES: RouteObject[] = [
+  ...buildRoutes(NAV_ITEMS),
+  {
+    path: '/auth/mobile/google',
+    element: (
+      <Suspense fallback={<div />}>
+        <MobileGoogleCallback />
+      </Suspense>
+    ),
+  },
+];

--- a/src/routes/MobileGoogleCallback.tsx
+++ b/src/routes/MobileGoogleCallback.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+
+import { supabase } from '../lib/supabase';
+
+const MobileGoogleCallback = () => {
+  const [status, setStatus] = useState('Memproses login...');
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const idToken = params.get('id_token');
+
+    if (!idToken) {
+      setStatus('Tidak ada id_token.');
+      return;
+    }
+
+    const signIn = async () => {
+      const { error } = await supabase.auth.signInWithIdToken({
+        provider: 'google',
+        token: idToken,
+      });
+
+      if (error) {
+        console.error(error);
+        setStatus(`Gagal login: ${error.message}`);
+        return;
+      }
+
+      setStatus('Berhasil login. Mengalihkan...');
+      window.location.replace('/');
+    };
+
+    void signIn();
+  }, []);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4 text-center">
+      <p>{status}</p>
+    </div>
+  );
+};
+
+export default MobileGoogleCallback;


### PR DESCRIPTION
## Summary
- add a mobile Google auth callback route component that signs users in with an id_token
- register the callback route with the router so the path /auth/mobile/google is handled

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da9f4058808332a46116601faf59c3