### PR TITLE
Add mobile Google auth callback route

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,6 +58,7 @@ import MoneyTalkProvider, {
 } from "./context/MoneyTalkContext.jsx";
 import { ModeProvider, useMode } from "./hooks/useMode";
 import AuthCallback from "./pages/AuthCallback";
+import MobileGoogleCallback from "./pages/mobile/google";
 
 const uid = () =>
   globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
@@ -1068,6 +1069,10 @@ function AppShell({ prefs, setPrefs }) {
           <Routes>
             <Route path="/auth" element={<AuthLogin />} />
             <Route path="/auth/callback" element={<AuthCallback />} />
+            <Route
+              path="/auth/mobile/google"
+              element={<MobileGoogleCallback />}
+            />
             <Route element={<AuthGuard />}>
               <Route
                 path="/"

--- a/src/pages/mobile/google.tsx
+++ b/src/pages/mobile/google.tsx
@@ -1,11 +1,7 @@
 import { useEffect, useState } from 'react';
-import { createClient } from '@supabase/supabase-js';
+import { supabase } from '../../lib/supabase';
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-  { auth: { persistSession: true } }
-);
+const REDIRECT_SUCCESS = '/';
 
 export default function MobileGoogleCallback() {
   const [msg, setMsg] = useState('Memproses login…');
@@ -21,25 +17,39 @@ export default function MobileGoogleCallback() {
           return;
         }
 
-        const { data, error } = await supabase.auth.signInWithIdToken({
+        const { error } = await supabase.auth.signInWithIdToken({
           provider: 'google',
           token: idToken,
         });
 
         if (error) {
-          console.error('[MOBILE GOOGLE] signInWithIdToken error', error);
+          console.error('[MOBILE GOOGLE] error:', error);
           setMsg('Gagal login: ' + error.message);
           return;
         }
 
         setMsg('Berhasil login. Mengalihkan…');
-        window.location.replace('/');
+        window.location.replace(REDIRECT_SUCCESS);
       } catch (e: any) {
-        console.error('[MOBILE GOOGLE] unexpected error', e);
+        console.error('[MOBILE GOOGLE] unexpected:', e);
         setMsg('Terjadi error tak terduga.');
       }
     })();
   }, []);
 
-  return <p style={{ textAlign: 'center', marginTop: 64 }}>{msg}</p>;
+  return (
+    <main
+      style={{
+        display: 'grid',
+        placeItems: 'center',
+        minHeight: '60vh',
+        fontFamily: 'system-ui',
+      }}
+    >
+      <div>
+        <h1>HematWoi</h1>
+        <p>{msg}</p>
+      </div>
+    </main>
+  );
 }

--- a/src/pages/mobile/google.tsx
+++ b/src/pages/mobile/google.tsx
@@ -13,7 +13,7 @@ export default function MobileGoogleCallback() {
         const idToken = p.get('id_token');
 
         if (!idToken) {
-          setMsg('Tidak ada id_token.');
+          setMsg('Token tidak valid.');
           return;
         }
 

--- a/src/router/nav.config.tsx
+++ b/src/router/nav.config.tsx
@@ -149,4 +149,10 @@ export const NAV_ITEMS: NavItem[] = [
     inSidebar: false,
     protected: false,
   },
+  {
+    title: 'Auth Mobile Google',
+    path: '/auth/mobile/google',
+    inSidebar: false,
+    protected: false,
+  },
 ];

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -38,6 +38,8 @@ function loadComponent(path: string) {
       return lazy(() => import('../pages/Profile'));
     case '/auth':
       return lazy(() => import('../pages/AuthLogin'));
+    case '/auth/mobile/google':
+      return lazy(() => import('../pages/mobile/google'));
     default:
       return lazy(() => import('../pages/Dashboard'));
   }


### PR DESCRIPTION
## Summary
- update the mobile Google auth callback page to use the shared Supabase client and improved UI messaging
- register the `/auth/mobile/google` route in the router configuration so it can be navigated to

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68daa205e6ac8332ad90eac92f082bdc