### PR TITLE
Fix mobile Google auth callback routing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,6 +58,7 @@ import MoneyTalkProvider, {
 } from "./context/MoneyTalkContext.jsx";
 import { ModeProvider, useMode } from "./hooks/useMode";
 import AuthCallback from "./pages/AuthCallback";
+import MobileGoogleCallback from "./routes/MobileGoogleCallback";
 
 const uid = () =>
   globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
@@ -1068,6 +1069,7 @@ function AppShell({ prefs, setPrefs }) {
           <Routes>
             <Route path="/auth" element={<AuthLogin />} />
             <Route path="/auth/callback" element={<AuthCallback />} />
+            <Route path="/auth/mobile/google" element={<MobileGoogleCallback />} />
             <Route element={<AuthGuard />}>
               <Route
                 path="/"


### PR DESCRIPTION
## Summary
- add the mobile Google callback route to the client router so the Supabase sign-in flow can complete instead of redirecting home

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68daa51b87bc8332abb8257b14b1fa8f