### PR TITLE
Redirect app logins to native Google login page

### DIFF
--- a/pages/auth/mobile/google.tsx
+++ b/pages/auth/mobile/google.tsx
@@ -29,7 +29,7 @@ export default function MobileGoogleCallback() {
       }
 
       setMsg('Berhasil login. Mengalihkan…');
-      window.location.replace('/');
+      window.location.replace('/native-google-login');
     })();
   }, []);
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,6 +28,7 @@ import SettingsPage from "./pages/SettingsPage";
 import ProfilePage from "./pages/Profile";
 import AccountsPage from "./pages/AccountsPage";
 import AuthLogin from "./pages/AuthLogin";
+import NativeGoogleLogin from "./pages/NativeGoogleLogin";
 import AdminPage from "./pages/AdminPage";
 import ChallengesPage from "./pages/Challenges.jsx";
 import WishlistPage from "./pages/WishlistPage";
@@ -1070,6 +1071,7 @@ function AppShell({ prefs, setPrefs }) {
             <Route path="/auth" element={<AuthLogin />} />
             <Route path="/auth/callback" element={<AuthCallback />} />
             <Route path="/auth/mobile/google" element={<MobileGoogleCallback />} />
+            <Route path="/native-google-login" element={<NativeGoogleLogin />} />
             <Route element={<AuthGuard />}>
               <Route
                 path="/"

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -4,6 +4,7 @@ import ErrorBoundary from '../components/system/ErrorBoundary';
 import { supabase } from '../lib/supabase';
 import { syncGuestToCloud } from '../lib/sync';
 import { formatOAuthErrorMessage, formatOAuthQueryError } from '../lib/oauth-error';
+import { isHematWoiApp } from '../lib/ua';
 
 const DIGEST_TRIGGER_KEY = 'hw:digest:trigger';
 
@@ -14,6 +15,7 @@ export default function AuthCallback() {
   const navigate = useNavigate();
   const [status, setStatus] = useState<StatusState>('processing');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const postLoginPath = useMemo(() => (isHematWoiApp() ? '/native-google-login' : '/'), []);
 
   const searchParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
   const hashParams = useMemo(
@@ -56,7 +58,7 @@ export default function AuthCallback() {
       markOnlineMode();
       void syncSession(userId);
       if (!cancelled) {
-        navigate('/', { replace: true });
+        navigate(postLoginPath, { replace: true });
       }
     };
 
@@ -158,6 +160,7 @@ export default function AuthCallback() {
     errorStatus,
     hasImplicitSession,
     navigate,
+    postLoginPath,
     refreshToken,
   ]);
 

--- a/src/pages/AuthLogin.tsx
+++ b/src/pages/AuthLogin.tsx
@@ -7,6 +7,7 @@ import { getSession, onAuthStateChange } from '../lib/auth';
 import { supabase } from '../lib/supabase';
 import { syncGuestToCloud } from '../lib/sync';
 import { formatOAuthErrorMessage } from '../lib/oauth-error';
+import { isHematWoiApp } from '../lib/ua';
 
 const heroTips = [
   'Pantau cash flow harian tanpa ribet.',
@@ -28,6 +29,7 @@ export default function AuthLogin() {
   });
   const [googleLoading, setGoogleLoading] = useState(false);
   const [googleError, setGoogleError] = useState<string | null>(null);
+  const postLoginPath = useMemo(() => (isHematWoiApp() ? '/native-google-login' : '/'), []);
   const googleRedirectTo = useMemo(() => {
     const env = typeof import.meta !== 'undefined' ? import.meta.env ?? {} : {};
     const configuredBase =
@@ -90,7 +92,7 @@ export default function AuthLogin() {
         const session = await getSession();
         if (!isMounted) return;
         if (session) {
-          navigate('/', { replace: true });
+          navigate(postLoginPath, { replace: true });
           return;
         }
         setChecking(false);
@@ -113,7 +115,7 @@ export default function AuthLogin() {
         }
         void syncGuestData(session.user?.id ?? null);
         if (location.pathname === '/auth') {
-          navigate('/', { replace: true });
+          navigate(postLoginPath, { replace: true });
         }
       }
     });
@@ -122,7 +124,7 @@ export default function AuthLogin() {
       isMounted = false;
       listener?.subscription?.unsubscribe();
     };
-  }, [location.pathname, navigate, syncGuestData]);
+  }, [location.pathname, navigate, postLoginPath, syncGuestData]);
 
   const skeleton = useMemo(
     () => (
@@ -167,8 +169,8 @@ export default function AuthLogin() {
     } catch (error) {
       console.error('[AuthLogin] Gagal membaca sesi setelah login', error);
     }
-    navigate('/', { replace: true });
-  }, [navigate, syncGuestData]);
+    navigate(postLoginPath, { replace: true });
+  }, [navigate, postLoginPath, syncGuestData]);
 
   return (
     <ErrorBoundary>

--- a/src/pages/NativeGoogleLogin.tsx
+++ b/src/pages/NativeGoogleLogin.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import ErrorBoundary from '../components/system/ErrorBoundary';
+import { isHematWoiApp } from '../lib/ua';
+
+export default function NativeGoogleLogin() {
+  const [inApp, setInApp] = useState(false);
+  const [manualNotice, setManualNotice] = useState(false);
+
+  useEffect(() => {
+    setInApp(isHematWoiApp());
+  }, []);
+
+  const handleContinue = () => {
+    try {
+      if (typeof window !== 'undefined') {
+        window.location.href = '/';
+      }
+    } catch {
+      /* ignore */
+    }
+    setManualNotice(true);
+  };
+
+  return (
+    <ErrorBoundary>
+      <main className="flex min-h-screen items-center justify-center bg-surface-alt px-6 py-16 text-text">
+        <div className="w-full max-w-md space-y-6 rounded-3xl border border-border-subtle bg-surface p-8 text-center shadow-sm">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full border border-success/40 bg-success/10 text-success">
+            ✓
+          </div>
+          <div className="space-y-2">
+            <h1 className="text-lg font-semibold">Login berhasil</h1>
+            <p className="text-sm text-muted">
+              {inApp
+                ? 'Kamu sudah berhasil login di HematWoi App. Tutup jendela ini atau pilih tombol di bawah untuk melanjutkan.'
+                : 'Kamu sudah masuk ke HematWoi. Pilih tombol di bawah untuk menuju dashboard.'}
+            </p>
+          </div>
+          <div className="space-y-2">
+            <button
+              type="button"
+              onClick={handleContinue}
+              className="w-full rounded-2xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90"
+            >
+              {inApp ? 'Kembali ke aplikasi' : 'Masuk ke dashboard'}
+            </button>
+            {inApp && manualNotice ? (
+              <p className="text-xs text-muted">
+                Jika aplikasi belum berubah, tutup jendela ini secara manual lalu kembali ke HematWoi.
+              </p>
+            ) : null}
+          </div>
+        </div>
+      </main>
+    </ErrorBoundary>
+  );
+}

--- a/src/pages/mobile/google.tsx
+++ b/src/pages/mobile/google.tsx
@@ -33,7 +33,7 @@ export default function MobileGoogleCallback() {
         }
 
         setMsg('Berhasil login. Mengalihkan…');
-        window.location.replace('/');
+        window.location.replace('/native-google-login');
       } catch (e: any) {
         console.error('[MOBILE GOOGLE] unexpected error', e);
         setMsg('Terjadi error tak terduga.');

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -5,6 +5,7 @@ import AuthGuard from '../guards/AuthGuard';
 import { isFeatureEnabled } from '../featureFlags';
 
 const MobileGoogleCallback = lazy(() => import('../routes/MobileGoogleCallback'));
+const NativeGoogleLogin = lazy(() => import('../pages/NativeGoogleLogin'));
 
 function loadComponent(path: string) {
   switch (path) {
@@ -40,6 +41,8 @@ function loadComponent(path: string) {
       return lazy(() => import('../pages/Profile'));
     case '/auth':
       return lazy(() => import('../pages/AuthLogin'));
+    case '/native-google-login':
+      return lazy(() => import('../pages/NativeGoogleLogin'));
     default:
       return lazy(() => import('../pages/Dashboard'));
   }
@@ -69,6 +72,14 @@ export const ROUTES: RouteObject[] = [
     element: (
       <Suspense fallback={<div />}>
         <MobileGoogleCallback />
+      </Suspense>
+    ),
+  },
+  {
+    path: '/native-google-login',
+    element: (
+      <Suspense fallback={<div />}>
+        <NativeGoogleLogin />
       </Suspense>
     ),
   },


### PR DESCRIPTION
## Summary
- add a dedicated /native-google-login page for users finishing sign-in inside the app
- redirect web, callback, and mobile login flows to the native page when a session is detected in the app
- register the new route in the router configuration so it can be accessed outside protected sections

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68daad21e68c8332a66716b245cca717