### PR TITLE
Redirect post-login flow to native Google handoff

### DIFF
--- a/src/components/GoogleLoginButton.tsx
+++ b/src/components/GoogleLoginButton.tsx
@@ -64,7 +64,7 @@ const DEFAULT_GOOGLE_WEB_LOGIN_URL = resolveUrl(
   '/auth/google',
   'https://www.hemat-woi.me/auth/google'
 );
-const DEFAULT_NATIVE_TRIGGER_URL = resolveUrl(
+export const DEFAULT_NATIVE_TRIGGER_URL = resolveUrl(
   envNativeTrigger,
   '/auth/mobile/google',
   'https://www.hemat-woi.me/auth/mobile/google',

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -56,7 +56,7 @@ export default function AuthCallback() {
       markOnlineMode();
       void syncSession(userId);
       if (!cancelled) {
-        navigate('/', { replace: true });
+        navigate('/native-google-login', { replace: true });
       }
     };
 

--- a/src/pages/AuthLogin.tsx
+++ b/src/pages/AuthLogin.tsx
@@ -90,7 +90,7 @@ export default function AuthLogin() {
         const session = await getSession();
         if (!isMounted) return;
         if (session) {
-          navigate('/', { replace: true });
+          navigate('/native-google-login', { replace: true });
           return;
         }
         setChecking(false);
@@ -113,7 +113,7 @@ export default function AuthLogin() {
         }
         void syncGuestData(session.user?.id ?? null);
         if (location.pathname === '/auth') {
-          navigate('/', { replace: true });
+          navigate('/native-google-login', { replace: true });
         }
       }
     });
@@ -167,7 +167,7 @@ export default function AuthLogin() {
     } catch (error) {
       console.error('[AuthLogin] Gagal membaca sesi setelah login', error);
     }
-    navigate('/', { replace: true });
+    navigate('/native-google-login', { replace: true });
   }, [navigate, syncGuestData]);
 
   return (

--- a/src/pages/NativeGoogleLogin.tsx
+++ b/src/pages/NativeGoogleLogin.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import GoogleLoginButton, { DEFAULT_NATIVE_TRIGGER_URL } from '../components/GoogleLoginButton';
+import { isHematWoiApp } from '../lib/ua';
+
+const httpPattern = /^https?:\/\//i;
+
+export default function NativeGoogleLogin() {
+  const navigate = useNavigate();
+  const [isNativeApp] = useState(() => isHematWoiApp());
+  const [showManualTrigger, setShowManualTrigger] = useState(false);
+
+  const targetUrl = useMemo(() => DEFAULT_NATIVE_TRIGGER_URL, []);
+  const canTriggerNative = isNativeApp && Boolean(targetUrl) && !httpPattern.test(targetUrl);
+
+  useEffect(() => {
+    if (!isNativeApp) {
+      navigate('/', { replace: true });
+      return;
+    }
+
+    if (!canTriggerNative) {
+      navigate('/', { replace: true });
+      return;
+    }
+
+    const triggerTimeout = window.setTimeout(() => {
+      window.location.href = targetUrl;
+    }, 150);
+
+    const fallbackTimeout = window.setTimeout(() => {
+      setShowManualTrigger(true);
+    }, 3000);
+
+    return () => {
+      window.clearTimeout(triggerTimeout);
+      window.clearTimeout(fallbackTimeout);
+    };
+  }, [canTriggerNative, isNativeApp, navigate, targetUrl]);
+
+  if (!isNativeApp) {
+    return null;
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-surface px-6 py-12 text-center text-text">
+      <div className="max-w-md space-y-5">
+        <h1 className="text-2xl font-semibold">Membuka aplikasi HematWoi...</h1>
+        <p className="text-sm text-muted">
+          Kami sedang membuka aplikasi HematWoi agar kamu bisa melanjutkan proses login Google secara mulus di
+          perangkat ini.
+        </p>
+        {showManualTrigger && (
+          <button
+            type="button"
+            onClick={() => {
+              window.location.href = targetUrl;
+            }}
+            className="inline-flex w-full items-center justify-center rounded-2xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow"
+          >
+            Buka aplikasi secara manual
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => {
+            navigate('/', { replace: true });
+          }}
+          className="inline-flex w-full items-center justify-center rounded-2xl border border-border-subtle px-4 py-2 text-sm font-semibold text-text"
+        >
+          Gunakan versi web saja
+        </button>
+        <div className="rounded-2xl border border-border-subtle bg-surface-alt px-4 py-3 text-left text-xs text-muted">
+          <p className="font-semibold text-text">Perlu login ulang?</p>
+          <p>
+            Kamu bisa mencoba login ulang melalui tombol Google berikut. Jika proses login berhasil, aplikasi akan
+            terbuka secara otomatis.
+          </p>
+          <GoogleLoginButton className="mt-3 w-full rounded-2xl bg-surface px-4 py-2 text-sm font-semibold text-text" />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -5,6 +5,7 @@ import AuthGuard from '../guards/AuthGuard';
 import { isFeatureEnabled } from '../featureFlags';
 
 const MobileGoogleCallback = lazy(() => import('../routes/MobileGoogleCallback'));
+const NativeGoogleLogin = lazy(() => import('../pages/NativeGoogleLogin'));
 
 function loadComponent(path: string) {
   switch (path) {
@@ -40,6 +41,8 @@ function loadComponent(path: string) {
       return lazy(() => import('../pages/Profile'));
     case '/auth':
       return lazy(() => import('../pages/AuthLogin'));
+    case '/native-google-login':
+      return lazy(() => import('../pages/NativeGoogleLogin'));
     default:
       return lazy(() => import('../pages/Dashboard'));
   }
@@ -69,6 +72,14 @@ export const ROUTES: RouteObject[] = [
     element: (
       <Suspense fallback={<div />}>
         <MobileGoogleCallback />
+      </Suspense>
+    ),
+  },
+  {
+    path: '/native-google-login',
+    element: (
+      <Suspense fallback={<div />}>
+        <NativeGoogleLogin />
       </Suspense>
     ),
   },

--- a/src/routes/MobileGoogleCallback.tsx
+++ b/src/routes/MobileGoogleCallback.tsx
@@ -27,7 +27,7 @@ const MobileGoogleCallback = () => {
       }
 
       setStatus('Berhasil login. Mengalihkan...');
-      window.location.replace('/');
+      window.location.replace('/native-google-login');
     };
 
     void signIn();


### PR DESCRIPTION
## Summary
- add a dedicated /native-google-login page to hand off sessions back to the HematWoi app
- route all successful Google sign-ins through the new page and expose the native trigger URL constant

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68daad21e68c8332a66716b245cca717