### PR TITLE
Ensure Google OAuth shows account selection prompt

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -229,7 +229,17 @@ export async function signInWithProvider(provider: Provider): Promise<OAuthRespo
   try {
     const { data, error } = await supabase.auth.signInWithOAuth({
       provider,
-      options: { redirectTo: resolveRedirect('/'), flowType: 'pkce' },
+      options: {
+        redirectTo: resolveRedirect('/'),
+        flowType: 'pkce',
+        queryParams:
+          provider === 'google'
+            ? {
+                access_type: 'offline',
+                prompt: 'consent select_account',
+              }
+            : undefined,
+      },
     });
     if (error) throw error;
     return data;

--- a/src/pages/AuthLogin.tsx
+++ b/src/pages/AuthLogin.tsx
@@ -68,7 +68,7 @@ export default function AuthLogin() {
           redirectTo: googleRedirectTo,
           queryParams: {
             access_type: 'offline',
-            prompt: 'consent',
+            prompt: 'consent select_account',
           },
         },
       });


### PR DESCRIPTION
## Summary
- update the Google web login flow to request the account chooser during OAuth
- extend the shared provider login helper so Google sign-ins always request account selection and offline access

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68daba7320048332a404fa7cb01bc710