### PR TITLE
Fix Google login fallback when native trigger unavailable

### DIFF
--- a/src/components/GoogleLoginButton.tsx
+++ b/src/components/GoogleLoginButton.tsx
@@ -86,13 +86,20 @@ export default function GoogleLoginButton({
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
 
-    if (isHematWoiApp()) {
+    const insideApp = isHematWoiApp();
+    const normalizedNativeTrigger =
+      typeof nativeTriggerUrl === 'string' ? nativeTriggerUrl.trim() : undefined;
+    const canUseNativeTrigger =
+      insideApp && typeof normalizedNativeTrigger === 'string' && normalizedNativeTrigger.length > 0 &&
+      !httpPattern.test(normalizedNativeTrigger);
+
+    if (canUseNativeTrigger) {
       // Di dalam app (WebView) → arahkan ke /native-google-login (atau custom scheme jika diset di ENV)
-      if (typeof window !== 'undefined') window.location.href = nativeTriggerUrl;
+      if (typeof window !== 'undefined') window.location.href = normalizedNativeTrigger;
       return;
     }
 
-    // Di browser biasa → pakai web OAuth (Supabase) atau handler custom
+    // Di browser biasa (atau fallback ketika native trigger belum tersedia)
     if (onWebLogin) {
       void onWebLogin(event);
       return;


### PR DESCRIPTION
## Summary
- ensure the Google login button only redirects to the native trigger when a custom scheme is provided
- fall back to the existing web OAuth handler so the Google account chooser appears when the native trigger is unavailable

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68daba7320048332a404fa7cb01bc710