### PR TITLE
Redirect Google login flow to native URL

### DIFF
--- a/src/lib/native-google-login.ts
+++ b/src/lib/native-google-login.ts
@@ -1,0 +1,10 @@
+export const NATIVE_GOOGLE_LOGIN_URL = 'https://www.hemat-woi.me/native-google-login';
+
+export function redirectToNativeGoogleLogin() {
+  if (typeof window === 'undefined') return;
+  try {
+    window.location.replace(NATIVE_GOOGLE_LOGIN_URL);
+  } catch {
+    window.location.href = NATIVE_GOOGLE_LOGIN_URL;
+  }
+}

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import ErrorBoundary from '../components/system/ErrorBoundary';
+import { redirectToNativeGoogleLogin } from '../lib/native-google-login';
 import { supabase } from '../lib/supabase';
 import { syncGuestToCloud } from '../lib/sync';
 import { formatOAuthErrorMessage, formatOAuthQueryError } from '../lib/oauth-error';
@@ -56,7 +57,7 @@ export default function AuthCallback() {
       markOnlineMode();
       void syncSession(userId);
       if (!cancelled) {
-        navigate('/native-google-login', { replace: true });
+        redirectToNativeGoogleLogin();
       }
     };
 
@@ -157,7 +158,7 @@ export default function AuthCallback() {
     errorHint,
     errorStatus,
     hasImplicitSession,
-    navigate,
+    redirectToNativeGoogleLogin,
     refreshToken,
   ]);
 

--- a/src/pages/AuthLogin.tsx
+++ b/src/pages/AuthLogin.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import GoogleLoginButton from '../components/GoogleLoginButton';
 import LoginCard from '../components/auth/LoginCard';
 import ErrorBoundary from '../components/system/ErrorBoundary';
 import { getSession, onAuthStateChange } from '../lib/auth';
+import { redirectToNativeGoogleLogin } from '../lib/native-google-login';
 import { supabase } from '../lib/supabase';
 import { syncGuestToCloud } from '../lib/sync';
 import { formatOAuthErrorMessage } from '../lib/oauth-error';
@@ -15,7 +16,6 @@ const heroTips = [
 ];
 
 export default function AuthLogin() {
-  const navigate = useNavigate();
   const location = useLocation();
   const [checking, setChecking] = useState(true);
   const [sessionError, setSessionError] = useState<string | null>(null);
@@ -90,7 +90,7 @@ export default function AuthLogin() {
         const session = await getSession();
         if (!isMounted) return;
         if (session) {
-          navigate('/native-google-login', { replace: true });
+          redirectToNativeGoogleLogin();
           return;
         }
         setChecking(false);
@@ -113,7 +113,7 @@ export default function AuthLogin() {
         }
         void syncGuestData(session.user?.id ?? null);
         if (location.pathname === '/auth') {
-          navigate('/native-google-login', { replace: true });
+          redirectToNativeGoogleLogin();
         }
       }
     });
@@ -122,7 +122,7 @@ export default function AuthLogin() {
       isMounted = false;
       listener?.subscription?.unsubscribe();
     };
-  }, [location.pathname, navigate, syncGuestData]);
+  }, [location.pathname, redirectToNativeGoogleLogin, syncGuestData]);
 
   const skeleton = useMemo(
     () => (
@@ -167,8 +167,8 @@ export default function AuthLogin() {
     } catch (error) {
       console.error('[AuthLogin] Gagal membaca sesi setelah login', error);
     }
-    navigate('/native-google-login', { replace: true });
-  }, [navigate, syncGuestData]);
+    redirectToNativeGoogleLogin();
+  }, [redirectToNativeGoogleLogin, syncGuestData]);
 
   return (
     <ErrorBoundary>


### PR DESCRIPTION
## Summary
- add a helper for redirecting users to the native Google login endpoint
- update the auth login flow to send signed-in users to https://www.hemat-woi.me/native-google-login
- ensure the OAuth callback also redirects through the new helper

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db1272aef88332b4cc7c36943d95b2