### PR TITLE
Fix Google login callback redirect handling

### DIFF
--- a/src/components/GoogleLoginButton.tsx
+++ b/src/components/GoogleLoginButton.tsx
@@ -1,15 +1,13 @@
 import type { ButtonHTMLAttributes, MouseEvent, ReactNode } from 'react'
 
+import { getNativeGoogleLoginUrl } from '../lib/native-google-login'
 import { isHematWoiApp } from '../lib/ua'
 
 const DEFAULT_DOMAIN = 'https://www.hemat-woi.me'
 const DEFAULT_WEB_LOGIN_PATH = '/auth/google'
 const DEFAULT_WEB_LOGIN_ABSOLUTE = `${DEFAULT_DOMAIN}${DEFAULT_WEB_LOGIN_PATH}`
-const DEFAULT_NATIVE_LOGIN_PATH = '/native-google-login'
-const DEFAULT_NATIVE_LOGIN_ABSOLUTE = `${DEFAULT_DOMAIN}${DEFAULT_NATIVE_LOGIN_PATH}`
-
 export const DEFAULT_GOOGLE_WEB_LOGIN_URL = DEFAULT_WEB_LOGIN_ABSOLUTE
-export const DEFAULT_NATIVE_TRIGGER_URL = DEFAULT_NATIVE_LOGIN_ABSOLUTE
+export const DEFAULT_NATIVE_TRIGGER_URL = getNativeGoogleLoginUrl()
 
 type Environment = Record<string, string | undefined>
 
@@ -80,12 +78,7 @@ export default function GoogleLoginButton({
   children,
   ...rest
 }: GoogleLoginButtonProps) {
-  const computedNativeUrl = resolveUrl(
-    nativeTriggerUrl,
-    'VITE_NATIVE_GOOGLE_LOGIN_URL',
-    DEFAULT_NATIVE_LOGIN_PATH,
-    DEFAULT_NATIVE_LOGIN_ABSOLUTE
-  )
+  const computedNativeUrl = getNativeGoogleLoginUrl(nativeTriggerUrl)
 
   const computedWebLoginUrl = resolveUrl(
     webLoginUrl,

--- a/src/lib/native-google-login.ts
+++ b/src/lib/native-google-login.ts
@@ -1,10 +1,70 @@
-export const NATIVE_GOOGLE_LOGIN_URL = 'https://www.hemat-woi.me/native-google-login';
+type Environment = Record<string, string | undefined>;
 
-export function redirectToNativeGoogleLogin() {
-  if (typeof window === 'undefined') return;
+const DEFAULT_DOMAIN = 'https://www.hemat-woi.me';
+const DEFAULT_NATIVE_LOGIN_PATH = '/native-google-login';
+const DEFAULT_NATIVE_LOGIN_ABSOLUTE = `${DEFAULT_DOMAIN}${DEFAULT_NATIVE_LOGIN_PATH}`;
+
+const browserEnv: Environment =
+  typeof import.meta !== 'undefined' && (import.meta as ImportMeta).env
+    ? ((import.meta as ImportMeta).env as Environment)
+    : {};
+const nodeEnv: Environment =
+  typeof process !== 'undefined' && process?.env ? (process.env as Environment) : {};
+
+function getEnvValue(key: string): string | undefined {
+  return browserEnv?.[key] ?? nodeEnv?.[key];
+}
+
+function getBaseUrl(): string {
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return window.location.origin;
+  }
+
+  return DEFAULT_DOMAIN;
+}
+
+function makeAbsoluteUrl(url: string | undefined, fallbackAbsolute: string): string {
+  const value = url?.trim();
+  if (!value) {
+    return fallbackAbsolute;
+  }
+
+  const hasScheme = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(value);
+  if (hasScheme) {
+    return value;
+  }
+
   try {
-    window.location.replace(NATIVE_GOOGLE_LOGIN_URL);
+    const base = getBaseUrl();
+    return new URL(value, base).toString();
+  } catch (error) {
+    console.warn(
+      'Failed to construct native Google login URL for',
+      value,
+      'falling back to',
+      fallbackAbsolute,
+      error
+    );
+    return fallbackAbsolute;
+  }
+}
+
+export function getNativeGoogleLoginUrl(overrideUrl?: string): string {
+  const envValue = getEnvValue('VITE_NATIVE_GOOGLE_LOGIN_URL');
+  const selected = overrideUrl ?? envValue ?? DEFAULT_NATIVE_LOGIN_PATH;
+
+  return makeAbsoluteUrl(selected, DEFAULT_NATIVE_LOGIN_ABSOLUTE);
+}
+
+export const NATIVE_GOOGLE_LOGIN_URL = getNativeGoogleLoginUrl();
+
+export function redirectToNativeGoogleLogin(overrideUrl?: string) {
+  if (typeof window === 'undefined') return;
+  const target = getNativeGoogleLoginUrl(overrideUrl);
+
+  try {
+    window.location.replace(target);
   } catch {
-    window.location.href = NATIVE_GOOGLE_LOGIN_URL;
+    window.location.href = target;
   }
 }

--- a/src/pages/NativeGoogleLogin.tsx
+++ b/src/pages/NativeGoogleLogin.tsx
@@ -1,10 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import GoogleLoginButton, {
-  DEFAULT_GOOGLE_WEB_LOGIN_URL,
-  DEFAULT_NATIVE_TRIGGER_URL,
-} from '../components/GoogleLoginButton';
+import GoogleLoginButton, { DEFAULT_GOOGLE_WEB_LOGIN_URL } from '../components/GoogleLoginButton';
+import { getNativeGoogleLoginUrl } from '../lib/native-google-login';
 import { isHematWoiApp } from '../lib/ua';
 
 const httpPattern = /^https?:\/\//i;
@@ -14,7 +12,7 @@ export default function NativeGoogleLogin() {
   const [isNativeApp] = useState(() => isHematWoiApp());
   const [showManualTrigger, setShowManualTrigger] = useState(false);
 
-  const targetUrl = useMemo(() => DEFAULT_NATIVE_TRIGGER_URL, []);
+  const targetUrl = useMemo(() => getNativeGoogleLoginUrl(), []);
   const fallbackWebLoginUrl = useMemo(() => DEFAULT_GOOGLE_WEB_LOGIN_URL, []);
   const canTriggerNative =
     isNativeApp && Boolean(targetUrl) && !httpPattern.test(targetUrl) && /^[a-z][a-z0-9+.-]*:/i.test(targetUrl);

--- a/src/routes/MobileGoogleCallback.tsx
+++ b/src/routes/MobileGoogleCallback.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { DEFAULT_NATIVE_TRIGGER_URL } from '../components/GoogleLoginButton';
+import { getNativeGoogleLoginUrl } from '../lib/native-google-login';
 import { supabase } from '../lib/supabase';
 
 const httpPattern = /^https?:\/\//i;
@@ -31,7 +31,7 @@ const MobileGoogleCallback = () => {
 
       setStatus('Berhasil login. Mengalihkan...');
 
-      const target = DEFAULT_NATIVE_TRIGGER_URL;
+      const target = getNativeGoogleLoginUrl();
       try {
         window.location.replace(target);
       } catch {


### PR DESCRIPTION
## Summary
- derive the native Google login redirect target from environment variables or the current origin so PKCE sessions work after returning from Google
- update the Google login button, native login page, and mobile callback to use the shared resolver

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dbb6f069548332ba7abc4932595dbb