### PR TITLE
Prevent saldo card icons from shifting

### DIFF
--- a/src/components/dashboard/DashboardSummary.tsx
+++ b/src/components/dashboard/DashboardSummary.tsx
@@ -146,7 +146,7 @@ function DashboardSummary({
                     {loading ? (
                       <SkeletonBar />
                     ) : (
-                      <span className="text-lg font-semibold text-amber-600 dark:text-amber-400">
+                      <span className="text-lg font-semibold text-amber-600 dark:text-amber-400 whitespace-nowrap">
                         {formatValue(cashBalance)}
                       </span>
                     )}
@@ -161,7 +161,7 @@ function DashboardSummary({
                     {loading ? (
                       <SkeletonBar />
                     ) : (
-                      <span className="text-lg font-semibold text-sky-600 dark:text-sky-400">
+                      <span className="text-lg font-semibold text-sky-600 dark:text-sky-400 whitespace-nowrap">
                         {formatValue(nonCashBalance)}
                       </span>
                     )}
@@ -182,7 +182,7 @@ function DashboardSummary({
               {loading ? (
                 <SkeletonBar />
               ) : (
-                <p className="text-2xl font-bold tracking-tight text-foreground md:text-3xl">
+                <p className="text-2xl font-bold tracking-tight text-foreground md:text-3xl whitespace-nowrap">
                   {formatValue(totalBalance)}
                 </p>
               )}


### PR DESCRIPTION
## Summary
- prevent saldo balance values from wrapping so the icons stay aligned
- keep total saldo amount on a single line to maintain consistent layout

## Testing
- pnpm dev --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68dbcd5fc6f08332a1f88bc6004f8383