### PR TITLE
Fix dashboard insights to use calendar month boundaries

### DIFF
--- a/src/hooks/useInsights.test.js
+++ b/src/hooks/useInsights.test.js
@@ -79,4 +79,19 @@ describe("aggregateInsights", () => {
     const res = aggregateInsights(txs);
     expect(res.topSpends.map((t) => t.amount)).toEqual([400, 300, 200]);
   });
+
+  it("uses calendar month starting from the 1st in Asia/Jakarta", () => {
+    const baseTime = new Date("2024-06-15T00:00:00.000Z");
+    vi.setSystemTime(new Date("2024-07-15T12:00:00+07:00"));
+
+    const julyTxs = [
+      { id: 100, date: "2024-07-01T00:00:00+07:00", type: "expense", amount: 500 },
+      { id: 101, date: "2024-06-30T23:00:00+07:00", type: "expense", amount: 250 },
+    ];
+
+    const res = aggregateInsights(julyTxs);
+    expect(res.kpis.expense).toBe(500);
+
+    vi.setSystemTime(baseTime);
+  });
 });


### PR DESCRIPTION
## Summary
- align the dashboard category distribution and top spend insights with calendar-month ranges starting on the 1st in Asia/Jakarta
- add a regression test to ensure month filtering ignores late-night transactions from the previous month

## Testing
- pnpm test src/hooks/useInsights.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc68812dec83328f4295593a2c1b12