### PR TITLE
Support month-based insights filtering

### DIFF
--- a/src/hooks/useInsights.test.js
+++ b/src/hooks/useInsights.test.js
@@ -79,4 +79,15 @@ describe("aggregateInsights", () => {
     const res = aggregateInsights(txs);
     expect(res.topSpends.map((t) => t.amount)).toEqual([400, 300, 200]);
   });
+
+  it("supports selecting a specific month starting from day one", () => {
+    const res = aggregateInsights(txs, "2024-05");
+    expect(res.kpis.income).toBe(1000);
+    expect(res.kpis.expense).toBe(500);
+    expect(res.kpis.avgDaily).toBeCloseTo(16.13, 2);
+    expect(res.topSpends.map((t) => t.amount)).toEqual([500]);
+    expect(res.categories).toEqual([
+      { name: "Lainnya", value: 500, color: undefined },
+    ]);
+  });
 });

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -19,7 +19,7 @@ import BudgetHighlights from "../components/dashboard/BudgetHighlights";
 const DEFAULT_PRESET = "month";
 
 // Each content block uses <Section> to maintain a single vertical rhythm.
-export default function Dashboard({ stats, txs }) {
+export default function Dashboard({ stats, txs, monthForReport }) {
   const [periodPreset, setPeriodPreset] = useState(DEFAULT_PRESET);
   const [periodRange, setPeriodRange] = useState(() => getPresetRange(DEFAULT_PRESET));
   const balances = useDashboardBalances(periodRange);
@@ -67,7 +67,7 @@ export default function Dashboard({ stats, txs }) {
     return count;
   }, [txs]);
 
-  const insights = useInsights(txs);
+  const insights = useInsights(txs, monthForReport);
   const savingsTarget = stats?.savingsTarget || 1_000_000;
 
   return (


### PR DESCRIPTION
## Summary
- allow the insights aggregation hook to accept an explicit month and filter transactions within that calendar month
- ensure the dashboard passes its selected report month so category and top spend data align with the month starting on day one
- extend the insights tests to cover month-specific aggregation behaviour

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dc68812dec83328f4295593a2c1b12