### PR TITLE
Fix dashboard monthly insights to respect Jakarta month boundaries

### DIFF
--- a/src/hooks/useInsights.test.js
+++ b/src/hooks/useInsights.test.js
@@ -79,4 +79,33 @@ describe("aggregateInsights", () => {
     const res = aggregateInsights(txs);
     expect(res.topSpends.map((t) => t.amount)).toEqual([400, 300, 200]);
   });
+
+  it("uses Jakarta month boundaries", () => {
+    const originalDate = new Date("2024-06-15T00:00:00.000Z");
+    vi.setSystemTime(new Date("2024-06-01T00:30:00.000Z"));
+
+    const boundaryTxs = [
+      {
+        id: 99,
+        date: "2024-05-31T18:00:00.000Z",
+        type: "expense",
+        amount: 150,
+        category: "Boundary",
+      },
+      {
+        id: 100,
+        date: "2024-05-31T16:59:59.999Z",
+        type: "expense",
+        amount: 200,
+        category: "Previous",
+      },
+    ];
+
+    const res = aggregateInsights(boundaryTxs);
+
+    expect(res.topSpends.map((t) => t.amount)).toEqual([150]);
+    expect(res.categories).toHaveLength(1);
+
+    vi.setSystemTime(originalDate);
+  });
 });


### PR DESCRIPTION
## Summary
- update monthly insight aggregation to derive month keys in Asia/Jakarta so the category distribution and top spends start on the 1st
- ensure trend calculations are month-aware and skip non income/expense types when aggregating
- add a regression test covering the Jakarta boundary to lock in the new behaviour

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dc68812dec83328f4295593a2c1b12