### PR TITLE
Enhance dashboard achievements with transaction insights

### DIFF
--- a/src/components/AchievementBadges.jsx
+++ b/src/components/AchievementBadges.jsx
@@ -1,4 +1,12 @@
-import { Award, Target, Star } from "lucide-react";
+import {
+  Award,
+  Flame,
+  Leaf,
+  MoonStar,
+  Sparkles,
+  Target,
+  Star,
+} from "lucide-react";
 import "./Animations.css";
 
 function toRupiah(n = 0) {
@@ -9,7 +17,143 @@ function toRupiah(n = 0) {
   }).format(n);
 }
 
-export default function AchievementBadges({ stats = {}, streak = 0, target = 0 }) {
+const JAKARTA_TIMEZONE = "Asia/Jakarta";
+
+const jakartaDateFormatter = new Intl.DateTimeFormat("en-CA", {
+  timeZone: JAKARTA_TIMEZONE,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+function getDateParts(input) {
+  const date = new Date(input);
+  if (Number.isNaN(date.getTime())) return null;
+
+  const parts = jakartaDateFormatter.formatToParts(date);
+  const lookup = Object.create(null);
+  for (const part of parts) {
+    if (part.type === "year" || part.type === "month" || part.type === "day") {
+      lookup[part.type] = part.value;
+    }
+  }
+
+  const year = Number.parseInt(lookup.year ?? "", 10);
+  const month = lookup.month;
+  const day = Number.parseInt(lookup.day ?? "", 10);
+
+  if (!year || !month || !day) return null;
+
+  return { year, month, day };
+}
+
+function getMonthKey(input) {
+  const parts = getDateParts(input);
+  if (!parts) return null;
+  return `${parts.year}-${parts.month}`;
+}
+
+function getCurrentMonthKey(baseDate = new Date()) {
+  const parts = getDateParts(baseDate);
+  if (!parts) return null;
+  return `${parts.year}-${parts.month}`;
+}
+
+function toNumber(value) {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function getCategoryAggregations(txs = []) {
+  return txs
+    .filter((t) => t.type === "expense")
+    .reduce((map, tx) => {
+      const amount = toNumber(tx.amount);
+      if (!amount) return map;
+
+      const key = tx.category || "Lainnya";
+      const existing = map.get(key) ?? {
+        name: key,
+        total: 0,
+        count: 0,
+        color: undefined,
+      };
+
+      existing.total += amount;
+      existing.count += 1;
+      if (!existing.color && typeof tx.category_color === "string" && tx.category_color) {
+        existing.color = tx.category_color;
+      }
+
+      map.set(key, existing);
+      return map;
+    }, new Map());
+}
+
+function getPreviousMonth(date = new Date()) {
+  const prev = new Date(date);
+  prev.setMonth(prev.getMonth() - 1);
+  return prev;
+}
+
+function calculateNoSpendStreak(expenseTxs = []) {
+  if (!expenseTxs.length) {
+    const today = new Date();
+    const days = today.getDate();
+    return days;
+  }
+
+  const today = new Date();
+  const startOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+  const limit = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+
+  const spentDays = new Set(
+    expenseTxs
+      .map((tx) => {
+        const date = new Date(tx.date);
+        if (Number.isNaN(date.getTime())) return null;
+        return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+      })
+      .filter((value) => value != null)
+  );
+
+  let longest = 0;
+  let current = 0;
+
+  for (
+    let cursor = new Date(startOfMonth);
+    cursor <= limit;
+    cursor.setDate(cursor.getDate() + 1)
+  ) {
+    const key = new Date(
+      cursor.getFullYear(),
+      cursor.getMonth(),
+      cursor.getDate()
+    ).getTime();
+    if (!spentDays.has(key)) {
+      current += 1;
+      longest = Math.max(longest, current);
+    } else {
+      current = 0;
+    }
+  }
+
+  return longest;
+}
+
+function formatPercentageDrop(previous, current) {
+  if (!previous) return null;
+  const drop = previous - current;
+  if (drop <= 0) return null;
+  return Math.round((drop / previous) * 100);
+}
+
+export default function AchievementBadges({
+  stats = {},
+  streak = 0,
+  target = 0,
+  txs = [],
+}) {
   const badges = [];
   const balance = stats?.balance ?? 0;
   if (balance >= 500000) {
@@ -33,6 +177,73 @@ export default function AchievementBadges({ stats = {}, streak = 0, target = 0 }
       text: `Streak ${streak} hari 🔥`,
     });
   }
+  const currentMonthKey = getCurrentMonthKey();
+  const prevMonthKey = getMonthKey(getPreviousMonth());
+
+  const monthTxs = txs.filter((tx) => getMonthKey(tx.date) === currentMonthKey);
+  const prevMonthTxs = txs.filter((tx) => getMonthKey(tx.date) === prevMonthKey);
+
+  const monthCategoryMap = getCategoryAggregations(monthTxs);
+  const prevCategoryMap = getCategoryAggregations(prevMonthTxs);
+
+  const monthCategories = Array.from(monthCategoryMap.values());
+
+  if (monthCategories.length) {
+    const topCategory = monthCategories.reduce(
+      (max, cat) => (!max || cat.total > max.total ? cat : max),
+      null
+    );
+    if (topCategory) {
+      badges.push({
+        id: "top-category",
+        icon: <Flame className="h-4 w-4 text-destructive" />,
+        text: `Pengeluaran terbesar ada di kategori ${topCategory.name} sebesar ${toRupiah(
+          topCategory.total
+        )}. Yuk cek lagi kebutuhannya!`,
+      });
+    }
+
+    const favoriteCategory = monthCategories.reduce(
+      (fav, cat) => (!fav || cat.count > fav.count ? cat : fav),
+      null
+    );
+    if (favoriteCategory) {
+      badges.push({
+        id: "favorite-category",
+        icon: <Sparkles className="h-4 w-4 text-brand" />,
+        text: `Kategori favoritmu bulan ini adalah ${favoriteCategory.name} dengan ${favoriteCategory.count} transaksi.`,
+      });
+    }
+
+    const bestImprovement = monthCategories
+      .map((cat) => {
+        const previous = prevCategoryMap.get(cat.name)?.total ?? 0;
+        const drop = formatPercentageDrop(previous, cat.total);
+        return { cat, previous, drop };
+      })
+      .filter((item) => item.drop != null && item.drop >= 10)
+      .sort((a, b) => b.drop - a.drop)[0];
+
+    if (bestImprovement) {
+      badges.push({
+        id: "category-improvement",
+        icon: <Leaf className="h-4 w-4 text-success" />,
+        text: `Pengeluaran ${bestImprovement.cat.name} turun ${bestImprovement.drop}% dibanding bulan lalu. Pertahankan!`,
+      });
+    }
+
+    const noSpendStreak = calculateNoSpendStreak(
+      monthTxs.filter((tx) => tx.type === "expense")
+    );
+    if (noSpendStreak >= 2) {
+      badges.push({
+        id: "no-spend-streak",
+        icon: <MoonStar className="h-4 w-4 text-indigo-500" />,
+        text: `Ada ${noSpendStreak} hari berturut-turut tanpa pengeluaran bulan ini. Good job!`,
+      });
+    }
+  }
+
   if (!badges.length) return null;
 
   const visible = badges.slice(0, 4);

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -119,6 +119,7 @@ export default function Dashboard({ stats, txs }) {
           stats={stats}
           streak={streak}
           target={savingsTarget}
+          txs={txs}
         />
 
         <QuickActions />


### PR DESCRIPTION
## Summary
- enrich the dashboard achievement badges with transaction and category analytics
- surface highlights like top spending categories, category improvements, and no-spend streaks
- pass transaction history into the achievement component for dynamic messaging

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dc70e066248332b34e436dd4d4b076