### PR TITLE
Fix tenor navigation grouping when debt date changes

### DIFF
--- a/src/pages/Debts.tsx
+++ b/src/pages/Debts.tsx
@@ -87,7 +87,8 @@ function getTenorSeriesKey(debt: DebtRecord): string {
     debt.rate_percent != null && Number.isFinite(debt.rate_percent)
       ? debt.rate_percent.toFixed(4)
       : 'null';
-  const seriesStart = getSeriesStartDate(debt);
+  const createdAt = new Date(debt.created_at);
+  const seriesIdentifier = Number.isNaN(createdAt.getTime()) ? getSeriesStartDate(debt) : createdAt.toISOString();
   return [
     debt.user_id,
     debt.type,
@@ -97,7 +98,7 @@ function getTenorSeriesKey(debt: DebtRecord): string {
     normalizedAmount,
     normalizedRate,
     debt.tenor_months,
-    seriesStart,
+    seriesIdentifier,
   ].join('|');
 }
 


### PR DESCRIPTION
## Summary
- ensure multi-tenor debts keep the same navigation group by keying them with their creation timestamp, falling back to the previous start-date logic when unavailable

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dcf71a683c833297eae40fb4da0c1f