### PR TITLE
Enhance MoneyTalk responses with dynamic transaction awareness

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -796,6 +796,8 @@ function AppShell({ prefs, setPrefs }) {
     speak({
       category,
       amount,
+      type: tx.type,
+      currency: tx.currency || prefs.currency || "IDR",
       context: { isHigh, isSavings, isOverBudget },
     });
   };

--- a/src/lib/moneyTalkContent.js
+++ b/src/lib/moneyTalkContent.js
@@ -158,14 +158,179 @@ export const tips = {
 
 export const special = {
   id: {
-    high: "Kenapa aku dibelikan mahal-mahal? 😵",
-    savings: "Nice! Aku disimpan buat masa depan 💰✨",
-    overbudget: "Aku capek dipakai terus… istirahat dulu ya 😭",
+    high: "Kenapa aku dibelikan mahal-mahal? {{amount}} langsung melayang! 😵",
+    savings: "Nice! Aku disimpan buat masa depan 💰✨ {{amount}} parkir manis di tabungan.",
+    overbudget:
+      "Aku capek dipakai terus… kategori {{category}} sudah kebablasan sebesar {{amount}} 😭",
   },
   en: {
-    high: "Why am I bought so pricey? 😵",
-    savings: "Nice! I'm saved for the future 💰✨",
-    overbudget: "I'm tired of being spent… give me a break 😭",
+    high: "Why am I bought so pricey? {{amount}} just vanished! 😵",
+    savings: "Nice! I'm saved for the future 💰✨ {{amount}} is lounging in savings now.",
+    overbudget:
+      "I'm tired of being spent… {{category}} blew past the plan by {{amount}} 😭",
+  },
+};
+
+export const amountReactions = {
+  id: {
+    expense: {
+      zero: [
+        "Transaksi {{category}} ini nol? Aku cuma olahraga pemanasan doang. 🏃‍♂️",
+        "Tidak ada uang keluar, tapi aku sudah siap joget. Kasih angka dikit dong. 😅",
+      ],
+      tiny: [
+        "Pengeluaran {{category}} cuma {{amount}}. Aku masih senyum-senyum. 🙂",
+        "Cemilan {{category}} seharga {{amount}}? Aku ikutan ngeces aja deh. 🤤",
+      ],
+      small: [
+        "{{amount}} meluncur ke {{category}}. Dompetku masih santai, tapi jangan kebablasan ya. 😌",
+        "Oke, {{category}} dapat {{amount}}. Aku bakal hemat air mata dulu. 😉",
+      ],
+      medium: [
+        "Uh-oh, {{amount}} terbang ke {{category}}. Aku mulai ngos-ngosan nih. 🥵",
+        "{{category}} nelen {{amount}} sekaligus. Aku butuh kipas angin sekarang. 🪭",
+      ],
+      large: [
+        "Waduh, {{amount}} langsung teleport ke {{category}}! Dompetku tepuk jidat. 🤯",
+        "{{category}} barusan buka konser dan {{amount}} beli tiket VIP. Aku bengong dulu. 🤸",
+      ],
+      mega: [
+        "Halo, Bank Indonesia? Ada {{amount}} kabur ke {{category}}! 🚨",
+        "{{amount}} keluar sekaligus? Aku pingsan bentar ya… panggilin teh manis. 🫠",
+      ],
+    },
+    income: {
+      zero: [
+        "Katanya ada pemasukan, tapi angkanya nol. Jangan PHP aku dong. 😏",
+        "Saldo cuma disapa doang tanpa angka. Aku baper nih. 🥺",
+      ],
+      tiny: [
+        "Yeay, recehan {{amount}} mampir! Aku jingkrak kecil dulu. 💃",
+        "{{amount}} masuk ke {{category}}. Kecil-kecil cabe rawit nih. 🌶️",
+      ],
+      small: [
+        "Asik, {{amount}} mendarat mulus. Dompet langsung senyum tipis. 😊",
+        "Ada pemasukan {{amount}} buat {{category}}. Aku siap-siap bikin pesta kecil. 🎉",
+      ],
+      medium: [
+        "Wow, {{amount}} turun dari langit! Tolong gelar karpet merah dong. 🛬",
+        "{{category}} kedatangan {{amount}}. Aku mendadak optimis sama masa depan. ✨",
+      ],
+      large: [
+        "Ini dia! {{amount}} masuk, dompet langsung body goals. 💪",
+        "{{amount}} mampir? Aku siap bikin rapor keuangan warna hijau semua! 📗",
+      ],
+      mega: [
+        "Awas, tsunami pemasukan {{amount}}! Aku butuh kapal pesiar buat nampung. 🛳️",
+        "Seseorang panggil penasihat keuangan, {{amount}} baru jatuh dari langit! 🤑",
+      ],
+    },
+    transfer: {
+      zero: [
+        "Mutasi nol? Aku cuma pindah kursi doang nih. 🪑",
+        "Tidak ada uang pindah, cuma drama doang rupanya. 🎭",
+      ],
+      tiny: [
+        "{{amount}} pindah kos ke {{category}}. Semoga kamarnya lebih adem. 🧳",
+        "Transfer mungil {{amount}} ini lucu juga, kayak aku digelitik. 😄",
+      ],
+      small: [
+        "Aku pindahan ke {{category}} bawa koper {{amount}}. Jangan lupa sambutanku ya. 🙋",
+        "{{amount}} lagi cari suasana baru di {{category}}. Tolong kasih welcome drink. 🍹",
+      ],
+      medium: [
+        "Relokasi {{amount}} ke {{category}} berjalan lancar. Aku kangen rumah lama sih. 🏡",
+        "{{amount}} pindah alamat! Semoga alamat barunya ada Wi-Fi gratis. 📦",
+      ],
+      large: [
+        "Konvoi besar-besaran: {{amount}} pindah ke {{category}}! Aku ikut sirinean dulu. 🚚",
+        "{{amount}} migrasi masal ke {{category}}. Tolong pasang spanduk selamat datang. 🎉",
+      ],
+      mega: [
+        "Evakuasi super: {{amount}} kabur bareng-bareng ke {{category}}! 🚁",
+        "Sepertinya {{amount}} butuh travel agent buat pindah ke {{category}}. Aku ikut jadi pemandu. 🧭",
+      ],
+    },
+  },
+  en: {
+    expense: {
+      zero: [
+        "A zero-amount {{category}}? Guess I'm just stretching my legs. 🏃‍♂️",
+        "No cash left my pocket, but I'm already warmed up. Toss me a number! 😅",
+      ],
+      tiny: [
+        "Only {{amount}} for {{category}}. I'm still smiling. 🙂",
+        "A snack-level {{category}} bill of {{amount}}? I'm just drooling. 🤤",
+      ],
+      small: [
+        "{{amount}} floated to {{category}}. Wallet's still chill, just don't overdo it. 😌",
+        "Okay, {{category}} claimed {{amount}}. I'll save my tears for later. 😉",
+      ],
+      medium: [
+        "Uh-oh, {{amount}} warped over to {{category}}. I'm getting sweaty here. 🥵",
+        "{{category}} just gulped {{amount}}. Someone bring me a fan. 🪭",
+      ],
+      large: [
+        "Yikes, {{amount}} teleported to {{category}}! My wallet facepalmed. 🤯",
+        "{{category}} hosted a concert and {{amount}} bought VIP seats. I'm stunned. 🤸",
+      ],
+      mega: [
+        "Hello, central bank? {{amount}} just fled to {{category}}! 🚨",
+        "{{amount}} gone in one swoop? I'm fainting—fetch sweet tea! 🫠",
+      ],
+    },
+    income: {
+      zero: [
+        "Income with zero amount? Don't ghost me like that. 😏",
+        "The balance only got a hello, no numbers. Feelings: hurt. 🥺",
+      ],
+      tiny: [
+        "Yay, {{amount}} spare change arrived! Doing a mini dance. 💃",
+        "{{amount}} coming into {{category}}. Small but spicy. 🌶️",
+      ],
+      small: [
+        "Nice, {{amount}} just landed. Wallet smiles softly. 😊",
+        "{{amount}} joined {{category}}. Time for a tiny celebration. 🎉",
+      ],
+      medium: [
+        "Whoa, {{amount}} dropped from the sky! Roll out the red carpet. 🛬",
+        "{{category}} received {{amount}}. Suddenly I'm optimistic about the future. ✨",
+      ],
+      large: [
+        "Here we go! {{amount}} came in and my wallet has abs now. 💪",
+        "{{amount}} showed up? I'm painting the finance report green! 📗",
+      ],
+      mega: [
+        "Incoming cash tsunami of {{amount}}! I need a yacht to hold it. 🛳️",
+        "Call the money advisor, {{amount}} just fell from the sky! 🤑",
+      ],
+    },
+    transfer: {
+      zero: [
+        "Zero transfer? Guess I'm just swapping seats. 🪑",
+        "No cash moved—just dramatic flair. 🎭",
+      ],
+      tiny: [
+        "{{amount}} is moving into {{category}}. Hope the new place has AC. 🧳",
+        "This petite {{amount}} transfer tickles! 😄",
+      ],
+      small: [
+        "Carrying {{amount}} over to {{category}}. Please welcome me properly. 🙋",
+        "{{amount}} is trying out {{category}}. Serve a welcome drink, please. 🍹",
+      ],
+      medium: [
+        "Relocating {{amount}} to {{category}} went smoothly. I do miss the old place though. 🏡",
+        "{{amount}} changed address! Fingers crossed for free Wi-Fi there. 📦",
+      ],
+      large: [
+        "Mass migration: {{amount}} is off to {{category}}! Sirens on. 🚚",
+        "{{amount}} moved en masse to {{category}}. Hang the welcome banner! 🎉",
+      ],
+      mega: [
+        "Mega evacuation: {{amount}} just airlifted to {{category}}! 🚁",
+        "Looks like {{amount}} hired a travel agent for {{category}}. I'm the tour guide. 🧭",
+      ],
+    },
   },
 };
 


### PR DESCRIPTION
## Summary
- add amount-aware joke templates for each transaction type in the MoneyTalk content
- update MoneyTalk provider to pick dynamic messages based on transaction amount, type, and savings/budget context
- pass transaction type and currency into the MoneyTalk trigger so reactions can format the value correctly

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dcf87d3e208332a8ab244e974dee70