### PR TITLE
Fix MoneyTalk bubble reliability and positioning

### DIFF
--- a/src/components/MoneyTalkBubble.jsx
+++ b/src/components/MoneyTalkBubble.jsx
@@ -6,38 +6,43 @@ export default function MoneyTalkBubble({ message, tip, avatar = "coin", onDismi
   const icon = avatar === "bill" ? "💵" : "🪙";
 
   return (
-    <div className="fixed bottom-4 right-4 z-50" aria-live="polite">
-      <div
-        tabIndex={0}
-        role="status"
-        className={clsx(
-          "card shadow-lg p-3 flex items-start gap-2 cursor-pointer focus:outline-none",
-          "animate-slide"
-        )}
-        onClick={() => setOpen((o) => !o)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") setOpen((o) => !o);
-          if (e.key === "Escape") onDismiss();
-        }}
-      >
-        <span className="text-2xl" aria-hidden="true">{icon}</span>
-        <div className="flex-1 text-sm">{message}</div>
-        <button
-          type="button"
-          className="ml-2 text-xs"
-          onClick={(e) => {
-            e.stopPropagation();
-            onDismiss();
+    <div
+      className="fixed inset-x-0 bottom-4 z-50 flex justify-end px-4 pointer-events-none"
+      aria-live="polite"
+    >
+      <div className="flex flex-col items-end gap-2 pointer-events-auto">
+        <div
+          tabIndex={0}
+          role="status"
+          className={clsx(
+            "card shadow-lg p-3 flex items-start gap-2 cursor-pointer focus:outline-none",
+            "animate-slide"
+          )}
+          onClick={() => setOpen((o) => !o)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") setOpen((o) => !o);
+            if (e.key === "Escape") onDismiss();
           }}
         >
-          &times;
-        </button>
-      </div>
-      {open && tip && (
-        <div className="mt-2 card shadow p-2 text-xs animate-slide" role="dialog">
-          {tip}
+          <span className="text-2xl" aria-hidden="true">{icon}</span>
+          <div className="flex-1 text-sm">{message}</div>
+          <button
+            type="button"
+            className="ml-2 text-xs"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDismiss();
+            }}
+          >
+            &times;
+          </button>
         </div>
-      )}
+        {open && tip && (
+          <div className="card shadow p-2 text-xs animate-slide" role="dialog">
+            {tip}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/lib/moneyTalkQueue.js
+++ b/src/lib/moneyTalkQueue.js
@@ -1,13 +1,36 @@
+const WINDOW_MS = 60_000;
+
 export function createMoneyTalkLimiter(intensity = "normal") {
   const events = [];
   const max = intensity === "jarang" ? 1 : intensity === "ramai" ? 3 : 2;
-  function tryConsume(now = Date.now()) {
-    while (events.length && now - events[0] > 60000) {
+
+  function prune(now = Date.now()) {
+    while (events.length && now - events[0] > WINDOW_MS) {
       events.shift();
     }
-    if (events.length >= max) return false;
-    events.push(now);
-    return true;
   }
-  return { tryConsume, get count() { return events.length; } };
+
+  function estimateWait(now = Date.now()) {
+    prune(now);
+    if (events.length < max) return 0;
+    return Math.max(0, WINDOW_MS - (now - events[0]));
+  }
+
+  function tryConsume(now = Date.now()) {
+    prune(now);
+    if (events.length >= max) {
+      return { allowed: false, wait: estimateWait(now) };
+    }
+    events.push(now);
+    return { allowed: true, wait: 0 };
+  }
+
+  return {
+    tryConsume,
+    estimateWait,
+    get count() {
+      prune();
+      return events.length;
+    },
+  };
 }

--- a/src/lib/moneyTalkQueue.test.js
+++ b/src/lib/moneyTalkQueue.test.js
@@ -5,11 +5,13 @@ describe("moneyTalk limiter", () => {
   it("limits messages per minute", () => {
     const limiter = createMoneyTalkLimiter("normal"); // max 2 per minute
     const base = 0;
-    expect(limiter.tryConsume(base)).toBe(true);
-    expect(limiter.tryConsume(base + 1000)).toBe(true);
-    // third within same minute should be blocked
-    expect(limiter.tryConsume(base + 2000)).toBe(false);
+    expect(limiter.tryConsume(base).allowed).toBe(true);
+    expect(limiter.tryConsume(base + 1000).allowed).toBe(true);
+    // third within same minute should be blocked and return wait time
+    const thirdAttempt = limiter.tryConsume(base + 2000);
+    expect(thirdAttempt.allowed).toBe(false);
+    expect(thirdAttempt.wait).toBeGreaterThan(0);
     // after a minute it should allow again
-    expect(limiter.tryConsume(base + 61000)).toBe(true);
+    expect(limiter.tryConsume(base + 61000).allowed).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- update the MoneyTalk limiter to report wait times and retry queued messages instead of dropping them
- guarantee a fallback message for every transaction and keep the bubble queue processing after dismissals
- adjust the MoneyTalk bubble layout so the toast stays anchored to the bottom-right corner

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dd0d406734833291f23e0bc7ec760b