### PR TITLE
Revamp MoneyTalk copy and align toast placement

### DIFF
--- a/src/components/MoneyTalkBubble.jsx
+++ b/src/components/MoneyTalkBubble.jsx
@@ -17,7 +17,7 @@ export default function MoneyTalkBubble({ message, tip, avatar = "coin", onDismi
 
   return createPortal(
     <div
-      className="pointer-events-none fixed bottom-6 right-6 z-50 sm:bottom-8 sm:right-8"
+      className="pointer-events-none fixed bottom-6 right-6 z-50 flex flex-col items-end sm:bottom-8 sm:right-8"
       aria-live="polite"
     >
       <div

--- a/src/lib/moneyTalkContent.js
+++ b/src/lib/moneyTalkContent.js
@@ -7,6 +7,9 @@ export const quotes = {
       "Makan lagi? Aku butuh diet.",
       "Setiap gigitan, aku semakin tipis.",
       "Aku lebih suka disimpan daripada dimakan.",
+      "Menu pedas, saldo ikut kepedesan. 🔥💸",
+      "Perang sambal selesai, dompetku jadi korbannya. 🥲",
+      "Lidahmu pesta, aku yang bayarin semuanya. 🎉💵",
     ],
     Transport: [
       "Wusshh! Aku ikut ngebut. 🚗",
@@ -15,6 +18,9 @@ export const quotes = {
       "Mungkin coba jalan kaki?",
       "Tiap kilometer, aku berpamitan.",
       "Bis kan murah? hemat dong.",
+      "Setiap klakson, aku lompat dari kursi belakang. 🚕",
+      "Ban berputar, aku ikut muter balik ke masa gajian. 🔄",
+      "Nebeng angin aja yuk, biar aku nggak ngos-ngosan. 🌬️",
     ],
     Hiburan: [
       "Yay, diajak bersenang-senang!",
@@ -23,6 +29,9 @@ export const quotes = {
       "Game baru? Ingat cicilan!",
       "Aku tertawa, tapi sambil nangis.",
       "Seru-seru, tapi tabungan melambai.",
+      "Popcorn habis, saldo gantian dikunyah. 🍿💀",
+      "Soundtrack seru, dompetku yang tegang. 🎧",
+      "Komedi lucu, tapi aku yang jadi punchline. 😂💸",
     ],
     Belanja: [
       "Keranjangmu penuh, aku kosong.",
@@ -31,6 +40,9 @@ export const quotes = {
       "Mungkin cari yang second?",
       "Aku berharap kita cuma window shopping.",
       "Barang baru lagi? Aku belum pulih.",
+      "Scan barcode lagi? Aku butuh napas buatan. 🛍️‍♂️",
+      "Kotak paket datang, aku langsung kabur. 📦💨",
+      "Wishlistmu bahagia, saldoku malah was-was. 😬",
     ],
     Tagihan: [
       "Halo, bulan ini aku datang lagi.",
@@ -39,6 +51,9 @@ export const quotes = {
       "Aku pergi begitu saja tiap tanggal tua.",
       "Langganan banyak, aku seret.",
       "Mungkin matikan lampu kalau tidak dipakai.",
+      "Notifikasi tagihan bunyi, aku langsung push-up. 📲💪",
+      "Meteran muter, aku ikut muter mikir cicilan. 🔄",
+      "Tagihan streaming? Aku kan nggak ikut nonton. 📺😭",
     ],
     Tabungan: [
       "Tidur dulu ya, bangunkan nanti.",
@@ -47,6 +62,9 @@ export const quotes = {
       "Aku senang di celengan.",
       "Tambah lagi dong biar gemuk.",
       "Pelan-pelan jadi bukit.",
+      "Ssst, jangan ganggu aku lagi numpuk masa depan. 🤫💤",
+      "Aku diparkir rapi, jangan derek ya. 🚗🔒",
+      "Tambahanku bikin dompet punya saudara kembar. 👯💵",
     ],
   },
   en: {
@@ -57,6 +75,9 @@ export const quotes = {
       "Eating again? I need a diet.",
       "Every bite makes me thinner.",
       "I'd rather be saved than eaten.",
+      "Spicy menu, spicy wallet burn. 🔥💸",
+      "Sambal war won, my balance lost. 🥲",
+      "Your taste buds party, I pay the bill. 🎉💵",
     ],
     Transport: [
       "Zoom! I'm speeding away. 🚗",
@@ -65,6 +86,9 @@ export const quotes = {
       "Maybe try walking?",
       "Each kilometer, I say goodbye.",
       "Buses are cheaper, you know.",
+      "Every honk launches me out the window. 🚕",
+      "Tires spin, I time-travel to payday. 🔄",
+      "Let's hitch a ride on the wind to save me. 🌬️",
     ],
     Hiburan: [
       "Yay, out for fun!",
@@ -73,6 +97,9 @@ export const quotes = {
       "New game? Remember the bills!",
       "I'm laughing while crying inside.",
       "Fun times, waving goodbye to savings.",
+      "Popcorn's gone, now they're munching my balance. 🍿💀",
+      "Epic soundtrack, terrified wallet. 🎧",
+      "Comedy's funny; I'm the punchline. 😂💸",
     ],
     Belanja: [
       "Your cart is full, I'm empty.",
@@ -81,6 +108,9 @@ export const quotes = {
       "Maybe buy second-hand?",
       "I hoped it was just window shopping.",
       "Another new item? I'm not recovered yet.",
+      "Another barcode scan? I need mouth-to-mouth. 🛍️‍♂️",
+      "Package arrived, I bolted instantly. 📦💨",
+      "Wishlist thrilled, balance thrilled... with fear. 😬",
     ],
     Tagihan: [
       "Hello, it's that time of month.",
@@ -89,6 +119,9 @@ export const quotes = {
       "I vanish every due date.",
       "Too many subscriptions drain me.",
       "Turn off unused lights maybe?",
+      "Bill alert sounds, I'm doing panic push-ups. 📲💪",
+      "Meter spins, I spiral thinking of payments. 🔄",
+      "Streaming bill? I didn't even watch! 📺😭",
     ],
     Tabungan: [
       "Let me sleep for the future.",
@@ -97,6 +130,9 @@ export const quotes = {
       "Happy inside the piggy bank.",
       "Feed me more to grow fat.",
       "Slowly but surely I pile up.",
+      "Shh, I'm stacking future funds. 🤫💤",
+      "Parked neatly—no towing my savings. 🚗🔒",
+      "Each deposit gives my wallet a twin. 👯💵",
     ],
   },
 };
@@ -158,16 +194,18 @@ export const tips = {
 
 export const special = {
   id: {
-    high: "Kenapa aku dibelikan mahal-mahal? {{amount}} langsung melayang! 😵",
-    savings: "Nice! Aku disimpan buat masa depan 💰✨ {{amount}} parkir manis di tabungan.",
+    high: "Siapa pesan paket sultan? {{amount}} meluncur kayak jet pribadi! 😵‍💫",
+    savings:
+      "Mantap! {{amount}} ditidurin manis di tabungan, jangan lupa selimut bunga. 💰✨",
     overbudget:
-      "Aku capek dipakai terus… kategori {{category}} sudah kebablasan sebesar {{amount}} 😭",
+      "Kategori {{category}} udah over {{amount}}. Tolong, aku mau cuti swadaya dulu. 😭",
   },
   en: {
-    high: "Why am I bought so pricey? {{amount}} just vanished! 😵",
-    savings: "Nice! I'm saved for the future 💰✨ {{amount}} is lounging in savings now.",
+    high: "Who ordered the royal package? {{amount}} blasted off like a private jet! 😵‍💫",
+    savings:
+      "Sweet! {{amount}} is tucked into savings—bring a compound-interest blanket. 💰✨",
     overbudget:
-      "I'm tired of being spent… {{category}} blew past the plan by {{amount}} 😭",
+      "{{category}} blew past the plan by {{amount}}. I'm filing for self-care leave. 😭",
   },
 };
 
@@ -177,78 +215,96 @@ export const amountReactions = {
       zero: [
         "Transaksi {{category}} ini nol? Aku cuma olahraga pemanasan doang. 🏃‍♂️",
         "Tidak ada uang keluar, tapi aku sudah siap joget. Kasih angka dikit dong. 😅",
+        "{{category}} gratisan? Aku cuma jadi MC tanpa honor. 🎤",
       ],
       tiny: [
         "Pengeluaran {{category}} cuma {{amount}}. Aku masih senyum-senyum. 🙂",
         "Cemilan {{category}} seharga {{amount}}? Aku ikutan ngeces aja deh. 🤤",
+        "{{amount}} untuk {{category}}? Aku masih kuat senyum sambil ngemil angin. 😎",
       ],
       small: [
         "{{amount}} meluncur ke {{category}}. Dompetku masih santai, tapi jangan kebablasan ya. 😌",
         "Oke, {{category}} dapat {{amount}}. Aku bakal hemat air mata dulu. 😉",
+        "{{category}} ambil {{amount}}. Aku goyang tipis aja, jangan ajak breakdance. 🪩",
       ],
       medium: [
         "Uh-oh, {{amount}} terbang ke {{category}}. Aku mulai ngos-ngosan nih. 🥵",
         "{{category}} nelen {{amount}} sekaligus. Aku butuh kipas angin sekarang. 🪭",
+        "{{amount}} bikin {{category}} kenyang, aku butuh kompres es dulu. 🧊",
       ],
       large: [
         "Waduh, {{amount}} langsung teleport ke {{category}}! Dompetku tepuk jidat. 🤯",
         "{{category}} barusan buka konser dan {{amount}} beli tiket VIP. Aku bengong dulu. 🤸",
+        "{{amount}} keluar, aku langsung buka thread curhat di grup dompet. 🧵",
       ],
       mega: [
         "Halo, Bank Indonesia? Ada {{amount}} kabur ke {{category}}! 🚨",
         "{{amount}} keluar sekaligus? Aku pingsan bentar ya… panggilin teh manis. 🫠",
+        "{{amount}} kabur? Aku buka crowdfunding buat pulangin dia. 🙏",
       ],
     },
     income: {
       zero: [
         "Katanya ada pemasukan, tapi angkanya nol. Jangan PHP aku dong. 😏",
         "Saldo cuma disapa doang tanpa angka. Aku baper nih. 🥺",
+        "Pemasukan nol? Jangan bikin aku refresh saldo sendirian. 🔄",
       ],
       tiny: [
         "Yeay, recehan {{amount}} mampir! Aku jingkrak kecil dulu. 💃",
         "{{amount}} masuk ke {{category}}. Kecil-kecil cabe rawit nih. 🌶️",
+        "{{amount}} mampir, aku gelar karpet keset dulu. 🚪",
       ],
       small: [
         "Asik, {{amount}} mendarat mulus. Dompet langsung senyum tipis. 😊",
         "Ada pemasukan {{amount}} buat {{category}}. Aku siap-siap bikin pesta kecil. 🎉",
+        "{{amount}} mendarat, aku siap selfie sama saldo baru. 🤳",
       ],
       medium: [
         "Wow, {{amount}} turun dari langit! Tolong gelar karpet merah dong. 🛬",
         "{{category}} kedatangan {{amount}}. Aku mendadak optimis sama masa depan. ✨",
+        "{{amount}} turun, aku langsung update status 'menuju kaya'. 🚀",
       ],
       large: [
         "Ini dia! {{amount}} masuk, dompet langsung body goals. 💪",
         "{{amount}} mampir? Aku siap bikin rapor keuangan warna hijau semua! 📗",
+        "{{amount}} bikin aku tegap kayak ATM baru diisi. 🏦",
       ],
       mega: [
         "Awas, tsunami pemasukan {{amount}}! Aku butuh kapal pesiar buat nampung. 🛳️",
         "Seseorang panggil penasihat keuangan, {{amount}} baru jatuh dari langit! 🤑",
+        "{{amount}} masuk? Aku pesen satpam pribadi sekarang juga. 🛡️",
       ],
     },
     transfer: {
       zero: [
         "Mutasi nol? Aku cuma pindah kursi doang nih. 🪑",
         "Tidak ada uang pindah, cuma drama doang rupanya. 🎭",
+        "Transfer tanpa angka itu namanya surat cinta, bukan transaksi. 💌",
       ],
       tiny: [
         "{{amount}} pindah kos ke {{category}}. Semoga kamarnya lebih adem. 🧳",
         "Transfer mungil {{amount}} ini lucu juga, kayak aku digelitik. 😄",
+        "{{amount}} pindah? Aku bantu angkat kardusnya sekalian. 📦",
       ],
       small: [
         "Aku pindahan ke {{category}} bawa koper {{amount}}. Jangan lupa sambutanku ya. 🙋",
         "{{amount}} lagi cari suasana baru di {{category}}. Tolong kasih welcome drink. 🍹",
+        "{{amount}} lagi nyari suasana baru di {{category}}, tolong share lokasi. 📍",
       ],
       medium: [
         "Relokasi {{amount}} ke {{category}} berjalan lancar. Aku kangen rumah lama sih. 🏡",
         "{{amount}} pindah alamat! Semoga alamat barunya ada Wi-Fi gratis. 📦",
+        "Relokasi {{amount}} sukses. Aku titip pesan: jangan lupa kabar-kabar. ☎️",
       ],
       large: [
         "Konvoi besar-besaran: {{amount}} pindah ke {{category}}! Aku ikut sirinean dulu. 🚚",
         "{{amount}} migrasi masal ke {{category}}. Tolong pasang spanduk selamat datang. 🎉",
+        "{{amount}} pindahan besar, aku jadi koordinator RT antar saldo. 🧑‍⚖️",
       ],
       mega: [
         "Evakuasi super: {{amount}} kabur bareng-bareng ke {{category}}! 🚁",
         "Sepertinya {{amount}} butuh travel agent buat pindah ke {{category}}. Aku ikut jadi pemandu. 🧭",
+        "{{amount}} migrasi massal, aku sewa helikopter cadangan. 🚁",
       ],
     },
   },
@@ -257,78 +313,96 @@ export const amountReactions = {
       zero: [
         "A zero-amount {{category}}? Guess I'm just stretching my legs. 🏃‍♂️",
         "No cash left my pocket, but I'm already warmed up. Toss me a number! 😅",
+        "{{category}} was free? I'm just the unpaid host here. 🎤",
       ],
       tiny: [
         "Only {{amount}} for {{category}}. I'm still smiling. 🙂",
         "A snack-level {{category}} bill of {{amount}}? I'm just drooling. 🤤",
+        "{{amount}} for {{category}}? I'm cool, still snacking on air. 😎",
       ],
       small: [
         "{{amount}} floated to {{category}}. Wallet's still chill, just don't overdo it. 😌",
         "Okay, {{category}} claimed {{amount}}. I'll save my tears for later. 😉",
+        "{{category}} claimed {{amount}}. Chill wobble only—no breakdance. 🪩",
       ],
       medium: [
         "Uh-oh, {{amount}} warped over to {{category}}. I'm getting sweaty here. 🥵",
         "{{category}} just gulped {{amount}}. Someone bring me a fan. 🪭",
+        "{{amount}} stuffed {{category}}; I'm icing my balance now. 🧊",
       ],
       large: [
         "Yikes, {{amount}} teleported to {{category}}! My wallet facepalmed. 🤯",
         "{{category}} hosted a concert and {{amount}} bought VIP seats. I'm stunned. 🤸",
+        "{{amount}} left and I'm starting a support group chat. 🧵",
       ],
       mega: [
         "Hello, central bank? {{amount}} just fled to {{category}}! 🚨",
         "{{amount}} gone in one swoop? I'm fainting—fetch sweet tea! 🫠",
+        "{{amount}} escaped? I'm launching a crowdfunding campaign. 🙏",
       ],
     },
     income: {
       zero: [
         "Income with zero amount? Don't ghost me like that. 😏",
         "The balance only got a hello, no numbers. Feelings: hurt. 🥺",
+        "Zero income? Don't leave me refreshing alone. 🔄",
       ],
       tiny: [
         "Yay, {{amount}} spare change arrived! Doing a mini dance. 💃",
         "{{amount}} coming into {{category}}. Small but spicy. 🌶️",
+        "{{amount}} popped in—rolling out the welcome doormat. 🚪",
       ],
       small: [
         "Nice, {{amount}} just landed. Wallet smiles softly. 😊",
         "{{amount}} joined {{category}}. Time for a tiny celebration. 🎉",
+        "{{amount}} arrived; snapping a selfie with the balance. 🤳",
       ],
       medium: [
         "Whoa, {{amount}} dropped from the sky! Roll out the red carpet. 🛬",
         "{{category}} received {{amount}}. Suddenly I'm optimistic about the future. ✨",
+        "{{amount}} dropped in, updating status to 'getting rich-ish'. 🚀",
       ],
       large: [
         "Here we go! {{amount}} came in and my wallet has abs now. 💪",
         "{{amount}} showed up? I'm painting the finance report green! 📗",
+        "{{amount}} made me stand tall like a freshly loaded ATM. 🏦",
       ],
       mega: [
         "Incoming cash tsunami of {{amount}}! I need a yacht to hold it. 🛳️",
         "Call the money advisor, {{amount}} just fell from the sky! 🤑",
+        "{{amount}} landed? Hiring personal security immediately. 🛡️",
       ],
     },
     transfer: {
       zero: [
         "Zero transfer? Guess I'm just swapping seats. 🪑",
         "No cash moved—just dramatic flair. 🎭",
+        "Zero transfer? That's a love letter, not a transaction. 💌",
       ],
       tiny: [
         "{{amount}} is moving into {{category}}. Hope the new place has AC. 🧳",
         "This petite {{amount}} transfer tickles! 😄",
+        "{{amount}} moved; I'm helping carry the little boxes. 📦",
       ],
       small: [
         "Carrying {{amount}} over to {{category}}. Please welcome me properly. 🙋",
         "{{amount}} is trying out {{category}}. Serve a welcome drink, please. 🍹",
+        "{{amount}} seeking new vibes in {{category}}—send location. 📍",
       ],
       medium: [
         "Relocating {{amount}} to {{category}} went smoothly. I do miss the old place though. 🏡",
         "{{amount}} changed address! Fingers crossed for free Wi-Fi there. 📦",
+        "{{amount}} relocated smoothly. Text me when you arrive. ☎️",
       ],
       large: [
         "Mass migration: {{amount}} is off to {{category}}! Sirens on. 🚚",
         "{{amount}} moved en masse to {{category}}. Hang the welcome banner! 🎉",
+        "{{amount}} staged a big move; I'm the neighborhood coordinator now. 🧑‍⚖️",
       ],
       mega: [
         "Mega evacuation: {{amount}} just airlifted to {{category}}! 🚁",
         "Looks like {{amount}} hired a travel agent for {{category}}. I'm the tour guide. 🧭",
+        "{{amount}} migrating en masse; chartering extra helicopters. 🚁",
       ],
     },
   },


### PR DESCRIPTION
## Summary
- expand MoneyTalk quotes and reactions with new playful Indonesian and English lines while keeping transactional context intact
- refresh special-case messages for savings, high spend, and overbudget scenarios
- adjust the MoneyTalk bubble container so the toast anchors to the right side of the viewport

## Testing
- pnpm test -- --runTestsByPath src/lib/moneyTalkQueue.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd148062548332aa7ac89e76dc4c41