### PR TITLE
Differentiate MoneyTalk bubbles by transaction direction

### DIFF
--- a/src/components/MoneyTalkBubble.jsx
+++ b/src/components/MoneyTalkBubble.jsx
@@ -2,7 +2,14 @@ import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import clsx from "clsx";
 
-export default function MoneyTalkBubble({ message, tip, avatar = "coin", onDismiss }) {
+export default function MoneyTalkBubble({
+  message,
+  tip,
+  avatar = "coin",
+  variant = "expense",
+  typeLabel,
+  onDismiss,
+}) {
   const [open, setOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
 
@@ -11,7 +18,21 @@ export default function MoneyTalkBubble({ message, tip, avatar = "coin", onDismi
     return () => setMounted(false);
   }, []);
 
-  const icon = avatar === "bill" ? "💵" : "🪙";
+  const icon =
+    avatar === "bill"
+      ? "💸"
+      : avatar === "transfer"
+      ? "🔁"
+      : "🪙";
+
+  const badgeClass = clsx(
+    "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold",
+    variant === "income"
+      ? "bg-emerald-100 text-emerald-700"
+      : variant === "transfer"
+      ? "bg-sky-100 text-sky-700"
+      : "bg-rose-100 text-rose-700"
+  );
 
   if (!mounted) return null;
 
@@ -34,7 +55,10 @@ export default function MoneyTalkBubble({ message, tip, avatar = "coin", onDismi
         }}
       >
         <span className="text-2xl" aria-hidden="true">{icon}</span>
-        <div className="flex-1 text-sm">{message}</div>
+        <div className="flex-1 text-sm">
+          {typeLabel && <div className={badgeClass}>{typeLabel}</div>}
+          <div>{message}</div>
+        </div>
         <button
           type="button"
           className="ml-2 text-xs"

--- a/src/context/MoneyTalkContext.jsx
+++ b/src/context/MoneyTalkContext.jsx
@@ -155,7 +155,14 @@ export default function MoneyTalkProvider({ prefs = {}, children }) {
           Math.random().toString(36).slice(2),
         message,
         tip,
-        avatar: Math.random() > 0.5 ? "bill" : "coin",
+        avatar:
+          normalizedType === "income"
+            ? "coin"
+            : normalizedType === "transfer"
+            ? "transfer"
+            : "bill",
+        variant: normalizedType,
+        typeLabel: langTypeLabels?.[normalizedType] || normalizedType,
         duration: baseDuration + Math.random() * 1500,
       });
       if (queue.current.length > 3) queue.current.splice(3);
@@ -179,6 +186,8 @@ export default function MoneyTalkProvider({ prefs = {}, children }) {
           message={current.message}
           tip={current.tip}
           avatar={current.avatar}
+          variant={current.variant}
+          typeLabel={current.typeLabel}
           onDismiss={() => {
             handleDismiss();
             process();


### PR DESCRIPTION
## Summary
- tag MoneyTalk notifications with their transaction type and consistent avatars
- render a visual badge in the MoneyTalk bubble so income, expense, and transfer events are easy to tell apart

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de3901efa883329aee9e486d1c71af