### PR TITLE
Adjust toast position to appear below topbar

### DIFF
--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -35,7 +35,12 @@ function ToastItem({ toast, onDismiss }) {
 
 export default function Toast({ toasts = [], onDismiss }) {
   return (
-    <div className="fixed top-4 right-4 space-y-2 z-50">
+    <div
+      className="fixed right-4 space-y-2 z-50"
+      style={{
+        top: "calc(var(--app-header-height, var(--app-topbar-h, 0px)) + 16px)",
+      }}
+    >
       {toasts.map((t) => (
         <ToastItem key={t.id} toast={t} onDismiss={onDismiss} />
       ))}


### PR DESCRIPTION
## Summary
- offset toast container so notifications render below the sticky top bar
- ensure the toast positioning respects any custom header height values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfefbb3c80833286e2428afd7c3614