### PR TITLE
Use descriptive wishlist priority labels

### DIFF
--- a/src/components/wishlist/WishlistBatchToolbar.tsx
+++ b/src/components/wishlist/WishlistBatchToolbar.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Trash2 } from 'lucide-react';
 import type { WishlistStatus } from '../../lib/wishlistApi';
+import { WISHLIST_PRIORITY_LABELS } from '../../lib/wishlistPriority';
 
 interface WishlistBatchToolbarProps {
   selectedCount: number;
@@ -66,11 +67,11 @@ export default function WishlistBatchToolbar({
                 disabled={disabled}
               >
                 <option value="">Set prioritas…</option>
-                <option value="1">1</option>
-                <option value="2">2</option>
-                <option value="3">3</option>
-                <option value="4">4</option>
-                <option value="5">5</option>
+                {Object.entries(WISHLIST_PRIORITY_LABELS).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    Prioritas {label}
+                  </option>
+                ))}
               </select>
             </label>
           </div>

--- a/src/components/wishlist/WishlistCard.tsx
+++ b/src/components/wishlist/WishlistCard.tsx
@@ -11,6 +11,7 @@ import {
   Trash2,
 } from 'lucide-react';
 import type { WishlistItem, WishlistStatus } from '../../lib/wishlistApi';
+import { getWishlistPriorityLabel } from '../../lib/wishlistPriority';
 
 interface WishlistCardProps {
   item: WishlistItem;
@@ -100,12 +101,13 @@ export default function WishlistCard({
 
   const priorityBadge = useMemo(() => {
     const value = item.priority != null ? Math.round(item.priority) : null;
-    if (!value || value < 1 || value > 5) return null;
+    const label = getWishlistPriorityLabel(item.priority);
+    if (!value || value < 1 || value > 5 || !label) return null;
     return (
       <span
         className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium ${PRIORITY_STYLE[value]}`}
       >
-        Prioritas {value}
+        Prioritas {label}
       </span>
     );
   }, [item.priority]);

--- a/src/components/wishlist/WishlistFilterBar.tsx
+++ b/src/components/wishlist/WishlistFilterBar.tsx
@@ -1,6 +1,7 @@
 import { ChangeEvent, FormEvent } from 'react';
 import { RotateCcw, Search } from 'lucide-react';
 import type { WishlistStatus } from '../../lib/wishlistApi';
+import { WISHLIST_PRIORITY_LABELS } from '../../lib/wishlistPriority';
 import type { WishlistFilters } from '../../hooks/useWishlist';
 
 export interface WishlistFilterState extends WishlistFilters {
@@ -35,11 +36,10 @@ const STATUS_OPTIONS: { value: WishlistFilterState['status']; label: string }[] 
 
 const PRIORITY_OPTIONS: { value: WishlistFilterState['priority']; label: string }[] = [
   { value: 'all', label: 'Semua prioritas' },
-  { value: 1, label: 'Prioritas 1' },
-  { value: 2, label: 'Prioritas 2' },
-  { value: 3, label: 'Prioritas 3' },
-  { value: 4, label: 'Prioritas 4' },
-  { value: 5, label: 'Prioritas 5' },
+  ...(Object.entries(WISHLIST_PRIORITY_LABELS).map(([value, label]) => ({
+    value: Number(value) as WishlistFilterState['priority'],
+    label: `Prioritas ${label}`,
+  })) as { value: WishlistFilterState['priority']; label: string }[]),
 ];
 
 const SORT_OPTIONS: { value: WishlistFilterState['sort']; label: string }[] = [

--- a/src/components/wishlist/WishlistFormDialog.tsx
+++ b/src/components/wishlist/WishlistFormDialog.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 import type { WishlistCreatePayload, WishlistItem, WishlistStatus } from '../../lib/wishlistApi';
+import { WISHLIST_PRIORITY_LABELS } from '../../lib/wishlistPriority';
 
 interface CategoryOption {
   id: string;
@@ -223,7 +224,7 @@ export default function WishlistFormDialog({
               </div>
               <div className="space-y-2">
                 <label className="text-sm font-medium text-slate-200" htmlFor="wishlist-priority">
-                  Prioritas (1-5)
+                  Prioritas
                 </label>
                 <select
                   id="wishlist-priority"
@@ -233,11 +234,11 @@ export default function WishlistFormDialog({
                   disabled={submitting}
                 >
                   <option value="">Pilih prioritas</option>
-                  <option value="1">1 - Mendesak</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                  <option value="5">5 - Nice to have</option>
+                  {Object.entries(WISHLIST_PRIORITY_LABELS).map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
                 </select>
                 {errors.priority ? <p className="text-sm text-rose-300">{errors.priority}</p> : null}
               </div>

--- a/src/lib/wishlistPriority.ts
+++ b/src/lib/wishlistPriority.ts
@@ -1,0 +1,14 @@
+export const WISHLIST_PRIORITY_LABELS: Record<number, string> = {
+  1: 'Mendesak',
+  2: 'Tinggi',
+  3: 'Sedang',
+  4: 'Rendah',
+  5: 'Nice to have',
+};
+
+export function getWishlistPriorityLabel(priority?: number | null): string | null {
+  if (priority == null) return null;
+  const rounded = Math.round(priority);
+  if (Number.isNaN(rounded)) return null;
+  return WISHLIST_PRIORITY_LABELS[rounded] ?? null;
+}


### PR DESCRIPTION
## Summary
- add shared wishlist priority label helpers for reuse
- replace numeric priority text with descriptive phrases across wishlist UI

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dfefe65a8c83328d60fe11053b1ac4