### PR TITLE
Handle transient budget fetch errors silently

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -673,12 +673,12 @@ function AppShell({ prefs, setPrefs }) {
           budgetRetryVisibilityHandlerRef.current = null;
         }
         const offline = typeof navigator !== "undefined" && navigator.onLine === false;
-        addToast(
-          offline
-            ? "Gagal memuat data anggaran: Tidak ada koneksi internet. Kami akan mencoba lagi setelah tersambung."
-            : "Gagal memuat data anggaran karena jaringan tidak stabil. Mencoba lagi...",
-          "error"
-        );
+        if (offline) {
+          addToast(
+            "Gagal memuat data anggaran: Tidak ada koneksi internet. Kami akan mencoba lagi setelah tersambung.",
+            "error"
+          );
+        }
         const retryFetch = () => {
           budgetRetryTimeoutRef.current = null;
           void fetchBudgetsCloud();


### PR DESCRIPTION
## Summary
- stop showing the budget fetch error toast when the only failure is a transient "Failed to fetch"
- keep retry logic and only notify users when the device is offline

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dff4872584833296bd0cdef0d5995c