### PR TITLE
feat: allow prioritizing accounts manually

### DIFF
--- a/src/pages/AccountsPage.tsx
+++ b/src/pages/AccountsPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
-import { Loader2, Pencil, Plus, Trash2 } from 'lucide-react';
+import { ArrowDown, ArrowUp, Loader2, Pencil, Plus, Trash2 } from 'lucide-react';
 import Page from '../layout/Page';
 import PageHeader from '../layout/PageHeader';
 import Section from '../layout/Section';
@@ -13,6 +13,7 @@ import {
   createAccount,
   deleteAccount,
   listAccounts,
+  reorderAccounts,
   updateAccount,
 } from '../lib/api.ts';
 import useSupabaseUser from '../hooks/useSupabaseUser';
@@ -32,8 +33,30 @@ const FILTER_OPTIONS: { value: 'all' | AccountType; label: string }[] = [
   { value: 'other', label: 'Lainnya' },
 ];
 
-function sortAccounts(list: AccountRecord[]): AccountRecord[] {
-  return [...list].sort((a, b) => (a.name || '').localeCompare(b.name || '', 'id', { sensitivity: 'base' }));
+function orderAccounts(list: AccountRecord[]): AccountRecord[] {
+  return [...list].sort((a, b) => {
+    const orderDiff = (a.sort_order ?? Number.MAX_SAFE_INTEGER) - (b.sort_order ?? Number.MAX_SAFE_INTEGER);
+    if (orderDiff !== 0) {
+      return orderDiff;
+    }
+    const createdDiff = Date.parse(a.created_at ?? '') - Date.parse(b.created_at ?? '');
+    if (Number.isFinite(createdDiff) && createdDiff !== 0) {
+      return createdDiff;
+    }
+    return (a.name || '').localeCompare(b.name || '', 'id', { sensitivity: 'base' });
+  });
+}
+
+function resequenceAccounts(list: AccountRecord[]): AccountRecord[] {
+  return list.map((account, index) => ({ ...account, sort_order: index }));
+}
+
+function moveItem<T>(list: T[], fromIndex: number, toIndex: number): T[] {
+  if (fromIndex === toIndex) return [...list];
+  const next = [...list];
+  const [item] = next.splice(fromIndex, 1);
+  next.splice(toIndex, 0, item);
+  return next;
 }
 
 function formatDate(iso: string | null): string {
@@ -56,6 +79,7 @@ export default function AccountsPage() {
   const [modalError, setModalError] = useState<string | null>(null);
   const [selectedAccount, setSelectedAccount] = useState<AccountRecord | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [reorderPendingIds, setReorderPendingIds] = useState<Set<string>>(new Set());
 
   const fetchAccounts = useCallback(async () => {
     const uid = user?.id ?? null;
@@ -69,7 +93,7 @@ export default function AccountsPage() {
     setLoadError(null);
     try {
       const rows = await listAccounts(uid);
-      setAccounts(sortAccounts(rows));
+      setAccounts(orderAccounts(rows));
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Gagal memuat akun. Silakan coba lagi.';
@@ -84,10 +108,89 @@ export default function AccountsPage() {
     void fetchAccounts();
   }, [fetchAccounts]);
 
+  const orderedAccounts = useMemo(() => orderAccounts(accounts), [accounts]);
+
   const filteredAccounts = useMemo(() => {
-    if (filter === 'all') return accounts;
-    return accounts.filter((account) => account.type === filter);
-  }, [accounts, filter]);
+    if (filter === 'all') return orderedAccounts;
+    return orderedAccounts.filter((account) => account.type === filter);
+  }, [filter, orderedAccounts]);
+
+  const orderIndexMap = useMemo(() => {
+    return new Map(orderedAccounts.map((account, index) => [account.id, index]));
+  }, [orderedAccounts]);
+
+  const addReorderPending = useCallback((ids: string[]) => {
+    if (!ids.length) return;
+    setReorderPendingIds((prev) => {
+      const next = new Set(prev);
+      ids.forEach((id) => next.add(id));
+      return next;
+    });
+  }, []);
+
+  const removeReorderPending = useCallback((ids: string[]) => {
+    if (!ids.length) return;
+    setReorderPendingIds((prev) => {
+      const next = new Set(prev);
+      ids.forEach((id) => next.delete(id));
+      return next;
+    });
+  }, []);
+
+  const handleReorder = useCallback(
+    (accountId: string, direction: 'up' | 'down') => {
+      if (!user?.id) {
+        addToast('Masuk untuk mengatur urutan akun.', 'error');
+        return;
+      }
+      if (loading) return;
+
+      const snapshot = accounts.slice();
+      const ordered = orderAccounts(snapshot);
+      const currentIndex = ordered.findIndex((item) => item.id === accountId);
+      if (currentIndex < 0) {
+        return;
+      }
+      const targetIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1;
+      if (targetIndex < 0 || targetIndex >= ordered.length) {
+        return;
+      }
+
+      const moved = moveItem(ordered, currentIndex, targetIndex);
+      const resequenced = resequenceAccounts(moved);
+      const affectedIds = Array.from(new Set([ordered[currentIndex].id, ordered[targetIndex].id]))
+        .filter(Boolean);
+
+      setAccounts(resequenced);
+      addReorderPending(affectedIds);
+
+      void reorderAccounts(user.id, resequenced.map((item) => item.id)).catch((error) => {
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Gagal mengubah urutan akun. Silakan coba lagi.';
+        setAccounts(snapshot);
+        addToast(message, 'error');
+      }).finally(() => {
+        removeReorderPending(affectedIds);
+      });
+    },
+    [accounts, addReorderPending, addToast, loading, removeReorderPending, user?.id],
+  );
+
+  const handleMoveUp = useCallback(
+    (accountId: string) => {
+      handleReorder(accountId, 'up');
+    },
+    [handleReorder],
+  );
+
+  const handleMoveDown = useCallback(
+    (accountId: string) => {
+      handleReorder(accountId, 'down');
+    },
+    [handleReorder],
+  );
 
   const modalInitialValues = useMemo(() => {
     if (modalMode === 'edit' && selectedAccount) {
@@ -128,14 +231,16 @@ export default function AccountsPage() {
       try {
         if (modalMode === 'edit' && selectedAccount) {
           const updated = await updateAccount(selectedAccount.id, values);
-          setAccounts((prev) => sortAccounts(prev.map((acc) => (acc.id === updated.id ? updated : acc))));
+          setAccounts((prev) =>
+            orderAccounts(prev.map((acc) => (acc.id === updated.id ? updated : acc))),
+          );
           addToast('Akun diperbarui', 'success');
         } else {
           if (!user?.id) {
             throw new Error('Anda harus login untuk menambah akun.');
           }
           const created = await createAccount(user.id, values);
-          setAccounts((prev) => sortAccounts([...prev, created]));
+          setAccounts((prev) => orderAccounts([...prev, created]));
           addToast('Akun ditambahkan', 'success');
         }
         resetModalState();
@@ -181,6 +286,8 @@ export default function AccountsPage() {
   }, [modalBusy, resetModalState]);
 
   const canManage = Boolean(user?.id);
+  const totalAccounts = orderedAccounts.length;
+  const canReorder = canManage && filter === 'all';
 
   return (
     <Page>
@@ -201,7 +308,7 @@ export default function AccountsPage() {
         <Card>
           <CardHeader
             title="Daftar Akun"
-            subtext="Tambah, ubah, atau hapus akun sesuai kebutuhan Anda."
+            subtext="Tambah, atur prioritas, ubah, atau hapus akun sesuai kebutuhan Anda."
           />
           {!userLoading && !canManage ? (
             <div className="mx-4 mb-4 rounded-lg border border-dashed border-border bg-surface-2/60 p-4 text-sm text-muted">
@@ -209,7 +316,7 @@ export default function AccountsPage() {
             </div>
           ) : null}
           <CardBody className="space-y-5">
-            <div className="flex flex-wrap gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               {FILTER_OPTIONS.map((option) => (
                 <button
                   key={option.value}
@@ -249,52 +356,84 @@ export default function AccountsPage() {
               </div>
             ) : (
               <ul className="space-y-3">
-                {filteredAccounts.map((account) => (
-                  <li
-                    key={account.id}
-                    className="rounded-3xl border border-border-subtle bg-surface-alt/60 p-5 shadow-sm transition-all hover:border-border-strong"
-                  >
-                    <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-                      <div className="min-w-0">
-                        <p className="truncate text-base font-semibold text-text">
-                          {account.name || 'Tanpa Nama'}
-                        </p>
-                        <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-muted">
-                          <span className="badge-muted">{ACCOUNT_TYPE_LABELS[account.type]}</span>
-                          <span className="rounded-full bg-surface px-3 py-1 font-medium text-text">
-                            {account.currency || 'IDR'}
-                          </span>
-                          <span className="flex items-center gap-1">
-                            Dibuat {formatDate(account.created_at)}
-                          </span>
+                {filteredAccounts.map((account) => {
+                  const orderIndex = orderIndexMap.get(account.id) ?? 0;
+                  const isFirst = orderIndex === 0;
+                  const isLast = orderIndex === totalAccounts - 1;
+                  const isReordering = reorderPendingIds.has(account.id);
+                  const disableMoveUp =
+                    !canReorder || isFirst || totalAccounts < 2 || isReordering || Boolean(deletingId);
+                  const disableMoveDown =
+                    !canReorder || isLast || totalAccounts < 2 || isReordering || Boolean(deletingId);
+                  return (
+                    <li
+                      key={account.id}
+                      className="rounded-3xl border border-border-subtle bg-surface-alt/60 p-5 shadow-sm transition-all hover:border-border-strong"
+                    >
+                      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                        <div className="min-w-0">
+                          <p className="truncate text-base font-semibold text-text">
+                            {account.name || 'Tanpa Nama'}
+                          </p>
+                          <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-muted">
+                            <span className="badge-muted">{ACCOUNT_TYPE_LABELS[account.type]}</span>
+                            <span className="rounded-full bg-surface px-3 py-1 font-medium text-text">
+                              {account.currency || 'IDR'}
+                            </span>
+                            <span className="flex items-center gap-1">
+                              Dibuat {formatDate(account.created_at)}
+                            </span>
+                          </div>
+                        </div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          {canReorder && totalAccounts > 1 ? (
+                            <div className="flex items-center gap-1">
+                              <button
+                                type="button"
+                                onClick={() => handleMoveUp(account.id)}
+                                disabled={disableMoveUp}
+                                className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border-subtle bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50"
+                                aria-label="Naikkan urutan akun"
+                              >
+                                <ArrowUp className="h-4 w-4" />
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => handleMoveDown(account.id)}
+                                disabled={disableMoveDown}
+                                className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border-subtle bg-transparent text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50"
+                                aria-label="Turunkan urutan akun"
+                              >
+                                <ArrowDown className="h-4 w-4" />
+                              </button>
+                            </div>
+                          ) : null}
+                          <button
+                            type="button"
+                            className="btn btn-secondary"
+                            onClick={() => handleEditClick(account)}
+                            disabled={modalBusy || deletingId === account.id || isReordering}
+                          >
+                            <Pencil className="h-4 w-4" /> Edit
+                          </button>
+                          <button
+                            type="button"
+                            className="btn btn-danger"
+                            onClick={() => handleDelete(account)}
+                            disabled={deletingId === account.id || isReordering}
+                          >
+                            {deletingId === account.id ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : (
+                              <Trash2 className="h-4 w-4" />
+                            )}
+                            Hapus
+                          </button>
                         </div>
                       </div>
-                      <div className="flex flex-wrap gap-2">
-                        <button
-                          type="button"
-                          className="btn btn-secondary"
-                          onClick={() => handleEditClick(account)}
-                          disabled={modalBusy || deletingId === account.id}
-                        >
-                          <Pencil className="h-4 w-4" /> Edit
-                        </button>
-                        <button
-                          type="button"
-                          className="btn btn-danger"
-                          onClick={() => handleDelete(account)}
-                          disabled={deletingId === account.id}
-                        >
-                          {deletingId === account.id ? (
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                          ) : (
-                            <Trash2 className="h-4 w-4" />
-                          )}
-                          Hapus
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                ))}
+                    </li>
+                  );
+                })}
               </ul>
             )}
           </CardBody>


### PR DESCRIPTION
## Summary
- add sort order support for accounts, including normalized field handling and a Supabase upsert to persist manual order changes
- replace the accounts page sort dropdown with reorder controls so users can prioritize accounts similarly to categories, with optimistic state updates and error handling

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dfef9fd5d08332ad0fd990c495c6dd