### PR TITLE
Improve account creation name validation

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -65,6 +65,9 @@ function toUserMessage(error: unknown, fallback: string): string {
     if (typed.code === '23505') {
       return 'Nama akun sudah digunakan. Silakan gunakan nama lain.';
     }
+    if (typed.code === '23502') {
+      return 'Nama akun wajib diisi.';
+    }
     if (typeof typed.message === 'string' && typed.message.trim()) {
       return `${fallback.replace(/[:.]?$/, '')}: ${typed.message}`;
     }


### PR DESCRIPTION
## Summary
- prevent submitting the account form without a name and surface field-level feedback
- translate Supabase not-null errors into a friendly toast message for account operations

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dffb51b66483329007aaefcf6dd54b