### PR TITLE
Fix account reorder validation error

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -197,22 +197,27 @@ export async function updateAccount(
   return normalizeAccount(data);
 }
 
+type ReorderAccountInput = Pick<AccountRecord, 'id' | 'name' | 'type' | 'currency'>;
+
 export async function reorderAccounts(
   userId: string,
-  orderedIds: string[],
+  orderedAccounts: ReorderAccountInput[],
 ): Promise<void> {
   if (!userId) {
     throw new Error('ID pengguna tidak valid.');
   }
 
-  if (!Array.isArray(orderedIds) || orderedIds.length === 0) {
+  if (!Array.isArray(orderedAccounts) || orderedAccounts.length === 0) {
     return;
   }
 
-  const payload = orderedIds.map((id, index) => ({
-    id,
+  const payload = orderedAccounts.map((account, index) => ({
+    id: account.id,
     user_id: userId,
     sort_order: index,
+    name: account.name,
+    type: normalizeAccountType(account.type),
+    currency: normalizeCurrency(account.currency),
   }));
 
   const { error } = await supabase

--- a/src/pages/AccountsPage.tsx
+++ b/src/pages/AccountsPage.tsx
@@ -197,7 +197,7 @@ export default function AccountsPage() {
       }
       setReorderBusy(true);
       try {
-        await reorderAccounts(user.id, nextOrdered.map((item) => item.id));
+        await reorderAccounts(user.id, nextOrdered);
       } catch (error) {
         const message =
           error instanceof Error ? error.message : 'Gagal mengurutkan akun. Silakan coba lagi.';
@@ -270,7 +270,7 @@ export default function AccountsPage() {
         });
         if (user?.id && nextAccounts) {
           try {
-            await reorderAccounts(user.id, nextAccounts.map((item) => item.id));
+            await reorderAccounts(user.id, nextAccounts);
           } catch (error) {
             const message =
               error instanceof Error


### PR DESCRIPTION
## Summary
- ensure account reorder API calls include account fields required by Supabase
- update the Accounts page to pass reordered account records instead of only IDs

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e002587be483329c09b57504fff89a