### PR TITLE
Align transaction account list with account page ordering

### DIFF
--- a/src/pages/TransactionAdd.jsx
+++ b/src/pages/TransactionAdd.jsx
@@ -159,12 +159,12 @@ export default function TransactionAdd({ onAdd }) {
           listCategories('income'),
         ]);
         if (!active) return;
-        const sortedAccounts = (accountRows || []).slice().sort((a, b) => {
-          return (a.name || '').localeCompare(b.name || '', 'id');
-        });
-        setAccounts(sortedAccounts);
-        if (sortedAccounts.length) {
-          setAccountId(sortedAccounts[0].id);
+        const orderedAccounts = Array.isArray(accountRows)
+          ? accountRows.filter(Boolean)
+          : [];
+        setAccounts(orderedAccounts);
+        if (orderedAccounts.length) {
+          setAccountId((prev) => prev || orderedAccounts[0].id);
         }
         const combinedCategories = [
           ...(expenseRows || []),


### PR DESCRIPTION
## Summary
- add reusable helpers to normalize and sort account records by their configured order
- ensure listAccounts returns source accounts in the same order as the Accounts page, including sort_order metadata
- preserve account ordering on the add transaction page by removing client-side alphabetical sorting

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e056ee5e4c83328c52aae6e74c77c5