### PR TITLE
Add Rp1,000 quick amount option

### DIFF
--- a/src/pages/TransactionAdd.jsx
+++ b/src/pages/TransactionAdd.jsx
@@ -66,7 +66,7 @@ const SEGMENTED_CLASS =
 const SEGMENT_ITEM_CLASS =
   'flex items-center gap-2 rounded-xl px-3 text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary';
 
-const QUICK_AMOUNT_OPTIONS = [5000, 10000, 50000, 100000, 500000];
+const QUICK_AMOUNT_OPTIONS = [1000, 5000, 10000, 50000, 100000, 500000];
 
 const DATE_FORMATTER = new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Jakarta' });
 const CURRENCY_FORMATTER = new Intl.NumberFormat('id-ID', { minimumFractionDigits: 0 });


### PR DESCRIPTION
## Summary
- add Rp1,000 to the transaction quick amount buttons so users can pick the smaller nominal

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1d0b86c3c8332aa8c5a5d14ce6f99