### PR TITLE
Silence toast for fetch errors

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -699,6 +699,9 @@ function AppShell({ prefs, setPrefs }) {
         return;
       }
       if (isAbortError) return;
+      if (message && message.toLowerCase().includes("failed to fetch")) {
+        return;
+      }
       const detail = message ? `: ${message}` : "";
       addToast(`Gagal memuat data anggaran${detail}`, "error");
     }


### PR DESCRIPTION
## Summary
- prevent the budget fetch error toast from appearing when the error message only indicates a fetch failure

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2050af7608332b883f135e32da8c3