### PR TITLE
feat: trigger moneytalk responses from titles

### DIFF
--- a/docs/moneytalk-title-triggers.md
+++ b/docs/moneytalk-title-triggers.md
@@ -1,0 +1,122 @@
+# MoneyTalk Title Triggers
+
+Daftar judul atau kata kunci transaksi yang memicu respon MoneyTalk berdasarkan kecocokan teks pada judul.
+
+Total entri: 116
+
+- americano
+- angkot
+- angkut
+- angkutan
+- apple music
+- apple tv
+- ayam
+- baju
+- bakso
+- bensin
+- bitcoin
+- boba
+- boots
+- burger
+- bus
+- cadangan
+- camera
+- celana
+- coffee
+- crypto
+- dana
+- darurat
+- data
+- diamond
+- diesel
+- disney
+- dress
+- electric
+- emas
+- emergency
+- espresso
+- fashion
+- fiber
+- fried chicken
+- fuel
+- fund
+- gadget
+- game
+- gaming
+- gas
+- genshin
+- gojek
+- gold
+- grab
+- heels
+- hoodie
+- hp
+- indihome
+- internet
+- invest
+- iqiyi
+- jacket
+- jaket
+- kamera
+- kemeja
+- kereta
+- kopi
+- laptop
+- latte
+- listrik
+- lrt
+- mlbb
+- modem
+- monitor
+- mrt
+- mutual
+- netflix
+- ngopi
+- nintendo
+- ojek
+- ojol
+- outfit
+- pakaian
+- pants
+- pc
+- pertalite
+- pertamax
+- phone
+- pizza
+- playstation
+- pln
+- power
+- prime
+- ps4
+- ps5
+- ramen
+- reksa
+- saham
+- sandals
+- sepatu
+- shell
+- shirt
+- shoes
+- sinking fund
+- sneaker
+- sneakers
+- spotify
+- steak
+- steam
+- stock
+- sushi
+- tablet
+- taksi
+- taxi
+- tea
+- teh
+- token
+- top up
+- train
+- uber
+- valorant
+- vidio
+- viu
+- wifi
+- xbox
+- youtube

--- a/src/lib/moneyTalkIntents.test.js
+++ b/src/lib/moneyTalkIntents.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveMoneyTalkIntent } from "./moneyTalkIntents";
+import {
+  MONEY_TALK_TITLE_TRIGGERS,
+  resolveMoneyTalkIntent,
+} from "./moneyTalkIntents";
 
 describe("resolveMoneyTalkIntent", () => {
   const baseValues = {
@@ -9,10 +12,9 @@ describe("resolveMoneyTalkIntent", () => {
     title: "Ngopi di Starbucks",
   };
 
-  it("detects coffee outings in Indonesian", () => {
+  it("detects coffee outings in Indonesian without category info", () => {
     const result = resolveMoneyTalkIntent({
       lang: "id",
-      category: "Makan",
       title: "Ngopi di Starbucks",
       values: baseValues,
     });
@@ -21,20 +23,19 @@ describe("resolveMoneyTalkIntent", () => {
     expect(result?.tip).toContain("kopi");
   });
 
-  it("supports category aliases and English copy", () => {
+  it("responds to streaming spends even when category mismatches", () => {
     const result = resolveMoneyTalkIntent({
       lang: "en",
-      category: "Food & Drinks",
-      title: "Latte run",
+      category: "Transport",
+      title: "Bayar Netflix Premium",
       values: {
         ...baseValues,
-        category: "Food & Drinks",
-        title: "Latte run",
+        category: "Transport",
+        title: "Bayar Netflix Premium",
       },
     });
     expect(result).toBeTruthy();
-    expect(result?.message).toContain("Coffee run");
-    expect(result?.tip).toContain("home");
+    expect(result?.message).toContain("Netflix");
   });
 
   it("matches streaming keywords", () => {
@@ -56,15 +57,23 @@ describe("resolveMoneyTalkIntent", () => {
   it("returns null when no keyword matches", () => {
     const result = resolveMoneyTalkIntent({
       lang: "id",
-      category: "Transport",
       title: "Meeting dengan klien",
       values: {
         amount: "Rp75.000",
-        category: "Transport",
         type: "expense",
         title: "Meeting dengan klien",
       },
     });
     expect(result).toBeNull();
+  });
+
+  it("exposes the compiled list of title triggers", () => {
+    expect(Array.isArray(MONEY_TALK_TITLE_TRIGGERS)).toBe(true);
+    expect(MONEY_TALK_TITLE_TRIGGERS.length).toBeGreaterThan(0);
+    expect(MONEY_TALK_TITLE_TRIGGERS).toEqual(
+      expect.arrayContaining(["kopi", "coffee", "sepatu"])
+    );
+    const uniqueCount = new Set(MONEY_TALK_TITLE_TRIGGERS).size;
+    expect(uniqueCount).toBe(MONEY_TALK_TITLE_TRIGGERS.length);
   });
 });


### PR DESCRIPTION
## Summary
- make MoneyTalk reactions rely on title keyword matches instead of categories
- expose and document the consolidated `MONEY_TALK_TITLE_TRIGGERS` list for reference

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e25f9b84d0833297d2cbc9b558e9d2