### PR TITLE
feat: add weekly budgets and dashboard highlights

### DIFF
--- a/src/components/dashboard/DashboardHighlightedBudgets.tsx
+++ b/src/components/dashboard/DashboardHighlightedBudgets.tsx
@@ -1,0 +1,125 @@
+import { useMemo } from 'react';
+import { AlertTriangle, Sparkles } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { useHighlightedBudgets } from '../../hooks/useHighlightedBudgets';
+import { formatCurrency } from '../../lib/format';
+import type { PeriodRange } from './PeriodPicker';
+
+interface DashboardHighlightedBudgetsProps {
+  period: PeriodRange;
+}
+
+function getPeriodFromRange(range: PeriodRange): string {
+  const base = range?.end || range?.start;
+  if (!base) {
+    const now = new Date();
+    const month = `${now.getMonth() + 1}`.padStart(2, '0');
+    return `${now.getFullYear()}-${month}`;
+  }
+  return base.slice(0, 7);
+}
+
+function getProgressColor(percentage: number) {
+  if (percentage > 1) return 'bg-rose-500';
+  if (percentage >= 0.9) return 'bg-orange-500';
+  if (percentage >= 0.75) return 'bg-amber-500';
+  return 'bg-[color:var(--accent)]';
+}
+
+function getTrackColor(percentage: number) {
+  if (percentage > 1) return 'bg-rose-500/15';
+  if (percentage >= 0.9) return 'bg-orange-500/15';
+  if (percentage >= 0.75) return 'bg-amber-500/15';
+  return 'bg-[color:var(--accent)]/15';
+}
+
+function formatPercentage(value: number) {
+  const pct = Math.max(0, value);
+  if (pct > 2) return `${(pct * 100).toFixed(0)}%`;
+  return `${Math.round(pct * 100)}%`;
+}
+
+export default function DashboardHighlightedBudgets({ period }: DashboardHighlightedBudgetsProps) {
+  const periodMonth = useMemo(() => getPeriodFromRange(period), [period]);
+  const { highlights, loading, error } = useHighlightedBudgets({ period: periodMonth });
+
+  return (
+    <section className="rounded-3xl border border-border/60 bg-gradient-to-br from-white via-white to-[color:var(--accent)]/5 p-6 shadow-sm transition dark:border-border/40 dark:from-zinc-900/80 dark:via-zinc-900/60 dark:to-[color:var(--accent)]/10">
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <span className="inline-flex items-center gap-2 rounded-full bg-[color:var(--accent)]/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-[color:var(--accent)]">
+            <Sparkles className="h-3.5 w-3.5" />
+            Highlighted Budgets
+          </span>
+          <h2 className="mt-3 text-xl font-semibold text-foreground sm:text-2xl">Anggaran Prioritasmu</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Pantau anggaran penting yang kamu tandai langsung dari dashboard.
+          </p>
+        </div>
+        <Link
+          to="/budgets"
+          className="inline-flex items-center rounded-full border border-transparent bg-[color:var(--accent)] px-4 py-2 text-sm font-semibold text-white shadow transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)]/40"
+        >
+          Kelola
+        </Link>
+      </header>
+
+      <div className="mt-6 space-y-4">
+        {loading ? (
+          <div className="grid gap-4 sm:grid-cols-2">
+            {Array.from({ length: 2 }).map((_, index) => (
+              <div key={index} className="h-28 animate-pulse rounded-2xl border border-dashed border-border/60 bg-white/60 dark:bg-zinc-900/40" />
+            ))}
+          </div>
+        ) : error ? (
+          <div className="flex items-center gap-3 rounded-2xl border border-rose-200/80 bg-rose-50/70 p-4 text-sm text-rose-700 dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-200">
+            <AlertTriangle className="h-4 w-4" />
+            {error}
+          </div>
+        ) : highlights.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-border/60 bg-white/60 p-6 text-sm text-muted-foreground shadow-sm dark:border-border/40 dark:bg-zinc-900/40">
+            Tandai maksimal dua anggaran di halaman Budgets untuk ditampilkan di sini.
+          </div>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2">
+            {highlights.map((item) => {
+              const progress = Math.max(0, item.percentage);
+              const displayProgress = Math.min(progress, 1);
+              const plannedLabel = formatCurrency(item.planned, 'IDR');
+              const actualLabel = formatCurrency(item.actual, 'IDR');
+              const remaining = item.planned - item.actual;
+              const remainingLabel = formatCurrency(remaining, 'IDR');
+              const remainingClass = remaining < 0 ? 'text-rose-500 dark:text-rose-300' : 'text-emerald-600 dark:text-emerald-300';
+              return (
+                <article
+                  key={item.record_id}
+                  className="flex flex-col gap-4 rounded-2xl border border-border/60 bg-white/80 p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-border/40 dark:bg-zinc-900/70"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-foreground">{item.label}</p>
+                      <p className="text-xs text-muted-foreground">{plannedLabel} • {actualLabel} terpakai</p>
+                    </div>
+                    <span className="inline-flex items-center rounded-full bg-muted/20 px-3 py-1 text-xs font-semibold text-muted">
+                      {item.badge}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between text-xs text-muted-foreground">
+                    <span className={remainingClass}>{remaining >= 0 ? `${remainingLabel} sisa` : `${remainingLabel} over`}</span>
+                    <span className="font-semibold text-muted">{formatPercentage(progress)}</span>
+                  </div>
+                  <div className={getTrackColor(progress) + ' h-2 w-full overflow-hidden rounded-full'}>
+                    <div
+                      className={getProgressColor(progress) + ' h-full rounded-full transition-all'}
+                      style={{ width: `${displayProgress * 100}%` }}
+                    />
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/hooks/useBudgets.ts
+++ b/src/hooks/useBudgets.ts
@@ -1,12 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  buildSummary,
-  computeSpent,
-  listBudgets,
-  mergeBudgetsWithSpent,
-  type BudgetSummary,
-  type BudgetWithSpent,
-} from '../lib/budgetApi';
+import { buildSummary, listMonthlyBudgets, type BudgetSummary, type BudgetWithSpent } from '../lib/budgetApi';
 
 const EMPTY_SUMMARY: BudgetSummary = {
   planned: 0,
@@ -28,10 +21,7 @@ export function useBudgets(period: string): UseBudgetsResult {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchCombined = useCallback(async () => {
-    const [budgetRows, spentMap] = await Promise.all([listBudgets(period), computeSpent(period)]);
-    return mergeBudgetsWithSpent(budgetRows, spentMap);
-  }, [period]);
+  const fetchCombined = useCallback(() => listMonthlyBudgets(period), [period]);
 
   useEffect(() => {
     let active = true;

--- a/src/hooks/useHighlightedBudgets.ts
+++ b/src/hooks/useHighlightedBudgets.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  listHighlightedBudgets,
+  listHighlightedBudgetRecords,
+  toggleHighlight,
+  type HighlightBudgetRecord,
+  type HighlightBudgetType,
+  type HighlightedBudgetItem,
+} from '../lib/budgetApi';
+
+interface UseHighlightedBudgetsOptions {
+  period: string;
+}
+
+interface UseHighlightedBudgetsResult {
+  highlights: HighlightedBudgetItem[];
+  records: HighlightBudgetRecord[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  toggle: (input: { type: HighlightBudgetType; id: string }) => Promise<'added' | 'removed'>;
+}
+
+const EMPTY: HighlightedBudgetItem[] = [];
+const EMPTY_RECORDS: HighlightBudgetRecord[] = [];
+
+export function useHighlightedBudgets({ period }: UseHighlightedBudgetsOptions): UseHighlightedBudgetsResult {
+  const [highlights, setHighlights] = useState<HighlightedBudgetItem[]>(EMPTY);
+  const [records, setRecords] = useState<HighlightBudgetRecord[]>(EMPTY_RECORDS);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAll = useCallback(async () => {
+    const [recordRows, highlightRows] = await Promise.all([
+      listHighlightedBudgetRecords(),
+      listHighlightedBudgets(period),
+    ]);
+    return { recordRows, highlightRows };
+  }, [period]);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError(null);
+    fetchAll()
+      .then(({ recordRows, highlightRows }) => {
+        if (!active) return;
+        setRecords(recordRows);
+        setHighlights(highlightRows);
+      })
+      .catch((err: unknown) => {
+        if (!active) return;
+        setRecords(EMPTY_RECORDS);
+        setHighlights(EMPTY);
+        setError(err instanceof Error ? err.message : 'Gagal memuat highlight anggaran');
+      })
+      .finally(() => {
+        if (!active) return;
+        setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [fetchAll]);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { recordRows, highlightRows } = await fetchAll();
+      setRecords(recordRows);
+      setHighlights(highlightRows);
+    } catch (err) {
+      setRecords(EMPTY_RECORDS);
+      setHighlights(EMPTY);
+      setError(err instanceof Error ? err.message : 'Gagal memuat highlight anggaran');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchAll]);
+
+  const toggleAction = useCallback(
+    async (input: { type: HighlightBudgetType; id: string }) => {
+      const result = await toggleHighlight(input);
+      await refresh();
+      return result;
+    },
+    [refresh]
+  );
+
+  return {
+    highlights: useMemo(() => highlights, [highlights]),
+    records: useMemo(() => records, [records]),
+    loading,
+    error,
+    refresh,
+    toggle: toggleAction,
+  };
+}
+
+export type { HighlightBudgetType, HighlightedBudgetItem };

--- a/src/hooks/useWeeklyBudgets.ts
+++ b/src/hooks/useWeeklyBudgets.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  listWeeklyBudgets,
+  type WeeklyBudgetSummaryRow,
+  type WeeklyBudgetWithActual,
+  type WeeklyBudgetsResult,
+} from '../lib/budgetApi';
+
+interface UseWeeklyBudgetsResult extends WeeklyBudgetsResult {
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+const EMPTY_RESULT: WeeklyBudgetsResult = {
+  rows: [],
+  summaries: [],
+};
+
+export function useWeeklyBudgets(period: string): UseWeeklyBudgetsResult {
+  const [state, setState] = useState<WeeklyBudgetsResult>(EMPTY_RESULT);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    const result = await listWeeklyBudgets(period);
+    return result;
+  }, [period]);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError(null);
+    fetchData()
+      .then((result) => {
+        if (!active) return;
+        setState(result);
+      })
+      .catch((err: unknown) => {
+        if (!active) return;
+        setState(EMPTY_RESULT);
+        setError(err instanceof Error ? err.message : 'Gagal memuat anggaran mingguan');
+      })
+      .finally(() => {
+        if (!active) return;
+        setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [fetchData]);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchData();
+      setState(result);
+    } catch (err) {
+      setState(EMPTY_RESULT);
+      setError(err instanceof Error ? err.message : 'Gagal memuat anggaran mingguan');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchData]);
+
+  const memoResult = useMemo(() => state, [state]);
+
+  return {
+    rows: memoResult.rows,
+    summaries: memoResult.summaries,
+    loading,
+    error,
+    refresh,
+  };
+}
+
+export type { WeeklyBudgetSummaryRow, WeeklyBudgetWithActual };

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -15,6 +15,7 @@ import useDashboardBalances from "../hooks/useDashboardBalances";
 import DailyDigestModal from "../components/DailyDigestModal";
 import useShowDigestOnLogin from "../hooks/useShowDigestOnLogin";
 import BudgetHighlights from "../components/dashboard/BudgetHighlights";
+import DashboardHighlightedBudgets from "../components/dashboard/DashboardHighlightedBudgets";
 
 const DEFAULT_PRESET = "month";
 
@@ -123,6 +124,8 @@ export default function Dashboard({ stats, txs }) {
         />
 
         <QuickActions />
+
+        <DashboardHighlightedBudgets period={periodRange} />
 
         <BudgetHighlights period={periodRange} />
 

--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -1,59 +1,110 @@
 import { useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
-import { CalendarRange, CalendarDays, History, Plus, RefreshCw } from 'lucide-react';
+import { Calendar, CalendarDays, Plus } from 'lucide-react';
 import Page from '../../layout/Page';
-import Section from '../../layout/Section';
 import PageHeader from '../../layout/PageHeader';
+import Section from '../../layout/Section';
 import { useToast } from '../../context/ToastContext';
 import SummaryCards from './components/SummaryCards';
-import BudgetTable from './components/BudgetTable';
+import { BudgetCard, BudgetCardSkeleton } from './components/BudgetCard';
 import BudgetFormModal, { type BudgetFormValues } from './components/BudgetFormModal';
+import WeeklyBudgetFormModal, { type WeeklyBudgetFormValues } from './components/WeeklyBudgetFormModal';
+import WeeklyPicker from './components/WeeklyPicker';
+import MonthlyFromWeeklySummary from './components/MonthlyFromWeeklySummary';
 import { useBudgets } from '../../hooks/useBudgets';
+import { useWeeklyBudgets } from '../../hooks/useWeeklyBudgets';
+import { useHighlightedBudgets } from '../../hooks/useHighlightedBudgets';
 import {
   deleteBudget,
+  deleteWeeklyBudget,
   listCategoriesExpense,
-  upsertBudget,
   type BudgetWithSpent,
   type ExpenseCategory,
+  type WeeklyBudgetWithActual,
+  upsertBudget,
+  upsertWeeklyBudget,
 } from '../../lib/budgetApi';
 
-const SEGMENTS = [
-  { value: 'current', label: 'Bulan ini', icon: CalendarDays },
-  { value: 'previous', label: 'Bulan lalu', icon: History },
-  { value: 'custom', label: 'Custom', icon: CalendarRange },
+const VIEW_OPTIONS = [
+  { value: 'monthly', label: 'Bulanan' },
+  { value: 'weekly', label: 'Mingguan' },
 ] as const;
 
-type SegmentValue = (typeof SEGMENTS)[number]['value'];
+const LOCALE = 'id-ID';
 
-function formatPeriod(date: Date): string {
-  const year = date.getFullYear();
-  const month = `${date.getMonth() + 1}`.padStart(2, '0');
-  return `${year}-${month}`;
-}
+type BudgetView = (typeof VIEW_OPTIONS)[number]['value'];
+
+type WeeklyOption = {
+  value: string;
+  label: string;
+  start: Date;
+  end: Date;
+};
 
 function getCurrentPeriod() {
-  return formatPeriod(new Date());
-}
-
-function getPreviousPeriod() {
   const now = new Date();
-  const previous = new Date(now.getFullYear(), now.getMonth() - 1, 1);
-  return formatPeriod(previous);
+  const month = `${now.getMonth() + 1}`.padStart(2, '0');
+  return `${now.getFullYear()}-${month}`;
 }
 
-function toHumanReadable(period: string): string {
-  const [year, month] = period.split('-').map((value) => Number.parseInt(value, 10));
+function formatMonth(period: string) {
+  const [year, month] = period.split('-').map((part) => Number.parseInt(part, 10));
   if (!year || !month) return period;
-  const formatter = new Intl.DateTimeFormat('id-ID', { month: 'long', year: 'numeric' });
-  return formatter.format(new Date(year, month - 1, 1));
+  return new Intl.DateTimeFormat(LOCALE, { month: 'long', year: 'numeric' }).format(new Date(year, month - 1, 1));
 }
 
-function isoToPeriod(isoDate: string | null | undefined): string {
-  if (!isoDate) return getCurrentPeriod();
-  return isoDate.slice(0, 7);
+function toWeekRangeLabel(start: Date, end: Date) {
+  const formatter = new Intl.DateTimeFormat(LOCALE, { day: 'numeric', month: 'short' });
+  const startLabel = formatter.format(start);
+  const endLabel = formatter.format(end);
+  return `Sen ${startLabel} – Min ${endLabel}`;
 }
 
-const DEFAULT_FORM_VALUES: BudgetFormValues = {
+function getWeeksForPeriod(period: string): WeeklyOption[] {
+  const [year, month] = period.split('-').map((part) => Number.parseInt(part, 10));
+  if (!year || !month) return [];
+  const startDate = new Date(Date.UTC(year, month - 1, 1));
+  const nextMonth = new Date(Date.UTC(year, month, 1));
+  const options: WeeklyOption[] = [];
+
+  const firstMonday = (() => {
+    const temp = new Date(startDate.getTime());
+    const day = temp.getUTCDay();
+    const diff = day === 0 ? 1 : day === 1 ? 0 : 8 - day;
+    temp.setUTCDate(temp.getUTCDate() + diff);
+    return temp;
+  })();
+
+  let cursor = firstMonday;
+  while (cursor < nextMonth) {
+    const start = new Date(cursor.getTime());
+    const end = new Date(cursor.getTime());
+    end.setUTCDate(end.getUTCDate() + 6);
+    if (end >= nextMonth) {
+      end.setTime(nextMonth.getTime());
+      end.setUTCDate(end.getUTCDate() - 1);
+    }
+    const label = toWeekRangeLabel(start, end);
+    options.push({ value: cursor.toISOString().slice(0, 10), label, start, end });
+    cursor = new Date(cursor.getTime());
+    cursor.setUTCDate(cursor.getUTCDate() + 7);
+  }
+
+  return options;
+}
+
+function findDefaultWeek(period: string, options: WeeklyOption[]): string {
+  const now = new Date();
+  const [year, month] = period.split('-').map((part) => Number.parseInt(part, 10));
+  if (now.getFullYear() === year && now.getMonth() + 1 === month) {
+    const today = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
+    const match = options.find((option) => today >= option.start && today <= option.end);
+    if (match) return match.value;
+  }
+  return options[0]?.value ?? 'all';
+}
+
+const EMPTY_BUDGET_FORM: BudgetFormValues = {
   period: getCurrentPeriod(),
   category_id: '',
   amount_planned: 0,
@@ -61,26 +112,63 @@ const DEFAULT_FORM_VALUES: BudgetFormValues = {
   notes: '',
 };
 
+const EMPTY_WEEKLY_FORM: WeeklyBudgetFormValues = {
+  week_start: '',
+  category_id: '',
+  amount_planned: 0,
+  notes: '',
+};
+
+function toMonthlyFormValues(row: BudgetWithSpent): BudgetFormValues {
+  return {
+    period: row.period_month?.slice(0, 7) ?? getCurrentPeriod(),
+    category_id: row.category_id ?? '',
+    amount_planned: Number(row.amount_planned ?? 0),
+    carryover_enabled: row.carryover_enabled,
+    notes: row.notes ?? '',
+  };
+}
+
+function toWeeklyFormValues(row: WeeklyBudgetWithActual): WeeklyBudgetFormValues {
+  return {
+    week_start: row.week_start,
+    category_id: row.category_id,
+    amount_planned: Number(row.amount_planned ?? 0),
+    notes: row.notes ?? '',
+  };
+}
+
 export default function BudgetsPage() {
   const { addToast } = useToast();
-  const [segment, setSegment] = useState<SegmentValue>('current');
-  const [customPeriod, setCustomPeriod] = useState<string>(getCurrentPeriod());
+  const [view, setView] = useState<BudgetView>('monthly');
   const [period, setPeriod] = useState<string>(getCurrentPeriod());
-  const [modalOpen, setModalOpen] = useState(false);
-  const [editing, setEditing] = useState<BudgetWithSpent | null>(null);
-  const [submitting, setSubmitting] = useState(false);
   const [categories, setCategories] = useState<ExpenseCategory[]>([]);
   const [categoriesLoading, setCategoriesLoading] = useState(true);
+  const [monthlyModalOpen, setMonthlyModalOpen] = useState(false);
+  const [weeklyModalOpen, setWeeklyModalOpen] = useState(false);
+  const [editingMonthly, setEditingMonthly] = useState<BudgetWithSpent | null>(null);
+  const [editingWeekly, setEditingWeekly] = useState<WeeklyBudgetWithActual | null>(null);
+  const [submitting, setSubmitting] = useState(false);
 
-  const { rows, summary, loading, error, refresh } = useBudgets(period);
+  const monthly = useBudgets(period);
+  const weekly = useWeeklyBudgets(period);
+  const highlights = useHighlightedBudgets({ period });
+
+  const weeks = useMemo(() => getWeeksForPeriod(period), [period]);
+  const defaultWeek = useMemo(() => findDefaultWeek(period, weeks), [period, weeks]);
+  const [activeWeek, setActiveWeek] = useState<string>(defaultWeek);
+
+  useEffect(() => {
+    setActiveWeek(defaultWeek);
+  }, [defaultWeek]);
 
   useEffect(() => {
     let active = true;
     setCategoriesLoading(true);
     listCategoriesExpense()
-      .then((data) => {
+      .then((rows) => {
         if (!active) return;
-        setCategories(data);
+        setCategories(rows);
       })
       .catch((err) => {
         if (!active) return;
@@ -97,62 +185,142 @@ export default function BudgetsPage() {
   }, [addToast]);
 
   useEffect(() => {
-    if (!error) return;
-    addToast(error, 'error');
-  }, [error, addToast]);
+    if (monthly.error) addToast(monthly.error, 'error');
+  }, [monthly.error, addToast]);
 
   useEffect(() => {
-    if (segment === 'current') {
-      setPeriod(getCurrentPeriod());
-    } else if (segment === 'previous') {
-      setPeriod(getPreviousPeriod());
-    } else {
-      setPeriod(customPeriod || getCurrentPeriod());
+    if (weekly.error) addToast(weekly.error, 'error');
+  }, [weekly.error, addToast]);
+
+  useEffect(() => {
+    if (highlights.error) addToast(highlights.error, 'error');
+  }, [highlights.error, addToast]);
+
+  const highlightedMonthlyIds = useMemo(() => {
+    return new Set(
+      highlights.records.filter((record) => record.budget_type === 'monthly').map((record) => record.budget_id)
+    );
+  }, [highlights.records]);
+
+  const highlightedWeeklyIds = useMemo(() => {
+    return new Set(
+      highlights.records.filter((record) => record.budget_type === 'weekly').map((record) => record.budget_id)
+    );
+  }, [highlights.records]);
+
+  const weeklyTotalsSummary = useMemo(() => {
+    const planned = weekly.summaries.reduce((acc, row) => acc + Number(row.planned ?? 0), 0);
+    const actual = weekly.summaries.reduce((acc, row) => acc + Number(row.actual ?? 0), 0);
+    const remaining = planned - actual;
+    const percentage = planned > 0 ? Math.min(actual / planned, 1) : 0;
+    return { planned, spent: actual, remaining, percentage };
+  }, [weekly.summaries]);
+
+  const periodLabel = useMemo(() => formatMonth(period), [period]);
+
+  const filteredWeeklyRows = useMemo(() => {
+    if (activeWeek === 'all') return weekly.rows;
+    return weekly.rows.filter((row) => row.week_start === activeWeek);
+  }, [weekly.rows, activeWeek]);
+
+  const monthLink = (categoryId: string, start?: string, end?: string) => {
+    const params = new URLSearchParams();
+    params.set('category', categoryId);
+    if (start) params.set('start', start);
+    if (end) params.set('end', end);
+    else params.set('month', period);
+    return `/transactions?${params.toString()}`;
+  };
+
+  const initialMonthlyValues = editingMonthly ? toMonthlyFormValues(editingMonthly) : { ...EMPTY_BUDGET_FORM, period };
+  const initialWeeklyValues = editingWeekly
+    ? toWeeklyFormValues(editingWeekly)
+    : { ...EMPTY_WEEKLY_FORM, week_start: activeWeek === 'all' ? '' : activeWeek };
+
+  const handleToggleHighlight = async (type: 'monthly' | 'weekly', id: string) => {
+    try {
+      const result = await highlights.toggle({ type, id });
+      addToast(result === 'added' ? 'Ditambahkan ke highlight' : 'Highlight dihapus', 'success');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Gagal mengubah highlight';
+      if (message.toLowerCase().includes('maks')) {
+        addToast('Maks. 2 highlight', 'error');
+      } else {
+        addToast(message, 'error');
+      }
     }
-  }, [segment, customPeriod]);
+  };
 
-  const initialFormValues = useMemo<BudgetFormValues>(() => {
-    if (editing) {
-      return {
-        period: isoToPeriod(editing.period_month),
-        category_id: editing.category_id ?? '',
-        amount_planned: Number(editing.amount_planned ?? 0),
-        carryover_enabled: editing.carryover_enabled,
-        notes: editing.notes ?? '',
-      };
+  const handleSubmitMonthly = async (values: BudgetFormValues) => {
+    try {
+      setSubmitting(true);
+      await upsertBudget({
+        category_id: values.category_id,
+        period: values.period,
+        amount_planned: Number(values.amount_planned),
+        carryover_enabled: values.carryover_enabled,
+        notes: values.notes || undefined,
+      });
+      addToast('Anggaran tersimpan', 'success');
+      setMonthlyModalOpen(false);
+      setEditingMonthly(null);
+      await Promise.all([monthly.refresh(), highlights.refresh()]);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Gagal menyimpan anggaran';
+      addToast(message, 'error');
+    } finally {
+      setSubmitting(false);
     }
-    return { ...DEFAULT_FORM_VALUES, period };
-  }, [editing, period]);
-
-  const handleSegmentChange = (value: SegmentValue) => {
-    setSegment(value);
   };
 
-  const handleCustomPeriodChange = (value: string) => {
-    setCustomPeriod(value);
-    setPeriod(value || getCurrentPeriod());
+  const handleSubmitWeekly = async (values: WeeklyBudgetFormValues) => {
+    try {
+      setSubmitting(true);
+      await upsertWeeklyBudget({
+        id: editingWeekly?.id,
+        category_id: values.category_id,
+        week_start: values.week_start,
+        amount_planned: Number(values.amount_planned),
+        notes: values.notes || undefined,
+      });
+      addToast('Anggaran mingguan tersimpan', 'success');
+      setWeeklyModalOpen(false);
+      setEditingWeekly(null);
+      await Promise.all([weekly.refresh(), highlights.refresh()]);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Gagal menyimpan anggaran mingguan';
+      addToast(message, 'error');
+    } finally {
+      setSubmitting(false);
+    }
   };
 
-  const handleOpenCreate = () => {
-    setEditing(null);
-    setModalOpen(true);
-  };
-
-  const handleEdit = (row: BudgetWithSpent) => {
-    setEditing(row);
-    setModalOpen(true);
-  };
-
-  const handleDelete = async (row: BudgetWithSpent) => {
-    const confirmed = window.confirm(`Hapus anggaran untuk ${row.category?.name ?? 'kategori ini'}?`);
+  const handleDeleteMonthly = async (row: BudgetWithSpent) => {
+    const confirmed = window.confirm(`Hapus anggaran ${row.category?.name ?? 'ini'}?`);
     if (!confirmed) return;
     try {
       setSubmitting(true);
       await deleteBudget(row.id);
-      await refresh();
       addToast('Anggaran dihapus', 'success');
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Gagal menghapus anggaran';
+      await Promise.all([monthly.refresh(), highlights.refresh()]);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Gagal menghapus anggaran';
+      addToast(message, 'error');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDeleteWeekly = async (row: WeeklyBudgetWithActual) => {
+    const confirmed = window.confirm(`Hapus anggaran minggu ${row.week_start}?`);
+    if (!confirmed) return;
+    try {
+      setSubmitting(true);
+      await deleteWeeklyBudget(row.id);
+      addToast('Anggaran mingguan dihapus', 'success');
+      await Promise.all([weekly.refresh(), highlights.refresh()]);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Gagal menghapus anggaran mingguan';
       addToast(message, 'error');
     } finally {
       setSubmitting(false);
@@ -163,149 +331,246 @@ export default function BudgetsPage() {
     try {
       await upsertBudget({
         category_id: row.category_id,
-        period: isoToPeriod(row.period_month),
+        period: row.period_month?.slice(0, 7) ?? period,
         amount_planned: Number(row.amount_planned ?? 0),
         carryover_enabled: carryover,
         notes: row.notes ?? undefined,
       });
-      await refresh();
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Gagal memperbarui carryover';
+      await Promise.all([monthly.refresh(), highlights.refresh()]);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Gagal memperbarui carryover';
       addToast(message, 'error');
     }
   };
 
-  const handleSubmit = async (values: BudgetFormValues) => {
-    try {
-      setSubmitting(true);
-      await upsertBudget({
-        category_id: values.category_id,
-        period: values.period,
-        amount_planned: Number(values.amount_planned),
-        carryover_enabled: values.carryover_enabled,
-        notes: values.notes ? values.notes : undefined,
-      });
-      setModalOpen(false);
-      setEditing(null);
-      addToast('Anggaran tersimpan', 'success');
-      await refresh();
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Gagal menyimpan anggaran';
-      addToast(message, 'error');
-    } finally {
-      setSubmitting(false);
-    }
-  };
+  const weekOptions = useMemo(() => weeks.map(({ value, label }) => ({ value, label })), [weeks]);
 
   return (
     <Page>
-      <PageHeader
-        title="Anggaran"
-        description="Atur dan pantau alokasi pengeluaranmu tiap bulan."
-      >
-        <button
-          type="button"
-          onClick={refresh}
-          className="hidden h-11 items-center gap-2 rounded-2xl border border-border bg-surface px-4 text-sm font-semibold text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 md:inline-flex"
-        >
-          <RefreshCw className="h-4 w-4" />
-          Segarkan
-        </button>
-        <button
-          type="button"
-          disabled={categoriesLoading}
-          onClick={handleOpenCreate}
-          className="inline-flex h-11 items-center gap-2 rounded-2xl bg-brand px-5 text-sm font-semibold text-brand-foreground shadow transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)] disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          <Plus className="h-4 w-4" />
-          Tambah anggaran
-        </button>
-      </PageHeader>
-
-      <Section first>
-        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div className="grid w-full grid-cols-3 gap-2">
-            {SEGMENTS.map(({ value, label, icon: Icon }) => {
-              const active = value === segment;
+      <PageHeader title="Anggaran" description="Pantau anggaran bulanan dan mingguanmu.">
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="inline-flex rounded-full border border-border/60 bg-surface/80 p-1 text-sm font-semibold text-muted shadow-inner">
+            {VIEW_OPTIONS.map((option) => {
+              const active = view === option.value;
               return (
                 <button
-                  key={value}
+                  key={option.value}
                   type="button"
-                  onClick={() => handleSegmentChange(value)}
+                  onClick={() => setView(option.value)}
                   className={clsx(
-                    'group inline-flex h-10 w-full items-center justify-center gap-2 rounded-xl border px-4 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
+                    'relative flex items-center gap-2 rounded-full px-4 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
                     active
-                      ? 'border-transparent bg-brand text-brand-foreground shadow-lg shadow-brand/30'
-                      : 'border-border/60 bg-surface/80 text-muted hover:bg-surface hover:text-text'
+                      ? 'bg-[color:var(--accent)] text-white shadow'
+                      : 'text-muted hover:text-text'
                   )}
+                  aria-pressed={active}
                 >
-                  <Icon
-                    className={clsx(
-                      'h-4 w-4 transition-colors',
-                      active ? 'text-brand-foreground' : 'text-muted group-hover:text-text'
-                    )}
-                  />
-                  {label}
+                  {option.label}
                 </button>
               );
             })}
           </div>
-
-          {segment === 'custom' ? (
-            <label className="flex h-10 items-center gap-2 rounded-xl border border-border/60 bg-surface/80 px-3 text-sm font-medium text-text shadow-inner transition focus-within:border-brand/40 focus-within:bg-brand/5 focus-within:text-text focus-within:outline-none focus-within:ring-2 focus-within:ring-brand/40">
-              <CalendarRange className="h-4 w-4 text-muted" aria-hidden="true" />
-              <input
-                type="month"
-                value={customPeriod}
-                onChange={(event) => handleCustomPeriodChange(event.target.value)}
-                className="w-full appearance-none bg-transparent text-sm font-medium text-text outline-none"
-                aria-label="Pilih periode custom"
-              />
-            </label>
-          ) : (
-            <div className="flex items-center gap-2 rounded-xl border border-border/60 bg-surface/80 px-3 py-1.5 text-sm font-medium text-muted shadow-inner">
-              <CalendarRange className="h-4 w-4" />
-              <span>{toHumanReadable(period)}</span>
-            </div>
-          )}
+          <label className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-surface/80 px-3 py-2 text-sm font-medium text-text shadow-inner focus-within:border-brand/40 focus-within:ring-2 focus-within:ring-brand/40">
+            <Calendar className="h-4 w-4 text-muted" aria-hidden="true" />
+            <span className="sr-only">Pilih bulan</span>
+            <input
+              type="month"
+              value={period}
+              onChange={(event) => setPeriod(event.target.value || getCurrentPeriod())}
+              className="bg-transparent text-sm font-medium text-text outline-none"
+            />
+          </label>
+          <button
+            type="button"
+            disabled={categoriesLoading}
+            onClick={() => {
+              if (view === 'monthly') {
+                setEditingMonthly(null);
+                setMonthlyModalOpen(true);
+              } else {
+                setEditingWeekly(null);
+                setWeeklyModalOpen(true);
+              }
+            }}
+            className="inline-flex h-11 items-center gap-2 rounded-full bg-[color:var(--accent)] px-5 text-sm font-semibold text-white shadow transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)]/40 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <Plus className="h-4 w-4" />
+            Tambah anggaran
+          </button>
         </div>
-      </Section>
+      </PageHeader>
 
-      <Section>
-        <SummaryCards summary={summary} loading={loading} />
-      </Section>
+      {view === 'monthly' ? (
+        <>
+          <Section first>
+            <SummaryCards summary={monthly.summary} loading={monthly.loading} />
+          </Section>
 
-      {error ? (
-        <Section>
-          <div className="rounded-2xl border border-rose-200/70 bg-rose-50/70 p-4 text-sm text-rose-600 shadow-sm dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-300">
-            Terjadi kesalahan saat memuat data anggaran. Silakan coba lagi.
-          </div>
-        </Section>
-      ) : null}
+          <Section>
+            {monthly.loading && monthly.rows.length === 0 ? (
+              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {Array.from({ length: 6 }).map((_, index) => (
+                  <BudgetCardSkeleton key={index} />
+                ))}
+              </div>
+            ) : monthly.rows.length === 0 ? (
+              <div className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-border/60 bg-surface/70 p-8 text-center text-sm text-muted shadow-inner">
+                <span className="flex h-12 w-12 items-center justify-center rounded-full bg-[color:var(--accent)]/15 text-[color:var(--accent)]">
+                  <Plus className="h-5 w-5" />
+                </span>
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold text-text">Belum ada anggaran bulan {periodLabel}</p>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setEditingMonthly(null);
+                      setMonthlyModalOpen(true);
+                    }}
+                    className="text-sm font-semibold text-[color:var(--accent)] underline-offset-4 hover:underline"
+                  >
+                    Tambah Anggaran
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {monthly.rows.map((row) => (
+                  <BudgetCard
+                    key={row.id}
+                    name={row.category?.name ?? 'Tanpa kategori'}
+                    categoryType={row.category?.type === 'income' ? 'income' : 'expense'}
+                    planned={Number(row.amount_planned ?? 0)}
+                    actual={Number(row.spent ?? 0)}
+                    remaining={Number(row.remaining ?? 0)}
+                    percentage={Number(row.amount_planned ?? 0) > 0 ? Number(row.spent ?? 0) / Number(row.amount_planned ?? 0) : 0}
+                    periodLabel={periodLabel}
+                    badge="Bulanan"
+                    notes={row.notes}
+                    carryoverEnabled={row.carryover_enabled}
+                    onToggleCarryover={(value) => handleToggleCarryover(row, value)}
+                    onEdit={() => {
+                      setEditingMonthly(row);
+                      setMonthlyModalOpen(true);
+                    }}
+                    onDelete={() => handleDeleteMonthly(row)}
+                    highlightSelected={highlightedMonthlyIds.has(row.id)}
+                    onToggleHighlight={() => handleToggleHighlight('monthly', row.id)}
+                    linkToTransactions={monthLink(row.category_id)}
+                  />
+                ))}
+              </div>
+            )}
+          </Section>
+        </>
+      ) : (
+        <>
+          <Section first>
+            <SummaryCards summary={weeklyTotalsSummary} loading={weekly.loading} />
+          </Section>
 
-      <Section>
-        <BudgetTable
-          rows={rows}
-          loading={loading || submitting}
-          onEdit={handleEdit}
-          onDelete={handleDelete}
-          onToggleCarryover={handleToggleCarryover}
-        />
-      </Section>
+          <Section>
+            <div className="space-y-4">
+              <div className="flex flex-col gap-3 rounded-2xl border border-border/60 bg-surface/80 p-5 shadow-sm supports-[backdrop-filter]:bg-surface/60">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <h3 className="text-base font-semibold text-text dark:text-white">Ringkasan Weekly (Month-to-date)</h3>
+                    <p className="text-sm text-muted">Akumulasi per kategori selama bulan {periodLabel}.</p>
+                  </div>
+                  <WeeklyPicker options={weekOptions} value={activeWeek} onChange={setActiveWeek} />
+                </div>
+                <MonthlyFromWeeklySummary rows={weekly.summaries} loading={weekly.loading} />
+              </div>
+
+              {weekly.loading && weekly.rows.length === 0 ? (
+                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                  {Array.from({ length: 6 }).map((_, index) => (
+                    <BudgetCardSkeleton key={index} />
+                  ))}
+                </div>
+              ) : filteredWeeklyRows.length === 0 ? (
+                <div className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-border/60 bg-surface/70 p-8 text-center text-sm text-muted shadow-inner">
+                  <span className="flex h-12 w-12 items-center justify-center rounded-full bg-[color:var(--accent)]/15 text-[color:var(--accent)]">
+                    <CalendarDays className="h-5 w-5" />
+                  </span>
+                  <div className="space-y-1">
+                    <p className="text-sm font-semibold text-text">Belum ada anggaran minggu ini</p>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setEditingWeekly(null);
+                        setWeeklyModalOpen(true);
+                      }}
+                      className="text-sm font-semibold text-[color:var(--accent)] underline-offset-4 hover:underline"
+                    >
+                      Tambah Anggaran
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                  {filteredWeeklyRows.map((row) => {
+                    const planned = Number(row.amount_planned ?? 0);
+                    const actual = Number(row.actual ?? 0);
+                    const weekEnd = row.week_end ?? row.week_start;
+                    const linkStart = row.week_start;
+                    const linkEnd = weekEnd;
+                    return (
+                      <BudgetCard
+                        key={row.id}
+                        name={row.category?.name ?? 'Tanpa kategori'}
+                        categoryType={row.category?.type === 'income' ? 'income' : 'expense'}
+                        planned={planned}
+                        actual={actual}
+                        remaining={row.remaining}
+                        percentage={planned > 0 ? actual / planned : 0}
+                        periodLabel={periodLabel}
+                        badge="Mingguan"
+                        notes={row.notes}
+                        onEdit={() => {
+                          setEditingWeekly(row);
+                          setWeeklyModalOpen(true);
+                        }}
+                        onDelete={() => handleDeleteWeekly(row)}
+                        highlightSelected={highlightedWeeklyIds.has(row.id)}
+                        onToggleHighlight={() => handleToggleHighlight('weekly', row.id)}
+                        linkToTransactions={monthLink(row.category_id, linkStart, linkEnd)}
+                        weekRangeLabel={toWeekRangeLabel(new Date(`${row.week_start}T00:00:00.000Z`), new Date(`${weekEnd}T00:00:00.000Z`))}
+                      />
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </Section>
+        </>
+      )}
 
       <BudgetFormModal
-        open={modalOpen}
-        title={editing ? 'Edit anggaran' : 'Tambah anggaran'}
+        open={monthlyModalOpen}
+        title={editingMonthly ? 'Edit anggaran' : 'Tambah anggaran'}
         categories={categories}
-        initialValues={initialFormValues}
+        initialValues={initialMonthlyValues}
         submitting={submitting}
         onClose={() => {
-          setModalOpen(false);
-          setEditing(null);
+          setMonthlyModalOpen(false);
+          setEditingMonthly(null);
         }}
-        onSubmit={handleSubmit}
+        onSubmit={handleSubmitMonthly}
+      />
+
+      <WeeklyBudgetFormModal
+        open={weeklyModalOpen}
+        title={editingWeekly ? 'Edit anggaran mingguan' : 'Tambah anggaran mingguan'}
+        categories={categories}
+        weekOptions={weekOptions}
+        initialValues={initialWeeklyValues}
+        submitting={submitting}
+        onClose={() => {
+          setWeeklyModalOpen(false);
+          setEditingWeekly(null);
+        }}
+        onSubmit={handleSubmitWeekly}
       />
     </Page>
   );
 }
-

--- a/src/pages/budgets/components/BudgetCard.tsx
+++ b/src/pages/budgets/components/BudgetCard.tsx
@@ -1,0 +1,213 @@
+import clsx from 'clsx';
+import { Eye, Pencil, Star, Trash2 } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { formatCurrency } from '../../../lib/format';
+
+interface BudgetCardProps {
+  name: string;
+  categoryType: 'income' | 'expense';
+  planned: number;
+  actual: number;
+  remaining: number;
+  percentage: number;
+  periodLabel: string;
+  badge: 'Bulanan' | 'Mingguan';
+  notes?: string | null;
+  carryoverEnabled?: boolean;
+  onToggleCarryover?: (value: boolean) => void;
+  onEdit: () => void;
+  onDelete: () => void;
+  highlightSelected: boolean;
+  onToggleHighlight: () => void;
+  linkToTransactions?: string;
+  weekRangeLabel?: string;
+}
+
+function getProgressColor(percentage: number) {
+  if (percentage > 1) return 'bg-rose-500';
+  if (percentage >= 0.9) return 'bg-orange-500';
+  if (percentage >= 0.75) return 'bg-amber-500';
+  return 'bg-[color:var(--accent)]';
+}
+
+function getProgressTrackColor(percentage: number) {
+  if (percentage > 1) return 'bg-rose-500/15';
+  if (percentage >= 0.9) return 'bg-orange-500/15';
+  if (percentage >= 0.75) return 'bg-amber-500/15';
+  return 'bg-[color:var(--accent)]/15';
+}
+
+function formatPercentage(percentage: number) {
+  const pct = Math.max(0, percentage);
+  if (pct > 2) {
+    return `${(pct * 100).toFixed(0)}%`;
+  }
+  return `${Math.round(pct * 100)}%`;
+}
+
+export function BudgetCard({
+  name,
+  categoryType,
+  planned,
+  actual,
+  remaining,
+  percentage,
+  periodLabel,
+  badge,
+  notes,
+  carryoverEnabled,
+  onToggleCarryover,
+  onEdit,
+  onDelete,
+  highlightSelected,
+  onToggleHighlight,
+  linkToTransactions,
+  weekRangeLabel,
+}: BudgetCardProps) {
+  const pct = Math.max(0, percentage);
+  const displayPct = Math.min(1, pct);
+  const progressColor = getProgressColor(pct);
+  const trackColor = getProgressTrackColor(pct);
+  const remainingClass = remaining < 0 ? 'text-rose-500 dark:text-rose-300' : 'text-emerald-500 dark:text-emerald-300';
+  const badgeClass = categoryType === 'income' ? 'bg-emerald-500/10 text-emerald-600' : 'bg-sky-500/10 text-sky-600';
+
+  return (
+    <article className="flex flex-col gap-6 rounded-2xl border border-border/60 bg-surface/80 p-5 shadow-lg shadow-black/5 transition hover:-translate-y-1 hover:shadow-xl supports-[backdrop-filter]:bg-surface/60">
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted">
+            <span className="rounded-full bg-muted/20 px-3 py-1 text-[0.7rem] font-semibold text-muted">{badge}</span>
+            <span>{periodLabel}</span>
+          </div>
+          <h3 className="text-lg font-semibold text-text dark:text-white">{name}</h3>
+          {weekRangeLabel ? <p className="text-xs text-muted">{weekRangeLabel}</p> : null}
+        </div>
+        <div className="flex items-center gap-2">
+          <span
+            className={clsx(
+              'inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ring-1 ring-inset ring-border/50',
+              badgeClass
+            )}
+          >
+            {categoryType === 'income' ? 'Income' : 'Expense'}
+          </span>
+          <button
+            type="button"
+            onClick={onToggleHighlight}
+            aria-label={highlightSelected ? 'Hapus dari highlight' : 'Tambahkan ke highlight'}
+            className={clsx(
+              'inline-flex h-10 w-10 items-center justify-center rounded-full border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
+              highlightSelected
+                ? 'border-amber-400 bg-amber-400/20 text-amber-500 dark:border-amber-500 dark:text-amber-300'
+                : 'border-border/60 bg-surface/80 text-muted hover:text-text'
+            )}
+          >
+            <Star className={clsx('h-5 w-5', highlightSelected ? 'fill-current' : undefined)} />
+          </button>
+        </div>
+      </header>
+
+      <section className="grid gap-4 text-sm sm:grid-cols-3">
+        <div className="space-y-1">
+          <span className="text-[0.68rem] uppercase tracking-[0.18em] text-muted">Planned</span>
+          <p className="text-base font-semibold text-text">{formatCurrency(planned, 'IDR')}</p>
+          <p className="text-xs text-muted">Target minggu/bulan ini</p>
+        </div>
+        <div className="space-y-1">
+          <span className="text-[0.68rem] uppercase tracking-[0.18em] text-muted">Actual</span>
+          <p className="text-base font-semibold text-text">{formatCurrency(actual, 'IDR')}</p>
+          <p className="text-xs text-muted">{formatPercentage(displayPct)} tercapai</p>
+        </div>
+        <div className="space-y-1">
+          <span className="text-[0.68rem] uppercase tracking-[0.18em] text-muted">Sisa</span>
+          <p className={clsx('text-base font-semibold', remainingClass)}>{formatCurrency(remaining, 'IDR')}</p>
+          <p className="text-xs text-muted">{remaining < 0 ? 'Melebihi anggaran' : 'Masih tersedia'}</p>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex items-center justify-between text-xs font-semibold text-muted">
+          <span>Progress</span>
+          <span>{formatPercentage(pct)}</span>
+        </div>
+        <div className={clsx('h-2 w-full overflow-hidden rounded-full', trackColor)}>
+          <div className={clsx('h-full rounded-full transition-all', progressColor)} style={{ width: `${Math.min(100, displayPct * 100)}%` }} />
+        </div>
+      </section>
+
+      {notes ? (
+        <p className="rounded-xl border border-dashed border-border/60 bg-surface/70 p-4 text-sm leading-relaxed text-muted">
+          {notes}
+        </p>
+      ) : null}
+
+      <footer className="flex flex-wrap items-center gap-2">
+        {typeof carryoverEnabled === 'boolean' && onToggleCarryover ? (
+          <button
+            type="button"
+            onClick={() => onToggleCarryover(!carryoverEnabled)}
+            className={clsx(
+              'inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
+              carryoverEnabled
+                ? 'border-emerald-400/60 bg-emerald-500/10 text-emerald-600'
+                : 'border-border/60 bg-surface/80 text-muted hover:text-text'
+            )}
+            aria-label={carryoverEnabled ? 'Matikan carryover' : 'Aktifkan carryover'}
+          >
+            <span className="block h-2 w-2 rounded-full bg-current" />
+            Carryover {carryoverEnabled ? 'on' : 'off'}
+          </button>
+        ) : null}
+
+        <div className="ml-auto flex items-center gap-2">
+          {linkToTransactions ? (
+            <Link
+              to={linkToTransactions}
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border/60 bg-surface/80 text-muted transition hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+              aria-label="Lihat transaksi"
+            >
+              <Eye className="h-4 w-4" />
+            </Link>
+          ) : null}
+          <button
+            type="button"
+            onClick={onEdit}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border/60 bg-surface/80 text-muted transition hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+            aria-label="Edit anggaran"
+          >
+            <Pencil className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={onDelete}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-rose-400/60 bg-rose-500/10 text-rose-500 transition hover:bg-rose-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400/40"
+            aria-label="Hapus anggaran"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+        </div>
+      </footer>
+    </article>
+  );
+}
+
+export function BudgetCardSkeleton() {
+  return (
+    <div className="animate-pulse rounded-2xl border border-dashed border-border/60 bg-surface/70 p-5">
+      <div className="h-4 w-32 rounded-full bg-muted/30" />
+      <div className="mt-4 h-6 w-48 rounded-full bg-muted/30" />
+      <div className="mt-6 h-2 w-full rounded-full bg-muted/20" />
+      <div className="mt-2 h-2 w-5/6 rounded-full bg-muted/20" />
+      <div className="mt-6 grid gap-3 sm:grid-cols-3">
+        <div className="h-16 rounded-xl bg-muted/10" />
+        <div className="h-16 rounded-xl bg-muted/10" />
+        <div className="h-16 rounded-xl bg-muted/10" />
+      </div>
+      <div className="mt-6 flex gap-2">
+        <div className="h-10 w-10 rounded-full bg-muted/20" />
+        <div className="h-10 w-10 rounded-full bg-muted/20" />
+        <div className="h-10 w-10 rounded-full bg-muted/20" />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/budgets/components/MonthlyFromWeeklySummary.tsx
+++ b/src/pages/budgets/components/MonthlyFromWeeklySummary.tsx
@@ -1,0 +1,76 @@
+import clsx from 'clsx';
+import { formatCurrency } from '../../../lib/format';
+import type { WeeklyBudgetSummaryRow } from '../../../lib/budgetApi';
+
+interface MonthlyFromWeeklySummaryProps {
+  rows: WeeklyBudgetSummaryRow[];
+  loading?: boolean;
+}
+
+function getProgressColor(percentage: number) {
+  if (percentage > 1) return 'bg-rose-500';
+  if (percentage >= 0.9) return 'bg-orange-500';
+  if (percentage >= 0.75) return 'bg-amber-500';
+  return 'bg-[color:var(--accent)]';
+}
+
+function getTrackColor(percentage: number) {
+  if (percentage > 1) return 'bg-rose-500/15';
+  if (percentage >= 0.9) return 'bg-orange-500/15';
+  if (percentage >= 0.75) return 'bg-amber-500/15';
+  return 'bg-[color:var(--accent)]/15';
+}
+
+export default function MonthlyFromWeeklySummary({ rows, loading }: MonthlyFromWeeklySummaryProps) {
+  if (loading) {
+    return (
+      <div className="space-y-3">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className="h-16 animate-pulse rounded-2xl border border-dashed border-border/60 bg-surface/70" />
+        ))}
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-border/60 bg-surface/70 p-6 text-sm text-muted">
+        Belum ada anggaran mingguan untuk bulan ini. Tambahkan agar progres bulanannya dapat dipantau.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {rows.map((row) => {
+        const planned = Number(row.planned ?? 0);
+        const actual = Number(row.actual ?? 0);
+        const percentage = planned > 0 ? actual / planned : 0;
+        const progress = Math.min(Math.max(percentage, 0), 1);
+        const progressColor = getProgressColor(percentage);
+        const trackColor = getTrackColor(percentage);
+        const remaining = planned - actual;
+        const remainingClass = remaining < 0 ? 'text-rose-500 dark:text-rose-300' : 'text-muted';
+        return (
+          <article
+            key={row.category_id}
+            className="flex flex-col gap-3 rounded-2xl border border-border/60 bg-surface/80 p-4 shadow-sm supports-[backdrop-filter]:bg-surface/60"
+          >
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <h4 className="text-sm font-semibold text-text dark:text-white">{row.category_name}</h4>
+              <div className="flex items-center gap-3 text-xs text-muted">
+                <span className="font-semibold text-text">{formatCurrency(actual, 'IDR')}</span>
+                <span>/</span>
+                <span>{formatCurrency(planned, 'IDR')}</span>
+                <span className={remainingClass}>{formatCurrency(remaining, 'IDR')}</span>
+              </div>
+            </div>
+            <div className={clsx('h-2 w-full overflow-hidden rounded-full', trackColor)}>
+              <div className={clsx('h-full rounded-full transition-all', progressColor)} style={{ width: `${progress * 100}%` }} />
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/pages/budgets/components/WeeklyBudgetFormModal.tsx
+++ b/src/pages/budgets/components/WeeklyBudgetFormModal.tsx
@@ -1,0 +1,243 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { CalendarDays, PiggyBank } from 'lucide-react';
+import type { ExpenseCategory } from '../../../lib/budgetApi';
+
+export interface WeeklyBudgetFormValues {
+  week_start: string;
+  category_id: string;
+  amount_planned: number;
+  notes: string;
+}
+
+interface WeeklyBudgetFormModalProps {
+  open: boolean;
+  title: string;
+  categories: ExpenseCategory[];
+  weekOptions: { value: string; label: string }[];
+  initialValues: WeeklyBudgetFormValues;
+  submitting?: boolean;
+  onClose: () => void;
+  onSubmit: (values: WeeklyBudgetFormValues) => Promise<void> | void;
+}
+
+const MODAL_CLASS =
+  'fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-10 backdrop-blur-sm';
+
+const NUMBER_FORMATTER = new Intl.NumberFormat('id-ID');
+
+function formatAmount(value: number) {
+  if (!Number.isFinite(value) || value <= 0) return '';
+  return NUMBER_FORMATTER.format(value);
+}
+
+function parseAmount(input: string) {
+  const digits = input.replace(/\D/g, '');
+  if (!digits) return { display: '', value: 0 };
+  const numeric = Number.parseInt(digits, 10);
+  return { display: NUMBER_FORMATTER.format(numeric), value: numeric };
+}
+
+function validate(values: WeeklyBudgetFormValues) {
+  const errors: Partial<Record<keyof WeeklyBudgetFormValues, string>> = {};
+  if (!values.week_start) errors.week_start = 'Pilih minggu';
+  if (!values.category_id) errors.category_id = 'Kategori wajib dipilih';
+  if (!Number.isFinite(values.amount_planned) || values.amount_planned <= 0) {
+    errors.amount_planned = 'Nominal harus lebih dari 0';
+  }
+  return errors;
+}
+
+export default function WeeklyBudgetFormModal({
+  open,
+  title,
+  categories,
+  weekOptions,
+  initialValues,
+  submitting,
+  onClose,
+  onSubmit,
+}: WeeklyBudgetFormModalProps) {
+  const [values, setValues] = useState(initialValues);
+  const [errors, setErrors] = useState<Partial<Record<keyof WeeklyBudgetFormValues, string>>>({});
+  const [amountInput, setAmountInput] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setValues(initialValues);
+      setErrors({});
+      setAmountInput(formatAmount(initialValues.amount_planned));
+    }
+  }, [open, initialValues]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [open, onClose]);
+
+  const groupedCategories = useMemo(() => {
+    const groups = new Map<string, ExpenseCategory[]>();
+    for (const category of categories) {
+      const key = category.group_name ?? 'Ungrouped';
+      const list = groups.get(key) ?? [];
+      list.push(category);
+      groups.set(key, list);
+    }
+    return Array.from(groups.entries());
+  }, [categories]);
+
+  const handleChange = (field: keyof WeeklyBudgetFormValues, value: string | number) => {
+    setValues((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleAmountChange = (value: string) => {
+    const parsed = parseAmount(value);
+    setAmountInput(parsed.display);
+    setValues((prev) => ({ ...prev, amount_planned: parsed.value }));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const nextValues = { ...values, notes: values.notes.trim() };
+    const validation = validate(nextValues);
+    setErrors(validation);
+    if (Object.keys(validation).length > 0) return;
+    await onSubmit({ ...nextValues, amount_planned: Number(nextValues.amount_planned) });
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className={MODAL_CLASS} onClick={onClose}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="w-full max-w-xl rounded-3xl border border-white/20 bg-gradient-to-b from-white/90 to-white/60 p-6 shadow-[0_40px_120px_-60px_rgba(15,23,42,0.65)] backdrop-blur dark:border-white/10 dark:from-zinc-950/80 dark:to-zinc-900/70"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-50">{title}</h2>
+            <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+              Tetapkan alokasi mingguan untuk kategori pilihanmu.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/40 bg-white/70 text-zinc-500 shadow-sm transition hover:-translate-y-0.5 hover:bg-white dark:border-white/10 dark:bg-zinc-900/70 dark:text-zinc-300"
+            aria-label="Tutup"
+          >
+            ✕
+          </button>
+        </div>
+
+        <form className="mt-6 flex flex-col gap-5" onSubmit={handleSubmit}>
+          <label className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">
+            Minggu (mulai Senin)
+            <div className="relative">
+              <span className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-zinc-400">
+                <CalendarDays className="h-4 w-4" />
+              </span>
+              <select
+                value={values.week_start}
+                onChange={(event) => handleChange('week_start', event.target.value)}
+                className="h-11 w-full rounded-2xl border border-border bg-surface pl-11 pr-10 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+                required
+              >
+                <option value="" disabled>
+                  Pilih minggu
+                </option>
+                {weekOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            {errors.week_start ? <span className="text-xs font-medium text-rose-500">{errors.week_start}</span> : null}
+          </label>
+
+          <label className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">
+            Kategori
+            <div className="relative">
+              <span className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-zinc-400">
+                <PiggyBank className="h-4 w-4" aria-hidden="true" />
+              </span>
+              <select
+                value={values.category_id}
+                onChange={(event) => handleChange('category_id', event.target.value)}
+                className="h-11 w-full rounded-2xl border border-border bg-surface pl-11 pr-10 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+                required
+                disabled={categories.length === 0}
+              >
+                <option value="" disabled>
+                  Pilih kategori
+                </option>
+                {groupedCategories.map(([groupName, groupCategories]) => (
+                  <optgroup key={groupName} label={groupName}>
+                    {groupCategories.map((category) => (
+                      <option key={category.id} value={category.id}>
+                        {category.name}
+                      </option>
+                    ))}
+                  </optgroup>
+                ))}
+              </select>
+            </div>
+            {errors.category_id ? <span className="text-xs font-medium text-rose-500">{errors.category_id}</span> : null}
+          </label>
+
+          <label className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">
+            Nominal Anggaran (IDR)
+            <input
+              type="text"
+              inputMode="numeric"
+              value={amountInput}
+              onChange={(event) => handleAmountChange(event.target.value)}
+              placeholder="Masukkan nominal"
+              className="h-11 w-full rounded-2xl border border-border bg-surface px-4 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+              required
+            />
+            {errors.amount_planned ? (
+              <span className="text-xs font-medium text-rose-500">{errors.amount_planned}</span>
+            ) : null}
+          </label>
+
+          <label className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">
+            Catatan (opsional)
+            <textarea
+              rows={3}
+              value={values.notes}
+              onChange={(event) => handleChange('notes', event.target.value)}
+              className="min-h-[96px] rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+              placeholder="Catatan tambahan"
+            />
+          </label>
+
+          <div className="mt-2 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={onClose}
+              className="h-11 rounded-2xl border border-border px-6 text-sm font-semibold text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+            >
+              Batal
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="inline-flex h-11 items-center justify-center rounded-2xl bg-brand px-6 text-sm font-semibold text-brand-foreground shadow transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)] disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {submitting ? 'Menyimpan...' : 'Simpan anggaran'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/budgets/components/WeeklyPicker.tsx
+++ b/src/pages/budgets/components/WeeklyPicker.tsx
@@ -1,0 +1,51 @@
+import clsx from 'clsx';
+
+interface WeeklyPickerOption {
+  value: string;
+  label: string;
+}
+
+interface WeeklyPickerProps {
+  options: WeeklyPickerOption[];
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export default function WeeklyPicker({ options, value, onChange }: WeeklyPickerProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <button
+        type="button"
+        onClick={() => onChange('all')}
+        className={clsx(
+          'inline-flex items-center rounded-full border px-4 py-2 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
+          value === 'all'
+            ? 'border-transparent bg-[color:var(--accent)] text-white shadow'
+            : 'border-border/60 bg-surface/80 text-muted hover:text-text'
+        )}
+        aria-label="Tampilkan semua minggu"
+      >
+        Semua minggu
+      </button>
+      {options.map((option) => {
+        const active = value === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange(option.value)}
+            className={clsx(
+              'inline-flex items-center rounded-full border px-4 py-2 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
+              active
+                ? 'border-transparent bg-[color:var(--accent)] text-white shadow'
+                : 'border-border/60 bg-surface/80 text-muted hover:text-text'
+            )}
+            aria-pressed={active}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add weekly budget APIs, hooks, and CRUD UI with segmented monthly/weekly budgets view
- allow toggling up to two highlighted budgets and display them on the dashboard widget
- show month-to-date summaries, weekly pickers, and updated budget cards with highlight controls

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e25d02f51483329a27783832168564