### PR TITLE
feat: support weekly budgets and highlights

### DIFF
--- a/src/components/dashboard/DashboardHighlightedBudgets.tsx
+++ b/src/components/dashboard/DashboardHighlightedBudgets.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useMemo, useState } from 'react';
+import { AlertTriangle, Sparkles } from 'lucide-react';
+import { formatCurrency } from '../../lib/format';
+import {
+  listHighlightedBudgetDetails,
+  type HighlightedBudgetDetail,
+} from '../../lib/budgetApi';
+import type { PeriodRange } from './PeriodPicker';
+
+interface DashboardHighlightedBudgetsProps {
+  period: PeriodRange;
+}
+
+const PROGRESS_COLORS = {
+  accent: 'var(--accent)',
+  amber: '#f59e0b',
+  orange: '#fb923c',
+  rose: '#f43f5e',
+} as const;
+
+function getMonthFromRange(range: PeriodRange): string {
+  const base = range?.end || range?.start;
+  if (!base) {
+    const now = new Date();
+    return `${now.getFullYear()}-${`${now.getMonth() + 1}`.padStart(2, '0')}`;
+  }
+  return base.slice(0, 7);
+}
+
+function getProgressColor(percentage: number): string {
+  const percent = Math.round(percentage * 100);
+  if (percent <= 74) return PROGRESS_COLORS.accent;
+  if (percent <= 89) return PROGRESS_COLORS.amber;
+  if (percent <= 100) return PROGRESS_COLORS.orange;
+  return PROGRESS_COLORS.rose;
+}
+
+function formatPercentage(value: number): string {
+  return `${Math.round(Math.min(value, 2) * 100)}%`;
+}
+
+function useHighlightedBudgets(period: string) {
+  const [rows, setRows] = useState<HighlightedBudgetDetail[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError(null);
+    listHighlightedBudgetDetails(period)
+      .then((data) => {
+        if (!active) return;
+        setRows(data);
+      })
+      .catch((err: unknown) => {
+        if (!active) return;
+        const message = err instanceof Error ? err.message : 'Gagal memuat highlight';
+        setError(message);
+        setRows([]);
+      })
+      .finally(() => {
+        if (!active) return;
+        setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [period]);
+
+  return { rows, loading, error };
+}
+
+function SkeletonCard() {
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl border border-dashed border-border/60 bg-surface/70 p-4 shadow-inner">
+      <div className="h-4 w-32 animate-pulse rounded-full bg-muted/50" />
+      <div className="h-3 w-20 animate-pulse rounded-full bg-muted/40" />
+      <div className="h-2 w-full animate-pulse rounded-full bg-muted/40" />
+    </div>
+  );
+}
+
+export default function DashboardHighlightedBudgets({ period }: DashboardHighlightedBudgetsProps) {
+  const periodMonth = useMemo(() => getMonthFromRange(period), [period]);
+  const { rows, loading, error } = useHighlightedBudgets(periodMonth);
+
+  return (
+    <section className="rounded-3xl border border-border/60 bg-surface/80 p-6 shadow-sm transition dark:border-border/40 dark:bg-zinc-900/60">
+      <header className="flex items-center justify-between">
+        <div className="space-y-1">
+          <div className="inline-flex items-center gap-2 rounded-full bg-brand/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-brand">
+            <Sparkles className="h-3.5 w-3.5" />
+            Highlighted Budgets
+          </div>
+          <h2 className="text-xl font-semibold text-text">Fokus Anggaranmu</h2>
+          <p className="text-sm text-muted">Pantau cepat 1-2 anggaran pilihanmu untuk bulan ini.</p>
+        </div>
+      </header>
+
+      <div className="mt-6 space-y-4">
+        {loading ? (
+          <div className="grid gap-4 md:grid-cols-2">
+            <SkeletonCard />
+            <SkeletonCard />
+          </div>
+        ) : error ? (
+          <div className="flex items-center gap-3 rounded-2xl border border-rose-200/70 bg-rose-50/70 p-4 text-sm text-rose-600 shadow-sm dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-200">
+            <AlertTriangle className="h-4 w-4" />
+            {error}
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-border/60 bg-surface/70 p-6 text-sm text-muted shadow-inner">
+            Belum ada anggaran yang di-highlight. Tandai maksimal dua anggaran di halaman Budgets.
+          </div>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2">
+            {rows.map((item) => {
+              const planned = Number(item.planned ?? 0);
+              const actual = Number(item.actual ?? 0);
+              const remaining = planned - actual;
+              const ratio = planned > 0 ? actual / planned : 0;
+              const percentLabel = formatPercentage(ratio);
+              const color = getProgressColor(ratio);
+              return (
+                <article
+                  key={item.highlight_id}
+                  className="flex flex-col gap-4 rounded-2xl border border-border/60 bg-surface/90 p-4 shadow-sm dark:border-border/40 dark:bg-zinc-900/70"
+                >
+                  <header className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-text">{item.category_name ?? 'Tanpa kategori'}</p>
+                      <p className="text-xs text-muted">{item.category_type === 'income' ? 'Pemasukan' : 'Pengeluaran'}</p>
+                    </div>
+                    <span className="inline-flex items-center rounded-full bg-muted/20 px-3 py-1 text-[0.7rem] font-medium text-muted">
+                      {item.label}
+                    </span>
+                  </header>
+
+                  <div className="grid gap-3 text-sm text-muted sm:grid-cols-2">
+                    <div>
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted">Planned</p>
+                      <p className="text-sm font-semibold text-text">{formatCurrency(planned, 'IDR')}</p>
+                    </div>
+                    <div>
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted">Actual</p>
+                      <p className="text-sm font-semibold text-text">{formatCurrency(actual, 'IDR')}</p>
+                    </div>
+                    <div className="sm:col-span-2">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted">Sisa</p>
+                      <p className={`text-sm font-semibold ${remaining < 0 ? 'text-rose-500 dark:text-rose-300' : 'text-emerald-600 dark:text-emerald-300'}`}>
+                        {formatCurrency(remaining, 'IDR')}
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between text-xs font-semibold text-muted">
+                      <span>Progres</span>
+                      <span>{percentLabel}</span>
+                    </div>
+                    <div className="h-2 w-full overflow-hidden rounded-full bg-muted/20">
+                      <div
+                        className="h-full rounded-full transition-all"
+                        style={{
+                          width: `${Math.min(ratio * 100, 100)}%`,
+                          backgroundColor: color,
+                        }}
+                      />
+                    </div>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/hooks/useBudgetHighlights.ts
+++ b/src/hooks/useBudgetHighlights.ts
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  listHighlightBudgets,
+  toggleHighlight as toggleHighlightApi,
+  type BudgetType,
+  type HighlightBudgetRecord,
+} from '../lib/budgetApi';
+
+export interface UseBudgetHighlightsResult {
+  highlights: HighlightBudgetRecord[];
+  loading: boolean;
+  isHighlighted: (type: BudgetType, id: string) => boolean;
+  toggleHighlight: (type: BudgetType, id: string) => Promise<'added' | 'removed'>;
+  refresh: () => Promise<void>;
+}
+
+export function useBudgetHighlights(): UseBudgetHighlightsResult {
+  const [highlights, setHighlights] = useState<HighlightBudgetRecord[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  const refresh = useCallback(async () => {
+    const data = await listHighlightBudgets();
+    setHighlights(data);
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    refresh()
+      .catch((err) => {
+        if (!active) return;
+        console.error('[HW] gagal memuat highlight', err);
+      })
+      .finally(() => {
+        if (!active) return;
+        setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [refresh]);
+
+  const handleToggle = useCallback(
+    async (type: BudgetType, id: string) => {
+      const result = await toggleHighlightApi({ type, id });
+      await refresh();
+      return result;
+    },
+    [refresh]
+  );
+
+  const highlightSet = useMemo(() => {
+    const map = new Map<string, HighlightBudgetRecord>();
+    for (const item of highlights) {
+      map.set(`${item.budget_type}:${item.budget_id}`, item);
+    }
+    return map;
+  }, [highlights]);
+
+  const isHighlighted = useCallback(
+    (type: BudgetType, id: string) => highlightSet.has(`${type}:${id}`),
+    [highlightSet]
+  );
+
+  return {
+    highlights,
+    loading,
+    isHighlighted,
+    toggleHighlight: handleToggle,
+    refresh,
+  };
+}

--- a/src/hooks/useWeeklyBudgets.ts
+++ b/src/hooks/useWeeklyBudgets.ts
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  listWeeklyBudgets,
+  type WeeklyBudgetCategorySummary,
+  type WeeklyBudgetWithActual,
+} from '../lib/budgetApi';
+
+export interface UseWeeklyBudgetsResult {
+  rows: WeeklyBudgetWithActual[];
+  summaries: WeeklyBudgetCategorySummary[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+const EMPTY_SUMMARIES: WeeklyBudgetCategorySummary[] = [];
+
+export function useWeeklyBudgets(period: string): UseWeeklyBudgetsResult {
+  const [rows, setRows] = useState<WeeklyBudgetWithActual[]>([]);
+  const [summaries, setSummaries] = useState<WeeklyBudgetCategorySummary[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    const result = await listWeeklyBudgets(period);
+    return result;
+  }, [period]);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError(null);
+    fetchData()
+      .then((result) => {
+        if (!active) return;
+        setRows(result.rows);
+        setSummaries(result.summaries);
+      })
+      .catch((err: unknown) => {
+        if (!active) return;
+        setRows([]);
+        setSummaries([]);
+        setError(err instanceof Error ? err.message : 'Gagal memuat anggaran mingguan');
+      })
+      .finally(() => {
+        if (!active) return;
+        setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [fetchData]);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchData();
+      setRows(result.rows);
+      setSummaries(result.summaries);
+    } catch (err) {
+      setRows([]);
+      setSummaries([]);
+      setError(err instanceof Error ? err.message : 'Gagal memuat anggaran mingguan');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchData]);
+
+  const memoSummaries = useMemo(() => (loading && summaries.length === 0 ? EMPTY_SUMMARIES : summaries), [loading, summaries]);
+
+  return {
+    rows,
+    summaries: memoSummaries,
+    loading,
+    error,
+    refresh,
+  };
+}

--- a/src/lib/budgetApi.ts
+++ b/src/lib/budgetApi.ts
@@ -5,6 +5,8 @@ import { getCurrentUserId, getUserToken } from './session';
 import { listCategories as listAllCategories } from './api-categories';
 import { buildSupabaseHeaders, createRestUrl } from './supabaseRest';
 
+export type BudgetType = 'monthly' | 'weekly';
+
 type UUID = string;
 
 type Nullable<T> = T | null;
@@ -124,6 +126,73 @@ export interface BudgetSummary {
   percentage: number;
 }
 
+export interface WeeklyBudgetRow {
+  id: UUID;
+  user_id: UUID;
+  category_id: UUID;
+  amount_planned: number;
+  notes: Nullable<string>;
+  week_start: string; // ISO date YYYY-MM-DD (Monday)
+  created_at: string;
+  updated_at: string;
+  category: {
+    id: UUID;
+    name: string;
+    type: 'income' | 'expense';
+  } | null;
+}
+
+export interface WeeklyBudgetWithActual extends WeeklyBudgetRow {
+  week_end: string;
+  actual: number;
+  remaining: number;
+  percentage: number;
+}
+
+export interface WeeklyBudgetCategorySummary {
+  category_id: UUID;
+  category_name: string | null;
+  category_type: 'income' | 'expense' | null;
+  planned: number;
+  actual: number;
+  remaining: number;
+  percentage: number;
+}
+
+export interface WeeklyBudgetsResult {
+  rows: WeeklyBudgetWithActual[];
+  summaries: WeeklyBudgetCategorySummary[];
+}
+
+export interface UpsertWeeklyBudgetInput {
+  id?: UUID;
+  category_id: UUID;
+  week_start: string; // YYYY-MM-DD (Monday)
+  amount_planned: number;
+  notes?: Nullable<string>;
+}
+
+export interface HighlightBudgetRecord {
+  id: UUID;
+  budget_id: UUID;
+  budget_type: BudgetType;
+  created_at: string;
+}
+
+export interface HighlightedBudgetDetail {
+  highlight_id: UUID;
+  budget_type: BudgetType;
+  budget_id: UUID;
+  category_id: UUID | null;
+  category_name: string | null;
+  category_type: 'income' | 'expense' | null;
+  planned: number;
+  actual: number;
+  remaining: number;
+  percentage: number;
+  label: string;
+}
+
 export interface UpsertBudgetInput {
   id?: UUID;
   category_id: UUID;
@@ -184,7 +253,7 @@ async function fetchBudgetsForPeriod(userId: string, period: string): Promise<Bu
   return (data ?? []) as BudgetRow[];
 }
 
-function getMonthRange(period: string): { start: string; end: string } {
+export function getMonthRange(period: string): { start: string; end: string } {
   const start = new Date(`${toMonthStart(period)}T00:00:00.000Z`);
   const end = new Date(start);
   end.setUTCMonth(end.getUTCMonth() + 1);
@@ -198,6 +267,31 @@ function getMonthRange(period: string): { start: string; end: string } {
     start: format(start),
     end: format(end),
   };
+}
+
+function toUtcDateOnly(value: string): Date {
+  return new Date(`${value}T00:00:00.000Z`);
+}
+
+function formatIsoDate(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = (date.getUTCMonth() + 1).toString().padStart(2, '0');
+  const day = date.getUTCDate().toString().padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function normalizeWeekStart(value: string): string {
+  if (!value) {
+    throw new Error('Tanggal minggu wajib diisi');
+  }
+  const date = toUtcDateOnly(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('Tanggal minggu tidak valid');
+  }
+  const day = date.getUTCDay();
+  const diff = day === 0 ? -6 : 1 - day; // Adjust to Monday
+  date.setUTCDate(date.getUTCDate() + diff);
+  return formatIsoDate(date);
 }
 
 export async function listCategoriesExpense(): Promise<ExpenseCategory[]> {
@@ -372,6 +466,294 @@ export async function computeSpent(period: string): Promise<Record<string, numbe
     totals[categoryId] = (totals[categoryId] ?? 0) + amount;
   }
   return totals;
+}
+
+export async function listWeeklyBudgets(period: string): Promise<WeeklyBudgetsResult> {
+  const userId = await getCurrentUserId();
+  ensureAuth(userId);
+
+  const { start: monthStart, end: monthEndExclusive } = getMonthRange(period);
+  const monthEndExclusiveDate = toUtcDateOnly(monthEndExclusive);
+  const monthEndInclusive = new Date(monthEndExclusiveDate);
+  monthEndInclusive.setUTCDate(monthEndInclusive.getUTCDate() - 1);
+
+  const [budgetResult, txResult] = await Promise.all([
+    supabase
+      .from('budgets_weekly')
+      .select(
+        'id,user_id,category_id,amount_planned,notes,week_start,created_at,updated_at,category:categories(id,name,type)'
+      )
+      .eq('user_id', userId)
+      .gte('week_start', monthStart)
+      .lt('week_start', monthEndExclusive)
+      .order('week_start', { ascending: true }),
+    supabase
+      .from('transactions')
+      .select('category_id, amount, date')
+      .eq('user_id', userId)
+      .is('deleted_at', null)
+      .eq('type', 'expense')
+      .is('to_account_id', null)
+      .gte('date', monthStart)
+      .lt('date', monthEndExclusive),
+  ]);
+
+  if (budgetResult.error) throw budgetResult.error;
+  if (txResult.error) throw txResult.error;
+
+  const budgets = ((budgetResult.data ?? []) as WeeklyBudgetRow[]).map((row) => ({
+    ...row,
+    week_start: normalizeWeekStart(row.week_start),
+  }));
+
+  const transactions = (txResult.data ?? []) as { category_id: string | null; amount: number; date: string }[];
+
+  const transactionsByCategory = new Map<string, { amount: number; date: string }[]>();
+  const categoryTotals = new Map<string, number>();
+
+  for (const tx of transactions) {
+    const categoryId = tx.category_id;
+    if (!categoryId) continue;
+    const amount = Number(tx.amount ?? 0);
+    if (!Number.isFinite(amount)) continue;
+    const list = transactionsByCategory.get(categoryId) ?? [];
+    list.push({ amount, date: tx.date });
+    transactionsByCategory.set(categoryId, list);
+    categoryTotals.set(categoryId, (categoryTotals.get(categoryId) ?? 0) + amount);
+  }
+
+  const summaryMap = new Map<string, WeeklyBudgetCategorySummary>();
+
+  const rows: WeeklyBudgetWithActual[] = budgets.map((budget) => {
+    const planned = Number(budget.amount_planned ?? 0);
+    const weekStartDate = toUtcDateOnly(budget.week_start);
+    const weekExclusiveEnd = new Date(weekStartDate);
+    weekExclusiveEnd.setUTCDate(weekExclusiveEnd.getUTCDate() + 7);
+    const weekInclusiveEnd = new Date(weekExclusiveEnd);
+    weekInclusiveEnd.setUTCDate(weekInclusiveEnd.getUTCDate() - 1);
+
+    const effectiveWeekEnd = weekInclusiveEnd > monthEndInclusive ? monthEndInclusive : weekInclusiveEnd;
+    const txList = transactionsByCategory.get(budget.category_id) ?? [];
+    let actual = 0;
+    for (const tx of txList) {
+      const txDate = toUtcDateOnly(tx.date);
+      if (txDate >= weekStartDate && txDate < weekExclusiveEnd) {
+        actual += Number(tx.amount ?? 0);
+      }
+    }
+    const remaining = planned - actual;
+    const percentage = planned > 0 ? actual / planned : 0;
+
+    const summary = summaryMap.get(budget.category_id) ?? {
+      category_id: budget.category_id,
+      category_name: budget.category?.name ?? null,
+      category_type: budget.category?.type ?? null,
+      planned: 0,
+      actual: 0,
+      remaining: 0,
+      percentage: 0,
+    };
+    summary.planned += planned;
+    summaryMap.set(budget.category_id, summary);
+
+    return {
+      ...budget,
+      week_end: formatIsoDate(effectiveWeekEnd),
+      actual,
+      remaining,
+      percentage,
+    };
+  });
+
+  const summaries: WeeklyBudgetCategorySummary[] = Array.from(summaryMap.values()).map((summary) => {
+    const actual = categoryTotals.get(summary.category_id) ?? 0;
+    const remaining = summary.planned - actual;
+    const percentage = summary.planned > 0 ? actual / summary.planned : 0;
+    return {
+      ...summary,
+      actual,
+      remaining,
+      percentage,
+    };
+  });
+
+  return { rows, summaries };
+}
+
+export async function upsertWeeklyBudget(input: UpsertWeeklyBudgetInput): Promise<void> {
+  const userId = await getCurrentUserId();
+  ensureAuth(userId);
+
+  try {
+    await getUserToken();
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Not signed in') {
+      throw new Error('Silakan login untuk menyimpan anggaran');
+    }
+    throw error;
+  }
+
+  const payload = {
+    id: input.id ?? undefined,
+    user_id: userId,
+    category_id: input.category_id,
+    week_start: normalizeWeekStart(input.week_start),
+    amount_planned: Number(input.amount_planned ?? 0),
+    notes: input.notes ?? null,
+  };
+
+  const { error } = await supabase.from('budgets_weekly').upsert(payload, { onConflict: 'id' });
+  if (error) {
+    if (error.message === 'Unauthorized' || error.code === '401' || error.code === 'PGRST301') {
+      throw new Error('Silakan login untuk menyimpan anggaran');
+    }
+    throw error;
+  }
+}
+
+export async function deleteWeeklyBudget(id: UUID): Promise<void> {
+  const userId = await getCurrentUserId();
+  ensureAuth(userId);
+  const { error } = await supabase.from('budgets_weekly').delete().eq('user_id', userId).eq('id', id);
+  if (error) throw error;
+}
+
+export async function listHighlightBudgets(): Promise<HighlightBudgetRecord[]> {
+  const userId = await getCurrentUserId();
+  ensureAuth(userId);
+  const { data, error } = await supabase
+    .from('user_highlight_budgets')
+    .select('id,budget_id,budget_type,created_at')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: true });
+  if (error) throw error;
+  return (data ?? []) as HighlightBudgetRecord[];
+}
+
+function isHighlightLimitError(error: { code?: string; message?: string }): boolean {
+  if (!error) return false;
+  if (error.code === 'P0001' || error.code === '23514') return true;
+  const message = (error.message ?? '').toLowerCase();
+  return message.includes('max') || message.includes('maximum') || message.includes('limit');
+}
+
+export async function toggleHighlight({ type, id }: { type: BudgetType; id: UUID }): Promise<'added' | 'removed'> {
+  const userId = await getCurrentUserId();
+  ensureAuth(userId);
+
+  const { data: existing, error: selectError } = await supabase
+    .from('user_highlight_budgets')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('budget_type', type)
+    .eq('budget_id', id)
+    .maybeSingle();
+
+  if (selectError && selectError.code !== 'PGRST116') {
+    throw selectError;
+  }
+
+  if (existing) {
+    const { error } = await supabase
+      .from('user_highlight_budgets')
+      .delete()
+      .eq('user_id', userId)
+      .eq('id', existing.id);
+    if (error) throw error;
+    return 'removed';
+  }
+
+  const { error } = await supabase.from('user_highlight_budgets').insert({
+    user_id: userId,
+    budget_type: type,
+    budget_id: id,
+  });
+
+  if (error) {
+    if (isHighlightLimitError(error)) {
+      const err = new Error('Maksimal 2 highlight');
+      (err as { code?: string }).code = 'LIMIT_REACHED';
+      throw err;
+    }
+    throw error;
+  }
+
+  return 'added';
+}
+
+export async function listHighlightedBudgetDetails(period: string): Promise<HighlightedBudgetDetail[]> {
+  const highlights = await listHighlightBudgets();
+  if (highlights.length === 0) {
+    return [];
+  }
+
+  const [monthlyBudgets, spentMap, weeklyResult] = await Promise.all([
+    listBudgets(period),
+    computeSpent(period),
+    listWeeklyBudgets(period),
+  ]);
+
+  const monthlyMerged = mergeBudgetsWithSpent(monthlyBudgets, spentMap);
+  const monthlyMap = new Map<string, BudgetWithSpent>();
+  for (const row of monthlyMerged) {
+    monthlyMap.set(row.id, row);
+  }
+
+  const weeklyMap = new Map<string, WeeklyBudgetWithActual>();
+  for (const row of weeklyResult.rows) {
+    weeklyMap.set(row.id, row);
+  }
+
+  const weeklySummaryMap = new Map<string, WeeklyBudgetCategorySummary>();
+  for (const summary of weeklyResult.summaries) {
+    weeklySummaryMap.set(summary.category_id, summary);
+  }
+
+  const details: HighlightedBudgetDetail[] = [];
+
+  for (const highlight of highlights.slice(0, 2)) {
+    if (highlight.budget_type === 'monthly') {
+      const monthly = monthlyMap.get(highlight.budget_id);
+      if (!monthly) continue;
+      details.push({
+        highlight_id: highlight.id,
+        budget_type: 'monthly',
+        budget_id: monthly.id,
+        category_id: monthly.category_id,
+        category_name: monthly.category?.name ?? null,
+        category_type: monthly.category?.type ?? null,
+        planned: Number(monthly.amount_planned ?? 0),
+        actual: Number(monthly.spent ?? 0),
+        remaining: Number(monthly.remaining ?? 0),
+        percentage: Number(monthly.amount_planned ?? 0) > 0 ? Number(monthly.spent ?? 0) / Number(monthly.amount_planned ?? 0) : 0,
+        label: 'Bulanan',
+      });
+      continue;
+    }
+
+    const weekly = weeklyMap.get(highlight.budget_id);
+    if (!weekly) continue;
+    const summary = weeklySummaryMap.get(weekly.category_id);
+    const planned = summary?.planned ?? Number(weekly.amount_planned ?? 0);
+    const actual = summary?.actual ?? weekly.actual;
+    const remaining = planned - actual;
+    const percentage = planned > 0 ? actual / planned : 0;
+    details.push({
+      highlight_id: highlight.id,
+      budget_type: 'weekly',
+      budget_id: weekly.id,
+      category_id: weekly.category_id,
+      category_name: weekly.category?.name ?? null,
+      category_type: weekly.category?.type ?? null,
+      planned,
+      actual,
+      remaining,
+      percentage,
+      label: 'Mingguan',
+    });
+  }
+
+  return details;
 }
 
 export async function upsertBudget(input: UpsertBudgetInput): Promise<void> {

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -15,6 +15,7 @@ import useDashboardBalances from "../hooks/useDashboardBalances";
 import DailyDigestModal from "../components/DailyDigestModal";
 import useShowDigestOnLogin from "../hooks/useShowDigestOnLogin";
 import BudgetHighlights from "../components/dashboard/BudgetHighlights";
+import DashboardHighlightedBudgets from "../components/dashboard/DashboardHighlightedBudgets";
 
 const DEFAULT_PRESET = "month";
 
@@ -123,6 +124,8 @@ export default function Dashboard({ stats, txs }) {
         />
 
         <QuickActions />
+
+        <DashboardHighlightedBudgets period={periodRange} />
 
         <BudgetHighlights period={periodRange} />
 

--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
-import { CalendarRange, CalendarDays, History, Plus, RefreshCw } from 'lucide-react';
+import { CalendarRange, Plus, RefreshCw } from 'lucide-react';
 import Page from '../../layout/Page';
 import Section from '../../layout/Section';
 import PageHeader from '../../layout/PageHeader';
@@ -8,52 +8,95 @@ import { useToast } from '../../context/ToastContext';
 import SummaryCards from './components/SummaryCards';
 import BudgetTable from './components/BudgetTable';
 import BudgetFormModal, { type BudgetFormValues } from './components/BudgetFormModal';
+import WeeklyBudgetFormModal, {
+  type WeeklyBudgetFormValues,
+} from './components/WeeklyBudgetFormModal';
+import WeeklyBudgetsSection from './components/WeeklyBudgetsSection';
 import { useBudgets } from '../../hooks/useBudgets';
+import { useWeeklyBudgets } from '../../hooks/useWeeklyBudgets';
+import { useBudgetHighlights } from '../../hooks/useBudgetHighlights';
 import {
   deleteBudget,
+  deleteWeeklyBudget,
   listCategoriesExpense,
   upsertBudget,
+  upsertWeeklyBudget,
+  type BudgetType,
   type BudgetWithSpent,
   type ExpenseCategory,
+  type WeeklyBudgetWithActual,
 } from '../../lib/budgetApi';
 
-const SEGMENTS = [
-  { value: 'current', label: 'Bulan ini', icon: CalendarDays },
-  { value: 'previous', label: 'Bulan lalu', icon: History },
-  { value: 'custom', label: 'Custom', icon: CalendarRange },
+const VIEW_OPTIONS = [
+  { value: 'monthly', label: 'Bulanan' },
+  { value: 'weekly', label: 'Mingguan' },
 ] as const;
 
-type SegmentValue = (typeof SEGMENTS)[number]['value'];
+type ViewValue = (typeof VIEW_OPTIONS)[number]['value'];
 
-function formatPeriod(date: Date): string {
+type PeriodString = `${number}-${number}`;
+
+function formatPeriod(date: Date): PeriodString {
   const year = date.getFullYear();
   const month = `${date.getMonth() + 1}`.padStart(2, '0');
-  return `${year}-${month}`;
+  return `${year}-${month}` as PeriodString;
 }
 
-function getCurrentPeriod() {
+function getCurrentPeriod(): PeriodString {
   return formatPeriod(new Date());
 }
 
-function getPreviousPeriod() {
-  const now = new Date();
-  const previous = new Date(now.getFullYear(), now.getMonth() - 1, 1);
-  return formatPeriod(previous);
-}
-
-function toHumanReadable(period: string): string {
-  const [year, month] = period.split('-').map((value) => Number.parseInt(value, 10));
-  if (!year || !month) return period;
-  const formatter = new Intl.DateTimeFormat('id-ID', { month: 'long', year: 'numeric' });
-  return formatter.format(new Date(year, month - 1, 1));
-}
-
-function isoToPeriod(isoDate: string | null | undefined): string {
+function isoToPeriod(isoDate: string | null | undefined): PeriodString {
   if (!isoDate) return getCurrentPeriod();
-  return isoDate.slice(0, 7);
+  return isoDate.slice(0, 7) as PeriodString;
 }
 
-const DEFAULT_FORM_VALUES: BudgetFormValues = {
+function formatDateToISO(date: Date): string {
+  const year = date.getUTCFullYear().toString().padStart(4, '0');
+  const month = (date.getUTCMonth() + 1).toString().padStart(2, '0');
+  const day = date.getUTCDate().toString().padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function firstMondayOfMonth(year: number, month: number): Date {
+  const firstDay = new Date(Date.UTC(year, month - 1, 1));
+  const weekday = firstDay.getUTCDay();
+  const diff = weekday === 0 ? 1 : weekday === 1 ? 0 : 8 - weekday;
+  firstDay.setUTCDate(firstDay.getUTCDate() + diff);
+  return firstDay;
+}
+
+function getCurrentWeekStart(): string {
+  const now = new Date();
+  const weekday = now.getUTCDay();
+  const diff = weekday === 0 ? -6 : 1 - weekday;
+  now.setUTCDate(now.getUTCDate() + diff);
+  return formatDateToISO(now);
+}
+
+function getDefaultWeekStart(period: string): string {
+  const [yearStr, monthStr] = period.split('-');
+  const year = Number.parseInt(yearStr, 10);
+  const month = Number.parseInt(monthStr, 10);
+  if (!Number.isFinite(year) || !Number.isFinite(month)) {
+    return getCurrentWeekStart();
+  }
+
+  const now = new Date();
+  if (now.getUTCFullYear() === year && now.getUTCMonth() + 1 === month) {
+    const start = new Date(Date.UTC(year, month - 1, now.getUTCDate()));
+    const weekday = start.getUTCDay();
+    const diff = weekday === 0 ? -6 : 1 - weekday;
+    start.setUTCDate(start.getUTCDate() + diff);
+    if (start.getUTCMonth() === month - 1) {
+      return formatDateToISO(start);
+    }
+  }
+
+  return formatDateToISO(firstMondayOfMonth(year, month));
+}
+
+const DEFAULT_MONTHLY_FORM: BudgetFormValues = {
   period: getCurrentPeriod(),
   category_id: '',
   amount_planned: 0,
@@ -63,16 +106,21 @@ const DEFAULT_FORM_VALUES: BudgetFormValues = {
 
 export default function BudgetsPage() {
   const { addToast } = useToast();
-  const [segment, setSegment] = useState<SegmentValue>('current');
-  const [customPeriod, setCustomPeriod] = useState<string>(getCurrentPeriod());
-  const [period, setPeriod] = useState<string>(getCurrentPeriod());
-  const [modalOpen, setModalOpen] = useState(false);
-  const [editing, setEditing] = useState<BudgetWithSpent | null>(null);
-  const [submitting, setSubmitting] = useState(false);
+  const [view, setView] = useState<ViewValue>('monthly');
+  const [period, setPeriod] = useState<PeriodString>(getCurrentPeriod());
+  const [monthlyModalOpen, setMonthlyModalOpen] = useState(false);
+  const [weeklyModalOpen, setWeeklyModalOpen] = useState(false);
+  const [editingMonthly, setEditingMonthly] = useState<BudgetWithSpent | null>(null);
+  const [editingWeekly, setEditingWeekly] = useState<WeeklyBudgetWithActual | null>(null);
+  const [submittingMonthly, setSubmittingMonthly] = useState(false);
+  const [submittingWeekly, setSubmittingWeekly] = useState(false);
   const [categories, setCategories] = useState<ExpenseCategory[]>([]);
   const [categoriesLoading, setCategoriesLoading] = useState(true);
+  const [highlightLoadingKey, setHighlightLoadingKey] = useState<string | null>(null);
 
-  const { rows, summary, loading, error, refresh } = useBudgets(period);
+  const monthly = useBudgets(period);
+  const weekly = useWeeklyBudgets(period);
+  const highlights = useBudgetHighlights();
 
   useEffect(() => {
     let active = true;
@@ -97,65 +145,105 @@ export default function BudgetsPage() {
   }, [addToast]);
 
   useEffect(() => {
-    if (!error) return;
-    addToast(error, 'error');
-  }, [error, addToast]);
+    if (monthly.error) {
+      addToast(monthly.error, 'error');
+    }
+  }, [monthly.error, addToast]);
 
   useEffect(() => {
-    if (segment === 'current') {
-      setPeriod(getCurrentPeriod());
-    } else if (segment === 'previous') {
-      setPeriod(getPreviousPeriod());
-    } else {
-      setPeriod(customPeriod || getCurrentPeriod());
+    if (weekly.error) {
+      addToast(weekly.error, 'error');
     }
-  }, [segment, customPeriod]);
+  }, [weekly.error, addToast]);
 
-  const initialFormValues = useMemo<BudgetFormValues>(() => {
-    if (editing) {
+  const monthlyFormValues = useMemo<BudgetFormValues>(() => {
+    if (editingMonthly) {
       return {
-        period: isoToPeriod(editing.period_month),
-        category_id: editing.category_id ?? '',
-        amount_planned: Number(editing.amount_planned ?? 0),
-        carryover_enabled: editing.carryover_enabled,
-        notes: editing.notes ?? '',
+        period: isoToPeriod(editingMonthly.period_month),
+        category_id: editingMonthly.category_id ?? '',
+        amount_planned: Number(editingMonthly.amount_planned ?? 0),
+        carryover_enabled: editingMonthly.carryover_enabled,
+        notes: editingMonthly.notes ?? '',
       };
     }
-    return { ...DEFAULT_FORM_VALUES, period };
-  }, [editing, period]);
+    return { ...DEFAULT_MONTHLY_FORM, period };
+  }, [editingMonthly, period]);
 
-  const handleSegmentChange = (value: SegmentValue) => {
-    setSegment(value);
+  const weeklyFormValues = useMemo<WeeklyBudgetFormValues>(() => {
+    if (editingWeekly) {
+      return {
+        week_start: editingWeekly.week_start,
+        category_id: editingWeekly.category_id ?? '',
+        amount_planned: Number(editingWeekly.amount_planned ?? 0),
+        notes: editingWeekly.notes ?? '',
+      };
+    }
+    return {
+      week_start: getDefaultWeekStart(period),
+      category_id: '',
+      amount_planned: 0,
+      notes: '',
+    };
+  }, [editingWeekly, period]);
+
+  const handleViewChange = (nextView: ViewValue) => {
+    setView(nextView);
   };
 
-  const handleCustomPeriodChange = (value: string) => {
-    setCustomPeriod(value);
-    setPeriod(value || getCurrentPeriod());
+  const handlePeriodChange = (value: string) => {
+    if (!value) return;
+    setPeriod(value as PeriodString);
   };
 
   const handleOpenCreate = () => {
-    setEditing(null);
-    setModalOpen(true);
+    if (view === 'monthly') {
+      setEditingMonthly(null);
+      setMonthlyModalOpen(true);
+    } else {
+      setEditingWeekly(null);
+      setWeeklyModalOpen(true);
+    }
   };
 
-  const handleEdit = (row: BudgetWithSpent) => {
-    setEditing(row);
-    setModalOpen(true);
+  const handleEditMonthly = (row: BudgetWithSpent) => {
+    setEditingMonthly(row);
+    setMonthlyModalOpen(true);
   };
 
-  const handleDelete = async (row: BudgetWithSpent) => {
+  const handleEditWeekly = (row: WeeklyBudgetWithActual) => {
+    setEditingWeekly(row);
+    setWeeklyModalOpen(true);
+  };
+
+  const handleDeleteMonthly = async (row: BudgetWithSpent) => {
     const confirmed = window.confirm(`Hapus anggaran untuk ${row.category?.name ?? 'kategori ini'}?`);
     if (!confirmed) return;
     try {
-      setSubmitting(true);
+      setSubmittingMonthly(true);
       await deleteBudget(row.id);
-      await refresh();
+      await monthly.refresh();
       addToast('Anggaran dihapus', 'success');
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Gagal menghapus anggaran';
       addToast(message, 'error');
     } finally {
-      setSubmitting(false);
+      setSubmittingMonthly(false);
+    }
+  };
+
+  const handleDeleteWeekly = async (row: WeeklyBudgetWithActual) => {
+    const confirmed = window.confirm(`Hapus anggaran minggu ${row.week_start}?`);
+    if (!confirmed) return;
+    try {
+      setSubmittingWeekly(true);
+      await deleteWeeklyBudget(row.id);
+      await weekly.refresh();
+      addToast('Anggaran mingguan dihapus', 'success');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Gagal menghapus anggaran mingguan';
+      addToast(message, 'error');
+    } finally {
+      setSubmittingWeekly(false);
     }
   };
 
@@ -168,16 +256,16 @@ export default function BudgetsPage() {
         carryover_enabled: carryover,
         notes: row.notes ?? undefined,
       });
-      await refresh();
+      await monthly.refresh();
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Gagal memperbarui carryover';
       addToast(message, 'error');
     }
   };
 
-  const handleSubmit = async (values: BudgetFormValues) => {
+  const handleSubmitMonthly = async (values: BudgetFormValues) => {
     try {
-      setSubmitting(true);
+      setSubmittingMonthly(true);
       await upsertBudget({
         category_id: values.category_id,
         period: values.period,
@@ -185,27 +273,96 @@ export default function BudgetsPage() {
         carryover_enabled: values.carryover_enabled,
         notes: values.notes ? values.notes : undefined,
       });
-      setModalOpen(false);
-      setEditing(null);
+      setMonthlyModalOpen(false);
+      setEditingMonthly(null);
       addToast('Anggaran tersimpan', 'success');
-      await refresh();
+      await monthly.refresh();
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Gagal menyimpan anggaran';
       addToast(message, 'error');
     } finally {
-      setSubmitting(false);
+      setSubmittingMonthly(false);
     }
   };
 
+  const handleSubmitWeekly = async (values: WeeklyBudgetFormValues) => {
+    try {
+      setSubmittingWeekly(true);
+      await upsertWeeklyBudget({
+        id: editingWeekly?.id,
+        category_id: values.category_id,
+        week_start: values.week_start,
+        amount_planned: Number(values.amount_planned),
+        notes: values.notes ? values.notes : undefined,
+      });
+      setWeeklyModalOpen(false);
+      setEditingWeekly(null);
+      addToast('Anggaran mingguan tersimpan', 'success');
+      await weekly.refresh();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Gagal menyimpan anggaran mingguan';
+      addToast(message, 'error');
+    } finally {
+      setSubmittingWeekly(false);
+    }
+  };
+
+  const handleHighlight = async (type: BudgetType, id: string, label: string) => {
+    if (highlightLoadingKey) return;
+    try {
+      setHighlightLoadingKey(`${type}:${id}`);
+      const result = await highlights.toggleHighlight(type, id);
+      const successMessage =
+        result === 'added'
+          ? `${label} ditambahkan ke highlight`
+          : `${label} dihapus dari highlight`;
+      addToast(successMessage, 'success');
+    } catch (err) {
+      const limit = err instanceof Error && (err as { code?: string }).code === 'LIMIT_REACHED';
+      if (limit) {
+        addToast('Maks. 2 highlight', 'error');
+      } else {
+        const message = err instanceof Error ? err.message : 'Gagal mengubah highlight';
+        addToast(message, 'error');
+      }
+    } finally {
+      setHighlightLoadingKey(null);
+    }
+  };
+
+  const handleHighlightMonthly = (row: BudgetWithSpent) => {
+    const label = row.category?.name ?? 'Anggaran bulanan';
+    void handleHighlight('monthly', row.id, label);
+  };
+
+  const handleHighlightWeekly = (row: WeeklyBudgetWithActual) => {
+    const label = row.category?.name ?? 'Anggaran mingguan';
+    void handleHighlight('weekly', row.id, label);
+  };
+
+  const handleRefresh = async () => {
+    try {
+      if (view === 'monthly') {
+        await monthly.refresh();
+      } else {
+        await weekly.refresh();
+      }
+      addToast('Data anggaran diperbarui', 'success');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Gagal menyegarkan data';
+      addToast(message, 'error');
+    }
+  };
+
+  const monthlyLoadingState = monthly.loading || submittingMonthly;
+  const weeklyLoadingState = weekly.loading || submittingWeekly;
+
   return (
     <Page>
-      <PageHeader
-        title="Anggaran"
-        description="Atur dan pantau alokasi pengeluaranmu tiap bulan."
-      >
+      <PageHeader title="Anggaran" description="Atur dan pantau alokasi pengeluaranmu tiap bulan.">
         <button
           type="button"
-          onClick={refresh}
+          onClick={handleRefresh}
           className="hidden h-11 items-center gap-2 rounded-2xl border border-border bg-surface px-4 text-sm font-semibold text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 md:inline-flex"
         >
           <RefreshCw className="h-4 w-4" />
@@ -224,58 +381,47 @@ export default function BudgetsPage() {
 
       <Section first>
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div className="grid w-full grid-cols-3 gap-2">
-            {SEGMENTS.map(({ value, label, icon: Icon }) => {
-              const active = value === segment;
+          <div className="inline-flex w-full gap-2 rounded-2xl border border-border/60 bg-surface/80 p-1 shadow-inner md:w-auto">
+            {VIEW_OPTIONS.map(({ value, label }) => {
+              const active = value === view;
               return (
                 <button
                   key={value}
                   type="button"
-                  onClick={() => handleSegmentChange(value)}
+                  onClick={() => handleViewChange(value)}
                   className={clsx(
-                    'group inline-flex h-10 w-full items-center justify-center gap-2 rounded-xl border px-4 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
+                    'flex-1 rounded-xl px-4 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 md:flex-initial',
                     active
-                      ? 'border-transparent bg-brand text-brand-foreground shadow-lg shadow-brand/30'
-                      : 'border-border/60 bg-surface/80 text-muted hover:bg-surface hover:text-text'
+                      ? 'bg-brand text-brand-foreground shadow-lg shadow-brand/30'
+                      : 'text-muted hover:text-text'
                   )}
                 >
-                  <Icon
-                    className={clsx(
-                      'h-4 w-4 transition-colors',
-                      active ? 'text-brand-foreground' : 'text-muted group-hover:text-text'
-                    )}
-                  />
                   {label}
                 </button>
               );
             })}
           </div>
 
-          {segment === 'custom' ? (
-            <label className="flex h-10 items-center gap-2 rounded-xl border border-border/60 bg-surface/80 px-3 text-sm font-medium text-text shadow-inner transition focus-within:border-brand/40 focus-within:bg-brand/5 focus-within:text-text focus-within:outline-none focus-within:ring-2 focus-within:ring-brand/40">
-              <CalendarRange className="h-4 w-4 text-muted" aria-hidden="true" />
-              <input
-                type="month"
-                value={customPeriod}
-                onChange={(event) => handleCustomPeriodChange(event.target.value)}
-                className="w-full appearance-none bg-transparent text-sm font-medium text-text outline-none"
-                aria-label="Pilih periode custom"
-              />
-            </label>
-          ) : (
-            <div className="flex items-center gap-2 rounded-xl border border-border/60 bg-surface/80 px-3 py-1.5 text-sm font-medium text-muted shadow-inner">
-              <CalendarRange className="h-4 w-4" />
-              <span>{toHumanReadable(period)}</span>
-            </div>
-          )}
+          <label className="flex h-10 items-center gap-2 rounded-xl border border-border/60 bg-surface/80 px-3 text-sm font-medium text-text shadow-inner transition focus-within:border-brand/40 focus-within:bg-brand/5 focus-within:text-text focus-within:outline-none focus-within:ring-2 focus-within:ring-brand/40">
+            <CalendarRange className="h-4 w-4 text-muted" aria-hidden="true" />
+            <input
+              type="month"
+              value={period}
+              onChange={(event) => handlePeriodChange(event.target.value)}
+              className="w-full appearance-none bg-transparent text-sm font-medium text-text outline-none"
+              aria-label="Pilih bulan"
+            />
+          </label>
         </div>
       </Section>
 
-      <Section>
-        <SummaryCards summary={summary} loading={loading} />
-      </Section>
+      {view === 'monthly' ? (
+        <Section>
+          <SummaryCards summary={monthly.summary} loading={monthlyLoadingState} />
+        </Section>
+      ) : null}
 
-      {error ? (
+      {(view === 'monthly' ? monthly.error : weekly.error) ? (
         <Section>
           <div className="rounded-2xl border border-rose-200/70 bg-rose-50/70 p-4 text-sm text-rose-600 shadow-sm dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-300">
             Terjadi kesalahan saat memuat data anggaran. Silakan coba lagi.
@@ -284,28 +430,54 @@ export default function BudgetsPage() {
       ) : null}
 
       <Section>
-        <BudgetTable
-          rows={rows}
-          loading={loading || submitting}
-          onEdit={handleEdit}
-          onDelete={handleDelete}
-          onToggleCarryover={handleToggleCarryover}
-        />
+        {view === 'monthly' ? (
+          <BudgetTable
+            rows={monthly.rows}
+            loading={monthlyLoadingState}
+            onEdit={handleEditMonthly}
+            onDelete={handleDeleteMonthly}
+            onToggleCarryover={handleToggleCarryover}
+            onToggleHighlight={handleHighlightMonthly}
+            isHighlighted={(id) => highlights.isHighlighted('monthly', id)}
+          />
+        ) : (
+          <WeeklyBudgetsSection
+            rows={weekly.rows}
+            summaries={weekly.summaries}
+            loading={weeklyLoadingState}
+            onEdit={handleEditWeekly}
+            onDelete={handleDeleteWeekly}
+            onHighlight={handleHighlightWeekly}
+            isHighlighted={(id) => highlights.isHighlighted('weekly', id)}
+          />
+        )}
       </Section>
 
       <BudgetFormModal
-        open={modalOpen}
-        title={editing ? 'Edit anggaran' : 'Tambah anggaran'}
+        open={monthlyModalOpen}
+        title={editingMonthly ? 'Edit anggaran' : 'Tambah anggaran'}
         categories={categories}
-        initialValues={initialFormValues}
-        submitting={submitting}
+        initialValues={monthlyFormValues}
+        submitting={submittingMonthly}
         onClose={() => {
-          setModalOpen(false);
-          setEditing(null);
+          setMonthlyModalOpen(false);
+          setEditingMonthly(null);
         }}
-        onSubmit={handleSubmit}
+        onSubmit={handleSubmitMonthly}
+      />
+
+      <WeeklyBudgetFormModal
+        open={weeklyModalOpen}
+        title={editingWeekly ? 'Edit anggaran mingguan' : 'Tambah anggaran mingguan'}
+        categories={categories}
+        initialValues={weeklyFormValues}
+        submitting={submittingWeekly}
+        onClose={() => {
+          setWeeklyModalOpen(false);
+          setEditingWeekly(null);
+        }}
+        onSubmit={handleSubmitWeekly}
       />
     </Page>
   );
 }
-

--- a/src/pages/budgets/components/BudgetTable.tsx
+++ b/src/pages/budgets/components/BudgetTable.tsx
@@ -7,6 +7,7 @@ import {
   Pencil,
   RefreshCcw,
   Sparkles,
+  Star,
   Trash2,
 } from 'lucide-react';
 import { formatCurrency } from '../../../lib/format';
@@ -18,6 +19,8 @@ interface BudgetTableProps {
   onEdit: (row: BudgetWithSpent) => void;
   onDelete: (row: BudgetWithSpent) => void;
   onToggleCarryover: (row: BudgetWithSpent, carryover: boolean) => void;
+  onToggleHighlight: (row: BudgetWithSpent) => void;
+  isHighlighted: (id: string) => boolean;
 }
 
 const CARD_WRAPPER_CLASS = 'grid gap-4 md:grid-cols-2 xl:grid-cols-3';
@@ -63,7 +66,15 @@ function EmptyState() {
   );
 }
 
-export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleCarryover }: BudgetTableProps) {
+export default function BudgetTable({
+  rows,
+  loading,
+  onEdit,
+  onDelete,
+  onToggleCarryover,
+  onToggleHighlight,
+  isHighlighted,
+}: BudgetTableProps) {
   if (loading) {
     return <LoadingCards />;
   }
@@ -115,6 +126,7 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
         const categoryName = row.category?.name ?? 'Tanpa kategori';
         const categoryInitial = categoryName.trim().charAt(0).toUpperCase() || 'B';
         const StatusIcon = status.icon;
+        const highlighted = isHighlighted(row.id);
 
         return (
           <article key={row.id} className={CARD_CLASS}>
@@ -167,6 +179,19 @@ export default function BudgetTable({ rows, loading, onEdit, onDelete, onToggleC
                       <span className="relative ml-[3px] h-3.5 w-3.5 rounded-full bg-white shadow transition-transform peer-checked:translate-x-5 dark:bg-zinc-900" />
                     </label>
                   </div>
+                  <button
+                    type="button"
+                    onClick={() => onToggleHighlight(row)}
+                    className={clsx(
+                      'inline-flex h-9 w-9 items-center justify-center rounded-xl border bg-surface/80 text-muted shadow-sm transition hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
+                      highlighted
+                        ? 'border-amber-400/60 text-amber-500 hover:text-amber-500'
+                        : 'border-border/60 hover:text-text'
+                    )}
+                    aria-label={highlighted ? `Hapus highlight ${categoryName}` : `Highlight ${categoryName}`}
+                  >
+                    <Star className={clsx('h-4 w-4', highlighted ? 'fill-current' : undefined)} aria-hidden="true" />
+                  </button>
                   <button
                     type="button"
                     onClick={() => onEdit(row)}

--- a/src/pages/budgets/components/WeeklyBudgetFormModal.tsx
+++ b/src/pages/budgets/components/WeeklyBudgetFormModal.tsx
@@ -1,0 +1,251 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { CalendarDays, PiggyBank } from 'lucide-react';
+import type { ExpenseCategory } from '../../../lib/budgetApi';
+
+export interface WeeklyBudgetFormValues {
+  week_start: string;
+  category_id: string;
+  amount_planned: number;
+  notes: string;
+}
+
+interface WeeklyBudgetFormModalProps {
+  open: boolean;
+  title: string;
+  categories: ExpenseCategory[];
+  initialValues: WeeklyBudgetFormValues;
+  submitting?: boolean;
+  onClose: () => void;
+  onSubmit: (values: WeeklyBudgetFormValues) => Promise<void> | void;
+}
+
+const MODAL_CLASS =
+  'fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-10 backdrop-blur-sm';
+
+const ID_NUMBER_FORMATTER = new Intl.NumberFormat('id-ID');
+
+function formatAmountDisplay(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return '';
+  return ID_NUMBER_FORMATTER.format(value);
+}
+
+function parseAmountInput(input: string): { display: string; value: number } {
+  const digits = input.replace(/\D/g, '');
+  if (!digits) {
+    return { display: '', value: 0 };
+  }
+  const numeric = Number.parseInt(digits, 10);
+  return {
+    display: ID_NUMBER_FORMATTER.format(numeric),
+    value: numeric,
+  };
+}
+
+function validate(values: WeeklyBudgetFormValues) {
+  const errors: Partial<Record<keyof WeeklyBudgetFormValues, string>> = {};
+  if (!values.week_start) {
+    errors.week_start = 'Tanggal minggu wajib diisi';
+  }
+  if (!values.category_id) {
+    errors.category_id = 'Kategori wajib dipilih';
+  }
+  if (!Number.isFinite(values.amount_planned) || values.amount_planned <= 0) {
+    errors.amount_planned = 'Nominal anggaran harus lebih dari 0';
+  }
+  return errors;
+}
+
+export default function WeeklyBudgetFormModal({
+  open,
+  title,
+  categories,
+  initialValues,
+  submitting,
+  onClose,
+  onSubmit,
+}: WeeklyBudgetFormModalProps) {
+  const [values, setValues] = useState<WeeklyBudgetFormValues>(initialValues);
+  const [errors, setErrors] = useState<Partial<Record<keyof WeeklyBudgetFormValues, string>>>({});
+  const [amountInput, setAmountInput] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setValues(initialValues);
+      setErrors({});
+      setAmountInput(formatAmountDisplay(initialValues.amount_planned));
+    }
+  }, [open, initialValues]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [open, onClose]);
+
+  const groupedCategories = useMemo(() => {
+    const groups = new Map<string, ExpenseCategory[]>();
+    for (const category of categories) {
+      const key = category.group_name ?? 'Ungrouped';
+      const list = groups.get(key) ?? [];
+      list.push(category);
+      groups.set(key, list);
+    }
+    return Array.from(groups.entries());
+  }, [categories]);
+
+  const emptyMessage = useMemo(() => {
+    if (categories.length === 0) {
+      return 'Belum ada kategori pengeluaran';
+    }
+    return null;
+  }, [categories.length]);
+
+  const handleChange = (field: keyof WeeklyBudgetFormValues, value: string | number) => {
+    setValues((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleAmountChange = (inputValue: string) => {
+    const parsed = parseAmountInput(inputValue);
+    setAmountInput(parsed.display);
+    setValues((prev) => ({ ...prev, amount_planned: parsed.value }));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const nextValues = { ...values, notes: values.notes.trim() };
+    const validation = validate(nextValues);
+    setErrors(validation);
+    if (Object.keys(validation).length > 0) return;
+    await onSubmit({ ...nextValues, amount_planned: Number(nextValues.amount_planned) });
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className={MODAL_CLASS} onClick={onClose}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="w-full max-w-xl rounded-3xl border border-white/20 bg-gradient-to-b from-white/90 to-white/60 p-6 shadow-[0_40px_120px_-60px_rgba(15,23,42,0.65)] backdrop-blur dark:border-white/10 dark:from-zinc-950/80 dark:to-zinc-900/70"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-50">{title}</h2>
+            <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+              Tetapkan anggaran untuk minggu terpilih dalam bulan ini.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/40 bg-white/70 text-zinc-500 shadow-sm transition hover:-translate-y-0.5 hover:bg-white dark:border-white/10 dark:bg-zinc-900/70 dark:text-zinc-300"
+            aria-label="Tutup"
+          >
+            ✕
+          </button>
+        </div>
+
+        <form className="mt-6 flex flex-col gap-5" onSubmit={handleSubmit}>
+          <label className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">
+            Minggu dimulai
+            <div className="relative">
+              <span className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-zinc-400">
+                <CalendarDays className="h-4 w-4" />
+              </span>
+              <input
+                type="date"
+                value={values.week_start}
+                onChange={(event) => handleChange('week_start', event.target.value)}
+                className="h-11 w-full rounded-2xl border border-border bg-surface pl-11 pr-4 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+                required
+              />
+            </div>
+            {errors.week_start ? <span className="text-xs font-medium text-rose-500">{errors.week_start}</span> : null}
+          </label>
+
+          <label className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">
+            Kategori
+            <div className="relative">
+              <span className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-zinc-400">
+                <PiggyBank className="h-4 w-4" aria-hidden="true" />
+              </span>
+              <select
+                value={values.category_id}
+                onChange={(event) => handleChange('category_id', event.target.value)}
+                className="h-11 w-full rounded-2xl border border-border bg-surface pl-11 pr-10 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+                required
+                disabled={categories.length === 0}
+              >
+                <option value="" disabled>
+                  Pilih kategori
+                </option>
+                {groupedCategories.map(([groupName, groupCategories]) => (
+                  <optgroup key={groupName} label={groupName}>
+                    {groupCategories.map((category) => (
+                      <option key={category.id} value={category.id}>
+                        {category.name}
+                      </option>
+                    ))}
+                  </optgroup>
+                ))}
+              </select>
+            </div>
+            {errors.category_id ? (
+              <span className="text-xs font-medium text-rose-500">{errors.category_id}</span>
+            ) : emptyMessage ? (
+              <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">{emptyMessage}</span>
+            ) : null}
+          </label>
+
+          <label className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">
+            Nominal Anggaran (IDR)
+            <input
+              type="text"
+              inputMode="numeric"
+              value={amountInput}
+              onChange={(event) => handleAmountChange(event.target.value)}
+              placeholder="Masukkan nominal"
+              className="h-11 w-full rounded-2xl border border-border bg-surface px-4 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+              required
+            />
+            {errors.amount_planned ? <span className="text-xs font-medium text-rose-500">{errors.amount_planned}</span> : null}
+          </label>
+
+          <label className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">
+            Catatan (opsional)
+            <textarea
+              rows={3}
+              value={values.notes}
+              onChange={(event) => handleChange('notes', event.target.value)}
+              className="min-h-[96px] rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+              placeholder="Catatan tambahan untuk anggaran ini"
+            />
+          </label>
+
+          <div className="mt-2 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={onClose}
+              className="h-11 rounded-2xl border border-border px-6 text-sm font-semibold text-text transition hover:border-brand/40 hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+            >
+              Batal
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="inline-flex h-11 items-center justify-center rounded-2xl bg-brand px-6 text-sm font-semibold text-brand-foreground shadow transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)] disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {submitting ? 'Menyimpan...' : 'Simpan anggaran'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/budgets/components/WeeklyBudgetsSection.tsx
+++ b/src/pages/budgets/components/WeeklyBudgetsSection.tsx
@@ -1,0 +1,281 @@
+import clsx from 'clsx';
+import { Eye, Pencil, Star, Trash2 } from 'lucide-react';
+import { formatCurrency } from '../../../lib/format';
+import type {
+  WeeklyBudgetCategorySummary,
+  WeeklyBudgetWithActual,
+} from '../../../lib/budgetApi';
+
+interface WeeklyBudgetsSectionProps {
+  rows: WeeklyBudgetWithActual[];
+  summaries: WeeklyBudgetCategorySummary[];
+  loading?: boolean;
+  onEdit: (row: WeeklyBudgetWithActual) => void;
+  onDelete: (row: WeeklyBudgetWithActual) => void;
+  onHighlight: (row: WeeklyBudgetWithActual) => void;
+  isHighlighted: (id: string) => boolean;
+  onViewTransactions?: (row: WeeklyBudgetWithActual) => void;
+}
+
+const GRID_CLASS = 'grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4';
+
+const WEEK_RANGE_FORMATTER = new Intl.DateTimeFormat('id-ID', {
+  day: 'numeric',
+  month: 'short',
+});
+
+const CATEGORY_TYPE_LABEL: Record<string, string> = {
+  expense: 'Pengeluaran',
+  income: 'Pemasukan',
+};
+
+function formatWeekRange(row: WeeklyBudgetWithActual): string {
+  try {
+    const start = new Date(`${row.week_start}T00:00:00.000Z`);
+    const end = new Date(`${row.week_end}T00:00:00.000Z`);
+    return `${WEEK_RANGE_FORMATTER.format(start)} – ${WEEK_RANGE_FORMATTER.format(end)}`;
+  } catch (error) {
+    return `${row.week_start} – ${row.week_end}`;
+  }
+}
+
+function getProgressColor(percentage: number): string {
+  const percent = Math.round(percentage * 100);
+  if (percent <= 74) return 'var(--accent)';
+  if (percent <= 89) return '#f59e0b';
+  if (percent <= 100) return '#fb923c';
+  return '#f43f5e';
+}
+
+function getProgressLabel(percentage: number): string {
+  return `${Math.round(Math.min(percentage, 2) * 100)}%`;
+}
+
+function LoadingGrid() {
+  return (
+    <div className={GRID_CLASS}>
+      {Array.from({ length: 4 }).map((_, index) => (
+        <div
+          // eslint-disable-next-line react/no-array-index-key
+          key={index}
+          className="flex flex-col gap-4 rounded-2xl border border-dashed border-border/50 bg-surface/60 p-5 shadow-sm"
+        >
+          <div className="h-4 w-28 rounded-full bg-muted/40" />
+          <div className="h-6 w-40 rounded-full bg-muted/40" />
+          <div className="h-5 w-24 rounded-full bg-muted/30" />
+          <div className="h-24 rounded-2xl bg-muted/20" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="rounded-2xl border border-dashed border-border/60 bg-surface/70 p-8 text-center text-sm text-muted shadow-inner">
+      Belum ada anggaran mingguan. Tambahkan anggaran untuk mulai melacak pengeluaran per minggu.
+    </div>
+  );
+}
+
+function SummarySection({ summaries }: { summaries: WeeklyBudgetCategorySummary[] }) {
+  if (summaries.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="mt-8 space-y-3">
+      <header>
+        <h3 className="text-sm font-semibold text-text">Total Weekly (Month-to-date)</h3>
+        <p className="text-xs text-muted">Akumulasi semua minggu dalam bulan terhadap transaksi aktual bulan ini.</p>
+      </header>
+      <div className="space-y-4">
+        {summaries.map((summary) => {
+          const percent = summary.planned > 0 ? summary.actual / summary.planned : 0;
+          const percentClamped = Math.max(0, Math.min(percent, 2));
+          const color = getProgressColor(percentClamped);
+          return (
+            <article
+              key={summary.category_id}
+              className="rounded-2xl border border-border/60 bg-surface/70 p-4 shadow-sm"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <p className="text-sm font-semibold text-text">
+                    {summary.category_name ?? 'Tanpa kategori'}
+                  </p>
+                  <p className="text-xs text-muted">
+                    {CATEGORY_TYPE_LABEL[summary.category_type ?? 'expense'] ?? 'Pengeluaran'}
+                  </p>
+                </div>
+                <div className="text-right text-xs text-muted">
+                  <p>
+                    {formatCurrency(summary.actual, 'IDR')} / {formatCurrency(summary.planned, 'IDR')}
+                  </p>
+                  <p className="font-semibold text-text">{getProgressLabel(percentClamped)}</p>
+                </div>
+              </div>
+              <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-muted/20">
+                <div
+                  className="h-full rounded-full transition-all"
+                  style={{
+                    width: `${Math.min(percentClamped * 100, 100)}%`,
+                    backgroundColor: color,
+                  }}
+                />
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+export default function WeeklyBudgetsSection({
+  rows,
+  summaries,
+  loading,
+  onEdit,
+  onDelete,
+  onHighlight,
+  isHighlighted,
+  onViewTransactions,
+}: WeeklyBudgetsSectionProps) {
+  if (loading) {
+    return (
+      <div className="space-y-8">
+        <LoadingGrid />
+        <SummarySection summaries={summaries} />
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="space-y-8">
+        <EmptyState />
+        <SummarySection summaries={summaries} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <div className={GRID_CLASS}>
+        {rows.map((row) => {
+          const planned = Number(row.amount_planned ?? 0);
+          const actual = Number(row.actual ?? 0);
+          const remaining = planned - actual;
+          const percent = planned > 0 ? actual / planned : 0;
+          const percentClamped = Math.max(0, Math.min(percent, 2));
+          const color = getProgressColor(percentClamped);
+          const highlighted = isHighlighted(row.id);
+          const categoryType = CATEGORY_TYPE_LABEL[row.category?.type ?? 'expense'] ?? 'Pengeluaran';
+          const onView = () => onViewTransactions?.(row);
+
+          return (
+            <article
+              key={row.id}
+              className="flex flex-col gap-5 rounded-2xl border border-border/60 bg-surface/80 p-5 shadow-[0_24px_45px_-28px_rgba(15,23,42,0.5)] transition duration-300 ease-out hover:-translate-y-1 hover:shadow-[0_30px_60px_-32px_rgba(15,23,42,0.55)]"
+            >
+              <header className="flex items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <p className="text-xs uppercase tracking-[0.18em] text-muted">{formatWeekRange(row)}</p>
+                  <h3 className="text-base font-semibold text-text">
+                    {row.category?.name ?? 'Tanpa kategori'}
+                  </h3>
+                  <span className="inline-flex items-center rounded-full bg-muted/20 px-3 py-1 text-[0.7rem] font-medium text-muted">
+                    {categoryType}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={onView}
+                    className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-border/60 bg-surface/80 text-muted shadow-sm transition hover:-translate-y-0.5 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+                    aria-label={`Lihat transaksi ${row.category?.name ?? ''}`}
+                  >
+                    <Eye className="h-4 w-4" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onEdit(row)}
+                    className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-border/60 bg-surface/80 text-muted shadow-sm transition hover:-translate-y-0.5 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+                    aria-label={`Edit anggaran ${row.category?.name ?? ''}`}
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onHighlight(row)}
+                    className={clsx(
+                      'inline-flex h-9 w-9 items-center justify-center rounded-xl border bg-surface/80 text-muted shadow-sm transition hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
+                      highlighted
+                        ? 'border-amber-400/60 text-amber-500 hover:text-amber-500'
+                        : 'border-border/60 hover:text-text'
+                    )}
+                    aria-label={highlighted ? `Hapus highlight ${row.category?.name ?? ''}` : `Highlight ${row.category?.name ?? ''}`}
+                  >
+                    <Star className={clsx('h-4 w-4', highlighted ? 'fill-current' : undefined)} aria-hidden="true" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onDelete(row)}
+                    className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-rose-200/70 bg-rose-50/70 text-rose-500 shadow-sm transition hover:-translate-y-0.5 hover:bg-rose-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 dark:border-rose-500/30 dark:bg-rose-500/15 dark:text-rose-200"
+                    aria-label={`Hapus anggaran ${row.category?.name ?? ''}`}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              </header>
+
+              <section className="space-y-4">
+                <div className="grid gap-4 sm:grid-cols-3">
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.18em] text-muted">Planned</p>
+                    <p className="text-base font-semibold text-text">{formatCurrency(planned, 'IDR')}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.18em] text-muted">Actual</p>
+                    <p className="text-base font-semibold text-text">{formatCurrency(actual, 'IDR')}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.18em] text-muted">Sisa</p>
+                    <p className={clsx('text-base font-semibold', remaining < 0 ? 'text-rose-500 dark:text-rose-300' : 'text-emerald-600 dark:text-emerald-300')}>
+                      {formatCurrency(remaining, 'IDR')}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between text-xs font-semibold text-muted">
+                    <span>Progres</span>
+                    <span>{getProgressLabel(percentClamped)}</span>
+                  </div>
+                  <div className="h-2 w-full overflow-hidden rounded-full bg-muted/20">
+                    <div
+                      className="h-full rounded-full transition-all"
+                      style={{
+                        width: `${Math.min(percentClamped * 100, 100)}%`,
+                        backgroundColor: color,
+                      }}
+                    />
+                  </div>
+                </div>
+
+                <p className="text-xs text-muted">
+                  {remaining < 0
+                    ? `Melebihi anggaran sebesar ${formatCurrency(Math.abs(remaining), 'IDR')}`
+                    : `Masih tersisa ${formatCurrency(remaining, 'IDR')}`}
+                </p>
+              </section>
+            </article>
+          );
+        })}
+      </div>
+
+      <SummarySection summaries={summaries} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add weekly budget data layer, CRUD modal, and grid with month-to-date summaries
- allow budgets to be highlighted and surface highlighted cards on the dashboard
- refresh budgets page layout to switch between monthly and weekly views with shared highlight controls

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68e25d02f51483329a27783832168564