### PR TITLE
Fix highlight detection on budgets page

### DIFF
--- a/src/pages/budgets/components/BudgetTable.tsx
+++ b/src/pages/budgets/components/BudgetTable.tsx
@@ -137,7 +137,7 @@ export default function BudgetTable({
               ? '#fb923c'
               : '#f43f5e';
 
-        const isHighlighted = highlightSet.has(row.id);
+        const isHighlighted = highlightSet.has(String(row.id));
         const disableHighlight = !isHighlighted && limitReached;
         const categoryType = row.category?.type === 'income' ? 'Pemasukan' : 'Pengeluaran';
         const categoryTypeClass = row.category?.type === 'income'

--- a/src/pages/budgets/components/WeeklyBudgetsGrid.tsx
+++ b/src/pages/budgets/components/WeeklyBudgetsGrid.tsx
@@ -99,7 +99,7 @@ export default function WeeklyBudgetsGrid({
         const rawPercentage = planned > 0 ? (spent / planned) * 100 : spent > 0 ? 200 : 0;
         const displayPercentage = Math.max(0, Math.min(100, Math.round(rawPercentage)));
         const progressColor = getProgressColor(rawPercentage);
-        const isHighlighted = highlightSet.has(row.id);
+        const isHighlighted = highlightSet.has(String(row.id));
         const disableHighlight = !isHighlighted && limitReached;
 
         const categoryType = row.category?.type === 'income' ? 'Pemasukan' : 'Pengeluaran';


### PR DESCRIPTION
## Summary
- ensure monthly budget cards check highlight membership using string ids
- ensure weekly budget cards also normalize ids before checking highlight state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e274d3d66c8332a2c99892e02b7ee0