### PR TITLE
Improve budget highlight styling and add highlight storage schema

### DIFF
--- a/src/pages/budgets/components/BudgetTable.tsx
+++ b/src/pages/budgets/components/BudgetTable.tsx
@@ -148,15 +148,24 @@ export default function BudgetTable({
         const categoryInitial = categoryName.trim().charAt(0).toUpperCase() || 'B';
         const StatusIcon = status.icon;
 
-        return (
-          <article key={row.id} className={CARD_CLASS}>
-            <div
-              aria-hidden
-              className="pointer-events-none absolute -right-20 -top-16 h-52 w-52 rounded-full blur-3xl"
-              style={{ background: `radial-gradient(circle at center, ${status.highlight} 0%, rgba(255,255,255,0) 70%)` }}
-            />
+        const cardClassName = clsx(
+          CARD_CLASS,
+          isHighlighted
+            ? 'border-brand/60 bg-gradient-to-br from-brand/15 via-surface/80 to-surface/80 ring-2 ring-brand/40 shadow-[0_32px_64px_-36px_rgba(59,130,246,0.55)] dark:from-brand/25'
+            : null
+        );
 
-            <header className="flex flex-col gap-4">
+        return (
+          <article key={row.id} className={cardClassName} data-highlighted={isHighlighted || undefined}>
+            {isHighlighted ? (
+              <div
+                aria-hidden
+                className="pointer-events-none absolute -right-16 -top-16 h-52 w-52 rounded-full blur-3xl"
+                style={{ background: `radial-gradient(circle at center, ${status.highlight} 0%, rgba(59,130,246,0.35) 55%, rgba(255,255,255,0) 75%)` }}
+              />
+            ) : null}
+
+            <header className="relative z-10 flex flex-col gap-4">
               <div className="flex flex-wrap items-start justify-between gap-4">
                 <div className="flex items-start gap-3">
                   <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-brand/10 text-sm font-semibold uppercase text-brand shadow-inner">
@@ -182,6 +191,11 @@ export default function BudgetTable({
                         <StatusIcon className="h-3.5 w-3.5" />
                         {status.label}
                       </span>
+                      {isHighlighted ? (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-brand/10 px-3 py-1 text-[0.68rem] font-semibold uppercase tracking-wide text-brand shadow-sm ring-1 ring-brand/40">
+                          <Sparkles className="h-3.5 w-3.5" /> Highlight
+                        </span>
+                      ) : null}
                     </div>
                     <p className="text-[0.68rem] uppercase tracking-[0.18em] text-muted">Periode {row.period_month?.slice(0, 7) ?? '-'}</p>
                   </div>
@@ -251,7 +265,7 @@ export default function BudgetTable({
               </div>
             </header>
 
-            <section className="space-y-5">
+            <section className="relative z-10 space-y-5">
               <div className="rounded-xl border border-border/50 bg-surface/70 p-4 shadow-inner">
                 <div className="grid gap-4 sm:grid-cols-3">
                   <div className="space-y-1">

--- a/src/pages/budgets/components/WeeklyBudgetsGrid.tsx
+++ b/src/pages/budgets/components/WeeklyBudgetsGrid.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { Eye, NotebookPen, Pencil, Star, Trash2 } from 'lucide-react';
+import { Eye, NotebookPen, Pencil, Sparkles, Star, Trash2 } from 'lucide-react';
 import { formatCurrency } from '../../../lib/format';
 import type { WeeklyBudgetWithSpent } from '../../../lib/budgetApi';
 
@@ -109,12 +109,23 @@ export default function WeeklyBudgetsGrid({
 
         const categoryName = row.category?.name ?? 'Tanpa kategori';
 
+        const cardClassName = clsx(
+          'relative flex h-full flex-col gap-5 overflow-hidden rounded-2xl border border-border/60 bg-surface/80 p-5 shadow-[0_24px_45px_-28px_rgba(15,23,42,0.5)] transition duration-300 ease-out hover:-translate-y-1 hover:shadow-[0_30px_60px_-32px_rgba(15,23,42,0.55)] backdrop-blur supports-[backdrop-filter]:bg-surface/60',
+          isHighlighted
+            ? 'border-brand/60 bg-gradient-to-br from-brand/15 via-surface/80 to-surface/80 ring-2 ring-brand/40 shadow-[0_32px_64px_-36px_rgba(59,130,246,0.55)] dark:from-brand/25'
+            : null
+        );
+
         return (
-          <article
-            key={row.id}
-            className="flex h-full flex-col gap-5 overflow-hidden rounded-2xl border border-border/60 bg-surface/80 p-5 shadow-[0_24px_45px_-28px_rgba(15,23,42,0.5)] transition duration-300 ease-out hover:-translate-y-1 hover:shadow-[0_30px_60px_-32px_rgba(15,23,42,0.55)] backdrop-blur supports-[backdrop-filter]:bg-surface/60"
-          >
-            <header className="flex flex-col gap-4">
+          <article key={row.id} className={cardClassName} data-highlighted={isHighlighted || undefined}>
+            {isHighlighted ? (
+              <div
+                aria-hidden
+                className="pointer-events-none absolute -right-16 -top-16 h-48 w-48 rounded-full blur-3xl"
+                style={{ background: 'radial-gradient(circle at center, rgba(59,130,246,0.45) 0%, rgba(59,130,246,0.2) 45%, rgba(255,255,255,0) 75%)' }}
+              />
+            ) : null}
+            <header className="relative z-10 flex flex-col gap-4">
               <div className="flex items-start justify-between gap-3">
                 <div className="space-y-2">
                   <div className="flex flex-wrap items-center gap-2">
@@ -130,6 +141,11 @@ export default function WeeklyBudgetsGrid({
                     <span className="inline-flex items-center rounded-full bg-muted/30 px-3 py-1 text-xs font-medium text-muted dark:bg-muted/20">
                       {formatRange(row.week_start, row.week_end)}
                     </span>
+                    {isHighlighted ? (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-brand/10 px-3 py-1 text-[0.68rem] font-semibold uppercase tracking-wide text-brand shadow-sm ring-1 ring-brand/40">
+                        <Sparkles className="h-3.5 w-3.5" /> Highlight
+                      </span>
+                    ) : null}
                   </div>
                   <p className="text-xs text-muted">Target minggu ini</p>
                 </div>
@@ -178,7 +194,7 @@ export default function WeeklyBudgetsGrid({
               </div>
             </header>
 
-            <section className="space-y-4">
+            <section className="relative z-10 space-y-4">
               <div className="rounded-xl border border-border/50 bg-surface/70 p-4 shadow-inner">
                 <div className="grid gap-4 sm:grid-cols-3">
                   <div className="space-y-1">

--- a/supabase/migrations/20250426000000_create_user_highlight_budgets.sql
+++ b/supabase/migrations/20250426000000_create_user_highlight_budgets.sql
@@ -1,0 +1,55 @@
+create table if not exists public.user_highlight_budgets (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  budget_type text not null check (budget_type in ('monthly','weekly')),
+  budget_id uuid not null,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create unique index if not exists user_highlight_budgets_unique
+  on public.user_highlight_budgets (user_id, budget_type, budget_id);
+
+create index if not exists user_highlight_budgets_user_created_idx
+  on public.user_highlight_budgets (user_id, created_at);
+
+create or replace function public.user_highlight_budgets_enforce_limit()
+returns trigger
+language plpgsql
+as $$
+declare
+  total integer;
+begin
+  if tg_op = 'UPDATE' then
+    select count(*)
+    into total
+    from public.user_highlight_budgets
+    where user_id = new.user_id
+      and id <> old.id;
+  else
+    select count(*)
+    into total
+    from public.user_highlight_budgets
+    where user_id = new.user_id;
+  end if;
+
+  if total >= 2 then
+    raise exception 'Maks. 2 highlight' using errcode = 'P0001';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists user_highlight_budgets_limit on public.user_highlight_budgets;
+create trigger user_highlight_budgets_limit
+before insert or update on public.user_highlight_budgets
+for each row
+execute function public.user_highlight_budgets_enforce_limit();
+
+alter table public.user_highlight_budgets enable row level security;
+
+create policy if not exists "User highlight select" on public.user_highlight_budgets
+  for select using (user_id = auth.uid());
+
+create policy if not exists "User highlight modify" on public.user_highlight_budgets
+  for all using (user_id = auth.uid()) with check (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- add prominent visual treatment for highlighted monthly and weekly budget cards, including badges and glow effects
- add database migration for storing user budget highlights with RLS and limit enforcement

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e27682113c8332b8b1c67760d7dd4c