### PR TITLE
Add weekly budget carryover controls and fix highlight progress

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -64,6 +64,7 @@
     --brand-foreground: hsl(var(--color-primary-foreground));
     --brand-soft: hsl(var(--color-primary-soft));
     --brand-ring: hsl(var(--color-ring-primary));
+    --accent: hsl(var(--color-primary));
 
     --tx-expense: #f87171;
     --tx-income: #34d399;
@@ -108,6 +109,7 @@
     --tx-expense: #fda4af;
     --tx-income: #4ade80;
     --tx-transfer: #38bdf8;
+    --accent: hsl(var(--color-primary));
   }
 
   body {

--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -86,6 +86,7 @@ const DEFAULT_WEEKLY_FORM: WeeklyBudgetFormValues = {
   week_start: getFirstWeekStartOfPeriod(getCurrentPeriod()),
   category_id: '',
   amount_planned: 0,
+  carryover_enabled: false,
   notes: '',
 };
 
@@ -183,6 +184,7 @@ export default function BudgetsPage() {
         week_start: editingWeekly.week_start,
         category_id: editingWeekly.category_id ?? '',
         amount_planned: Number(editingWeekly.amount_planned ?? 0),
+        carryover_enabled: editingWeekly.carryover_enabled,
         notes: editingWeekly.notes ?? '',
       };
     }
@@ -325,6 +327,7 @@ export default function BudgetsPage() {
         category_id: values.category_id,
         week_start: values.week_start,
         amount_planned: Number(values.amount_planned),
+        carryover_enabled: values.carryover_enabled,
         notes: values.notes ? values.notes : undefined,
       });
       setWeeklyModalOpen(false);
@@ -336,6 +339,23 @@ export default function BudgetsPage() {
       addToast(message, 'error');
     } finally {
       setSubmittingWeekly(false);
+    }
+  };
+
+  const handleToggleWeeklyCarryover = async (row: WeeklyBudgetWithSpent, carryover: boolean) => {
+    try {
+      await upsertWeeklyBudget({
+        id: row.id,
+        category_id: row.category_id,
+        week_start: row.week_start,
+        amount_planned: Number(row.amount_planned ?? 0),
+        carryover_enabled: carryover,
+        notes: row.notes ?? undefined,
+      });
+      await weekly.refresh();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Gagal memperbarui carryover mingguan';
+      addToast(message, 'error');
     }
   };
 
@@ -479,6 +499,7 @@ export default function BudgetsPage() {
               handleViewTransactions(row.category_id ?? '', { start: row.week_start, end: row.week_end })
             }
             onToggleHighlight={(row) => handleToggleHighlight('weekly', row.id)}
+            onToggleCarryover={handleToggleWeeklyCarryover}
           />
         </Section>
       )}

--- a/src/pages/budgets/components/WeeklyBudgetFormModal.tsx
+++ b/src/pages/budgets/components/WeeklyBudgetFormModal.tsx
@@ -6,6 +6,7 @@ export interface WeeklyBudgetFormValues {
   week_start: string;
   category_id: string;
   amount_planned: number;
+  carryover_enabled: boolean;
   notes: string;
 }
 
@@ -126,7 +127,7 @@ export default function WeeklyBudgetFormModal({
     return Array.from(groups.entries());
   }, [categories]);
 
-  const handleChange = (field: keyof WeeklyBudgetFormValues, value: string | number) => {
+  const handleChange = (field: keyof WeeklyBudgetFormValues, value: string | number | boolean) => {
     setValues((prev) => ({ ...prev, [field]: value }));
   };
 
@@ -254,6 +255,24 @@ export default function WeeklyBudgetFormModal({
               </span>
             </div>
             {errors.amount_planned ? <span className="text-xs font-medium text-rose-500">{errors.amount_planned}</span> : null}
+          </label>
+
+          <label className="flex items-center justify-between gap-4 rounded-2xl border border-border bg-surface px-4 py-3 text-sm font-medium text-text shadow-sm transition">
+            <span>Aktifkan carryover ke bulan berikutnya</span>
+            <button
+              type="button"
+              onClick={() => handleChange('carryover_enabled', !values.carryover_enabled)}
+              className={`relative inline-flex h-6 w-12 cursor-pointer items-center rounded-full ${
+                values.carryover_enabled ? 'bg-brand/80' : 'bg-border/80'
+              }`}
+              aria-pressed={values.carryover_enabled}
+            >
+              <span
+                className={`ml-1 h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
+                  values.carryover_enabled ? 'translate-x-6' : 'translate-x-0'
+                }`}
+              />
+            </button>
           </label>
 
           <label className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">

--- a/src/pages/budgets/components/WeeklyBudgetsGrid.tsx
+++ b/src/pages/budgets/components/WeeklyBudgetsGrid.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { Eye, NotebookPen, Pencil, Sparkles, Star, Trash2 } from 'lucide-react';
+import { Eye, NotebookPen, Pencil, RefreshCcw, Sparkles, Star, Trash2 } from 'lucide-react';
 import { formatCurrency } from '../../../lib/format';
 import type { WeeklyBudgetWithSpent } from '../../../lib/budgetApi';
 
@@ -12,6 +12,7 @@ interface WeeklyBudgetsGridProps {
   onDelete: (row: WeeklyBudgetWithSpent) => void;
   onViewTransactions: (row: WeeklyBudgetWithSpent) => void;
   onToggleHighlight: (row: WeeklyBudgetWithSpent) => void;
+  onToggleCarryover: (row: WeeklyBudgetWithSpent, carryover: boolean) => void;
 }
 
 const GRID_CLASS = 'grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4';
@@ -78,6 +79,7 @@ export default function WeeklyBudgetsGrid({
   onDelete,
   onViewTransactions,
   onToggleHighlight,
+  onToggleCarryover,
 }: WeeklyBudgetsGridProps) {
   if (loading) {
     return <LoadingCards />;
@@ -141,6 +143,11 @@ export default function WeeklyBudgetsGrid({
                     <span className="inline-flex items-center rounded-full bg-muted/30 px-3 py-1 text-xs font-medium text-muted dark:bg-muted/20">
                       {formatRange(row.week_start, row.week_end)}
                     </span>
+                    {row.carryover_enabled ? (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-3 py-1 text-[0.68rem] font-semibold uppercase tracking-wide text-emerald-600 dark:text-emerald-300">
+                        <RefreshCcw className="h-3.5 w-3.5" /> Carryover aktif
+                      </span>
+                    ) : null}
                     {isHighlighted ? (
                       <span className="inline-flex items-center gap-1 rounded-full bg-brand/10 px-3 py-1 text-[0.68rem] font-semibold uppercase tracking-wide text-brand shadow-sm ring-1 ring-brand/40">
                         <Sparkles className="h-3.5 w-3.5" /> Highlight
@@ -173,6 +180,20 @@ export default function WeeklyBudgetsGrid({
                     )}
                   >
                     <Star className="h-4 w-4" fill={isHighlighted ? 'currentColor' : 'none'} />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onToggleCarryover(row, !row.carryover_enabled)}
+                    aria-pressed={row.carryover_enabled}
+                    aria-label={`${row.carryover_enabled ? 'Nonaktifkan' : 'Aktifkan'} carryover untuk ${categoryName}`}
+                    className={clsx(
+                      'inline-flex h-9 w-9 items-center justify-center rounded-xl border text-muted shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
+                      row.carryover_enabled
+                        ? 'border-emerald-400/70 bg-emerald-500/15 text-emerald-600 dark:text-emerald-300'
+                        : 'border-border/60 bg-surface/80 hover:-translate-y-0.5 hover:text-text'
+                    )}
+                  >
+                    <RefreshCcw className="h-4 w-4" />
                   </button>
                   <button
                     type="button"


### PR DESCRIPTION
## Summary
- define a shared accent color token so dashboard highlight progress bars show even on low usage
- add weekly budget carryover support that auto-duplicates flagged weeks into the next period
- surface carryover controls in the weekly budget form and grid, with refresh logic for toggling

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e279ca4530833286cbbee051a058b8