### PR TITLE
Add weekly carryover toggle and fix highlight accent

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -64,6 +64,8 @@
     --brand-foreground: hsl(var(--color-primary-foreground));
     --brand-soft: hsl(var(--color-primary-soft));
     --brand-ring: hsl(var(--color-ring-primary));
+    --accent: var(--brand);
+    --accent-foreground: var(--brand-foreground);
 
     --tx-expense: #f87171;
     --tx-income: #34d399;
@@ -108,6 +110,8 @@
     --tx-expense: #fda4af;
     --tx-income: #4ade80;
     --tx-transfer: #38bdf8;
+    --accent: var(--brand);
+    --accent-foreground: var(--brand-foreground);
   }
 
   body {

--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -86,6 +86,7 @@ const DEFAULT_WEEKLY_FORM: WeeklyBudgetFormValues = {
   week_start: getFirstWeekStartOfPeriod(getCurrentPeriod()),
   category_id: '',
   amount_planned: 0,
+  carryover_enabled: false,
   notes: '',
 };
 
@@ -183,6 +184,7 @@ export default function BudgetsPage() {
         week_start: editingWeekly.week_start,
         category_id: editingWeekly.category_id ?? '',
         amount_planned: Number(editingWeekly.amount_planned ?? 0),
+        carryover_enabled: editingWeekly.carryover_enabled,
         notes: editingWeekly.notes ?? '',
       };
     }
@@ -295,6 +297,23 @@ export default function BudgetsPage() {
     }
   };
 
+  const handleToggleWeeklyCarryover = async (row: WeeklyBudgetWithSpent, carryover: boolean) => {
+    try {
+      await upsertWeeklyBudget({
+        id: row.id,
+        category_id: row.category_id,
+        week_start: row.week_start,
+        amount_planned: Number(row.amount_planned ?? 0),
+        carryover_enabled: carryover,
+        notes: row.notes ?? undefined,
+      });
+      await weekly.refresh();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Gagal memperbarui carryover';
+      addToast(message, 'error');
+    }
+  };
+
   const handleSubmitMonthly = async (values: BudgetFormValues) => {
     try {
       setSubmittingMonthly(true);
@@ -325,6 +344,7 @@ export default function BudgetsPage() {
         category_id: values.category_id,
         week_start: values.week_start,
         amount_planned: Number(values.amount_planned),
+        carryover_enabled: values.carryover_enabled,
         notes: values.notes ? values.notes : undefined,
       });
       setWeeklyModalOpen(false);
@@ -478,6 +498,7 @@ export default function BudgetsPage() {
             onViewTransactions={(row) =>
               handleViewTransactions(row.category_id ?? '', { start: row.week_start, end: row.week_end })
             }
+            onToggleCarryover={handleToggleWeeklyCarryover}
             onToggleHighlight={(row) => handleToggleHighlight('weekly', row.id)}
           />
         </Section>

--- a/src/pages/budgets/components/WeeklyBudgetFormModal.tsx
+++ b/src/pages/budgets/components/WeeklyBudgetFormModal.tsx
@@ -6,6 +6,7 @@ export interface WeeklyBudgetFormValues {
   week_start: string;
   category_id: string;
   amount_planned: number;
+  carryover_enabled: boolean;
   notes: string;
 }
 
@@ -126,7 +127,10 @@ export default function WeeklyBudgetFormModal({
     return Array.from(groups.entries());
   }, [categories]);
 
-  const handleChange = (field: keyof WeeklyBudgetFormValues, value: string | number) => {
+  const handleChange = (
+    field: keyof WeeklyBudgetFormValues,
+    value: string | number | boolean
+  ) => {
     setValues((prev) => ({ ...prev, [field]: value }));
   };
 
@@ -254,6 +258,23 @@ export default function WeeklyBudgetFormModal({
               </span>
             </div>
             {errors.amount_planned ? <span className="text-xs font-medium text-rose-500">{errors.amount_planned}</span> : null}
+          </label>
+
+          <label className="flex items-center justify-between gap-4 rounded-2xl border border-border bg-surface px-4 py-3 text-sm font-medium text-text shadow-sm transition">
+            <span>Aktifkan carryover ke minggu berikutnya</span>
+            <button
+              type="button"
+              onClick={() => handleChange('carryover_enabled', !values.carryover_enabled)}
+              className={`relative inline-flex h-6 w-12 cursor-pointer items-center rounded-full ${
+                values.carryover_enabled ? 'bg-brand/80' : 'bg-border/80'
+              }`}
+            >
+              <span
+                className={`ml-1 h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
+                  values.carryover_enabled ? 'translate-x-6' : 'translate-x-0'
+                }`}
+              />
+            </button>
           </label>
 
           <label className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">

--- a/src/pages/budgets/components/WeeklyBudgetsGrid.tsx
+++ b/src/pages/budgets/components/WeeklyBudgetsGrid.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { Eye, NotebookPen, Pencil, Sparkles, Star, Trash2 } from 'lucide-react';
+import { Eye, NotebookPen, Pencil, RefreshCcw, Sparkles, Star, Trash2 } from 'lucide-react';
 import { formatCurrency } from '../../../lib/format';
 import type { WeeklyBudgetWithSpent } from '../../../lib/budgetApi';
 
@@ -11,6 +11,7 @@ interface WeeklyBudgetsGridProps {
   onEdit: (row: WeeklyBudgetWithSpent) => void;
   onDelete: (row: WeeklyBudgetWithSpent) => void;
   onViewTransactions: (row: WeeklyBudgetWithSpent) => void;
+  onToggleCarryover: (row: WeeklyBudgetWithSpent, carryover: boolean) => void;
   onToggleHighlight: (row: WeeklyBudgetWithSpent) => void;
 }
 
@@ -77,6 +78,7 @@ export default function WeeklyBudgetsGrid({
   onEdit,
   onDelete,
   onViewTransactions,
+  onToggleCarryover,
   onToggleHighlight,
 }: WeeklyBudgetsGridProps) {
   if (loading) {
@@ -99,6 +101,7 @@ export default function WeeklyBudgetsGrid({
         const rawPercentage = planned > 0 ? (spent / planned) * 100 : spent > 0 ? 200 : 0;
         const displayPercentage = Math.max(0, Math.min(100, Math.round(rawPercentage)));
         const progressColor = getProgressColor(rawPercentage);
+        const carryoverEnabled = Boolean(row.carryover_enabled);
         const isHighlighted = highlightSet.has(String(row.id));
         const disableHighlight = !isHighlighted && limitReached;
 
@@ -150,6 +153,25 @@ export default function WeeklyBudgetsGrid({
                   <p className="text-xs text-muted">Target minggu ini</p>
                 </div>
                 <div className="flex flex-wrap items-center justify-end gap-2">
+                  <div className="flex items-center gap-2 rounded-full border border-border/60 bg-surface/70 px-3 py-1.5 text-[0.7rem] font-medium text-muted shadow-inner">
+                    <RefreshCcw className="h-3.5 w-3.5" />
+                    <span className="hidden sm:inline">Carryover</span>
+                    <span className="sm:hidden">CO</span>
+                    <span className="text-[0.7rem] uppercase tracking-widest text-muted/80">
+                      {carryoverEnabled ? 'Aktif' : 'Nonaktif'}
+                    </span>
+                    <label className="relative inline-flex h-5 w-10 cursor-pointer items-center">
+                      <input
+                        type="checkbox"
+                        checked={carryoverEnabled}
+                        onChange={(event) => onToggleCarryover(row, event.target.checked)}
+                        className="peer sr-only"
+                        aria-label={`Atur carryover untuk ${categoryName}`}
+                      />
+                      <span className="absolute inset-0 rounded-full bg-muted/30 transition peer-checked:bg-emerald-500/70 dark:bg-muted/40 dark:peer-checked:bg-emerald-500/60" />
+                      <span className="relative ml-[3px] h-3.5 w-3.5 rounded-full bg-white shadow transition-transform peer-checked:translate-x-5 dark:bg-zinc-900" />
+                    </label>
+                  </div>
                   <button
                     type="button"
                     onClick={() => onViewTransactions(row)}


### PR DESCRIPTION
## Summary
- define accent theme variables so dashboard highlight progress bars render with the active brand color
- add carryover support to weekly budgets, including UI toggles, form controls, and API updates to persist the flag

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e279ca4530833286cbbee051a058b8