### PR TITLE
Fix weekly budget edit handling and weekly spend range

### DIFF
--- a/src/lib/budgetApi.ts
+++ b/src/lib/budgetApi.ts
@@ -451,6 +451,7 @@ export async function listWeeklyBudgets(period: string): Promise<WeeklyBudgetsRe
   const userId = await getCurrentUserId();
   ensureAuth(userId);
   const { start, end } = getMonthRange(period);
+  const firstWeekStart = getWeekStartForDate(parseIsoDate(start));
 
   const [budgetsResponse, transactionsResponse] = await Promise.all([
     supabase
@@ -459,7 +460,7 @@ export async function listWeeklyBudgets(period: string): Promise<WeeklyBudgetsRe
         'id,user_id,category_id,amount_planned:planned_amount,carryover_enabled,notes,week_start,created_at,updated_at,category:categories(id,name,type)'
       )
       .eq('user_id', userId)
-      .gte('week_start', start)
+      .gte('week_start', firstWeekStart)
       .lt('week_start', end)
       .order('week_start', { ascending: true })
       .order('created_at', { ascending: false }),
@@ -470,7 +471,7 @@ export async function listWeeklyBudgets(period: string): Promise<WeeklyBudgetsRe
       .is('deleted_at', null)
       .eq('type', 'expense')
       .is('to_account_id', null)
-      .gte('date', start)
+      .gte('date', firstWeekStart)
       .lt('date', end),
   ]);
 

--- a/src/pages/budgets/components/WeeklyBudgetFormModal.tsx
+++ b/src/pages/budgets/components/WeeklyBudgetFormModal.tsx
@@ -152,7 +152,8 @@ export default function WeeklyBudgetFormModal({
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const nextValues = { ...values, notes: values.notes.trim() };
+    const noteText = typeof values.notes === 'string' ? values.notes.trim() : '';
+    const nextValues = { ...values, notes: noteText };
     const validation = validate(nextValues);
     setErrors(validation);
     if (Object.keys(validation).length > 0) return;


### PR DESCRIPTION
## Summary
- extend weekly budget queries to include the week that overlaps the beginning of the selected month and pull matching transactions so spending reflects the full Monday–Sunday period
- harden the weekly budget form submit handler so empty notes no longer trigger runtime errors when editing

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e2862096a08332bd2f737b3991ef5c