### PR TITLE
Fix invalid state styling on budget forms

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -176,7 +176,7 @@
       input:not([type='checkbox']):not([type='radio']):not([type='range']):not([type='color']):not([type='file']),
       select,
       textarea
-    ):invalid {
+    )[aria-invalid='true'] {
     @apply border-danger/60;
   }
 
@@ -184,7 +184,7 @@
       input:not([type='checkbox']):not([type='radio']):not([type='range']):not([type='color']):not([type='file']),
       select,
       textarea
-    ):focus-visible:invalid {
+    )[aria-invalid='true']:focus-visible {
     @apply border-danger ring-2 ring-danger/40;
   }
 

--- a/src/pages/budgets/components/BudgetFormModal.tsx
+++ b/src/pages/budgets/components/BudgetFormModal.tsx
@@ -169,6 +169,7 @@ export default function BudgetFormModal({
                   onChange={(event) => handleChange('period', event.target.value)}
                   className="h-11 w-full rounded-2xl border border-border bg-surface pl-11 pr-4 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
                   required
+                  aria-invalid={Boolean(errors.period)}
                 />
               </div>
               {errors.period ? <span className="text-xs font-medium text-rose-500">{errors.period}</span> : null}
@@ -186,6 +187,7 @@ export default function BudgetFormModal({
                   className="h-11 w-full rounded-2xl border border-border bg-surface pl-11 pr-10 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
                   required
                   disabled={categories.length === 0}
+                  aria-invalid={Boolean(errors.category_id)}
                 >
                   <option value="" disabled>
                     Pilih kategori
@@ -219,6 +221,7 @@ export default function BudgetFormModal({
               placeholder="Masukkan nominal"
               className="h-11 w-full rounded-2xl border border-border bg-surface px-4 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
               required
+              aria-invalid={Boolean(errors.amount_planned)}
             />
             {errors.amount_planned ? <span className="text-xs font-medium text-rose-500">{errors.amount_planned}</span> : null}
           </label>
@@ -250,6 +253,7 @@ export default function BudgetFormModal({
               onChange={(event) => handleChange('notes', event.target.value)}
               className="min-h-[96px] rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
               placeholder="Catatan tambahan untuk anggaran ini"
+              aria-invalid={Boolean(errors.notes)}
             />
           </label>
 

--- a/src/pages/budgets/components/WeeklyBudgetFormModal.tsx
+++ b/src/pages/budgets/components/WeeklyBudgetFormModal.tsx
@@ -204,6 +204,7 @@ export default function WeeklyBudgetFormModal({
                   onChange={(event) => handleWeekChange(event.target.value)}
                   className="h-11 w-full rounded-2xl border border-border bg-surface pl-11 pr-4 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
                   required
+                  aria-invalid={Boolean(errors.week_start)}
                 />
               </div>
               {weekLabel ? (
@@ -224,6 +225,7 @@ export default function WeeklyBudgetFormModal({
                   className="h-11 w-full rounded-2xl border border-border bg-surface pl-11 pr-10 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
                   required
                   disabled={categories.length === 0}
+                  aria-invalid={Boolean(errors.category_id)}
                 >
                   <option value="" disabled>
                     Pilih kategori
@@ -253,6 +255,7 @@ export default function WeeklyBudgetFormModal({
                 onChange={(event) => handleAmountChange(event.target.value)}
                 className="h-11 w-full rounded-2xl border border-border bg-surface px-4 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
                 placeholder="0"
+                aria-invalid={Boolean(errors.amount_planned)}
               />
               <span className="pointer-events-none absolute inset-y-0 right-4 flex items-center text-xs font-semibold uppercase tracking-[0.18em] text-muted">
                 IDR
@@ -285,6 +288,7 @@ export default function WeeklyBudgetFormModal({
               onChange={(event) => handleChange('notes', event.target.value)}
               className="h-28 w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
               placeholder="Opsional"
+              aria-invalid={Boolean(errors.notes)}
             />
           </label>
 


### PR DESCRIPTION
## Summary
- switch global form styling to rely on aria-invalid flags instead of native :invalid
- mark budget modal inputs with aria-invalid to control validation borders
- ensure weekly budget form inputs expose validation state for consistent styling

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e28f5716ac8332b855dca28430e78c