### PR TITLE
Add smooth scroll restoration to page navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import MainLayout from "./layout/MainLayout";
 import AppTopbar from "./layout/AppTopbar";
 import SettingsPanel from "./components/SettingsPanel";
 import BootGate from "./components/BootGate";
+import SmoothScrollRestoration from "./components/SmoothScrollRestoration";
 
 import Dashboard from "./pages/Dashboard";
 import Transactions from "./pages/Transactions";
@@ -180,14 +181,6 @@ function loadInitial() {
 function ProtectedAppContainer({ theme, setTheme, brand, setBrand }) {
   const location = useLocation();
   const hideNav = location.pathname.startsWith("/add");
-
-  useEffect(() => {
-    const frame = requestAnimationFrame(() => {
-      window.scrollTo({ top: 0, behavior: "smooth" });
-    });
-
-    return () => cancelAnimationFrame(frame);
-  }, [location.pathname, location.search, location.hash]);
 
   return (
     <MainLayout
@@ -1080,6 +1073,7 @@ function AppShell({ prefs, setPrefs }) {
     <CategoryProvider catMeta={catMeta}>
       <BootGate>
         <>
+          <SmoothScrollRestoration />
           <Routes>
             <Route path="/auth" element={<AuthLogin />} />
             <Route path="/auth/callback" element={<AuthCallback />} />

--- a/src/components/SmoothScrollRestoration.jsx
+++ b/src/components/SmoothScrollRestoration.jsx
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+function findHashTarget(hash) {
+  if (!hash) return null;
+
+  const fragment = hash.startsWith("#") ? hash.slice(1) : hash;
+  if (!fragment) return null;
+
+  const direct = document.getElementById(fragment);
+  if (direct) return direct;
+
+  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+    return document.querySelector(`[name="${CSS.escape(fragment)}"]`);
+  }
+
+  return null;
+}
+
+export default function SmoothScrollRestoration() {
+  const location = useLocation();
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      const target = findHashTarget(location.hash);
+
+      if (target) {
+        target.scrollIntoView({ behavior: "smooth", block: "start" });
+        return;
+      }
+
+      window.scrollTo({ top: 0, left: 0, behavior: "smooth" });
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [location.hash, location.pathname, location.search]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a SmoothScrollRestoration component to trigger smooth scrolling after route changes and hash navigation
- wire the restoration component into the app shell and remove the duplicated window scroll handler

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e291d93dec833290870f0988566478