### PR TITLE
Ensure smooth scroll resets inside protected layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,6 +32,7 @@ import AdminPage from "./pages/AdminPage";
 import ChallengesPage from "./pages/Challenges.jsx";
 import WishlistPage from "./pages/WishlistPage";
 import useChallenges from "./hooks/useChallenges.js";
+import usePrefersReducedMotion from "./hooks/usePrefersReducedMotion.js";
 import AuthGuard from "./components/AuthGuard";
 import AdminGuard from "./components/AdminGuard";
 import { DataProvider } from "./context/DataContext";
@@ -179,15 +180,37 @@ function loadInitial() {
 
 function ProtectedAppContainer({ theme, setTheme, brand, setBrand }) {
   const location = useLocation();
+  const prefersReducedMotion = usePrefersReducedMotion();
   const hideNav = location.pathname.startsWith("/add");
 
   useEffect(() => {
     const frame = requestAnimationFrame(() => {
-      window.scrollTo({ top: 0, behavior: "smooth" });
+      const behavior = prefersReducedMotion ? "auto" : "smooth";
+      const scroller = document.getElementById("main");
+
+      if (location.hash) {
+        const target = document.querySelector(location.hash);
+        if (target) {
+          target.scrollIntoView({ behavior, block: "start" });
+          return;
+        }
+      }
+
+      if (scroller) {
+        scroller.scrollTo({ top: 0, behavior });
+        return;
+      }
+
+      window.scrollTo({ top: 0, behavior });
     });
 
     return () => cancelAnimationFrame(frame);
-  }, [location.pathname, location.search, location.hash]);
+  }, [
+    location.pathname,
+    location.search,
+    location.hash,
+    prefersReducedMotion,
+  ]);
 
   return (
     <MainLayout

--- a/src/hooks/usePrefersReducedMotion.js
+++ b/src/hooks/usePrefersReducedMotion.js
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+
+export default function usePrefersReducedMotion() {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return false;
+    }
+
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const handleChange = (event) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    handleChange(mediaQuery);
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleChange);
+      return () => mediaQuery.removeEventListener("change", handleChange);
+    }
+
+    mediaQuery.addListener(handleChange);
+    return () => mediaQuery.removeListener(handleChange);
+  }, []);
+
+  return prefersReducedMotion;
+}


### PR DESCRIPTION
## Summary
- reset the protected layout's scroll container to the top during navigation while respecting reduced-motion settings

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e291d93dec833290870f0988566478