### PR TITLE
Remove calendar icon from add transaction date input

### DIFF
--- a/src/pages/TransactionAdd.jsx
+++ b/src/pages/TransactionAdd.jsx
@@ -685,12 +685,11 @@ export default function TransactionAdd({ onAdd }) {
                       Kemarin
                     </button>
                     <div className="relative">
-                      <Calendar className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted" aria-hidden="true" />
                       <input
                         type="date"
                         value={date}
                         onChange={(event) => handleDateSelect(event.target.value)}
-                        className={`${INPUT_CLASS} pl-9`}
+                        className={INPUT_CLASS}
                       />
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- remove the decorative calendar icon from the manual date field on the add transaction page
- adjust the input spacing now that the icon is gone

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2977154e88332a71d991be1e99eb3