### PR TITLE
Align weekly budgets with first Monday-based weeks

### DIFF
--- a/src/components/dashboard/DashboardHighlightedBudgets.tsx
+++ b/src/components/dashboard/DashboardHighlightedBudgets.tsx
@@ -145,7 +145,7 @@ export default function DashboardHighlightedBudgets({ period }: DashboardHighlig
         const weekMeta = weekly.weeks.find((week) => week.start === row.week_start);
         const subtitleParts: string[] = [];
         if (weekMeta) {
-          subtitleParts.push(`Minggu ke-${weekMeta.sequence}`);
+          subtitleParts.push(weekMeta.label);
         }
         subtitleParts.push(formatWeekRange(row.week_start, row.week_end));
         return {

--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -73,13 +73,17 @@ function getFirstWeekStartOfPeriod(period: string): string {
   if (!Number.isFinite(year) || !Number.isFinite(month)) {
     return getCurrentPeriod();
   }
-  const date = new Date(Date.UTC(year, month - 1, 1));
-  const day = date.getUTCDay();
+  const startDate = new Date(Date.UTC(year, month - 1, 1));
+  const initial = new Date(startDate);
+  const day = initial.getUTCDay();
   const diff = day === 0 ? 6 : day - 1;
-  date.setUTCDate(date.getUTCDate() - diff);
-  const startYear = date.getUTCFullYear();
-  const startMonth = `${date.getUTCMonth() + 1}`.padStart(2, '0');
-  const startDay = `${date.getUTCDate()}`.padStart(2, '0');
+  initial.setUTCDate(initial.getUTCDate() - diff);
+  if (initial < startDate) {
+    initial.setUTCDate(initial.getUTCDate() + 7);
+  }
+  const startYear = initial.getUTCFullYear();
+  const startMonth = `${initial.getUTCMonth() + 1}`.padStart(2, '0');
+  const startDay = `${initial.getUTCDate()}`.padStart(2, '0');
   return `${startYear}-${startMonth}-${startDay}`;
 }
 
@@ -304,7 +308,7 @@ export default function BudgetsPage() {
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="space-y-1">
             <p className="text-sm font-semibold text-text">
-              {selectedWeek ? `Minggu ke-${selectedWeek.sequence} dari ${total}` : 'Pilih minggu'}
+              {selectedWeek ? selectedWeek.label : 'Pilih minggu'}
             </p>
             {selectedWeek ? (
               <p className="text-xs text-muted">
@@ -330,7 +334,7 @@ export default function BudgetsPage() {
             >
               {weekly.weeks.map((week) => (
                 <option key={week.start} value={week.start}>
-                  {`Minggu ke-${week.sequence} (${formatWeekRangeLabel(week.start, week.end)})`}
+                  {`${week.label} (${formatWeekRangeLabel(week.start, week.end)})`}
                 </option>
               ))}
             </select>


### PR DESCRIPTION
## Summary
- ensure weekly budget periods start from the first Monday of the selected month
- expose human-readable week labels and month names for weekly budget metadata and UI
- update dashboards and budget selectors to display "Minggu ke X bulan <Month>" and keep carryover in sync with the active week

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e304b5bf7c8332a566bfdc5e77294c