### PR TITLE
Normalize transaction dates when computing weekly budget spending

### DIFF
--- a/src/lib/budgetApi.ts
+++ b/src/lib/budgetApi.ts
@@ -267,6 +267,26 @@ function parseIsoDate(value: string): Date {
   return new Date(`${value}T00:00:00.000Z`);
 }
 
+function normalizeTransactionDate(value: string): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    return trimmed;
+  }
+  try {
+    const parsed = new Date(trimmed);
+    if (Number.isNaN(parsed.getTime())) {
+      const fallback = trimmed.slice(0, 10);
+      return fallback.length === 10 ? fallback : null;
+    }
+    return formatIsoDateUTC(parsed);
+  } catch {
+    const fallback = trimmed.slice(0, 10);
+    return fallback.length === 10 ? fallback : null;
+  }
+}
+
 function getWeekStartOnOrAfter(date: Date): string {
   const result = new Date(date);
   const day = result.getUTCDay();
@@ -675,8 +695,10 @@ export async function listWeeklyBudgets(period: string): Promise<WeeklyBudgetsRe
     if (!Number.isFinite(amount)) continue;
     const dateValue = typeof row?.date === 'string' ? row.date : null;
     if (!dateValue) continue;
+    const normalizedDate = normalizeTransactionDate(dateValue);
+    if (!normalizedDate) continue;
     const list = transactionsByCategory.get(categoryId) ?? [];
-    list.push({ date: dateValue, amount });
+    list.push({ date: normalizedDate, amount });
     transactionsByCategory.set(categoryId, list);
   }
 


### PR DESCRIPTION
## Summary
- add a helper to normalize transaction timestamps to date-only strings when building weekly spending aggregates
- ensure weekly budget spending calculations use the normalized date so that end-of-week transactions are included

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e308460e7c8332beb3b705a79fc578