### PR TITLE
Fix weekly budget spent calculation

### DIFF
--- a/src/lib/budgetApi.ts
+++ b/src/lib/budgetApi.ts
@@ -673,7 +673,9 @@ export async function listWeeklyBudgets(period: string): Promise<WeeklyBudgetsRe
     if (!categoryId) continue;
     const amount = Number(row?.amount ?? 0);
     if (!Number.isFinite(amount)) continue;
-    const dateValue = typeof row?.date === 'string' ? row.date : null;
+    const rawDate = typeof row?.date === 'string' ? row.date : null;
+    if (!rawDate) continue;
+    const dateValue = rawDate.length >= 10 ? rawDate.slice(0, 10) : null;
     if (!dateValue) continue;
     const list = transactionsByCategory.get(categoryId) ?? [];
     list.push({ date: dateValue, amount });


### PR DESCRIPTION
## Summary
- normalize transaction dates before aggregating weekly budget spending so expenses on the last day of the week are counted correctly

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e308460e7c8332beb3b705a79fc578