### PR TITLE
Fix weekly budget transaction range and add test

### DIFF
--- a/src/lib/budgetApi.test.ts
+++ b/src/lib/budgetApi.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.hoisted(() => {
+  process.env.VITE_SUPABASE_URL = 'http://localhost';
+  process.env.VITE_SUPABASE_ANON_KEY = 'test-key';
+  process.env.VITE_SUPABASE_PUBLISHABLE_KEY = 'test-key';
+});
+
+const { getWeeklyTransactionEndExclusive } = await import('./budgetApi');
+
+describe('getWeeklyTransactionEndExclusive', () => {
+  it('extends to the end of the final week when the month ends mid-week', () => {
+    expect(getWeeklyTransactionEndExclusive('2024-05')).toBe('2024-06-03');
+  });
+
+  it('matches the next month start when the month ends on a Sunday', () => {
+    expect(getWeeklyTransactionEndExclusive('2024-03')).toBe('2024-04-01');
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure weekly budget spending queries include the final week's spillover days
- add a helper to compute the exclusive end date for weekly transactions and cover it with tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e308460e7c8332beb3b705a79fc578