### PR TITLE
Simplify weekly selector labels and align chevron

### DIFF
--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
-import { CalendarDays, CalendarRange, ChevronLeft, ChevronRight, Plus, RefreshCw } from 'lucide-react';
+import {
+  CalendarDays,
+  CalendarRange,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  Plus,
+  RefreshCw,
+} from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import Page from '../../layout/Page';
 import Section from '../../layout/Section';
@@ -27,6 +35,7 @@ import {
   type ExpenseCategory,
   type HighlightBudgetSelection,
   type WeeklyBudgetWithSpent,
+  type WeeklyBudgetPeriod,
 } from '../../lib/budgetApi';
 
 const TABS = [
@@ -96,6 +105,14 @@ function formatWeekRangeLabel(start: string, end: string): string {
   } catch (error) {
     return `${start} – ${end}`;
   }
+}
+
+function formatWeekTitle(sequence: number): string {
+  return `Minggu ke ${sequence}`;
+}
+
+function formatWeekOptionLabel(week: WeeklyBudgetPeriod): string {
+  return `${formatWeekTitle(week.sequence)} (${formatWeekRangeLabel(week.start, week.end)})`;
 }
 
 export default function BudgetsPage() {
@@ -288,7 +305,7 @@ export default function BudgetsPage() {
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="space-y-1">
             <p className="text-sm font-semibold text-text">
-              {selectedWeek ? selectedWeek.label : 'Pilih minggu'}
+              {selectedWeek ? formatWeekTitle(selectedWeek.sequence) : 'Pilih minggu'}
             </p>
             {selectedWeek ? (
               <p className="text-xs text-muted">
@@ -306,18 +323,21 @@ export default function BudgetsPage() {
             >
               <ChevronLeft className="h-4 w-4" />
             </button>
-            <select
-              value={selectValue}
-              onChange={(event) => setSelectedWeekStart(event.target.value || null)}
-              className="h-9 min-w-[10rem] rounded-xl border border-border/60 bg-surface/90 px-3 text-sm font-medium text-text shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-              aria-label="Pilih minggu"
-            >
-              {weekly.weeks.map((week) => (
-                <option key={week.start} value={week.start}>
-                  {`${week.label} (${formatWeekRangeLabel(week.start, week.end)})`}
-                </option>
-              ))}
-            </select>
+            <div className="relative">
+              <select
+                value={selectValue}
+                onChange={(event) => setSelectedWeekStart(event.target.value || null)}
+                className="h-9 min-w-[10rem] appearance-none rounded-xl border border-border/60 bg-surface/90 px-3 pr-10 text-sm font-medium text-text shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+                aria-label="Pilih minggu"
+              >
+                {weekly.weeks.map((week) => (
+                  <option key={week.start} value={week.start}>
+                    {formatWeekOptionLabel(week)}
+                  </option>
+                ))}
+              </select>
+              <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted" />
+            </div>
             <button
               type="button"
               onClick={() => goTo(1)}


### PR DESCRIPTION
## Summary
- update the weekly budget selector to show "Minggu ke X" alongside its date range
- add a custom chevron icon to the selector so the arrow stays aligned

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e312f4de4c83328370fdcabce5410f