### PR TITLE
Adjust weekly budget selector labels and arrow

### DIFF
--- a/src/lib/budgetApi.ts
+++ b/src/lib/budgetApi.ts
@@ -289,16 +289,8 @@ function getWeekEndFromStart(weekStart: string): string {
   return formatIsoDateUTC(startDate);
 }
 
-const WEEK_LABEL_MONTH_FORMATTER = new Intl.DateTimeFormat('id-ID', { month: 'long' });
-
-function formatWeeklyLabel(sequence: number, weekStart: string): string {
-  try {
-    const monthNameRaw = WEEK_LABEL_MONTH_FORMATTER.format(new Date(`${weekStart}T00:00:00.000Z`));
-    const monthName = monthNameRaw.charAt(0).toUpperCase() + monthNameRaw.slice(1);
-    return `Minggu ke ${sequence} bulan ${monthName}`;
-  } catch (error) {
-    return `Minggu ke ${sequence}`;
-  }
+function formatWeeklyLabel(sequence: number): string {
+  return `Minggu ke ${sequence}`;
 }
 
 export function getFirstWeekStartOfPeriod(period: string): string {
@@ -776,7 +768,7 @@ export async function listWeeklyBudgets(period: string): Promise<WeeklyBudgetsRe
         start: weekStart,
         end: weekEnd,
         sequence,
-        label: formatWeeklyLabel(sequence, weekStart),
+        label: formatWeeklyLabel(sequence),
       });
     }
   }

--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
-import { CalendarDays, CalendarRange, ChevronLeft, ChevronRight, Plus, RefreshCw } from 'lucide-react';
+import {
+  CalendarDays,
+  CalendarRange,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  Plus,
+  RefreshCw,
+} from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import Page from '../../layout/Page';
 import Section from '../../layout/Section';
@@ -288,11 +296,11 @@ export default function BudgetsPage() {
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="space-y-1">
             <p className="text-sm font-semibold text-text">
-              {selectedWeek ? selectedWeek.label : 'Pilih minggu'}
+              {selectedWeek ? `Minggu ke ${selectedWeek.sequence}` : 'Pilih minggu'}
             </p>
             {selectedWeek ? (
               <p className="text-xs text-muted">
-                {`Minggu ke ${selectedWeek.sequence} dari ${total} • Periode ${formatWeekRangeLabel(selectedWeek.start, selectedWeek.end)}`}
+                {formatWeekRangeLabel(selectedWeek.start, selectedWeek.end)}
               </p>
             ) : null}
           </div>
@@ -306,18 +314,21 @@ export default function BudgetsPage() {
             >
               <ChevronLeft className="h-4 w-4" />
             </button>
-            <select
-              value={selectValue}
-              onChange={(event) => setSelectedWeekStart(event.target.value || null)}
-              className="h-9 min-w-[10rem] rounded-xl border border-border/60 bg-surface/90 px-3 text-sm font-medium text-text shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
-              aria-label="Pilih minggu"
-            >
-              {weekly.weeks.map((week) => (
-                <option key={week.start} value={week.start}>
-                  {`${week.label} (${formatWeekRangeLabel(week.start, week.end)})`}
-                </option>
-              ))}
-            </select>
+            <div className="relative">
+              <select
+                value={selectValue}
+                onChange={(event) => setSelectedWeekStart(event.target.value || null)}
+                className="h-9 min-w-[10rem] appearance-none rounded-xl border border-border/60 bg-surface/90 px-3 pr-10 text-sm font-medium text-text shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+                aria-label="Pilih minggu"
+              >
+                {weekly.weeks.map((week) => (
+                  <option key={week.start} value={week.start}>
+                    {`Minggu ke ${week.sequence} (${formatWeekRangeLabel(week.start, week.end)})`}
+                  </option>
+                ))}
+              </select>
+              <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted" aria-hidden="true" />
+            </div>
             <button
               type="button"
               onClick={() => goTo(1)}


### PR DESCRIPTION
## Summary
- simplify weekly period labels to only show the week number
- show the selected week's date range separately and update the dropdown options
- wrap the week selector with a custom chevron icon so the arrow aligns correctly

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e312f4de4c83328370fdcabce5410f