### PR TITLE
Fix MoneyTalk title responses for new transactions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -808,9 +808,11 @@ function AppShell({ prefs, setPrefs }) {
     const amounts = catTx
       .map((t) => Number(t.amount || 0))
       .sort((a, b) => a - b);
-    const p75 =
-      amounts.length > 0 ? amounts[Math.floor(0.75 * (amounts.length - 1))] : 0;
-    const isHigh = amount > p75;
+    const hasHistory = amounts.length > 0;
+    const p75 = hasHistory
+      ? amounts[Math.floor(0.75 * (amounts.length - 1))]
+      : 0;
+    const isHigh = hasHistory && amount > p75;
     const month = tx.date?.slice(0, 7);
     const budget = data.budgets.find(
       (b) => b.category === category && b.month === month


### PR DESCRIPTION
## Summary
- ensure the MoneyTalk high-spend check only runs when there is category history
- allow contextual title-based responses to appear for the first transactions in a category

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68e3d1170c2c833299e10293827c999c