### PR TITLE
Improve budgets page desktop responsiveness

### DIFF
--- a/src/layout/Page.jsx
+++ b/src/layout/Page.jsx
@@ -1,11 +1,13 @@
+import clsx from "clsx";
+
 /**
  * Page container enforcing global vertical rhythm.
  * Applies top and bottom padding using --page-y.
  */
-export default function Page({ children }) {
+export default function Page({ children, maxWidthClass = "max-w-5xl", className }) {
   return (
     <main
-      className="mx-auto w-full max-w-5xl min-w-0 px-4"
+      className={clsx("mx-auto w-full min-w-0 px-4", maxWidthClass, className)}
       style={{ paddingTop: "var(--page-y)", paddingBottom: "var(--page-y)" }}
     >
       {children}

--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -301,8 +301,8 @@ export default function BudgetsPage() {
     const selectValue = selectedWeekStart ?? weekly.weeks[0]?.start ?? '';
 
     return (
-      <div className="flex flex-col gap-3 rounded-2xl border border-border/60 bg-surface/80 p-4 shadow-sm">
-        <div className="flex flex-wrap items-center justify-between gap-3">
+      <div className="flex flex-col gap-3 rounded-2xl border border-border/60 bg-surface/80 p-4 shadow-sm lg:gap-4">
+        <div className="flex flex-wrap items-center justify-between gap-3 lg:flex-col lg:items-stretch lg:gap-4">
           <div className="space-y-1">
             <p className="text-sm font-semibold text-text">
               {selectedWeek ? formatWeekTitle(selectedWeek.sequence) : 'Pilih minggu'}
@@ -313,7 +313,7 @@ export default function BudgetsPage() {
               </p>
             ) : null}
           </div>
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2 lg:w-full lg:justify-between">
             <button
               type="button"
               onClick={() => goTo(-1)}
@@ -327,7 +327,7 @@ export default function BudgetsPage() {
               <select
                 value={selectValue}
                 onChange={(event) => setSelectedWeekStart(event.target.value || null)}
-                className="h-9 min-w-[10rem] appearance-none rounded-xl border border-border/60 bg-surface/90 px-3 pr-10 text-sm font-medium text-text shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+                className="h-9 min-w-[10rem] appearance-none rounded-xl border border-border/60 bg-surface/90 px-3 pr-10 text-sm font-medium text-text shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 lg:w-full"
                 aria-label="Pilih minggu"
               >
                 {weekly.weeks.map((week) => (
@@ -556,8 +556,12 @@ export default function BudgetsPage() {
   const monthlyLoading = monthly.loading || submittingMonthly;
   const weeklyLoading = weekly.loading || submittingWeekly;
 
+  const desktopAsideClass =
+    'lg:order-2 lg:mt-0 lg:rounded-3xl lg:border lg:border-border/60 lg:bg-surface/80 lg:p-6 lg:shadow-[0_24px_45px_-28px_rgba(15,23,42,0.5)] lg:backdrop-blur lg:supports-[backdrop-filter]:bg-surface/60 lg:sticky lg:top-[calc(var(--page-y)+1.5rem)]';
+  const desktopMainSectionClass = 'lg:order-1 lg:mt-0';
+
   return (
-    <Page>
+    <Page maxWidthClass="max-w-6xl 2xl:max-w-7xl" className="lg:px-6 xl:px-10">
       <PageHeader
         title="Anggaran"
         description="Atur dan pantau alokasi pengeluaranmu per bulan atau per minggu."
@@ -581,9 +585,12 @@ export default function BudgetsPage() {
         </button>
       </PageHeader>
 
-      <Section first>
-        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div className="grid w-full grid-cols-2 gap-2 md:w-auto md:auto-cols-fr md:grid-flow-col">
+      <Section
+        first
+        className="lg:rounded-3xl lg:border lg:border-border/60 lg:bg-surface/80 lg:p-6 lg:shadow-[0_24px_45px_-28px_rgba(15,23,42,0.5)] lg:backdrop-blur lg:supports-[backdrop-filter]:bg-surface/60"
+      >
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between lg:gap-6">
+          <div className="grid w-full grid-cols-2 gap-2 md:w-auto md:auto-cols-fr md:grid-flow-col lg:auto-cols-max">
             {TABS.map(({ value, label, icon: Icon }) => {
               const active = value === tab;
               return (
@@ -624,64 +631,68 @@ export default function BudgetsPage() {
         </div>
       </Section>
 
-      {tab === 'monthly' ? (
-        <Section>
-          <SummaryCards summary={monthly.summary} loading={monthlyLoading} />
-        </Section>
-      ) : (
-        <Section>
-          <div className="space-y-4">
-            <h2 className="text-base font-semibold text-text">Total Weekly (Month-to-date)</h2>
-            <MonthlyFromWeeklySummary summary={weekly.summaryByCategory} loading={weeklyLoading} />
-            {weekSelector}
-          </div>
-        </Section>
-      )}
+      <div className="flex flex-col gap-[var(--section-y)] lg:grid lg:grid-cols-[minmax(0,1.6fr)_minmax(0,0.9fr)] lg:items-start lg:gap-x-8 lg:gap-y-[var(--section-y)] xl:gap-x-12">
+        {tab === 'monthly' ? (
+          <>
+            <Section className={desktopAsideClass}>
+              <SummaryCards summary={monthly.summary} loading={monthlyLoading} />
+            </Section>
 
-      {tab === 'monthly' ? (
-        <Section>
-          <BudgetTable
-            rows={monthly.rows}
-            loading={monthlyLoading}
-            highlightedIds={highlightedMonthlyIds}
-            highlightLimitReached={highlightLimitReached}
-            onEdit={handleEditMonthly}
-            onDelete={handleDeleteMonthly}
-            onToggleCarryover={handleToggleCarryover}
-            onViewTransactions={(row) =>
-              handleViewTransactions({
-                categoryId: row.category_id,
-                categoryType: row.category?.type ?? null,
-                range: 'month',
-                month: row.period_month?.slice(0, 7) ?? period,
-              })
-            }
-            onToggleHighlight={(row) => handleToggleHighlight('monthly', row.id)}
-          />
-        </Section>
-      ) : (
-        <Section>
-          <WeeklyBudgetsGrid
-            rows={weeklyRowsForDisplay}
-            loading={weeklyLoading}
-            highlightedIds={highlightedWeeklyIds}
-            highlightLimitReached={highlightLimitReached}
-            onEdit={handleEditWeekly}
-            onDelete={handleDeleteWeekly}
-            onViewTransactions={(row) =>
-              handleViewTransactions({
-                categoryId: row.category_id,
-                categoryType: row.category?.type ?? null,
-                range: 'custom',
-                start: row.week_start,
-                end: row.week_end,
-              })
-            }
-            onToggleCarryover={handleToggleWeeklyCarryover}
-            onToggleHighlight={(row) => handleToggleHighlight('weekly', row.id)}
-          />
-        </Section>
-      )}
+            <Section className={desktopMainSectionClass}>
+              <BudgetTable
+                rows={monthly.rows}
+                loading={monthlyLoading}
+                highlightedIds={highlightedMonthlyIds}
+                highlightLimitReached={highlightLimitReached}
+                onEdit={handleEditMonthly}
+                onDelete={handleDeleteMonthly}
+                onToggleCarryover={handleToggleCarryover}
+                onViewTransactions={(row) =>
+                  handleViewTransactions({
+                    categoryId: row.category_id,
+                    categoryType: row.category?.type ?? null,
+                    range: 'month',
+                    month: row.period_month?.slice(0, 7) ?? period,
+                  })
+                }
+                onToggleHighlight={(row) => handleToggleHighlight('monthly', row.id)}
+              />
+            </Section>
+          </>
+        ) : (
+          <>
+            <Section className={desktopAsideClass}>
+              <div className="space-y-4">
+                <h2 className="text-base font-semibold text-text">Total Weekly (Month-to-date)</h2>
+                <MonthlyFromWeeklySummary summary={weekly.summaryByCategory} loading={weeklyLoading} />
+                {weekSelector}
+              </div>
+            </Section>
+
+            <Section className={desktopMainSectionClass}>
+              <WeeklyBudgetsGrid
+                rows={weeklyRowsForDisplay}
+                loading={weeklyLoading}
+                highlightedIds={highlightedWeeklyIds}
+                highlightLimitReached={highlightLimitReached}
+                onEdit={handleEditWeekly}
+                onDelete={handleDeleteWeekly}
+                onViewTransactions={(row) =>
+                  handleViewTransactions({
+                    categoryId: row.category_id,
+                    categoryType: row.category?.type ?? null,
+                    range: 'custom',
+                    start: row.week_start,
+                    end: row.week_end,
+                  })
+                }
+                onToggleCarryover={handleToggleWeeklyCarryover}
+                onToggleHighlight={(row) => handleToggleHighlight('weekly', row.id)}
+              />
+            </Section>
+          </>
+        )}
+      </div>
 
       <BudgetFormModal
         open={monthlyModalOpen}

--- a/src/pages/budgets/components/BudgetTable.tsx
+++ b/src/pages/budgets/components/BudgetTable.tsx
@@ -26,10 +26,10 @@ interface BudgetTableProps {
   onToggleHighlight: (row: BudgetWithSpent) => void;
 }
 
-const CARD_WRAPPER_CLASS = 'grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4';
+const CARD_WRAPPER_CLASS = 'grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4';
 
 const CARD_CLASS =
-  'relative flex flex-col gap-5 overflow-hidden rounded-2xl border border-border/60 bg-surface/80 p-5 shadow-[0_24px_45px_-28px_rgba(15,23,42,0.5)] transition duration-300 ease-out hover:-translate-y-1 hover:shadow-[0_30px_60px_-32px_rgba(15,23,42,0.55)] backdrop-blur supports-[backdrop-filter]:bg-surface/60';
+  'relative flex h-full flex-col gap-5 overflow-hidden rounded-2xl border border-border/60 bg-surface/80 p-5 shadow-[0_24px_45px_-28px_rgba(15,23,42,0.5)] transition duration-300 ease-out hover:-translate-y-1 hover:shadow-[0_30px_60px_-32px_rgba(15,23,42,0.55)] backdrop-blur supports-[backdrop-filter]:bg-surface/60';
 
 function LoadingCards() {
   return (

--- a/src/pages/budgets/components/SummaryCards.tsx
+++ b/src/pages/budgets/components/SummaryCards.tsx
@@ -24,7 +24,7 @@ function SummarySkeleton() {
 export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
   if (loading) {
     return (
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-1 2xl:grid-cols-2">
         {Array.from({ length: 4 }).map((_, index) => (
           <SummarySkeleton key={index} />
         ))}
@@ -76,7 +76,7 @@ export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
   ] as const;
 
   return (
-    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-1 2xl:grid-cols-2">
       {cards.map(({
         label,
         description,

--- a/src/pages/budgets/components/WeeklyBudgetsGrid.tsx
+++ b/src/pages/budgets/components/WeeklyBudgetsGrid.tsx
@@ -15,7 +15,7 @@ interface WeeklyBudgetsGridProps {
   onToggleHighlight: (row: WeeklyBudgetWithSpent) => void;
 }
 
-const GRID_CLASS = 'grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4';
+const GRID_CLASS = 'grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4';
 
 const DATE_FORMATTER = new Intl.DateTimeFormat('id-ID', {
   day: 'numeric',


### PR DESCRIPTION
## Summary
- add width overrides to the Page container so the budgets view can expand on larger screens
- rework the budgets page desktop layout with a sticky summary column and improved weekly selector spacing
- tune budget and weekly grid cards to fill their rows and adjust summary card breakpoints for the new layout

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e3d5c7ce148332977f8c940046c743