### PR TITLE
Expand default expense categories

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -67,13 +67,21 @@ const uid = () =>
 const defaultCategories = {
   income: ["Gaji", "Bonus", "Lainnya"],
   expense: [
-    "Makan",
+    "Makanan",
+    "Minuman",
+    "Jajan",
+    "Bensin",
+    "Perawatan Motor",
     "Transport",
+    "Kuota",
     "Belanja",
+    "Belanja Online",
     "Tagihan",
-    "Tabungan",
+    "Baju",
+    "Celana",
     "Kesehatan",
     "Hiburan",
+    "Tabungan",
     "Lainnya",
   ],
 };

--- a/src/hooks/useFinanceSummary.js
+++ b/src/hooks/useFinanceSummary.js
@@ -11,7 +11,7 @@ const mockTxs = [
     date: new Date().toISOString().slice(0, 10),
     type: "expense",
     amount: 100000,
-    category: "Makan",
+    category: "Makanan",
   },
 ];
 

--- a/src/lib/challenges.js
+++ b/src/lib/challenges.js
@@ -10,7 +10,7 @@ export const CHALLENGE_TEMPLATES = [
     title: "No GoFood 7 Hari",
     type: "avoid",
     durationDays: 7,
-    rules: { category: "Makan" },
+    rules: { category: "Makanan" },
     rewardXP: 50,
   },
   {
@@ -45,7 +45,7 @@ export const CHALLENGE_TEMPLATES = [
     title: "No Kopi Seminggu",
     type: "avoid",
     durationDays: 7,
-    rules: { category: "Makan" },
+    rules: { category: "Makanan" },
     rewardXP: 50,
   },
   {

--- a/src/lib/challenges.test.js
+++ b/src/lib/challenges.test.js
@@ -7,14 +7,14 @@ describe("evaluateChallenge", () => {
   it("fails avoid challenge when violation occurs", () => {
     const challenge = {
       type: "avoid",
-      rules: { category: "Makan" },
+      rules: { category: "Makanan" },
       durationDays: 7,
       startDate: today,
       endDate: new Date(Date.now() + 6 * 86400000).toISOString(),
       status: "active",
     };
     const txs = [
-      { id: 1, category: "Makan", date: today, type: "expense", amount: 10000 },
+      { id: 1, category: "Makanan", date: today, type: "expense", amount: 10000 },
     ];
     const { status } = evaluateChallenge(challenge, txs, new Date());
     expect(status).toBe("failed");

--- a/src/lib/dummySeed.ts
+++ b/src/lib/dummySeed.ts
@@ -5,9 +5,22 @@ export function dummySeed() {
   const categories = [
     { id: uid(), name: 'Gaji', type: 'income' },
     { id: uid(), name: 'Bonus', type: 'income' },
-    { id: uid(), name: 'Makan', type: 'expense' },
+    { id: uid(), name: 'Makanan', type: 'expense' },
+    { id: uid(), name: 'Minuman', type: 'expense' },
+    { id: uid(), name: 'Jajan', type: 'expense' },
+    { id: uid(), name: 'Bensin', type: 'expense' },
+    { id: uid(), name: 'Perawatan Motor', type: 'expense' },
     { id: uid(), name: 'Transport', type: 'expense' },
+    { id: uid(), name: 'Kuota', type: 'expense' },
+    { id: uid(), name: 'Belanja', type: 'expense' },
+    { id: uid(), name: 'Belanja Online', type: 'expense' },
+    { id: uid(), name: 'Tagihan', type: 'expense' },
+    { id: uid(), name: 'Baju', type: 'expense' },
+    { id: uid(), name: 'Celana', type: 'expense' },
+    { id: uid(), name: 'Kesehatan', type: 'expense' },
     { id: uid(), name: 'Hiburan', type: 'expense' },
+    { id: uid(), name: 'Tabungan', type: 'expense' },
+    { id: uid(), name: 'Lainnya', type: 'expense' },
   ];
 
   const budgets = categories

--- a/src/lib/moneyTalkContent.js
+++ b/src/lib/moneyTalkContent.js
@@ -1,6 +1,6 @@
 export const quotes = {
   id: {
-    Makan: [
+    Makanan: [
       "Aku masuk mulut, bukan dompet! 🍜",
       "Habis makan enak, aku langsung melangsing. 😅",
       "Perut kenyang, dompet kempes!",
@@ -68,7 +68,7 @@ export const quotes = {
     ],
   },
   en: {
-    Makan: [
+    Makanan: [
       "I go to your belly, not your wallet! 🍜",
       "Great meal, sudden slim wallet. 😅",
       "Full tummy, empty pocket!",
@@ -139,7 +139,7 @@ export const quotes = {
 
 export const tips = {
   id: {
-    Makan: [
+    Makanan: [
       "Coba masak sendiri untuk lebih hemat.",
       "Bawa bekal dari rumah.",
     ],
@@ -165,7 +165,7 @@ export const tips = {
     ],
   },
   en: {
-    Makan: [
+    Makanan: [
       "Cook at home to save more.",
       "Bring your own lunch.",
     ],

--- a/src/lib/moneyTalkIntents.test.js
+++ b/src/lib/moneyTalkIntents.test.js
@@ -7,7 +7,7 @@ import {
 describe("resolveMoneyTalkIntent", () => {
   const baseValues = {
     amount: "Rp50.000",
-    category: "Makan",
+    category: "Makanan",
     type: "expense",
     title: "Ngopi di Starbucks",
   };

--- a/src/lib/seed.js
+++ b/src/lib/seed.js
@@ -4,12 +4,21 @@ import { getCurrentUserId } from "./session";
 const defaults = {
   income: ["Gaji", "Bonus", "Lainnya"],
   expense: [
-    "Makan",
+    "Makanan",
+    "Minuman",
+    "Jajan",
+    "Bensin",
+    "Perawatan Motor",
     "Transport",
+    "Kuota",
     "Belanja",
+    "Belanja Online",
     "Tagihan",
+    "Baju",
+    "Celana",
     "Kesehatan",
     "Hiburan",
+    "Tabungan",
     "Lainnya",
   ],
 };


### PR DESCRIPTION
## Summary
- expand the default expense categories with detailed daily spending types
- update seeds, mock data, and money talk references to use the renamed food category

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e3d85ff9748332878b9c836a6a4bba