### PR TITLE
feat(budgets): add custom budget names and multi-category monthly budgets

### DIFF
--- a/src/lib/budgetApi.ts
+++ b/src/lib/budgetApi.ts
@@ -111,6 +111,7 @@ interface RawBudgetCategory {
 interface RawBudgetRow {
   id: string;
   user_id: string;
+  name?: string | null;
   category_id?: string | null;
   amount_planned?: number | string | null;
   planned?: number | string | null;
@@ -195,6 +196,7 @@ function normalizeBudgetRow(row: RawBudgetRow): BudgetRow {
   return {
     id: String(row.id) as UUID,
     user_id: String(row.user_id) as UUID,
+    name: String(row.name ?? '').trim(),
     category_id: categoryId,
     category_ids: categoryId ? [categoryId] : [],
     amount_planned: Number(resolvedAmount),
@@ -363,6 +365,7 @@ function mergeExpenseCategoriesWithFallback(
 export interface BudgetRow {
   id: UUID;
   user_id: UUID;
+  name: string;
   category_id: Nullable<UUID>;
   category_ids: UUID[];
   amount_planned: number;
@@ -457,6 +460,7 @@ export interface HighlightBudgetSelection {
 
 export interface UpsertBudgetInput {
   id?: UUID;
+  name: string;
   category_id?: UUID;
   category_ids?: UUID[];
   period: string; // YYYY-MM
@@ -926,6 +930,7 @@ export async function listBudgets(period: string): Promise<BudgetRow[]> {
   const results = await Promise.allSettled(
     toCarryOver.map((row) =>
       upsertBudget({
+        name: row.name,
         category_id: row.category_id as string,
         category_ids: row.category_ids,
         period,
@@ -1348,9 +1353,65 @@ export async function upsertBudget(input: UpsertBudgetInput): Promise<BudgetRow>
   const normalizedCategoryIds = Array.from(
     new Set((input.category_ids ?? (input.category_id ? [input.category_id] : [])).filter(Boolean))
   );
+  const normalizedName = String(input.name ?? '').trim();
+  if (!normalizedName) {
+    throw new Error('Nama budget wajib diisi');
+  }
   const primaryCategoryId = normalizedCategoryIds[0] ?? input.category_id;
   if (!primaryCategoryId) {
     throw new Error('Kategori wajib dipilih');
+  }
+
+  if (input.id) {
+    const { data, error } = await supabase
+      .from('budgets')
+      .update({
+        name: normalizedName,
+        category_id: primaryCategoryId,
+        period_month: toMonthStart(input.period),
+        amount_planned: Number(input.amount_planned ?? 0),
+        carryover_enabled: Boolean(input.carryover_enabled),
+        notes: input.notes ?? null,
+      })
+      .eq('user_id', userId)
+      .eq('id', input.id)
+      .select('*, category:categories(id,name,type)')
+      .single();
+
+    if (error) {
+      throw new Error(error.message || 'Gagal menyimpan anggaran');
+    }
+
+    const normalized = normalizeBudgetRow(data as RawBudgetRow);
+
+    const payloadLinks = normalizedCategoryIds.map((categoryId) => ({
+      budget_id: normalized.id,
+      category_id: categoryId,
+      user_id: normalized.user_id,
+    }));
+
+    const { error: upsertLinksError } = await supabase
+      .from('budget_categories')
+      .upsert(payloadLinks, { onConflict: 'budget_id,category_id' });
+
+    if (upsertLinksError) {
+      const msg = (upsertLinksError.message ?? '').toLowerCase();
+      if (!(upsertLinksError.code === '42P01' || msg.includes('budget_categories'))) {
+        throw upsertLinksError;
+      }
+      return normalized;
+    }
+
+    const { error: deleteLinksError } = await supabase
+      .from('budget_categories')
+      .delete()
+      .eq('budget_id', normalized.id)
+      .not('category_id', 'in', `(${normalizedCategoryIds.map((id) => `"${id}"`).join(',')})`);
+
+    if (deleteLinksError) throw deleteLinksError;
+
+    const [withCategories] = await attachBudgetCategories([normalized]);
+    return withCategories;
   }
 
   const payload = {
@@ -1385,6 +1446,18 @@ export async function upsertBudget(input: UpsertBudgetInput): Promise<BudgetRow>
   }
 
   const normalized = normalizeBudgetRow(data as RawBudgetRow);
+
+  const { error: updateNameError } = await supabase
+    .from('budgets')
+    .update({ name: normalizedName })
+    .eq('user_id', normalized.user_id)
+    .eq('id', normalized.id);
+
+  if (updateNameError) {
+    throw updateNameError;
+  }
+
+  normalized.name = normalizedName;
 
   if (normalizedCategoryIds.length === 0) {
     return normalized;

--- a/src/lib/simScenarioApi.ts
+++ b/src/lib/simScenarioApi.ts
@@ -456,6 +456,7 @@ export async function applyScenario(
       const amount = clampBudget(category.baselineMonthly + category.deltaMonthly);
       monthlyUpdates.push(
         upsertBudget({
+          name: baselineCategory?.categoryName ?? category.categoryName,
           category_id: category.categoryId,
           period,
           amount_planned: amount,
@@ -496,4 +497,3 @@ export async function applyScenario(
 }
 
 export type { BaselineData, ProjectionMethod, SimulationOptions, SimulationResult };
-

--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -49,7 +49,7 @@ const TABS = [
 type TabValue = (typeof TABS)[number]['value'];
 
 type ViewTransactionsParams = {
-  categoryId?: string | null;
+  categoryIds?: string[];
   categoryType?: 'income' | 'expense' | null;
   range: 'month' | 'custom';
   month?: string;
@@ -81,6 +81,7 @@ function isoToPeriod(isoDate: string | null | undefined): string {
 
 const DEFAULT_MONTHLY_FORM: BudgetFormValues = {
   period: getCurrentPeriod(),
+  name: '',
   category_ids: [],
   amount_planned: 0,
   carryover_enabled: false,
@@ -275,6 +276,7 @@ export default function BudgetsPage() {
     if (editingMonthly) {
       return {
         period: isoToPeriod(editingMonthly.period_month),
+        name: editingMonthly.name ?? '',
         category_ids:
           editingMonthly.category_ids.length > 0
             ? editingMonthly.category_ids
@@ -566,7 +568,7 @@ export default function BudgetsPage() {
   });
 
   const handleDeleteMonthly = async (row: BudgetWithSpent) => {
-    const confirmed = window.confirm(`Hapus anggaran untuk ${row.category?.name ?? 'kategori ini'}?`);
+    const confirmed = window.confirm(`Hapus anggaran "${row.name || row.category?.name || 'Tanpa nama'}"?`);
     if (!confirmed) return;
     try {
       setSubmittingMonthly(true);
@@ -596,7 +598,10 @@ export default function BudgetsPage() {
   const handleToggleCarryover = async (row: BudgetWithSpent, carryover: boolean) => {
     try {
       await upsertBudget({
+        id: row.id,
+        name: row.name,
         category_id: row.category_id,
+        category_ids: row.category_ids,
         period: isoToPeriod(row.period_month),
         amount_planned: Number(row.amount_planned ?? 0),
         carryover_enabled: carryover,
@@ -630,6 +635,8 @@ export default function BudgetsPage() {
     try {
       setSubmittingMonthly(true);
       await upsertBudget({
+        id: editingMonthly?.id,
+        name: values.name,
         category_id: values.category_ids[0],
         category_ids: values.category_ids,
         period: values.period,
@@ -673,7 +680,7 @@ export default function BudgetsPage() {
   };
 
   const handleViewTransactions = ({
-    categoryId,
+    categoryIds,
     categoryType,
     range,
     month: monthParam,
@@ -694,8 +701,8 @@ export default function BudgetsPage() {
       params.delete('month');
     }
 
-    if (categoryId) {
-      params.set('categories', categoryId);
+    if (categoryIds && categoryIds.length > 0) {
+      params.set('categories', categoryIds.join(','));
     }
 
     if (categoryType === 'income' || categoryType === 'expense') {
@@ -839,7 +846,11 @@ export default function BudgetsPage() {
             onToggleCarryover={handleToggleCarryover}
             onViewTransactions={(row) =>
               handleViewTransactions({
-                categoryId: row.category_id,
+                categoryIds: row.category_ids.length > 0
+                  ? row.category_ids
+                  : row.category_id
+                  ? [row.category_id]
+                  : [],
                 categoryType: row.category?.type ?? null,
                 range: 'month',
                 month: row.period_month?.slice(0, 7) ?? period,
@@ -859,7 +870,7 @@ export default function BudgetsPage() {
             onDelete={handleDeleteWeekly}
             onViewTransactions={(row) =>
               handleViewTransactions({
-                categoryId: row.category_id,
+                categoryIds: row.category_id ? [row.category_id] : [],
                 categoryType: row.category?.type ?? null,
                 range: 'custom',
                 start: row.week_start,

--- a/src/pages/budgets/components/BudgetCard.tsx
+++ b/src/pages/budgets/components/BudgetCard.tsx
@@ -59,7 +59,7 @@ export default function BudgetCard({
     : budget.category
     ? [budget.category]
     : [{ id: 'unknown', name: 'Tanpa kategori', type: 'expense' as const }];
-  const primary = categories[0]?.name ?? 'Tanpa kategori';
+  const budgetTitle = budget.name?.trim() || categories[0]?.name || 'Tanpa nama budget';
   const extra = categories.length - 2;
 
   return (
@@ -71,7 +71,7 @@ export default function BudgetCard({
     >
       <header className="flex items-start justify-between gap-4">
         <div className="min-w-0 space-y-2">
-          <h3 className="truncate text-lg font-semibold text-white">{primary}</h3>
+          <h3 className="truncate text-lg font-semibold text-white">{budgetTitle}</h3>
           <div className="flex flex-wrap gap-2">
             {categories.slice(0, 2).map((category) => (
               <span key={category.id} className="rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-[11px] font-medium text-slate-300">
@@ -120,7 +120,7 @@ export default function BudgetCard({
 
       <div className="mt-4 flex items-center justify-between rounded-2xl border border-white/10 bg-white/[0.02] px-3 py-2 text-xs text-slate-300">
         <span className="inline-flex items-center gap-2"><RefreshCcw className="h-3.5 w-3.5" />Carryover</span>
-        <label className="relative inline-flex h-6 w-11 cursor-pointer items-center" aria-label={`Atur carryover untuk ${primary}`}>
+        <label className="relative inline-flex h-6 w-11 cursor-pointer items-center" aria-label={`Atur carryover untuk ${budgetTitle}`}>
           <input type="checkbox" checked={carryoverEnabled} onChange={(event) => onToggleCarryover(event.target.checked)} className="peer sr-only" />
           <span className="absolute inset-0 rounded-full bg-white/10 transition peer-checked:bg-brand/60" />
           <span className="relative ml-[3px] h-4 w-4 rounded-full bg-white transition-transform peer-checked:translate-x-5" />

--- a/src/pages/budgets/components/BudgetFormModal.tsx
+++ b/src/pages/budgets/components/BudgetFormModal.tsx
@@ -3,6 +3,7 @@ import type { ExpenseCategory } from '../../../lib/budgetApi';
 
 export interface BudgetFormValues {
   period: string;
+  name: string;
   category_ids: string[];
   amount_planned: number;
   carryover_enabled: boolean;
@@ -45,6 +46,9 @@ function validate(values: BudgetFormValues) {
   const errors: Partial<Record<keyof BudgetFormValues, string>> = {};
   if (!values.period) {
     errors.period = 'Periode wajib diisi';
+  }
+  if (!values.name.trim()) {
+    errors.name = 'Nama budget wajib diisi';
   }
   if (!values.category_ids.length) {
     errors.category_ids = 'Pilih minimal 1 kategori';
@@ -141,7 +145,7 @@ export default function BudgetFormModal({
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const nextValues = { ...values, notes: values.notes.trim() };
+    const nextValues = { ...values, name: values.name.trim(), notes: values.notes.trim() };
     const validation = validate(nextValues);
     setErrors(validation);
     if (Object.keys(validation).length > 0) return;
@@ -190,6 +194,19 @@ export default function BudgetFormModal({
                 required
               />
               {errors.period ? <span className="text-xs font-medium text-rose-500">{errors.period}</span> : null}
+            </label>
+
+            <label className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">
+              Nama Budget
+              <input
+                type="text"
+                value={values.name}
+                onChange={(event) => handleChange('name', event.target.value)}
+                placeholder="Contoh: Kebutuhan Pokok"
+                className="h-11 w-full rounded-2xl border border-border bg-surface px-4 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+                required
+              />
+              {errors.name ? <span className="text-xs font-medium text-rose-500">{errors.name}</span> : null}
             </label>
 
             <div className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">

--- a/src/pages/budgets/simulation/salary/SalarySimulationPage.tsx
+++ b/src/pages/budgets/simulation/salary/SalarySimulationPage.tsx
@@ -510,6 +510,8 @@ export default function SalarySimulationPage() {
         items.map((item) => {
           const existing = budgetMap.get(item.categoryId);
           return upsertBudget({
+            id: existing?.id,
+            name: existing?.name?.trim() || item.categoryName,
             category_id: item.categoryId,
             period,
             amount_planned: item.amount,

--- a/supabase/migrations/20260613000000_budget_name_and_backfill.sql
+++ b/supabase/migrations/20260613000000_budget_name_and_backfill.sql
@@ -1,0 +1,12 @@
+alter table public.budgets
+  add column if not exists name text;
+
+update public.budgets b
+set name = c.name
+from public.categories c
+where b.name is null
+  and b.category_id = c.id;
+
+update public.budgets
+set name = 'Budget Tanpa Nama'
+where name is null;


### PR DESCRIPTION
### Motivation

- Budget saat ini terikat 1:1 ke kategori dan nama mengikuti kategori sehingga tidak fleksibel untuk use-case envelope/custom budgets.
- Diperlukan relasi many-to-many agar 1 budget bisa mengumpulkan transaksi dari beberapa kategori.
- Budget perlu punya `name` sendiri agar bisa diberi judul/deskripsi berbeda dari nama kategori.

### Description

- Tambah kolom `name` pada model budget di klien dan normalisasi `RawBudgetRow` sehingga `BudgetRow` sekarang memiliki `name` dan `normalizeBudgetRow` mengisi `name` dari row. (file: `src/lib/budgetApi.ts`)
- Perbarui RPC/flow `upsertBudget` untuk mendukung: pembuatan budget dengan `name`, pengeditan berdasarkan `id`, serta sinkronisasi relasi many-to-many ke tabel pivot `budget_categories` (upsert link dan hapus link yang tidak dipilih). (file: `src/lib/budgetApi.ts`)
- Ubah form create/edit budget agar memiliki field `Nama Budget` wajib serta tetap mendukung multi-select kategori; trim input sebelum submit. (file: `src/pages/budgets/components/BudgetFormModal.tsx`)
- Perbarui tampilan `BudgetCard` untuk menampilkan `name` sebagai judul utama dan tetap menampilkan kategori sebagai chip kecil (dengan `+N` jika banyak). (file: `src/pages/budgets/components/BudgetCard.tsx`)
- Perbarui halaman budgets agar: form default menyertakan `name`, edit memuat `name` existing, submit/carryover mengirim `id`, `name` dan `category_ids`, serta navigasi ke halaman transaksi mengirim semua kategori terkait (`categories=id1,id2,...`). (file: `src/pages/budgets/BudgetsPage.tsx`)
- Sesuaikan alur simulasi/penyapihan skenario agar pemanggilan `upsertBudget` juga menyertakan `name` (tetap menggunakan fallback jika ada). (files: `src/pages/budgets/simulation/salary/SalarySimulationPage.tsx`, `src/lib/simScenarioApi.ts`)
- Tambah migration SQL `supabase/migrations/20260613000000_budget_name_and_backfill.sql` untuk menambahkan kolom `budgets.name` jika belum ada lalu backfill nilai dari `categories` dan fallback ke `'Budget Tanpa Nama'` untuk baris kosong.
- Tetap mempertahankan kompatibilitas mundur untuk instalasi tanpa pivot table (kode klien menangani error `budget_categories` dan akan tetap bekerja jika migration belum dijalankan).

### Testing

- Menjalankan build produksi dengan `pnpm -s build` berhasil tanpa error (menampilkan beberapa peringatan non-blocking terkait bundling). 
- Menjalankan lint terhadap file-file yang diubah dengan `pnpm -s eslint ...` menghasilkan peringatan konfigurasi repo tetapi tidak error kritikal; tidak ada error runtime dilaporkan.
- Menjalankan dev server (`pnpm -s dev`) lalu mengambil screenshot halaman `http://127.0.0.1:4173/budgets` untuk verifikasi UI (artifact: `browser:/tmp/codex_browser_invocations/.../artifacts/budgets-page.png`).
- Perubahan SQL migrasi baru tersedia di `supabase/migrations/20260613000000_budget_name_and_backfill.sql` dan harus dijalankan di server Supabase untuk mengaktifkan full multi-category behavior dan backfill nama budget.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b640388580832dbbacc645d7a30dd8)