### PR TITLE
Fix monthly multi-category budget create/edit to use single budget row

### DIFF
--- a/src/lib/budgetApi.ts
+++ b/src/lib/budgetApi.ts
@@ -1359,8 +1359,89 @@ export async function upsertBudget(input: UpsertBudgetInput): Promise<BudgetRow>
     new Set((input.category_ids ?? (input.category_id ? [input.category_id] : [])).filter(Boolean))
   );
   const primaryCategoryId = normalizedCategoryIds[0] ?? input.category_id;
-  if (!primaryCategoryId) {
+  if (!primaryCategoryId || normalizedCategoryIds.length === 0) {
     throw new Error('Kategori wajib dipilih');
+  }
+
+  const budgetPayload = {
+    user_id: userId,
+    name: normalizedName,
+    category_id: primaryCategoryId,
+    month: toMonthStart(input.period),
+    period_month: toMonthStart(input.period),
+    amount_planned: Number(input.amount_planned ?? 0),
+    carryover_enabled: Boolean(input.carryover_enabled),
+    notes: input.notes ?? null,
+    budget_type: 'monthly',
+  };
+
+  const syncBudgetCategories = async (budget: BudgetRow): Promise<BudgetRow> => {
+    const { error: deleteLinksError } = await supabase
+      .from('budget_categories')
+      .delete()
+      .eq('budget_id', budget.id);
+
+    if (deleteLinksError) {
+      const message = (deleteLinksError.message ?? '').toLowerCase();
+      if (!(deleteLinksError.code === '42P01' || message.includes('budget_categories'))) {
+        throw deleteLinksError;
+      }
+      return budget;
+    }
+
+    const payloadLinks = normalizedCategoryIds.map((categoryId) => ({
+      budget_id: budget.id,
+      category_id: categoryId,
+      user_id: budget.user_id,
+    }));
+
+    const { error: insertLinksError } = await supabase.from('budget_categories').insert(payloadLinks);
+
+    if (insertLinksError) {
+      const message = (insertLinksError.message ?? '').toLowerCase();
+      if (!(insertLinksError.code === '42P01' || message.includes('budget_categories'))) {
+        throw insertLinksError;
+      }
+      return budget;
+    }
+
+    const [withCategories] = await attachBudgetCategories([budget]);
+    return withCategories;
+  };
+
+  const upsertViaTable = async (): Promise<BudgetRow> => {
+    if (input.id) {
+      const { data, error } = await supabase
+        .from('budgets')
+        .update(budgetPayload)
+        .eq('user_id', userId)
+        .eq('id', input.id)
+        .select('*, category:categories(id,name,type)')
+        .maybeSingle();
+
+      if (error) throw error;
+      if (!data) {
+        throw new Error('Data anggaran tidak ditemukan');
+      }
+
+      return normalizeBudgetRow(data as RawBudgetRow);
+    }
+
+    const { data, error } = await supabase
+      .from('budgets')
+      .insert(budgetPayload)
+      .select('*, category:categories(id,name,type)')
+      .single();
+
+    if (error) throw error;
+    return normalizeBudgetRow(data as RawBudgetRow);
+  };
+
+  try {
+    const normalized = await upsertViaTable();
+    return await syncBudgetCategories(normalized);
+  } catch {
+    // Fallback untuk server lama yang masih bergantung pada RPC.
   }
 
   const payload = {
@@ -1397,39 +1478,7 @@ export async function upsertBudget(input: UpsertBudgetInput): Promise<BudgetRow>
   }
 
   const normalized = normalizeBudgetRow(data as RawBudgetRow);
-
-  if (normalizedCategoryIds.length === 0) {
-    return normalized;
-  }
-
-  const payloadLinks = normalizedCategoryIds.map((categoryId) => ({
-    budget_id: normalized.id,
-    category_id: categoryId,
-    user_id: normalized.user_id,
-  }));
-
-  const { error: upsertLinksError } = await supabase
-    .from('budget_categories')
-    .upsert(payloadLinks, { onConflict: 'budget_id,category_id' });
-
-  if (upsertLinksError) {
-    const msg = (upsertLinksError.message ?? '').toLowerCase();
-    if (!(upsertLinksError.code === '42P01' || msg.includes('budget_categories'))) {
-      throw upsertLinksError;
-    }
-    return normalized;
-  }
-
-  const { error: deleteLinksError } = await supabase
-    .from('budget_categories')
-    .delete()
-    .eq('budget_id', normalized.id)
-    .not('category_id', 'in', `(${normalizedCategoryIds.map((id) => `"${id}"`).join(',')})`);
-
-  if (deleteLinksError) throw deleteLinksError;
-
-  const [withCategories] = await attachBudgetCategories([normalized]);
-  return withCategories;
+  return syncBudgetCategories(normalized);
 }
 
 export async function deleteBudget(id: UUID): Promise<void> {

--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -602,6 +602,7 @@ export default function BudgetsPage() {
         id: row.id,
         name: row.name,
         category_id: row.category_id,
+        category_ids: row.category_ids,
         period: isoToPeriod(row.period_month),
         amount_planned: Number(row.amount_planned ?? 0),
         carryover_enabled: carryover,


### PR DESCRIPTION
### Motivation
- Terdapat bug saat membuat/mengedit budget multi-kategori dimana aplikasi membuat satu row `budgets` per kategori sehingga muncul duplicate budget cards.
- Penyebab utama: alur upsert untuk monthly masih mengandalkan semantics per-`category_id` (RPC lama / constraint `user_id, month, category_id`), bukan membuat satu row `budgets` dan menyimpan relasi di pivot `budget_categories`.

### Description
- Refactor `upsertBudget` di `src/lib/budgetApi.ts` sehingga alur utama sekarang membuat/ обновate hanya satu row di tabel `budgets` (insert untuk create, update by `id` untuk edit) lalu mensinkronisasi relasi kategori di pivot `budget_categories` dengan strategi hapus relasi lama dan insert relasi yang dipilih sekarang.
- Tambahkan fallback ke RPC lama (`bud_monthly_upsert`) untuk kompatibilitas server lama, namun tetap menjalankan sinkronisasi pivot setelah fallback agar hasil akhir konsisten multi-category.
- Perbaiki pemanggilan update kecil (carryover toggle) di `src/pages/budgets/BudgetsPage.tsx` supaya mengirim `category_ids` saat memanggil `upsertBudget` sehingga tidak mereduksi relasi multi-kategori secara tidak sengaja.
- File yang diubah: `src/lib/budgetApi.ts` dan `src/pages/budgets/BudgetsPage.tsx`.

### Testing
- `pnpm -s build` berhasil (production build selesai) so hasil perubahan tidak mematahkan proses build.
- Jalankan lint khusus pada target dengan `pnpm -s eslint src/lib/budgetApi.ts src/pages/budgets/BudgetsPage.tsx` menghasilkan peringatan (repo ESLint config mengabaikan pemanggilan langsung sehingga hanya peringatan), tetapi tidak memperlihatkan error terkait perubahan ini.
- `pnpm -s lint` gagal karena error lint pre-existing di file lain (tidak terkait perubahan ini), sehingga CI lint global masih menampilkan masalah terpisah dari scope PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6473f1d88832d9fdfe96c5539b3cf)