### PR TITLE
feat: align weekly budgets with monthly (named budgets + multi-category)

### DIFF
--- a/src/lib/budgetApi.ts
+++ b/src/lib/budgetApi.ts
@@ -140,7 +140,8 @@ interface RawBudgetCategoryLinkRow {
 interface RawWeeklyBudgetRow {
   id: string;
   user_id: string;
-  category_id: string;
+  name?: string | null;
+  category_id?: string | null;
   amount_planned?: number | string | null;
   planned_amount?: number | string | null;
   carryover_enabled?: boolean | null;
@@ -150,6 +151,13 @@ interface RawWeeklyBudgetRow {
   week_start?: string | null;
   created_at?: string | null;
   updated_at?: string | null;
+  category?: RawBudgetCategory | null;
+  categories?: RawBudgetCategory | null;
+}
+
+interface RawWeeklyBudgetCategoryLinkRow {
+  budget_weekly_id?: string | null;
+  category_id?: string | null;
   category?: RawBudgetCategory | null;
   categories?: RawBudgetCategory | null;
 }
@@ -293,10 +301,16 @@ function normalizeWeeklyBudgetRow(row: RawWeeklyBudgetRow): WeeklyBudgetRow {
   const updatedAtBase = row.updated_at ?? row.created_at;
   const updatedAt = updatedAtBase ? String(updatedAtBase) : createdAt;
 
+  const categoryId = row.category_id ? (String(row.category_id) as UUID) : null;
+  const categoryFallbackName = category?.name?.trim() ?? '';
+  const normalizedName = String(row.name ?? '').trim() || categoryFallbackName || 'Budget Tanpa Nama';
+
   return {
     id: String(row.id) as UUID,
     user_id: String(row.user_id) as UUID,
-    category_id: String(row.category_id) as UUID,
+    name: normalizedName,
+    category_id: categoryId,
+    category_ids: categoryId ? [categoryId] : [],
     amount_planned: Number(resolvedAmount),
     carryover_enabled: resolvedCarry,
     notes: normalizedNotes,
@@ -304,7 +318,53 @@ function normalizeWeeklyBudgetRow(row: RawWeeklyBudgetRow): WeeklyBudgetRow {
     created_at: createdAt,
     updated_at: updatedAt,
     category,
+    categories: category ? [category] : [],
   };
+}
+
+async function attachWeeklyBudgetCategories(rows: WeeklyBudgetRow[]): Promise<WeeklyBudgetRow[]> {
+  if (rows.length === 0) return rows;
+  const budgetIds = rows.map((row) => row.id);
+  const { data, error } = await supabase
+    .from('weekly_budget_categories')
+    .select('budget_weekly_id,category_id,category:categories(id,name,type)')
+    .in('budget_weekly_id', budgetIds);
+
+  if (error) {
+    const message = (error.message ?? '').toLowerCase();
+    if (error.code === '42P01' || message.includes('weekly_budget_categories')) {
+      return rows;
+    }
+    throw error;
+  }
+
+  const map = new Map<string, WeeklyBudgetRow['categories']>();
+  for (const link of (data ?? []) as RawWeeklyBudgetCategoryLinkRow[]) {
+    const budgetId = link.budget_weekly_id ? String(link.budget_weekly_id) : null;
+    const categoryId = link.category_id ? String(link.category_id) : null;
+    if (!budgetId || !categoryId) continue;
+    const raw = link.category ?? link.categories;
+    const list = map.get(budgetId) ?? [];
+    list.push({
+      id: categoryId,
+      name: String(raw?.name ?? 'Tanpa kategori'),
+      type: (raw?.type ?? raw?.category_type ?? null) as 'income' | 'expense' | null,
+    });
+    map.set(budgetId, list);
+  }
+
+  return rows.map((row) => {
+    const linked = map.get(String(row.id));
+    if (!linked || linked.length === 0) return row;
+    const categories = linked.filter((item, index, array) => array.findIndex((entry) => entry.id === item.id) === index);
+    return {
+      ...row,
+      category_ids: categories.map((item) => item.id as UUID),
+      category_id: categories[0]?.id ?? row.category_id,
+      category: categories[0] ?? row.category,
+      categories,
+    };
+  });
 }
 
 function mapCategoryRecordToExpense(category: {
@@ -408,7 +468,9 @@ export interface BudgetSummary {
 export interface WeeklyBudgetRow {
   id: UUID;
   user_id: UUID;
-  category_id: UUID;
+  name: string;
+  category_id: Nullable<UUID>;
+  category_ids: UUID[];
   amount_planned: number;
   carryover_enabled: boolean;
   notes: Nullable<string>;
@@ -420,6 +482,11 @@ export interface WeeklyBudgetRow {
     name: string;
     type?: 'income' | 'expense' | null;
   } | null;
+  categories: Array<{
+    id: UUID;
+    name: string;
+    type?: 'income' | 'expense' | null;
+  }>;
 }
 
 export interface WeeklyBudgetWithSpent extends WeeklyBudgetRow {
@@ -604,9 +671,11 @@ export function getWeeklyTransactionEndExclusive(period: string): string {
 }
 
 interface WeeklyCarryoverEntry {
-  planned_amount: number;
+  name: string;
+  amount_planned: number;
   carryover_enabled: boolean;
   notes: Nullable<string>;
+  category_ids: UUID[];
 }
 
 async function ensureWeeklyCarryover(
@@ -626,7 +695,7 @@ async function ensureWeeklyCarryover(
 
   const { data, error } = await supabase
     .from('budgets_weekly')
-    .select('category_id,planned_amount,carryover_enabled,notes,week_start')
+    .select('id,name,category_id,planned_amount,carryover_enabled,notes,week_start')
     .eq('user_id', userId)
     .gte('week_start', normalizedStart)
     .lt('week_start', rangeEnd)
@@ -634,35 +703,27 @@ async function ensureWeeklyCarryover(
 
   if (error) throw error;
 
+  const normalizedRows = (data ?? []).map((row) => normalizeWeeklyBudgetRow(row as RawWeeklyBudgetRow));
+  const withCategories = await attachWeeklyBudgetCategories(normalizedRows);
+
   const budgetsByWeek = new Map<string, Map<string, WeeklyCarryoverEntry>>();
 
-  for (const row of (data ?? []) as {
-    category_id: UUID | null;
-    planned_amount: number | null;
-    carryover_enabled: boolean | null;
-    notes: Nullable<string>;
-    week_start: string | null;
-  }[]) {
-    const categoryId = row.category_id ?? undefined;
-    const weekStartValue = row.week_start ?? undefined;
-    if (!categoryId || !weekStartValue) continue;
-
-    const normalizedWeekStart = getWeekStartForDate(parseIsoDate(weekStartValue));
+  for (const row of withCategories) {
+    if (!row.id || !row.week_start) continue;
+    const normalizedWeekStart = getWeekStartForDate(parseIsoDate(row.week_start));
     let currentWeekBudgets = budgetsByWeek.get(normalizedWeekStart);
     if (!currentWeekBudgets) {
       currentWeekBudgets = new Map();
       budgetsByWeek.set(normalizedWeekStart, currentWeekBudgets);
     }
 
-    const plannedAmount = Number(row.planned_amount ?? 0);
-    const carryoverEnabled = typeof row.carryover_enabled === 'boolean'
-      ? row.carryover_enabled
-      : Boolean(row.carryover_enabled);
-
-    currentWeekBudgets.set(categoryId, {
-      planned_amount: Number.isFinite(plannedAmount) ? plannedAmount : 0,
-      carryover_enabled: carryoverEnabled,
+    const plannedAmount = Number(row.amount_planned ?? 0);
+    currentWeekBudgets.set(String(row.id), {
+      name: row.name,
+      amount_planned: Number.isFinite(plannedAmount) ? plannedAmount : 0,
+      carryover_enabled: Boolean(row.carryover_enabled),
       notes: row.notes ?? null,
+      category_ids: row.category_ids.length > 0 ? row.category_ids : row.category_id ? [row.category_id] : [],
     });
   }
 
@@ -675,49 +736,46 @@ async function ensureWeeklyCarryover(
     weekStartDates.push(formatIsoDateUTC(current));
   }
 
-  const toInsert: {
-    category_id: UUID;
+  const toInsert: Array<{
+    name: string;
     week_start: string;
     planned_amount: number;
     carryover_enabled: boolean;
     notes: Nullable<string>;
-  }[] = [];
+    category_ids: UUID[];
+  }> = [];
 
   for (const weekStart of weekStartDates) {
     const currentBudgets = budgetsByWeek.get(weekStart);
     if (!currentBudgets) continue;
 
-    for (const [categoryId, budget] of currentBudgets.entries()) {
-      if (!budget.carryover_enabled) continue;
+    for (const budget of currentBudgets.values()) {
+      if (!budget.carryover_enabled || budget.category_ids.length === 0) continue;
 
       const nextWeekDate = parseIsoDate(weekStart);
       nextWeekDate.setUTCDate(nextWeekDate.getUTCDate() + 7);
       if (!(nextWeekDate < endDate)) continue;
 
       const nextWeekStart = formatIsoDateUTC(nextWeekDate);
-      let nextWeekBudgets = budgetsByWeek.get(nextWeekStart);
+      const nextWeekBudgets = budgetsByWeek.get(nextWeekStart);
+      const categoryKey = [...budget.category_ids].sort().join('|');
+      const duplicate = nextWeekBudgets
+        ? Array.from(nextWeekBudgets.values()).some((entry) => [...entry.category_ids].sort().join('|') === categoryKey)
+        : false;
+
+      if (duplicate) continue;
+
       if (!nextWeekBudgets) {
-        nextWeekBudgets = new Map();
-        budgetsByWeek.set(nextWeekStart, nextWeekBudgets);
+        budgetsByWeek.set(nextWeekStart, new Map());
       }
-
-      if (nextWeekBudgets.has(categoryId)) {
-        continue;
-      }
-
-      nextWeekBudgets.set(categoryId, {
-        planned_amount: budget.planned_amount,
-        carryover_enabled: budget.carryover_enabled,
-        notes: budget.notes ?? null,
-      });
 
       toInsert.push({
-        name: normalizedName,
-    category_id: categoryId,
+        name: budget.name,
         week_start: nextWeekStart,
-        planned_amount: budget.planned_amount,
+        planned_amount: budget.amount_planned,
         carryover_enabled: budget.carryover_enabled,
         notes: budget.notes ?? null,
+        category_ids: budget.category_ids,
       });
     }
   }
@@ -726,21 +784,16 @@ async function ensureWeeklyCarryover(
     return;
   }
 
-  const insertPayload = toInsert.map((item) => ({
-    user_id: userId,
-    category_id: item.category_id,
-    planned_amount: item.planned_amount,
-    carryover_enabled: item.carryover_enabled,
-    notes: item.notes ?? null,
-    week_start: item.week_start,
-  }));
-
-  const { error: upsertError } = await supabase
-    .from('budgets_weekly')
-    .upsert(insertPayload, { onConflict: 'user_id,category_id,week_start' });
-
-  if (upsertError) {
-    throw upsertError;
+  for (const item of toInsert) {
+    await upsertWeeklyBudget({
+      name: item.name,
+      category_ids: item.category_ids,
+      category_id: item.category_ids[0],
+      week_start: item.week_start,
+      amount_planned: item.planned_amount,
+      carryover_enabled: item.carryover_enabled,
+      notes: item.notes,
+    });
   }
 }
 
@@ -993,7 +1046,7 @@ export async function listWeeklyBudgets(period: string): Promise<WeeklyBudgetsRe
   const budgetsPromise = supabase
     .from('budgets_weekly')
     .select(
-      'id,user_id,category_id,amount_planned:planned_amount,carryover_enabled,notes,week_start,created_at,updated_at,category:categories(id,name,type)'
+      'id,user_id,name,category_id,amount_planned:planned_amount,carryover_enabled,notes,week_start,created_at,updated_at,category:categories(id,name,type)'
     )
     .eq('user_id', userId)
     .gte('week_start', firstWeekStart)
@@ -1041,35 +1094,48 @@ export async function listWeeklyBudgets(period: string): Promise<WeeklyBudgetsRe
     }
   >();
 
-  const rows = ((budgetsResponse.data ?? []) as WeeklyBudgetRow[]).map((row) => {
+  const normalizedRows = (budgetsResponse.data ?? []).map((row) => normalizeWeeklyBudgetRow(row as RawWeeklyBudgetRow));
+  const rows = (await attachWeeklyBudgetCategories(normalizedRows)).map((row) => {
     const rawWeekStart = row.week_start ?? start;
     const normalizedWeekStart = getWeekStartForDate(parseIsoDate(rawWeekStart));
     const weekEnd = getWeekEndFromStart(normalizedWeekStart);
     const planned = Number(row.amount_planned ?? 0);
-    const transactions = transactionsByCategory.get(row.category_id) ?? [];
-    const spent = transactions.reduce((total, transaction) => {
-      return transaction.date >= normalizedWeekStart && transaction.date <= weekEnd
-        ? total + transaction.amount
-        : total;
+    const categoryIds = row.category_ids.length > 0 ? row.category_ids : row.category_id ? [row.category_id] : [];
+    const spent = categoryIds.reduce((total, categoryId) => {
+      const transactions = transactionsByCategory.get(categoryId) ?? [];
+      const subtotal = transactions.reduce((sum, transaction) => {
+        return transaction.date >= normalizedWeekStart && transaction.date <= weekEnd
+          ? sum + transaction.amount
+          : sum;
+      }, 0);
+      return total + subtotal;
     }, 0);
     const remaining = planned - spent;
     const carryoverEnabled = typeof row.carryover_enabled === 'boolean'
       ? row.carryover_enabled
       : Boolean(row.carryover_enabled);
 
-    if (!summaryAccumulator.has(row.category_id)) {
-      summaryAccumulator.set(row.category_id, {
-        category_id: row.category_id,
-        category_name: row.category?.name ?? 'Tanpa kategori',
-        category_type: row.category?.type ?? null,
-        planned: 0,
-        spent: 0,
-      });
-    }
-    const current = summaryAccumulator.get(row.category_id);
-    if (current) {
-      current.planned += planned;
-      current.spent += spent;
+    const summaryCategories = row.categories.length > 0
+      ? row.categories
+      : row.category && row.category.id
+      ? [row.category]
+      : [];
+
+    for (const category of summaryCategories) {
+      if (!summaryAccumulator.has(category.id)) {
+        summaryAccumulator.set(category.id, {
+          category_id: category.id,
+          category_name: category.name ?? 'Tanpa kategori',
+          category_type: category.type ?? null,
+          planned: 0,
+          spent: 0,
+        });
+      }
+      const current = summaryAccumulator.get(category.id);
+      if (current) {
+        current.planned += planned;
+        current.spent += spent;
+      }
     }
 
     return {
@@ -1128,7 +1194,9 @@ export async function listWeeklyBudgets(period: string): Promise<WeeklyBudgetsRe
 
 export interface UpsertWeeklyBudgetInput {
   id?: UUID;
-  category_id: UUID;
+  name?: string;
+  category_id?: UUID;
+  category_ids?: UUID[];
   week_start: string; // YYYY-MM-DD
   amount_planned: number;
   carryover_enabled: boolean;
@@ -1154,12 +1222,88 @@ export async function upsertWeeklyBudget(input: UpsertWeeklyBudgetInput): Promis
   }
 
   const normalizedWeekStart = normalizeWeekStart(input.week_start);
+  const normalizedCategoryIds = Array.from(
+    new Set(
+      [
+        ...(input.category_ids ?? []),
+        ...(input.category_id ? [input.category_id] : []),
+      ]
+        .map((value) => String(value || '').trim())
+        .filter(Boolean)
+    )
+  );
+
+  if (normalizedCategoryIds.length === 0) {
+    throw new Error('Pilih minimal 1 kategori');
+  }
+
+  const normalizedName = String(input.name ?? '').trim() || 'Budget Tanpa Nama';
+
+  if (input.id) {
+    const { error: updateError } = await supabase
+      .from('budgets_weekly')
+      .update({
+        name: normalizedName,
+        planned_amount: Number(input.amount_planned ?? 0),
+        carryover_enabled: Boolean(input.carryover_enabled),
+        notes: input.notes ?? null,
+        week_start: normalizedWeekStart,
+      })
+      .eq('id', input.id)
+      .eq('user_id', userId);
+
+    if (updateError) {
+      throw new Error(updateError.message || 'Gagal menyimpan anggaran mingguan');
+    }
+
+    const { error: deleteLinkError } = await supabase
+      .from('weekly_budget_categories')
+      .delete()
+      .eq('user_id', userId)
+      .eq('budget_weekly_id', input.id);
+
+    if (deleteLinkError) {
+      const message = (deleteLinkError.message ?? '').toLowerCase();
+      if (!(deleteLinkError.code === '42P01' || message.includes('weekly_budget_categories'))) {
+        throw deleteLinkError;
+      }
+    }
+
+    const { error: insertLinkError } = await supabase
+      .from('weekly_budget_categories')
+      .insert(
+        normalizedCategoryIds.map((categoryId) => ({
+          user_id: userId,
+          budget_weekly_id: input.id,
+          category_id: categoryId,
+        }))
+      );
+
+    if (insertLinkError) {
+      const message = (insertLinkError.message ?? '').toLowerCase();
+      if (!(insertLinkError.code === '42P01' || message.includes('weekly_budget_categories'))) {
+        throw insertLinkError;
+      }
+    }
+
+    const { data, error } = await supabase
+      .from('budgets_weekly')
+      .select('id,user_id,name,category_id,planned_amount,carryover_enabled,notes,week_start,created_at,updated_at,category:categories(id,name,type)')
+      .eq('id', input.id)
+      .single();
+
+    if (error) throw error;
+    const [withCats] = await attachWeeklyBudgetCategories([normalizeWeeklyBudgetRow(data as RawWeeklyBudgetRow)]);
+    return withCats;
+  }
+
   const payload = {
-    p_category_id: input.category_id,
+    p_category_id: normalizedCategoryIds[0],
     p_week_start: normalizedWeekStart,
     p_planned_amount: Number(input.amount_planned ?? 0),
     p_carryover_enabled: Boolean(input.carryover_enabled),
     p_notes: input.notes ?? null,
+    p_name: normalizedName,
   };
 
   const { data, error } = await supabase.rpc('bud_weekly_upsert', payload);
@@ -1186,7 +1330,40 @@ export async function upsertWeeklyBudget(input: UpsertWeeklyBudgetInput): Promis
     throw new Error('Tidak ada data yang dikembalikan dari bud_weekly_upsert');
   }
 
-  return normalizeWeeklyBudgetRow(data as RawWeeklyBudgetRow);
+  const row = normalizeWeeklyBudgetRow(data as RawWeeklyBudgetRow);
+
+  const { error: deleteLinkError } = await supabase
+    .from('weekly_budget_categories')
+    .delete()
+    .eq('user_id', userId)
+    .eq('budget_weekly_id', row.id);
+
+  if (deleteLinkError) {
+    const message = (deleteLinkError.message ?? '').toLowerCase();
+    if (!(deleteLinkError.code === '42P01' || message.includes('weekly_budget_categories'))) {
+      throw deleteLinkError;
+    }
+  }
+
+  const { error: insertLinkError } = await supabase
+    .from('weekly_budget_categories')
+    .insert(
+      normalizedCategoryIds.map((categoryId) => ({
+        user_id: userId,
+        budget_weekly_id: row.id,
+        category_id: categoryId,
+      }))
+    );
+
+  if (insertLinkError) {
+    const message = (insertLinkError.message ?? '').toLowerCase();
+    if (!(insertLinkError.code === '42P01' || message.includes('weekly_budget_categories'))) {
+      throw insertLinkError;
+    }
+  }
+
+  const [withCats] = await attachWeeklyBudgetCategories([row]);
+  return withCats;
 }
 
 export async function deleteWeeklyBudget(id: UUID): Promise<void> {
@@ -1196,6 +1373,20 @@ export async function deleteWeeklyBudget(id: UUID): Promise<void> {
     await removeSync('budgets_weekly', id);
     return;
   }
+
+  const { error: deleteLinkError } = await supabase
+    .from('weekly_budget_categories')
+    .delete()
+    .eq('user_id', userId)
+    .eq('budget_weekly_id', id);
+
+  if (deleteLinkError) {
+    const message = (deleteLinkError.message ?? '').toLowerCase();
+    if (!(deleteLinkError.code === '42P01' || message.includes('weekly_budget_categories'))) {
+      throw deleteLinkError;
+    }
+  }
+
   const { error } = await supabase.from('budgets_weekly').delete().eq('user_id', userId).eq('id', id);
   if (error) throw error;
 }

--- a/src/pages/budgets/BudgetsPage.tsx
+++ b/src/pages/budgets/BudgetsPage.tsx
@@ -91,7 +91,8 @@ const DEFAULT_MONTHLY_FORM: BudgetFormValues = {
 
 const DEFAULT_WEEKLY_FORM: WeeklyBudgetFormValues = {
   week_start: getFirstWeekStartOfPeriod(getCurrentPeriod()),
-  category_id: '',
+  name: '',
+  category_ids: [],
   amount_planned: 0,
   carryover_enabled: false,
   notes: '',
@@ -262,11 +263,23 @@ export default function BudgetsPage() {
     }
 
     for (const row of weekly.rows) {
-      ensureBudgetCategory(row.category_id, row.category ?? undefined);
+      if (row.categories.length > 0) {
+        for (const category of row.categories) {
+          ensureBudgetCategory(category.id, category);
+        }
+      } else {
+        ensureBudgetCategory(row.category_id, row.category ?? undefined);
+      }
     }
 
     ensureBudgetCategory(editingMonthly?.category_id, editingMonthly?.category ?? undefined);
-    ensureBudgetCategory(editingWeekly?.category_id, editingWeekly?.category ?? undefined);
+    if (editingWeekly?.categories.length) {
+      for (const category of editingWeekly.categories) {
+        ensureBudgetCategory(category.id, category);
+      }
+    } else {
+      ensureBudgetCategory(editingWeekly?.category_id, editingWeekly?.category ?? undefined);
+    }
 
     fallback.sort((a, b) => a.name.localeCompare(b.name, 'id-ID', { sensitivity: 'base' }));
 
@@ -296,7 +309,12 @@ export default function BudgetsPage() {
     if (editingWeekly) {
       return {
         week_start: editingWeekly.week_start,
-        category_id: editingWeekly.category_id ?? '',
+        name: editingWeekly.name ?? '',
+        category_ids: editingWeekly.category_ids.length > 0
+          ? editingWeekly.category_ids
+          : editingWeekly.category_id
+          ? [editingWeekly.category_id]
+          : [],
         amount_planned: Number(editingWeekly.amount_planned ?? 0),
         carryover_enabled: editingWeekly.carryover_enabled,
         notes: editingWeekly.notes ?? '',
@@ -330,9 +348,8 @@ export default function BudgetsPage() {
     for (const selection of highlightSelections) {
       if (selection.budget_type !== 'weekly') continue;
       const match = weekly.rows.find((row) => String(row.id) === String(selection.budget_id));
-      if (match?.category_id) {
-        categoryIds.add(String(match.category_id));
-      }
+      const ids = match?.category_ids?.length ? match.category_ids : match?.category_id ? [match.category_id] : [];
+      ids.forEach((id) => categoryIds.add(String(id)));
     }
     return categoryIds;
   }, [highlightSelections, weekly.rows]);
@@ -618,7 +635,9 @@ export default function BudgetsPage() {
     try {
       await upsertWeeklyBudget({
         id: row.id,
-        category_id: row.category_id,
+        name: row.name,
+        category_id: row.category_id ?? undefined,
+        category_ids: row.category_ids,
         week_start: row.week_start,
         amount_planned: Number(row.amount_planned ?? 0),
         carryover_enabled: carryover,
@@ -661,7 +680,9 @@ export default function BudgetsPage() {
       setSubmittingWeekly(true);
       await upsertWeeklyBudget({
         id: editingWeekly?.id,
-        category_id: values.category_id,
+        name: values.name,
+        category_id: values.category_ids[0],
+        category_ids: values.category_ids,
         week_start: values.week_start,
         amount_planned: Number(values.amount_planned),
         carryover_enabled: values.carryover_enabled,
@@ -727,8 +748,8 @@ export default function BudgetsPage() {
         const selectionForCategory = highlightSelections.find((selection) => {
           if (selection.budget_type !== 'weekly') return false;
           const match = weekly.rows.find((row) => String(row.id) === String(selection.budget_id));
-          if (!match?.category_id) return false;
-          return String(match.category_id) === normalizedCategoryId;
+          const ids = match?.category_ids?.length ? match.category_ids : match?.category_id ? [match.category_id] : [];
+          return ids.some((id) => String(id) === normalizedCategoryId);
         });
 
         if (selectionForCategory && String(selectionForCategory.budget_id) !== String(id)) {
@@ -871,6 +892,7 @@ export default function BudgetsPage() {
             onDelete={handleDeleteWeekly}
             onViewTransactions={(row) =>
               handleViewTransactions({
+                categoryIds: row.category_ids,
                 categoryId: row.category_id,
                 categoryType: row.category?.type ?? null,
                 range: 'custom',
@@ -879,7 +901,7 @@ export default function BudgetsPage() {
               })
             }
             onToggleCarryover={handleToggleWeeklyCarryover}
-            onToggleHighlight={(row) => handleToggleHighlight('weekly', String(row.id), row.category_id)}
+            onToggleHighlight={(row) => handleToggleHighlight('weekly', String(row.id), row.category_ids[0] ?? row.category_id)}
           />
         </Section>
       )}

--- a/src/pages/budgets/components/WeeklyBudgetFormModal.tsx
+++ b/src/pages/budgets/components/WeeklyBudgetFormModal.tsx
@@ -3,7 +3,8 @@ import type { ExpenseCategory } from '../../../lib/budgetApi';
 
 export interface WeeklyBudgetFormValues {
   week_start: string;
-  category_id: string;
+  name: string;
+  category_ids: string[];
   amount_planned: number;
   carryover_enabled: boolean;
   notes: string;
@@ -67,8 +68,11 @@ function validate(values: WeeklyBudgetFormValues) {
   if (!values.week_start) {
     errors.week_start = 'Tanggal minggu wajib diisi';
   }
-  if (!values.category_id) {
-    errors.category_id = 'Kategori wajib dipilih';
+  if (!values.name.trim()) {
+    errors.name = 'Nama budget wajib diisi';
+  }
+  if (!values.category_ids.length) {
+    errors.category_ids = 'Pilih minimal 1 kategori';
   }
   if (!Number.isFinite(values.amount_planned) || values.amount_planned <= 0) {
     errors.amount_planned = 'Nilai anggaran harus lebih dari 0';
@@ -217,35 +221,85 @@ export default function WeeklyBudgetFormModal({
             </label>
 
             <label className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">
-              Kategori
-              <select
-                value={values.category_id}
-                onChange={(event) => handleChange('category_id', event.target.value)}
+              Nama Budget
+              <input
+                type="text"
+                value={values.name}
+                onChange={(event) => handleChange('name', event.target.value)}
                 className="h-11 w-full rounded-2xl border border-border bg-surface px-4 text-sm text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+                placeholder="Contoh: Makan Harian"
                 required
-                disabled={categories.length === 0}
-              >
-                <option value="" disabled>
-                  Pilih kategori
-                </option>
-                {groupedCategories.ungrouped.map((category) => (
-                  <option key={category.id} value={category.id}>
-                    {category.name}
-                  </option>
-                ))}
-                {groupedCategories.groups.map(([groupName, groupCategories]) => (
-                  <optgroup key={groupName} label={groupName}>
-                    {groupCategories.map((category) => (
-                      <option key={category.id} value={category.id}>
-                        {category.name}
-                      </option>
-                    ))}
-                  </optgroup>
-                ))}
-              </select>
-              {errors.category_id ? <span className="text-xs font-medium text-rose-500">{errors.category_id}</span> : null}
+              />
+              {errors.name ? <span className="text-xs font-medium text-rose-500">{errors.name}</span> : null}
             </label>
           </div>
+
+          <div className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">
+            Kategori (bisa lebih dari satu)
+            <div className="max-h-52 overflow-auto rounded-2xl border border-border bg-surface/80 p-2">
+              <div className="flex flex-wrap gap-2">
+                {groupedCategories.ungrouped.map((category) => {
+                  const active = values.category_ids.includes(category.id);
+                  return (
+                    <button
+                      key={category.id}
+                      type="button"
+                      onClick={() => {
+                        setValues((prev) => ({
+                          ...prev,
+                          category_ids: active
+                            ? prev.category_ids.filter((id) => id !== category.id)
+                            : [...prev.category_ids, category.id],
+                        }));
+                      }}
+                      className={`rounded-full px-3 py-1.5 text-xs font-medium transition ${
+                        active
+                          ? 'bg-brand/20 text-brand ring-1 ring-brand/40'
+                          : 'bg-muted/20 text-muted-foreground hover:text-text'
+                      }`}
+                    >
+                      {category.name}
+                    </button>
+                  );
+                })}
+                {groupedCategories.groups.map(([groupName, groupCategories]) => (
+                  <div key={groupName} className="w-full">
+                    <p className="mb-2 mt-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                      {groupName}
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      {groupCategories.map((category) => {
+                        const active = values.category_ids.includes(category.id);
+                        return (
+                          <button
+                            key={category.id}
+                            type="button"
+                            onClick={() => {
+                              setValues((prev) => ({
+                                ...prev,
+                                category_ids: active
+                                  ? prev.category_ids.filter((id) => id !== category.id)
+                                  : [...prev.category_ids, category.id],
+                              }));
+                            }}
+                            className={`rounded-full px-3 py-1.5 text-xs font-medium transition ${
+                              active
+                                ? 'bg-brand/20 text-brand ring-1 ring-brand/40'
+                                : 'bg-muted/20 text-muted-foreground hover:text-text'
+                            }`}
+                          >
+                            {category.name}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+            {errors.category_ids ? <span className="text-xs font-medium text-rose-500">{errors.category_ids}</span> : null}
+          </div>
+
 
           <label className="flex flex-col gap-2 text-sm font-medium text-zinc-600 dark:text-zinc-300">
             Nominal

--- a/src/pages/budgets/components/WeeklyBudgetsGrid.tsx
+++ b/src/pages/budgets/components/WeeklyBudgetsGrid.tsx
@@ -125,17 +125,20 @@ export default function WeeklyBudgetsGrid({
         const displayPercentage = Math.max(0, Math.min(100, Math.round(rawPercentage)));
         const progressColor = getProgressColor(rawPercentage);
         const carryoverEnabled = Boolean(row.carryover_enabled);
-        const categoryKey = row.category_id ? String(row.category_id) : null;
+        const categoryIds = row.category_ids.length > 0 ? row.category_ids : row.category_id ? [row.category_id] : [];
         const isHighlighted =
-          highlightSet.has(String(row.id)) || (categoryKey ? highlightCategorySet.has(categoryKey) : false);
+          highlightSet.has(String(row.id)) || categoryIds.some((id) => highlightCategorySet.has(String(id)));
 
         const categoryType = row.category?.type === 'income' ? 'Pemasukan' : 'Pengeluaran';
         const categoryTypeClass = row.category?.type === 'income'
           ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-300'
           : 'bg-rose-500/10 text-rose-600 dark:text-rose-300';
 
+        const budgetName = row.name?.trim() || row.category?.name || 'Budget Tanpa Nama';
         const categoryName = row.category?.name ?? 'Tanpa kategori';
-        const categoryInitial = categoryName.trim().charAt(0).toUpperCase() || 'B';
+        const categoryInitial = budgetName.trim().charAt(0).toUpperCase() || 'B';
+        const visibleCategories = row.categories.slice(0, 2);
+        const overflowCount = Math.max(0, row.categories.length - visibleCategories.length);
         const periodLabel = formatRange(row.week_start, row.week_end);
 
         const notes = row.notes?.trim();
@@ -170,7 +173,7 @@ export default function WeeklyBudgetsGrid({
               <div className="min-w-0 flex-1 space-y-2">
                 <div className="flex flex-wrap items-center gap-2">
                   <h3 className="line-clamp-1 break-words text-base font-semibold leading-tight tracking-tight text-text md:line-clamp-2 md:text-lg">
-                    {categoryName}
+                    {budgetName}
                   </h3>
                   <span
                     className={clsx(
@@ -186,6 +189,21 @@ export default function WeeklyBudgetsGrid({
                   {isHighlighted ? (
                     <span className="inline-flex items-center gap-1 shrink-0 rounded-full bg-brand/10 px-3 py-1 text-[0.68rem] font-semibold uppercase tracking-wide text-brand shadow-sm ring-1 ring-brand/40">
                       <Sparkles className="h-3.5 w-3.5" /> Highlight
+                    </span>
+                  ) : null}
+                </div>
+                <div className="flex flex-wrap items-center gap-1.5">
+                  {visibleCategories.map((category) => (
+                    <span
+                      key={category.id}
+                      className="inline-flex items-center rounded-full bg-muted/30 px-2.5 py-1 text-[0.68rem] font-semibold text-muted-foreground"
+                    >
+                      {category.name}
+                    </span>
+                  ))}
+                  {overflowCount > 0 ? (
+                    <span className="inline-flex items-center rounded-full bg-muted/30 px-2.5 py-1 text-[0.68rem] font-semibold text-muted-foreground">
+                      +{overflowCount}
                     </span>
                   ) : null}
                 </div>
@@ -210,7 +228,7 @@ export default function WeeklyBudgetsGrid({
                 <RefreshCcw className="h-4 w-4 shrink-0" />
                 <span className="hidden whitespace-nowrap sm:inline">Carryover</span>
                 <span className="sm:hidden">CO</span>
-                <label className="relative inline-flex h-6 w-11 cursor-pointer items-center" aria-label={`Atur carryover untuk ${categoryName}`}>
+                <label className="relative inline-flex h-6 w-11 cursor-pointer items-center" aria-label={`Atur carryover untuk ${budgetName}`}>
                   <input
                     type="checkbox"
                     checked={carryoverEnabled}
@@ -258,7 +276,7 @@ export default function WeeklyBudgetsGrid({
                 type="button"
                 onClick={() => onViewTransactions(row)}
                 className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-white/10 bg-surface/80 text-muted-foreground transition hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-                aria-label={`Lihat transaksi untuk ${categoryName}`}
+                aria-label={`Lihat transaksi untuk ${budgetName}`}
               >
                 <Eye className="h-4 w-4" />
               </button>
@@ -266,7 +284,7 @@ export default function WeeklyBudgetsGrid({
                 type="button"
                 onClick={() => onToggleHighlight(row)}
                 aria-pressed={isHighlighted}
-                aria-label={`${isHighlighted ? 'Hapus' : 'Tambah'} highlight untuk ${categoryName}`}
+                aria-label={`${isHighlighted ? 'Hapus' : 'Tambah'} highlight untuk ${budgetName}`}
                 className={clsx(
                   'inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]',
                   isHighlighted
@@ -280,7 +298,7 @@ export default function WeeklyBudgetsGrid({
                 type="button"
                 onClick={() => onEdit(row)}
                 className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-white/10 bg-surface/80 text-muted-foreground transition hover:text-text shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)]"
-                aria-label={`Edit ${categoryName}`}
+                aria-label={`Edit ${budgetName}`}
               >
                 <Pencil className="h-4 w-4" />
               </button>
@@ -288,7 +306,7 @@ export default function WeeklyBudgetsGrid({
                 type="button"
                 onClick={() => onDelete(row)}
                 className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-rose-500/40 bg-rose-500/10 text-rose-500 transition hover:text-rose-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400/50 dark:border-rose-500/30 dark:text-rose-200"
-                aria-label={`Hapus ${categoryName}`}
+                aria-label={`Hapus ${budgetName}`}
               >
                 <Trash2 className="h-4 w-4" />
               </button>

--- a/supabase/migrations/20260614000000_upgrade_weekly_budget_name_and_multi_category.sql
+++ b/supabase/migrations/20260614000000_upgrade_weekly_budget_name_and_multi_category.sql
@@ -1,0 +1,139 @@
+alter table if exists public.budgets_weekly
+  add column if not exists name text;
+
+update public.budgets_weekly bw
+set name = coalesce(nullif(btrim(c.name), ''), 'Budget Mingguan')
+from public.categories c
+where bw.category_id = c.id
+  and (bw.name is null or btrim(bw.name) = '');
+
+update public.budgets_weekly
+set name = 'Budget Mingguan'
+where name is null or btrim(name) = '';
+
+alter table if exists public.budgets_weekly
+  alter column name set not null;
+
+create table if not exists public.weekly_budget_categories (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  budget_weekly_id uuid not null references public.budgets_weekly (id) on delete cascade,
+  category_id uuid not null references public.categories (id) on delete cascade,
+  created_at timestamptz not null default timezone('utc', now()),
+  unique (budget_weekly_id, category_id)
+);
+
+create index if not exists weekly_budget_categories_user_idx on public.weekly_budget_categories (user_id);
+create index if not exists weekly_budget_categories_budget_idx on public.weekly_budget_categories (budget_weekly_id);
+create index if not exists weekly_budget_categories_category_idx on public.weekly_budget_categories (category_id);
+
+alter table public.weekly_budget_categories enable row level security;
+
+create policy if not exists "Weekly budget categories select" on public.weekly_budget_categories
+for select using (user_id = auth.uid());
+
+create policy if not exists "Weekly budget categories insert" on public.weekly_budget_categories
+for insert with check (user_id = auth.uid());
+
+create policy if not exists "Weekly budget categories update" on public.weekly_budget_categories
+for update using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+create policy if not exists "Weekly budget categories delete" on public.weekly_budget_categories
+for delete using (user_id = auth.uid());
+
+insert into public.weekly_budget_categories (user_id, budget_weekly_id, category_id)
+select bw.user_id, bw.id, bw.category_id
+from public.budgets_weekly bw
+left join public.weekly_budget_categories wbc
+  on wbc.budget_weekly_id = bw.id and wbc.category_id = bw.category_id
+where bw.category_id is not null
+  and wbc.id is null;
+
+create or replace function public.bud_weekly_upsert(
+  p_category_id uuid,
+  p_week_start date,
+  p_planned_amount numeric,
+  p_carryover_enabled boolean default false,
+  p_notes text default null,
+  p_name text default null
+) returns public.budgets_weekly
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_week_start date := p_week_start;
+  v_amount numeric := p_planned_amount;
+  v_notes text := nullif(btrim(p_notes), '');
+  v_name text := nullif(btrim(p_name), '');
+  v_carryover boolean := coalesce(p_carryover_enabled, false);
+  v_budget public.budgets_weekly;
+begin
+  if v_user_id is null then
+    raise exception 'User tidak terautentik' using errcode = 'P0001';
+  end if;
+
+  if p_category_id is null then
+    raise exception 'Kategori wajib dipilih' using errcode = 'P0001';
+  end if;
+
+  if v_week_start is null then
+    raise exception 'Tanggal mulai minggu wajib diisi' using errcode = 'P0001';
+  end if;
+
+  v_week_start := date_trunc('day', v_week_start)::date;
+
+  if extract(dow from v_week_start) <> 1 then
+    raise exception 'Tanggal mulai minggu harus hari Senin' using errcode = 'P0001';
+  end if;
+
+  if v_amount is null then
+    raise exception 'Nominal anggaran wajib diisi' using errcode = 'P0001';
+  end if;
+
+  if v_amount < 0 then
+    raise exception 'Nominal anggaran tidak boleh negatif' using errcode = 'P0001';
+  end if;
+
+  if v_name is null then
+    select coalesce(nullif(btrim(c.name), ''), 'Budget Mingguan')
+      into v_name
+    from public.categories c
+    where c.id = p_category_id;
+
+    v_name := coalesce(v_name, 'Budget Mingguan');
+  end if;
+
+  insert into public.budgets_weekly (
+    user_id,
+    name,
+    category_id,
+    week_start,
+    planned_amount,
+    carryover_enabled,
+    notes
+  )
+  values (
+    v_user_id,
+    v_name,
+    p_category_id,
+    v_week_start,
+    v_amount,
+    v_carryover,
+    v_notes
+  )
+  on conflict (user_id, category_id, week_start)
+  do update
+    set name = excluded.name,
+        planned_amount = excluded.planned_amount,
+        carryover_enabled = excluded.carryover_enabled,
+        notes = excluded.notes,
+        updated_at = timezone('utc', now())
+  returning * into v_budget;
+
+  return v_budget;
+end;
+$$;
+
+grant execute on function public.bud_weekly_upsert(uuid, date, numeric, boolean, text, text) to authenticated;


### PR DESCRIPTION
### Motivation
- Bring weekly budgets to parity with monthly budgets by adding a custom `name` and support for multiple categories per weekly budget so a single weekly budget can aggregate transactions from several categories.
- Preserve existing behavior (carryover, progress, highlight, edit/delete flows) while extending weekly logic, queries, forms, and UI to work with multi-category budgets.

### Description
- Database and RPC: add migration `supabase/migrations/20260614000000_upgrade_weekly_budget_name_and_multi_category.sql` that adds `name` to `budgets_weekly`, creates pivot `weekly_budget_categories`, backfills existing data, adds RLS/policies and extends `bud_weekly_upsert` to accept `p_name`.
- API / logic: update `src/lib/budgetApi.ts` to change weekly types (`WeeklyBudgetRow`/`UpsertWeeklyBudgetInput`), implement `attachWeeklyBudgetCategories`, change `listWeeklyBudgets` to sum transactions across all linked categories, update `ensureWeeklyCarryover` to carryover by category-sets, and modify `upsertWeeklyBudget` / `deleteWeeklyBudget` to synchronize `weekly_budget_categories`.
- Forms / pages: update `src/pages/budgets/components/WeeklyBudgetFormModal.tsx` to include `Nama Budget` and multi-select category chips and adjust validation; update `src/pages/budgets/BudgetsPage.tsx` to pass and handle `name` / `category_ids` for weekly flows; update `src/pages/budgets/components/WeeklyBudgetsGrid.tsx` to display budget `name`, show category chips with `+N` overflow, and make highlight/view actions category-aware.
- Misc: keep backwards-compatible fallbacks when pivot table / migration is not present and preserve original carryover/progress/highlight UX.

### Testing
- Ran unit tests with `pnpm -s test src/lib/budgetApi.test.ts` and the budget API tests passed (2 tests passed).
- Built production bundle with `pnpm -s build` and the build completed successfully.
- Ran the dev server and captured a visual snapshot of `/budgets` to validate the updated weekly UI (artifact: `weekly-budget-page.png`).
- Ran linting and noted existing repository lint issues unrelated to these changes; ESLint run on the modified files reported only environment warnings about config (no new errors blocking the change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b64a165ee8832da1b1aea64ac8a974)