### PR TITLE
Fix Fonnte anti-loop false positives and waMessageId fallback collisions

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -111,7 +111,12 @@ function extractDevice(body: WebhookBody): string {
 
 function extractWaMessageId(body: WebhookBody, sender: string, message: string): string {
   const raw =
-    body.id ?? body.message_id ?? body.msg_id ?? body.data?.id ?? body.data?.message_id ?? `${sender}-${message}`;
+    body.id ??
+    body.message_id ??
+    body.msg_id ??
+    body.data?.id ??
+    body.data?.message_id ??
+    `${sender}-${message}-${Date.now()}`;
   return String(raw);
 }
 
@@ -402,8 +407,9 @@ function isBotReply(body: WebhookBody, sender: string, device: string, message: 
       body.data?.from_me === true ||
       body.data?.fromMe === true ||
       body.data?.isMe === true ||
-      body.status === true ||
       statusText === "sent" ||
+      statusText === "delivered" ||
+      statusText === "read" ||
       (sender && device && sender === device) ||
       text.includes("sent via fonnte.com") ||
       hasBotPrefix,
@@ -721,7 +727,7 @@ Deno.serve(async (req: Request) => {
     try {
       if (waMessageId || sender || message) {
         await logMessage({
-          wa_message_id: waMessageId || `${sender}-${message || "empty"}`,
+          wa_message_id: waMessageId || `${sender}-${message || "empty"}-${Date.now()}`,
           phone: sender || "",
           user_id: userId,
           raw_text: message || "",


### PR DESCRIPTION
### Motivation
- Incoming Fonnte webhooks sometimes include `status: true`, which caused the bot to treat user messages as self/bot replies and ignore them, making the WhatsApp bot unresponsive.
- Repeated identical user commands produced the same fallback message ID and were marked as duplicates, preventing replies to repeated commands like `menu`.
- The goal is to stop false-positive anti-loop detection and avoid fallback ID collisions while preserving existing command handling behavior.

### Description
- Updated `isBotReply` to remove the `body.status === true` check and instead use normalized `status` text checks for `sent`, `delivered`, and `read`, while keeping other anti-loop heuristics; implemented in `isBotReply(body, sender, device, message)`.
- Changed `extractWaMessageId` fallback to include a timestamp by returning `${sender}-${message}-${Date.now()}` when no explicit ID is present.
- Updated the error-path fallback `wa_message_id` used in `logMessage` on exceptions to also append `-${Date.now()}` to avoid collisions.
- Confirmed that no command-handling branches (menu/saldo/summary/riwayat/budget/kategori/akun/info/ping/tambah transaksi/transfer/hapus/undo) were modified.

### Testing
- Attempted to run `deno check supabase/functions/fonnte-webhook-v2/index.ts`, but it failed in this environment because `deno` is not available (`deno: command not found`).
- No other automated test suite was executed in the runtime; recommend running `deno check` and CI/unit tests in the target environment to validate runtime types and behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a133a0188a8832d867cb751ee1c8276)