### PR TITLE
Improve webhook UX: compact menu, stable history, and monthly+weekly budgets

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -67,7 +67,7 @@ const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 const FONNTE_TOKEN = Deno.env.get("FONNTE_TOKEN") ?? "";
 
-const BOT_PREFIXES = ["🤖", "✅", "❌", "⚠️", "💰", "ℹ️", "📊", "📚", "🏦", "📌", "🗑️", "🧾", "🎯", "🔁", "🏓", "📋", "📆"];
+const BOT_PREFIXES = ["🤖", "✅", "❌", "⚠️", "💰", "ℹ️", "📊", "📚", "🏦", "📌", "🗑️", "🧾", "🎯", "🔁", "🏓", "📋", "📆", "🗓️"];
 const MENU_COMMANDS = new Set(["menu", "help", "bantuan", ".menu"]);
 
 const supabase: SupabaseClient = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
@@ -154,6 +154,26 @@ function getNextMonthStart(date = new Date()): string {
   const y = String(next.getFullYear());
   const m = String(next.getMonth() + 1).padStart(2, "0");
   return `${y}-${m}-01`;
+}
+
+function getWeekStartJakarta(date = new Date()): string {
+  const jakarta = new Date(date.toLocaleString("en-US", { timeZone: "Asia/Jakarta" }));
+  const day = jakarta.getDay();
+  const offset = day === 0 ? 6 : day - 1;
+  jakarta.setDate(jakarta.getDate() - offset);
+  const y = String(jakarta.getFullYear());
+  const m = String(jakarta.getMonth() + 1).padStart(2, "0");
+  const d = String(jakarta.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+function getNextWeekStartJakarta(date = new Date()): string {
+  const weekStart = new Date(`${getWeekStartJakarta(date)}T00:00:00+07:00`);
+  weekStart.setDate(weekStart.getDate() + 7);
+  const y = String(weekStart.getFullYear());
+  const m = String(weekStart.getMonth() + 1).padStart(2, "0");
+  const d = String(weekStart.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
 }
 
 async function replyWhatsApp(target: string, message: string): Promise<void> {
@@ -352,45 +372,144 @@ async function getMonthlyBudgetInfo(userId: string, categoryName: string): Promi
   return { categoryNames, planned, used, remaining, percentage };
 }
 
-function buildBudgetLines(info: BudgetInfo): string {
-  const lines = [
-    "📊 Info Budget",
-    `Kategori: ${info.categoryNames.join(", ")}`,
-    `Terpakai: ${formatIDR(info.used)} / ${formatIDR(info.planned)}`,
-    `Sisa: ${formatIDR(info.remaining)}`,
-  ];
-  if (info.percentage >= 80) {
-    lines.push(`⚠️ Budget hampir habis (${info.percentage.toFixed(1)}%)`);
+async function getWeeklyBudgetInfo(userId: string, categoryName: string): Promise<BudgetInfo | null> {
+  const category = await findCategory(userId, categoryName);
+  if (!category) return null;
+
+  const weekStart = getWeekStartJakarta();
+  const nextWeekStart = getNextWeekStartJakarta();
+
+  let budgetsWeekly: Array<Record<string, JsonValue>> = [];
+  const baseQuery = () => supabase
+    .from("budgets_weekly")
+    .select("id,amount_planned,planned,amount,category_id,name,week_start,start_date")
+    .eq("user_id", userId)
+    .eq("category_id", category.id);
+
+  const { data: byWeekStart, error: byWeekStartErr } = await baseQuery().eq("week_start", weekStart);
+  if (!byWeekStartErr) {
+    budgetsWeekly = (byWeekStart ?? []) as Array<Record<string, JsonValue>>;
+  } else {
+    const { data: byStartDate, error: byStartDateErr } = await baseQuery().eq("start_date", weekStart);
+    if (!byStartDateErr) {
+      budgetsWeekly = (byStartDate ?? []) as Array<Record<string, JsonValue>>;
+    } else {
+      const { data: fallbackDirect, error: fallbackErr } = await baseQuery();
+      if (!fallbackErr) budgetsWeekly = (fallbackDirect ?? []) as Array<Record<string, JsonValue>>;
+    }
   }
-  return lines.join("\n");
+
+  let pickedBudget: Record<string, JsonValue> | null = budgetsWeekly[0] ?? null;
+  let categoryIds: string[] = [category.id];
+
+  if (!pickedBudget) {
+    const { data: links, error: linkErr } = await supabase
+      .from("weekly_budget_categories")
+      .select("budget_weekly_id")
+      .eq("category_id", category.id);
+
+    if (!linkErr && links && links.length > 0) {
+      const budgetWeeklyIds = links.map((v: Record<string, JsonValue>) => String(v.budget_weekly_id));
+      if (budgetWeeklyIds.length > 0) {
+        const { data: weeklyRows, error: weeklyRowsErr } = await supabase
+          .from("budgets_weekly")
+          .select("id,amount_planned,planned,amount,category_id,name,week_start,start_date")
+          .eq("user_id", userId)
+          .in("id", budgetWeeklyIds);
+        if (!weeklyRowsErr && weeklyRows && weeklyRows.length > 0) {
+          pickedBudget = weeklyRows.find((row: Record<string, JsonValue>) => String(row.week_start ?? row.start_date ?? "") === weekStart) ?? weeklyRows[0];
+        }
+      }
+    }
+  }
+
+  if (!pickedBudget) return null;
+
+  const weeklyBudgetId = String(pickedBudget.id ?? "");
+  const planned = Number(pickedBudget.amount_planned ?? pickedBudget.planned ?? pickedBudget.amount ?? 0);
+
+  const { data: linkedCats, error: linkedCatsErr } = await supabase
+    .from("weekly_budget_categories")
+    .select("category_id")
+    .eq("budget_weekly_id", weeklyBudgetId);
+
+  if (!linkedCatsErr && linkedCats && linkedCats.length > 0) {
+    const linkedIds = linkedCats.map((v: Record<string, JsonValue>) => String(v.category_id));
+    categoryIds = [...new Set([...categoryIds, ...linkedIds])];
+  }
+
+  const { data: categoryNameRows } = await supabase
+    .from("categories")
+    .select("id,name")
+    .in("id", categoryIds);
+  const categoryNames = (categoryNameRows ?? []).map((row: Record<string, JsonValue>) => String(row.name));
+
+  const { data: txRows, error: txErr } = await supabase
+    .from("transactions")
+    .select("amount")
+    .eq("user_id", userId)
+    .eq("type", "expense")
+    .is("deleted_at", null)
+    .is("to_account_id", null)
+    .in("category_id", categoryIds)
+    .gte("date", weekStart)
+    .lt("date", nextWeekStart);
+  if (txErr) throw txErr;
+
+  const used = (txRows ?? []).reduce((acc, item: Record<string, JsonValue>) => acc + Number(item.amount ?? 0), 0);
+  const remaining = planned - used;
+  const percentage = planned > 0 ? (used / planned) * 100 : 0;
+
+  return { categoryNames, planned, used, remaining, percentage };
+}
+
+function buildCombinedBudgetLines(monthlyBudget: BudgetInfo | null, weeklyBudget: BudgetInfo | null): string[] {
+  const lines: string[] = [];
+
+  if (monthlyBudget) {
+    lines.push("📆 Budget Bulanan");
+    lines.push(`• Terpakai: ${formatIDR(monthlyBudget.used)} / ${formatIDR(monthlyBudget.planned)}`);
+    lines.push(`• Sisa: ${formatIDR(monthlyBudget.remaining)}`);
+    if (monthlyBudget.percentage >= 80) lines.push(`⚠️ Budget bulanan hampir habis (${monthlyBudget.percentage.toFixed(1)}%)`);
+  }
+
+  if (weeklyBudget) {
+    if (lines.length > 0) lines.push("");
+    lines.push("🗓️ Budget Mingguan");
+    lines.push(`• Terpakai: ${formatIDR(weeklyBudget.used)} / ${formatIDR(weeklyBudget.planned)}`);
+    lines.push(`• Sisa: ${formatIDR(weeklyBudget.remaining)}`);
+    if (weeklyBudget.percentage >= 80) lines.push(`⚠️ Budget mingguan hampir habis (${weeklyBudget.percentage.toFixed(1)}%)`);
+  }
+
+  return lines;
 }
 
 function buildMenuMessage(): string {
   return [
     "📋 *Menu HematWoi*",
     "",
+    "💰 *Cek Data*",
     "• saldo",
     "• summary",
     "• riwayat",
-    "• riwayat hari ini",
-    "• riwayat namaKategori",
-    "• budget namaKategori",
-    "• tf nominal akun_asal akun_tujuan",
-    "• kategori nominal akun",
-    "• kategori judul nominal akun",
-    "• hapus",
-    "• undo",
+    "• info",
+    "",
+    "➕ *Catat Transaksi*",
+    "• jajan 10000 cash",
+    "• jajan beli kopi 10000 cash",
+    "• gaji freelance 500000 seabank",
+    "",
+    "🔁 *Transfer*",
+    "• tf 50000 cash seabank",
+    "",
+    "🎯 *Budget*",
+    "• budget jajan",
+    "",
+    "🧾 *Lainnya*",
     "• kategori",
     "• akun",
-    "• info",
+    "• hapus",
     "• ping",
-    "",
-    "Contoh:",
-    "- jajan 10000 cash",
-    "- jajan beli kopi 10000 cash",
-    "- gaji freelance 500000 seabank",
-    "- tf 50000 cash seabank",
-    "- budget jajan",
   ].join("\n");
 }
 
@@ -516,7 +635,7 @@ Deno.serve(async (req: Request) => {
       const arg = normalized.replace(/^riwayat\s*/, "").trim();
       let query = supabase
         .from("transactions")
-        .select("title,amount,type,date,categories(name),accounts(name),category_id")
+        .select("id,title,amount,type,date,category_id,account_id,to_account_id")
         .eq("user_id", userId)
         .is("deleted_at", null)
         .order("inserted_at", { ascending: false })
@@ -534,25 +653,68 @@ Deno.serve(async (req: Request) => {
       }
 
       if (!reply) {
-        const { data, error } = await query;
-        if (error) throw error;
-        if (!data || data.length === 0) {
-          reply = "📚 Tidak ada riwayat transaksi.";
+        const { data: txRows, error: txErr } = await query;
+        if (txErr) throw txErr;
+
+        const transactions = (txRows ?? []) as Array<Record<string, JsonValue>>;
+        if (transactions.length === 0) {
+          reply = "📚 Belum ada riwayat transaksi.";
         } else {
-          const lines = data.map((tx: Record<string, JsonValue>, i: number) => {
+          const categoryIds = [...new Set(transactions.map((tx) => String(tx.category_id ?? "")).filter(Boolean))];
+          const accountIds = [...new Set(
+            transactions
+              .flatMap((tx) => [String(tx.account_id ?? ""), String(tx.to_account_id ?? "")])
+              .filter(Boolean),
+          )];
+
+          const categoryMap = new Map<string, string>();
+          const accountMap = new Map<string, string>();
+
+          if (categoryIds.length > 0) {
+            const { data: categoryRows } = await supabase.from("categories").select("id,name").in("id", categoryIds);
+            for (const row of (categoryRows ?? []) as Array<Record<string, JsonValue>>) {
+              categoryMap.set(String(row.id), String(row.name));
+            }
+          }
+
+          if (accountIds.length > 0) {
+            const { data: accountRows } = await supabase.from("accounts").select("id,name").in("id", accountIds);
+            for (const row of (accountRows ?? []) as Array<Record<string, JsonValue>>) {
+              accountMap.set(String(row.id), String(row.name));
+            }
+          }
+
+          const lines = transactions.map((tx, i) => {
             const type = String(tx.type ?? "expense");
-            const sign = type === "income" ? "+" : type === "transfer" ? "↔" : "-";
-            const cat = (tx.categories as { name?: string } | null)?.name ?? "-";
-            const acc = (tx.accounts as { name?: string } | null)?.name ?? "-";
-            return `${i + 1}. ${String(tx.date)} | ${cat}\n   ${sign}${formatIDR(Number(tx.amount ?? 0))} via ${acc}\n   ${String(tx.title ?? "-")}`;
+            const amount = Number(tx.amount ?? 0);
+            if (type === "transfer") {
+              const fromName = accountMap.get(String(tx.account_id ?? "")) ?? "-";
+              const toName = accountMap.get(String(tx.to_account_id ?? "")) ?? "-";
+              return `${i + 1}. ${String(tx.date)}\n   Transfer ${fromName} → ${toName}\n   ↔ ${formatIDR(amount)}`;
+            }
+            const sign = type === "income" ? "+" : "-";
+            const categoryName = categoryMap.get(String(tx.category_id ?? "")) ?? "-";
+            const title = String(tx.title ?? "-");
+            const accountName = accountMap.get(String(tx.account_id ?? "")) ?? "-";
+            return `${i + 1}. ${String(tx.date)}\n   ${categoryName} - ${title}\n   ${sign} ${formatIDR(amount)} via ${accountName}`;
           });
-          reply = `📚 Riwayat Transaksi\n\n${lines.join("\n")}`;
+
+          reply = `📚 *Riwayat Transaksi*\n\n${lines.join("\n\n")}`;
         }
       }
     } else if (normalized.startsWith("budget ")) {
       const categoryName = normalized.replace(/^budget\s+/, "").trim();
-      const info = await getMonthlyBudgetInfo(userId, categoryName);
-      reply = info ? buildBudgetLines(info) : `❌ Budget untuk kategori *${categoryName}* tidak ditemukan.`;
+      const [monthlyBudget, weeklyBudget] = await Promise.all([
+        getMonthlyBudgetInfo(userId, categoryName),
+        getWeeklyBudgetInfo(userId, categoryName),
+      ]);
+      if (!monthlyBudget && !weeklyBudget) {
+        reply = `📊 Budget untuk kategori *${categoryName}* belum ada.`;
+      } else {
+        const categoryLabel = monthlyBudget?.categoryNames?.[0] ?? weeklyBudget?.categoryNames?.[0] ?? categoryName;
+        const budgetLines = buildCombinedBudgetLines(monthlyBudget, weeklyBudget);
+        reply = ["📊 *Info Budget*", `Kategori: ${categoryLabel}`, "", ...budgetLines].join("\n");
+      }
     } else if (normalized === "kategori") {
       const { data, error } = await supabase.from("categories").select("name,type").eq("user_id", userId).order("name");
       if (error) throw error;
@@ -659,44 +821,33 @@ Deno.serve(async (req: Request) => {
             });
             if (error) throw error;
 
-            if (type === "income") {
-              const b = await getBalanceSummary(userId);
-              reply = [
-                "✅ Pemasukan tercatat",
-                "",
-                `Kategori: ${category.name}`,
-                `Judul: ${tx.title}`,
-                `Nominal: ${formatIDR(tx.amount)}`,
-                `Akun: ${account.name}`,
-                "",
-                "💰 Saldo Saat Ini",
-                `Cash: ${formatIDR(b.cash)}`,
-                `Non Cash: ${formatIDR(b.nonCash)}`,
-                `Total: ${formatIDR(b.total)}`,
-              ].join("\n");
-            } else {
-              const b = await getBalanceSummary(userId);
-              const budgetInfo = await getMonthlyBudgetInfo(userId, category.name);
-              const budgetText = budgetInfo
-                ? ["📆 Budget Bulanan", `• Terpakai: ${formatIDR(budgetInfo.used)} / ${formatIDR(budgetInfo.planned)}`, `• Sisa: ${formatIDR(budgetInfo.remaining)}`].join("\n")
-                : "📆 Budget Bulanan\n• Terpakai: -\n• Sisa: -";
+            const b = await getBalanceSummary(userId);
+            const baseLines = [
+              type === "income" ? "✅ Pemasukan tercatat" : "✅ Pengeluaran tercatat",
+              "",
+              `Kategori: ${category.name}`,
+              `Judul: ${tx.title}`,
+              `Nominal: ${formatIDR(tx.amount)}`,
+              `Akun: ${account.name}`,
+              "",
+              "💰 Saldo Saat Ini",
+              `Cash: ${formatIDR(b.cash)}`,
+              `Non Cash: ${formatIDR(b.nonCash)}`,
+              `Total: ${formatIDR(b.total)}`,
+            ];
 
-              reply = [
-                "✅ Pengeluaran tercatat",
-                "",
-                `Kategori: ${category.name}`,
-                `Judul: ${tx.title}`,
-                `Nominal: ${formatIDR(tx.amount)}`,
-                `Akun: ${account.name}`,
-                "",
-                "💰 Saldo Saat Ini",
-                `Cash: ${formatIDR(b.cash)}`,
-                `Non Cash: ${formatIDR(b.nonCash)}`,
-                `Total: ${formatIDR(b.total)}`,
-                "",
-                budgetText,
-              ].join("\n");
+            if (type === "expense") {
+              const [monthlyBudget, weeklyBudget] = await Promise.all([
+                getMonthlyBudgetInfo(userId, category.name),
+                getWeeklyBudgetInfo(userId, category.name),
+              ]);
+              const budgetLines = buildCombinedBudgetLines(monthlyBudget, weeklyBudget);
+              if (budgetLines.length > 0) {
+                baseLines.push("", ...budgetLines);
+              }
             }
+
+            reply = baseLines.join("\n");
           }
         }
       }


### PR DESCRIPTION
### Motivation
- Make the WhatsApp menu more compact and readable to reduce clutter and improve discoverability.
- Fix failures in the `riwayat` command caused by fragile relational selects and casting, and support safer, more resilient history lookups.
- Add weekly budget support and ensure budget display only appears when actual budget data exists (no empty placeholders after transaction entry).

### Description
- Replaced `buildMenuMessage()` with a concise, structured menu layout matching the requested groups (`Cek Data`, `Catat Transaksi`, `Transfer`, `Budget`, `Lainnya`).
- Reworked `riwayat` to first fetch transactions with `.select("id,title,amount,type,date,category_id,account_id,to_account_id")`, then separately query `categories` and `accounts` to build `categoryMap` and `accountMap`, and format results for `riwayat`, `riwayat hari ini`, and `riwayat <kategori>` without throwing on missing relations.
- Implemented `getWeeklyBudgetInfo(userId, categoryName)` to load weekly budgets from `budgets_weekly` with fallback on `week_start` / `start_date`, support `weekly_budget_categories`, compute `planned`, `used`, `remaining`, and `percentage`, and return `null` when no weekly budget exists.
- Kept and cross-checked `getMonthlyBudgetInfo(...)` logic for direct and multi-category monthly budgets and return `null` when absent.
- Added `buildCombinedBudgetLines(monthlyBudget, weeklyBudget)` to render only present budget sections and emit warning lines when `percentage >= 80`.
- Updated `budget <kategori>` to display monthly and/or weekly sections only when available, and updated expense transaction confirmations to include balance + optional budget sections (no empty `-` placeholders when budgets are missing).
- Preserved anti-loop, duplicate-message handling, logging, and other existing command flows.

### Testing
- Committed the changes successfully (`git commit`) and created PR metadata; commit completed without errors.
- Attempted static check with `deno check supabase/functions/fonnte-webhook-v2/index.ts`, but it failed in CI container because `deno` is not installed (`/bin/bash: deno: command not found`).
- Repository status checks (`git status`) and file updates were verified locally; no runtime integration tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a138e40a5b0832d90d9a5078d063777)