### PR TITLE
Fix weekly budget queries to use `planned_amount` and proper filters

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -628,7 +628,6 @@ async function getMonthlyBudgetInfo(userId: string, categoryName: string): Promi
 
 async function getWeeklyBudgetInfo(userId: string, categoryName: string): Promise<BudgetInfo | null> {
   const category = await findCategory(userId, categoryName);
-  console.log("[WEEKLY BUDGET] category", { userId, categoryName, category });
   if (!category) return null;
 
   const weekStart = getWeekStartJakarta();
@@ -637,29 +636,26 @@ async function getWeeklyBudgetInfo(userId: string, categoryName: string): Promis
   let budgetId: string | null = null;
   let planned = 0;
   let categoryIds: string[] = [category.id];
-  let selectedBudget: Record<string, JsonValue> | null = null;
-
-  const { data: directBudgets, error: directErr } = await supabase
+  const { data: directBudget, error: directErr } = await supabase
     .from("budgets_weekly")
-    .select("id,user_id,category_id,name,planned,amount_planned,amount,created_at")
+    .select("id,user_id,category_id,name,planned_amount,week_start,month_start,created_at")
     .eq("user_id", userId)
     .eq("category_id", category.id)
-    .order("created_at", { ascending: false });
+    .eq("week_start", weekStart)
+    .maybeSingle();
   if (directErr) throw directErr;
-  console.log("[WEEKLY BUDGET] directBudgets", directBudgets ?? []);
 
-  if ((directBudgets ?? []).length > 0) {
-    selectedBudget = (directBudgets ?? [])[0] as Record<string, JsonValue>;
-    budgetId = String(selectedBudget.id ?? "");
-    planned = Number(selectedBudget.planned ?? selectedBudget.amount_planned ?? selectedBudget.amount ?? 0);
+  if (directBudget) {
+    budgetId = String((directBudget as Record<string, JsonValue>).id ?? "");
+    planned = Number((directBudget as Record<string, JsonValue>).planned_amount ?? 0);
   }
 
   const { data: mappedRows, error: mappedErr } = await supabase
     .from("weekly_budget_categories")
     .select("budget_weekly_id,category_id")
+    .eq("user_id", userId)
     .eq("category_id", category.id);
   if (mappedErr) throw mappedErr;
-  console.log("[WEEKLY BUDGET] mappedRows", mappedRows ?? []);
 
   if (!budgetId) {
     const mappedBudgetIds = [...new Set((mappedRows ?? [])
@@ -667,36 +663,30 @@ async function getWeeklyBudgetInfo(userId: string, categoryName: string): Promis
       .filter(Boolean))];
 
     if (mappedBudgetIds.length > 0) {
-      const { data: mappedBudgets, error: mappedBudgetErr } = await supabase
+      const { data: mappedBudget, error: mappedBudgetErr } = await supabase
         .from("budgets_weekly")
-        .select("id,user_id,category_id,name,planned,amount_planned,amount,created_at")
+        .select("id,user_id,category_id,name,planned_amount,week_start,month_start,created_at")
         .eq("user_id", userId)
+        .eq("week_start", weekStart)
         .in("id", mappedBudgetIds)
-        .order("created_at", { ascending: false });
+        .maybeSingle();
       if (mappedBudgetErr) throw mappedBudgetErr;
 
-      if ((mappedBudgets ?? []).length > 0) {
-        selectedBudget = (mappedBudgets ?? [])[0] as Record<string, JsonValue>;
-        budgetId = String(selectedBudget.id ?? "");
-        planned = Number(selectedBudget.planned ?? selectedBudget.amount_planned ?? selectedBudget.amount ?? 0);
+      if (mappedBudget) {
+        budgetId = String((mappedBudget as Record<string, JsonValue>).id ?? "");
+        planned = Number((mappedBudget as Record<string, JsonValue>).planned_amount ?? 0);
       }
     }
   }
 
-  console.log("[WEEKLY BUDGET] selectedBudget", selectedBudget);
-  console.log("[WEEKLY BUDGET] planned", planned);
+  if (!budgetId) return null;
 
-  if (!budgetId || planned <= 0) return null;
-
-  // 3. Ambil semua kategori yang terhubung ke budget mingguan ini
   const { data: linkedRows, error: linkedErr } = await supabase
     .from("weekly_budget_categories")
     .select("category_id")
+    .eq("user_id", userId)
     .eq("budget_weekly_id", budgetId);
-
-  if (linkedErr) {
-    console.error("[WEEKLY BUDGET LINKED ERROR]", linkedErr);
-  }
+  if (linkedErr) throw linkedErr;
 
   const linkedCategoryIds = (linkedRows ?? [])
     .map((row: Record<string, JsonValue>) => String(row.category_id ?? ""))
@@ -706,7 +696,6 @@ async function getWeeklyBudgetInfo(userId: string, categoryName: string): Promis
     categoryIds = [...new Set([...categoryIds, ...linkedCategoryIds])];
   }
 
-  // 4. Ambil nama kategori
   const { data: categoryNameRows } = await supabase
     .from("categories")
     .select("id,name")
@@ -716,7 +705,6 @@ async function getWeeklyBudgetInfo(userId: string, categoryName: string): Promis
     .map((row: Record<string, JsonValue>) => String(row.name ?? ""))
     .filter(Boolean);
 
-  // 5. Hitung pemakaian minggu berjalan
   const { data: txRows, error: txErr } = await supabase
     .from("transactions")
     .select("amount")
@@ -727,11 +715,7 @@ async function getWeeklyBudgetInfo(userId: string, categoryName: string): Promis
     .in("category_id", categoryIds)
     .gte("date", weekStart)
     .lt("date", nextWeekStart);
-
-  if (txErr) {
-    console.error("[WEEKLY BUDGET TX ERROR]", txErr);
-    throw txErr;
-  }
+  if (txErr) throw txErr;
 
   const used = (txRows ?? []).reduce(
     (sum: number, tx: Record<string, JsonValue>) => sum + Number(tx.amount ?? 0),
@@ -740,8 +724,6 @@ async function getWeeklyBudgetInfo(userId: string, categoryName: string): Promis
 
   const remaining = planned - used;
   const percentage = planned > 0 ? (used / planned) * 100 : 0;
-
-  console.log("[WEEKLY BUDGET] used", used);
 
   return {
     categoryNames: categoryNames.length > 0 ? categoryNames : [category.name],


### PR DESCRIPTION
### Motivation
- Supabase logs reported `column budgets_weekly.planned does not exist`, indicating the code queried non-existent columns and used incorrect filters for weekly budgets.
- The weekly budget logic must match the actual `budgets_weekly` schema where the nominal field is `planned_amount` and lookups should include `user_id`, `category_id`, and `week_start`.

### Description
- Updated `getWeeklyBudgetInfo` to select only `id,user_id,category_id,name,planned_amount,week_start,month_start,created_at` from `budgets_weekly` and to use `planned_amount` as the planned value via `Number(...planned_amount ?? 0)`.
- Direct weekly lookup now filters by `user_id`, `category_id`, and `week_start` and uses `maybeSingle()` to fetch a single row when present.
- Multi-category mapping now queries `weekly_budget_categories` (filtered by `user_id` and `category_id`) to collect `budget_weekly_id`, then fetches `budgets_weekly` by `user_id`, `week_start`, and mapped IDs; linked categories are retrieved from `weekly_budget_categories` by `user_id` + `budget_weekly_id` and merged with the requested category.
- Kept transactions aggregation unchanged but ensured expense filters and date range `[weekStart, nextWeekStart)` are used to compute `used`, `remaining`, and `percentage` from the corrected `planned` value.

### Testing
- Inspected the patched file with `sed -n '1,980p' supabase/functions/fonnte-webhook-v2/index.ts` to verify the updated `getWeeklyBudgetInfo` implementation and fields, and this inspection succeeded.
- Validated the source no longer references invalid weekly columns by running `rg 'budgets_weekly|planned_amount|amount_planned|planned|start_date' supabase/functions/fonnte-webhook-v2/index.ts`, which confirmed `planned_amount` is used and invalid column usages were removed.
- Attempted `rg --files -g 'AGENTS.md'` to check agent docs but there were no matches (no AGENTS.md found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1421b18140832dbf39d60333f1b203)