### PR TITLE
feat: support optional DD/MM date for WhatsApp transactions

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -41,6 +41,11 @@ type ParsedTransaction = {
   accountName: string;
   amount: number;
   title: string;
+  date: string;
+};
+
+type ParsedTransactionError = {
+  error: "INVALID_DATE";
 };
 
 type ParsedTransfer = {
@@ -146,16 +151,25 @@ function parseAmount(raw: string): number {
   return Math.floor(value);
 }
 
-function parseOptionalDateToken(raw: string): string | null {
-  const match = raw.match(/^(\d{1,2})\/(\d{1,2})$/);
+function parseCustomDateToken(token: string): string | null {
+  const match = token.match(/^(\d{1,2})\/(\d{1,2})$/);
   if (!match) return null;
+
   const day = Number(match[1]);
   const month = Number(match[2]);
-  if (day < 1 || day > 31 || month < 1 || month > 12) return null;
+  if (!Number.isInteger(day) || !Number.isInteger(month) || day < 1 || month < 1 || month > 12) return null;
+
   const now = new Date();
   const jakartaNow = new Date(now.toLocaleString("en-US", { timeZone: "Asia/Jakarta" }));
   const year = jakartaNow.getFullYear();
+  const maxDay = new Date(year, month, 0).getDate();
+  if (day > maxDay) return null;
+
   return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+function isDateToken(token: string): boolean {
+  return /^(\d{1,2})\/(\d{1,2})$/.test(token);
 }
 
 function getTodayJakarta(): string {
@@ -569,29 +583,42 @@ async function handleAiFinanceChat(userId: string, question: string): Promise<{ 
   return { intent, reply: `🤖 *AI Finance Chat*\n\n${b.verdict.toUpperCase()} untuk beli ${formatIDR(b.amount)}.\nAlasan: ${b.reason}` };
 }
 
-function parseTransactionMessage(message: string): ParsedTransaction | null {
+function parseTransactionMessage(message: string): ParsedTransaction | ParsedTransactionError | null {
   const parts = message.trim().split(/\s+/);
   if (parts.length < 3) return null;
 
-  const categoryName = parts[0];
-  const accountName = parts[parts.length - 1];
+  let txDate = getTodayJakarta();
+  let workParts = [...parts];
+  const lastToken = workParts[workParts.length - 1] ?? "";
+
+  if (isDateToken(lastToken)) {
+    const parsedDate = parseCustomDateToken(lastToken);
+    if (!parsedDate) return { error: "INVALID_DATE" };
+    txDate = parsedDate;
+    workParts = workParts.slice(0, -1);
+  }
+
+  if (workParts.length < 3) return null;
+
+  const categoryName = workParts[0];
+  const accountName = workParts[workParts.length - 1];
   let amountIndex = -1;
 
-  for (let i = parts.length - 2; i >= 1; i--) {
-    if (parseAmount(parts[i]) > 0) {
+  for (let i = workParts.length - 2; i >= 1; i--) {
+    if (parseAmount(workParts[i]) > 0) {
       amountIndex = i;
       break;
     }
   }
 
   if (amountIndex < 1) return null;
-  const amount = parseAmount(parts[amountIndex]);
+  const amount = parseAmount(workParts[amountIndex]);
   if (amount <= 0) return null;
 
-  const titleParts = parts.slice(1, amountIndex);
+  const titleParts = workParts.slice(1, amountIndex);
   const title = titleParts.length > 0 ? titleParts.join(" ") : categoryName;
 
-  return { categoryName, accountName, amount, title };
+  return { categoryName, accountName, amount, title, date: txDate };
 }
 
 function parseTransferMessage(message: string): ParsedTransfer | null {
@@ -613,7 +640,7 @@ function parseDebtCommand(message: string): ParsedDebtCommand | null {
 
   let date = getTodayJakarta();
   let workParts = [...parts];
-  const maybeDate = parseOptionalDateToken(workParts[workParts.length - 1]);
+  const maybeDate = parseCustomDateToken(workParts[workParts.length - 1]);
   if (maybeDate) {
     date = maybeDate;
     workParts = workParts.slice(0, -1);
@@ -801,12 +828,13 @@ async function handleDebtCommand(userId: string, rawMessage: string, normalized:
   };
 }
 
-async function getMonthlyBudgetInfo(userId: string, categoryName: string): Promise<BudgetInfo | null> {
+async function getMonthlyBudgetInfo(userId: string, categoryName: string, date?: string): Promise<BudgetInfo | null> {
   const category = await findCategory(userId, categoryName);
   if (!category) return null;
 
-  const monthStart = getMonthStart();
-  const nextMonthStart = getNextMonthStart();
+  const baseDate = date ? new Date(`${date}T00:00:00+07:00`) : new Date();
+  const monthStart = getMonthStart(baseDate);
+  const nextMonthStart = getNextMonthStart(baseDate);
 
   const { data: directBudgets, error: directErr } = await supabase
     .from("budgets")
@@ -881,12 +909,13 @@ async function getMonthlyBudgetInfo(userId: string, categoryName: string): Promi
   return { categoryNames, planned, used, remaining, percentage };
 }
 
-async function getWeeklyBudgetInfo(userId: string, categoryName: string): Promise<BudgetInfo | null> {
+async function getWeeklyBudgetInfo(userId: string, categoryName: string, date?: string): Promise<BudgetInfo | null> {
   const category = await findCategory(userId, categoryName);
   if (!category) return null;
 
-  const weekStart = getWeekStartJakarta();
-  const nextWeekStart = getNextWeekStartJakarta();
+  const baseDate = date ? new Date(`${date}T00:00:00+07:00`) : new Date();
+  const weekStart = getWeekStartJakarta(baseDate);
+  const nextWeekStart = getNextWeekStartJakarta(baseDate);
 
   let budgetId: string | null = null;
   let planned = 0;
@@ -1025,6 +1054,8 @@ function buildMenuMessage(): string {
     "• jajan 10000 cash",
     "• jajan beli kopi 10000 cash",
     "• gaji freelance 500000 seabank",
+    "• jajan kopi 10000 cash 31/05",
+    "  Tanggal opsional: DD/MM",
     "",
     "🔁 *Transfer*",
     "• tf 50000 cash seabank",
@@ -1357,6 +1388,8 @@ Deno.serve(async (req: Request) => {
         const tx = parseTransactionMessage(normalized);
         if (!tx) {
           reply = "❌ Format tidak dikenali. Ketik menu untuk bantuan.";
+        } else if ("error" in tx && tx.error === "INVALID_DATE") {
+          reply = ["⚠️ Format tanggal tidak valid.", "", "Gunakan format:", "31/05"].join("\n");
         } else {
           parsedLog = { command: "transaction", category: tx.categoryName, account: tx.accountName, amount: tx.amount, title: tx.title };
           const category = await findCategory(userId, tx.categoryName);
@@ -1367,12 +1400,11 @@ Deno.serve(async (req: Request) => {
           } else if (!account) {
             reply = `❌ Akun *${tx.accountName}* tidak ditemukan.`;
           } else {
-            const today = getTodayJakarta();
             const type = category.type === "income" ? "income" : "expense";
 
             const { error } = await supabase.from("transactions").insert({
               user_id: userId,
-              date: today,
+              date: tx.date,
               type,
               category_id: category.id,
               account_id: account.id,
@@ -1386,6 +1418,7 @@ Deno.serve(async (req: Request) => {
             const baseLines = [
               type === "income" ? "✅ Pemasukan tercatat" : "✅ Pengeluaran tercatat",
               "",
+              `Tanggal: ${tx.date}`,
               `Kategori: ${category.name}`,
               `Judul: ${tx.title}`,
               `Nominal: ${formatIDR(tx.amount)}`,
@@ -1399,8 +1432,8 @@ Deno.serve(async (req: Request) => {
 
             if (type === "expense") {
               const [monthlyBudget, weeklyBudget] = await Promise.all([
-                getMonthlyBudgetInfo(userId, category.name),
-                getWeeklyBudgetInfo(userId, category.name),
+                getMonthlyBudgetInfo(userId, category.name, tx.date),
+                getWeeklyBudgetInfo(userId, category.name, tx.date),
               ]);
 
               const budgetLines = buildCombinedBudgetLines(monthlyBudget, weeklyBudget);


### PR DESCRIPTION
### Motivation

- Menambahkan kemampuan mencatat transaksi WhatsApp dengan tanggal manual di akhir pesan agar transaksi bisa disimpan pada tanggal yang diinginkan.
- Tetap mempertahankan kompatibilitas dengan format lama tanpa tanggal sehingga integrasi eksisting tidak terganggu.
- Pastikan budget/summary dihitung relatif ke tanggal transaksi bila tanggal custom diberikan.

### Description

- Tambah helper `parseCustomDateToken(token: string): string | null` yang memvalidasi regex `DD/MM`, memastikan hari/bulan valid (termasuk panjang bulan) dan mengembalikan `YYYY-MM-DD` memakai tahun sekarang timezone `Asia/Jakarta`, serta `isDateToken(token: string): boolean` untuk deteksi token tanggal.
- Update tipe `ParsedTransaction` untuk menyertakan `date: string` dan diperkenalkan `ParsedTransactionError` untuk kasus tanggal invalid (`{ error: "INVALID_DATE" }`).
- Perbarui `parseTransactionMessage` untuk mendeteksi token tanggal terakhir opsional, menghapusnya sebelum parsing transaksi, mengembalikan error khusus bila format/tanggal invalid, dan fallback ke `getTodayJakarta()` bila tidak ada token.
- Gunakan `tx.date` saat insert transaksi, tambahkan `Tanggal: ...` di reply sukses, dan ubah pemanggilan budget menjadi `getMonthlyBudgetInfo(..., tx.date)` / `getWeeklyBudgetInfo(..., tx.date)`.
- Perbarui signature `getMonthlyBudgetInfo(userId, categoryName, date?)` dan `getWeeklyBudgetInfo(userId, categoryName, date?)` agar range bulan/minggu dihitung dari `date` bila diberikan.
- Perbarui `buildMenuMessage()` menambahkan contoh `• jajan kopi 10000 cash 31/05` dan catatan singkat `Tanggal opsional: DD/MM`.

### Testing

- Dicoba menjalankan `deno check supabase/functions/fonnte-webhook-v2/index.ts` namun pemeriksaan otomatis gagal karena environment tidak memiliki binary `deno` (`/bin/bash: deno: command not found`).
- Perubahan dikodekan dan file `supabase/functions/fonnte-webhook-v2/index.ts` telah diperbarui sesuai spesifikasi; runtime/type-check sebaiknya divalidasi ulang di environment yang memiliki `deno`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1428c0524c832d8b1b3e9accfb3826)