### PR TITLE
Support `hapus <nomor>` to soft-delete a transaction from last `riwayat` results

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -1101,6 +1101,10 @@ function buildExampleMessage(): string {
     "• riwayat",
     "• riwayat 31/05",
     "• riwayat jajan 31/05",
+    "• hapus 3",
+    "",
+    "Setelah menampilkan riwayat, kamu bisa hapus berdasarkan nomor:",
+    "hapus 3",
     "",
     "🎯 *Budget*",
     "• budget jajan",
@@ -1346,19 +1350,44 @@ Deno.serve(async (req: Request) => {
             }
           }
 
+          const displayedTransactions: JsonValue[] = [];
           const lines = transactions.map((tx, i) => {
+            const no = i + 1;
             const type = String(tx.type ?? "expense");
             const amount = Number(tx.amount ?? 0);
+            const txId = String(tx.id ?? "");
+            const txDate = String(tx.date ?? "");
+            const categoryName = categoryMap.get(String(tx.category_id ?? "")) ?? "-";
+            const accountName = accountMap.get(String(tx.account_id ?? "")) ?? "-";
+            const title = String(tx.title ?? "-");
             if (type === "transfer") {
               const fromName = accountMap.get(String(tx.account_id ?? "")) ?? "-";
               const toName = accountMap.get(String(tx.to_account_id ?? "")) ?? "-";
-              return `${i + 1}. ${String(tx.date)}\n   Transfer ${fromName} → ${toName}\n   ↔ ${formatIDR(amount)}`;
+              displayedTransactions.push({
+                no,
+                id: txId,
+                title,
+                amount,
+                type,
+                date: txDate,
+                categoryName,
+                accountName,
+                toAccountName: toName,
+              });
+              return `${no}. ${txDate}\n   Transfer ${fromName} → ${toName}\n   ↔ ${formatIDR(amount)}`;
             }
             const sign = type === "income" ? "+" : "-";
-            const categoryName = categoryMap.get(String(tx.category_id ?? "")) ?? "-";
-            const title = String(tx.title ?? "-");
-            const accountName = accountMap.get(String(tx.account_id ?? "")) ?? "-";
-            return `${i + 1}. ${String(tx.date)}\n   ${categoryName} - ${title}\n   ${sign} ${formatIDR(amount)} via ${accountName}`;
+            displayedTransactions.push({
+              no,
+              id: txId,
+              title,
+              amount,
+              type,
+              date: txDate,
+              categoryName,
+              accountName,
+            });
+            return `${no}. ${txDate}\n   ${categoryName} - ${title}\n   ${sign} ${formatIDR(amount)} via ${accountName}`;
           });
 
           const headerLines = ["📚 *Riwayat Transaksi*"];
@@ -1369,8 +1398,84 @@ Deno.serve(async (req: Request) => {
           if (categoryLabel) {
             headerLines.push(`Kategori: ${categoryLabel.charAt(0).toUpperCase()}${categoryLabel.slice(1)}`);
           }
+          parsedLog = { command: "riwayat", categoryName, targetDate, displayedTransactions };
           const header = headerLines.length > 1 ? `${headerLines.join("\n")}\n` : headerLines[0];
           reply = `${header}\n\n${lines.join("\n\n")}`;
+        }
+      }
+    } else if (/^hapus\s+\d+$/.test(normalized)) {
+      const number = Number(normalized.replace(/^hapus\s+/, "").trim());
+      parsedLog = { command: "hapus_riwayat", number };
+
+      if (!Number.isInteger(number) || number < 1 || number > 5) {
+        reply = "⚠️ Nomor riwayat tidak valid.\n\nPilih nomor dari hasil riwayat terakhir.";
+      } else {
+        const { data: lastHistoryLog, error: lastHistoryError } = await supabase
+          .from("whatsapp_message_logs")
+          .select("parsed")
+          .eq("user_id", userId)
+          .eq("phone", sender)
+          .eq("status", "success")
+          .eq("parsed->>command", "riwayat")
+          .order("created_at", { ascending: false })
+          .limit(1)
+          .maybeSingle();
+        if (lastHistoryError) throw lastHistoryError;
+
+        const parsedHistory = (lastHistoryLog?.parsed ?? null) as Record<string, JsonValue> | null;
+        const displayedTransactions = (parsedHistory?.displayedTransactions ?? []) as Array<Record<string, JsonValue>>;
+
+        if (!parsedHistory || displayedTransactions.length === 0) {
+          reply = "⚠️ Belum ada riwayat terakhir.\n\nKirim *riwayat* dulu, lalu gunakan:\nhapus 3";
+        } else {
+          const selectedTransaction = displayedTransactions.find((item) => Number(item.no ?? 0) === number);
+          if (!selectedTransaction) {
+            reply = "⚠️ Nomor riwayat tidak ditemukan.\n\nKirim *riwayat* dulu, lalu pilih nomor yang ingin dihapus.\nContoh: hapus 3";
+          } else {
+            const transactionId = String(selectedTransaction.id ?? "");
+            const { data: deletedTx, error: deleteError } = await supabase
+              .from("transactions")
+              .update({ deleted_at: new Date().toISOString() })
+              .eq("id", transactionId)
+              .eq("user_id", userId)
+              .is("deleted_at", null)
+              .select("id")
+              .maybeSingle();
+            if (deleteError) throw deleteError;
+
+            if (!deletedTx) {
+              reply = "⚠️ Transaksi ini sudah tidak aktif atau sudah dihapus.";
+            } else {
+              parsedLog = { command: "hapus_riwayat", number, transactionId, deletedTransaction: selectedTransaction };
+              const type = String(selectedTransaction.type ?? "expense");
+              const date = String(selectedTransaction.date ?? "-");
+              const amount = Number(selectedTransaction.amount ?? 0);
+
+              if (type === "transfer") {
+                const fromName = String(selectedTransaction.accountName ?? "-");
+                const toName = String(selectedTransaction.toAccountName ?? "-");
+                reply = [
+                  "🗑️ Transfer berhasil dihapus",
+                  "",
+                  `No: ${number}`,
+                  `Tanggal: ${date}`,
+                  `Transfer: ${fromName} → ${toName}`,
+                  `Nominal: ${formatIDR(amount)}`,
+                ].join("\n");
+              } else {
+                reply = [
+                  "🗑️ Transaksi berhasil dihapus",
+                  "",
+                  `No: ${number}`,
+                  `Tanggal: ${date}`,
+                  `Kategori: ${String(selectedTransaction.categoryName ?? "-")}`,
+                  `Judul: ${String(selectedTransaction.title ?? "-")}`,
+                  `Nominal: ${formatIDR(amount)}`,
+                  `Akun: ${String(selectedTransaction.accountName ?? "-")}`,
+                ].join("\n");
+              }
+            }
+          }
         }
       }
     } else if (normalized.startsWith("budget ")) {


### PR DESCRIPTION
### Motivation

- Enable users to delete a specific transaction shown in the latest `riwayat` by referencing its displayed number (e.g. `hapus 3`).
- Persist the displayed riwayat items so subsequent `hapus <nomor>` commands can map a number to a transaction id via `whatsapp_message_logs.parsed`.
- Keep existing single-step `hapus` / `undo` behavior unchanged for deleting the last transaction.

### Description

- Update `buildExampleMessage()` to include the `hapus 3` example and a short note to explain deletion after `riwayat`.
- Extend the `riwayat` flow to collect and persist `displayedTransactions` (objects with `no`, `id`, `title`, `amount`, `type`, `date`, `categoryName`, `accountName`, and `toAccountName` for transfers) into the `parsed` field of the `whatsapp_message_logs` entry for the command.
- Add routing for the new pattern `^hapus\s+\d+$` placed before legacy `hapus`/`undo`, validate numbers in range `1-5`, and look up the most recent successful `riwayat` log filtered by `user_id`, `phone`, `status = success`, and `parsed->>command = riwayat` ordered by `created_at desc` with `limit 1`.
- Implement soft-delete of the selected transaction by updating `transactions.deleted_at = new Date().toISOString()` with filters on `id`, `user_id`, and `deleted_at is null`, and return detailed success/error replies including a transfer-specific message; also log parsed info for the delete action as `{ command: "hapus_riwayat", number, transactionId, deletedTransaction }`.

### Testing

- Attempted TypeScript check with `deno check supabase/functions/fonnte-webhook-v2/index.ts` but it failed because the `deno` binary is not available in the execution environment (`/bin/bash: deno: command not found`).
- No other automated test suite was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a142b7c55ac832d82bfc48a725e6e7d)