### PR TITLE
fix(edge): resolve duplicate extractAmountFromText declaration

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -866,7 +866,7 @@ function detectNaturalTransactionType(message: string): NaturalTransactionType |
   return null;
 }
 
-function extractAmountFromText(message: string): number {
+function extractNaturalAmountFromText(message: string): number {
   const compact = message.toLowerCase().replace(/\s+/g, "");
   const withUnit = compact.match(/rp?(\d+[.,]?\d*)(rb|ribu|k|jt|juta)\b|(\d+[.,]?\d*)(rb|ribu|k|jt|juta)\b/i);
   if (withUnit) {
@@ -935,7 +935,7 @@ function parseNaturalTransactionMessage(
 
   const type = detectNaturalTransactionType(message);
   if (!type || type === "transfer") return null;
-  const amount = extractAmountFromText(message);
+  const amount = extractNaturalAmountFromText(message);
   if (amount <= 0) return null;
   const account = extractAccountFromNaturalText(message, accounts);
   if (!account) {


### PR DESCRIPTION
### Motivation
- The Edge function failed to boot with `Identifier 'extractAmountFromText' has already been declared` due to two functions with the same name in the same file. 
- The natural-language amount parser conflicted with an existing helper, causing runtime boot failure for the Supabase Edge function. 
- Rename was needed to eliminate the identifier collision while preserving parsing behavior. 

### Description
- Renamed the natural-language parser from `extractAmountFromText` to `extractNaturalAmountFromText` in `supabase/functions/fonnte-webhook-v2/index.ts`. 
- Updated the natural transaction parser to call `extractNaturalAmountFromText` instead of the old name in `parseNaturalTransactionMessage`. 
- Left the original `extractAmountFromText` (used elsewhere) intact so other logic remains unaffected. 
- Changes were committed with message `fix(edge): resolve duplicate extractAmountFromText declaration`. 

### Testing
- Ran `rg -n "extractAmountFromText" /workspace/HematWoi` to confirm presence of duplicate declarations before the fix and to locate usages, which succeeded. 
- Ran `rg -n "function extractAmountFromText|extractNaturalAmountFromText\(" /workspace/HematWoi/supabase/functions/fonnte-webhook-v2/index.ts` to verify the rename, which showed the updated single declarations and succeeded. 
- Verified repository state with `git status --short` and committed the change using `git commit -m "fix(edge): resolve duplicate extractAmountFromText declaration"`, which succeeded. 
- Created the PR metadata with the repo helper (`make_pr`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a143b1ef094832da2594644aab0c5be)