### PR TITLE
fix(edge-function): avoid querying non-existent accounts.deleted_at by using accounts base query helper

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -386,26 +386,31 @@ async function findCategory(userId: string, name: string): Promise<{ id: string;
 }
 
 async function findAccount(userId: string, name: string): Promise<{ id: string; name: string; type: string } | null> {
-  const { data, error } = await supabase
-    .from("accounts")
-    .select("id,name,type")
-    .eq("user_id", userId)
+  const { data, error } = await getAccountsBaseQuery(userId, "id,name,type")
     .ilike("name", name.trim())
     .maybeSingle();
   if (error) throw error;
   return data;
 }
 
+function getAccountsBaseQuery(userId: string, columns = "*") {
+  console.log("[ACCOUNT QUERY]", {
+    userId,
+  });
+
+  return supabase
+    .from("accounts")
+    .select(columns)
+    .eq("user_id", userId);
+}
+
+
 async function getRealtimeBalanceSummary(userId: string): Promise<BalanceSummary> {
   const { data, error } = await supabase.rpc("get_account_type_balances", { p_user_id: userId });
   if (error) throw new Error(`RPC_BALANCE_FAILED: ${error.message}`);
   console.log("[RPC BALANCE]", data);
 
-  const { data: accountRows, error: accountError } = await supabase
-    .from("accounts")
-    .select("id,name,type")
-    .eq("user_id", userId)
-    .is("deleted_at", null);
+  const { data: accountRows, error: accountError } = await getAccountsBaseQuery(userId, "id,name,type");
   if (accountError) throw accountError;
 
   const row = Array.isArray(data) ? (data[0] ?? {}) : (data ?? {});
@@ -1593,11 +1598,8 @@ async function findAccountByTransactionHistory(
   const best = findBestAccountFromHistory(title, categoryId, txType, rows);
   if (!best) return null;
 
-  const { data, error } = await supabase
-    .from("accounts")
-    .select("id,name,type,user_id")
+  const { data, error } = await getAccountsBaseQuery(userId, "id,name,type,user_id")
     .eq("id", best.accountId)
-    .eq("user_id", userId)
     .maybeSingle();
   if (error) throw error;
   if (!data) return null;
@@ -3065,10 +3067,7 @@ Deno.serve(async (req: Request) => {
         } else {
           const smartTx = parseSmartTransactionMessage(normalized);
           if (!smartTx) {
-            const { data: accountRows, error: accountErr } = await supabase
-              .from("accounts")
-              .select("id,name,type")
-              .eq("user_id", userId);
+            const { data: accountRows, error: accountErr } = await getAccountsBaseQuery(userId, "id,name,type");
             if (accountErr) throw accountErr;
             const accounts = (accountRows ?? []) as Array<{ id: string; name: string; type: string }>;
             const naturalTx = parseNaturalTransactionMessage(normalized, accounts);


### PR DESCRIPTION
### Motivation
- Prevent runtime crash `column accounts.deleted_at does not exist` caused by queries filtering `deleted_at` on the `accounts` table in the Edge Function.
- Keep existing soft-delete filters for other tables (e.g. `transactions`) intact while making `accounts` queries safe.

### Description
- Added helper `getAccountsBaseQuery(userId, columns = "*")` in `supabase/functions/fonnte-webhook-v2/index.ts` that logs `console.log("[ACCOUNT QUERY]", { userId })` and returns `supabase.from("accounts").select(columns).eq("user_id", userId)`.
- Replaced direct `supabase.from("accounts")` calls used for lookups with the helper in `findAccount`, `getRealtimeBalanceSummary`, `findAccountByTransactionHistory`, and the natural/smart transaction account detection path so no `.is/.eq("deleted_at", null)` is applied to `accounts` queries.
- Left all other `deleted_at` filters on other tables (like `transactions`) unchanged.

### Testing
- Ran a targeted search for usages with `rg -n "from(\"accounts\")|deleted_at|getAccountsBaseQuery|ACCOUNT QUERY"` to verify `accounts` queries were routed through `getAccountsBaseQuery` and no `deleted_at` filters remain on `accounts` queries.
- Attempted `deno check supabase/functions/fonnte-webhook-v2/index.ts` but it failed in CI environment because `deno` is not available.  
- Confirmed code edits applied to `supabase/functions/fonnte-webhook-v2/index.ts` and that other tables' `deleted_at` usages remain unchanged based on search results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148240e030832da2d3a9272ae1feb4)