### PR TITLE
Preserve WhatsApp group JID when sending messages to Fonnte

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -685,15 +685,33 @@ function parseNaturalDateRange(rawInput: string): { startDate: string; endDate: 
 
 async function replyWhatsApp(target: string, message: string): Promise<void> {
   if (!FONNTE_TOKEN || !target || !message) return;
+  const finalTarget = target.includes("@g.us") ? target.trim() : normalizePhone(target);
+
+  console.log("[SEND WHATSAPP]", {
+    originalTarget: target,
+    finalTarget,
+    isGroup: finalTarget.includes("@g.us"),
+  });
+
   const form = new FormData();
-  form.append("target", target);
+  form.append("target", finalTarget);
   form.append("message", message);
 
-  await fetch("https://api.fonnte.com/send", {
-    method: "POST",
-    headers: { Authorization: FONNTE_TOKEN },
-    body: form,
-  });
+  try {
+    const response = await fetch("https://api.fonnte.com/send", {
+      method: "POST",
+      headers: { Authorization: FONNTE_TOKEN },
+      body: form,
+    });
+    const result = await response.text();
+
+    console.log("[FONNTE RESPONSE]", {
+      status: response.status,
+      result,
+    });
+  } catch (error) {
+    console.error("[FONNTE SEND ERROR]", error);
+  }
 }
 
 async function logMessage(input: {


### PR DESCRIPTION
### Motivation
- Fix bot failing to reply to WhatsApp groups because group JIDs were being normalized/stripped before sending to Fonnte, producing invalid targets.

### Description
- Update `replyWhatsApp(target, message)` to keep group JIDs intact (`finalTarget = target.includes("@g.us") ? target.trim() : normalizePhone(target)`), send `finalTarget` to Fonnte, add a `[SEND WHATSAPP]` debug log, wrap the send in `try/catch`, log `[FONNTE RESPONSE]` with `status` and `result`, and log `[FONNTE SEND ERROR]` on failure while leaving other features unchanged.

### Testing
- Ran code inspections and searches (`rg`) and viewed the modified function lines (`sed`/`nl`) and the file diff to confirm `finalTarget` usage and the new logs; these verifications succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15bb8ae0fc832db210d41ae0898361)