### PR TITLE
Normalize Fonnte WhatsApp target for group sends

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -208,6 +208,24 @@ function normalizePhone(raw: string): string {
   return digits;
 }
 
+function normalizeFonnteTarget(target: string): string {
+  const value = String(target || "").trim();
+
+  if (value.includes("@g.us")) {
+    return value.replace("@g.us", "");
+  }
+
+  if (value.includes("@s.whatsapp.net")) {
+    return value.replace("@s.whatsapp.net", "");
+  }
+
+  if (value.includes("@c.us")) {
+    return value.replace("@c.us", "");
+  }
+
+  return value.replace(/[^\d]/g, "");
+}
+
 function isGroupJid(raw: string): boolean {
   return /@g\.us$/i.test(raw.trim());
 }
@@ -685,12 +703,12 @@ function parseNaturalDateRange(rawInput: string): { startDate: string; endDate: 
 
 async function replyWhatsApp(target: string, message: string): Promise<void> {
   if (!FONNTE_TOKEN || !target || !message) return;
-  const finalTarget = target.includes("@g.us") ? target.trim() : normalizePhone(target);
+  const finalTarget = normalizeFonnteTarget(target);
 
   console.log("[SEND WHATSAPP]", {
     originalTarget: target,
     finalTarget,
-    isGroup: finalTarget.includes("@g.us"),
+    isGroup: target.includes("@g.us"),
   });
 
   const form = new FormData();


### PR DESCRIPTION
### Motivation

- Fonnte rejects raw group JIDs that include the `@g.us` suffix, causing group sends to fail with `invalid group id`.
- The goal is to normalize targets sent to Fonnte so group IDs are sent without the `@g.us` suffix while preserving existing group detection and other features.

### Description

- Add helper `function normalizeFonnteTarget(target: string): string` to strip `@g.us`, `@s.whatsapp.net`, and `@c.us` suffixes and fall back to digits-only for personal targets in `supabase/functions/fonnte-webhook-v2/index.ts`.
- Update `replyWhatsApp` to compute `const finalTarget = normalizeFonnteTarget(target);` and send `target: finalTarget` to Fonnte.
- Keep group detection logic unchanged by logging `isGroup` from the original `target` and preserve the existing `[FONNTE RESPONSE]` logging.
- No other features or parsers (sender, participant, chatTarget, transaction/AI/budget/history/etc.) were modified.

### Testing

- Ran `git diff -- supabase/functions/fonnte-webhook-v2/index.ts` to inspect the change and it showed the intended additions and replacement (succeeded).
- Committed the change with a descriptive message via automated commit (succeeded).
- No runtime or unit tests were executed as this is a small function-level formatting fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15bd607634832d8a8a74a06bb01558)