### PR TITLE
Fix daily summary saldo mapping, add last-3 history, and history command debug

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -3313,6 +3313,7 @@ Deno.serve(async (req: Request) => {
     } else if (normalized.startsWith("riwayat")) {
       reply = "⚠️ Command sudah diganti.\n\nGunakan:\nhistory";
     } else if (normalized.startsWith("history")) {
+      console.log("[HISTORY COMMAND]", { normalized, userId, sender: replyContextKey });
       const rawInput = normalized.replace(/^history\s*/, "").trim();
       const parsedRange = parseNaturalDateRange(rawInput);
       const dateRange = parsedRange ?? buildDateRange("today");

--- a/supabase/functions/whatsapp-daily-summary/index.ts
+++ b/supabase/functions/whatsapp-daily-summary/index.ts
@@ -12,6 +12,7 @@ type ExpenseTransaction = {
   amount: number;
   title: string | null;
   date: string;
+  inserted_at?: string;
 };
 
 type Category = {
@@ -65,20 +66,35 @@ async function getBalanceSummary(userId: string): Promise<BalanceSummary> {
   const { data, error } = await supabase.rpc("get_account_type_balances", {
     p_user_id: userId,
   });
-
+  console.log("[DAILY SUMMARY RPC BALANCE RAW]", data);
   if (error) throw error;
 
   const rows = Array.isArray(data) ? data : [];
+  const first = (rows[0] ?? {}) as Record<string, unknown>;
+
+  if (
+    typeof first.cash_balance !== "undefined" ||
+    typeof first.non_cash_balance !== "undefined" ||
+    typeof first.total_balance !== "undefined"
+  ) {
+    const cash = Number(first.cash_balance ?? 0);
+    const nonCash = Number(first.non_cash_balance ?? 0);
+    const total = Number(first.total_balance ?? cash + nonCash);
+    return { cash, nonCash, total };
+  }
+
   let cash = 0;
   let nonCash = 0;
 
   for (const row of rows) {
-    const accountType = String(row.account_type ?? "").toLowerCase();
-    const balance = Number(row.balance ?? 0);
-    if (accountType === "cash") {
-      cash += balance;
+    const accountType = String((row as Record<string, unknown>).type ?? (row as Record<string, unknown>).account_type ?? "").toLowerCase();
+    const amount = Number((row as Record<string, unknown>).balance ?? (row as Record<string, unknown>).total ?? (row as Record<string, unknown>).amount ?? 0);
+    if (accountType.includes("non")) {
+      nonCash += amount;
+    } else if (accountType.includes("cash")) {
+      cash += amount;
     } else {
-      nonCash += balance;
+      cash += amount;
     }
   }
 
@@ -330,19 +346,44 @@ Deno.serve(async (req: Request) => {
           0,
         );
         const totalTransactions = transactions.length;
-        const averageTransaction = totalTransactions > 0
-          ? totalExpense / totalTransactions
-          : 0;
-
         const largestCategory = getLargestCategory(transactions, categoryMap);
         const largestTransaction = getLargestTransaction(transactions, categoryMap);
+        const { data: historyData, error: historyError } = await supabase
+          .from("transactions")
+          .select("id,title,amount,category_id,inserted_at")
+          .eq("user_id", userId)
+          .eq("type", "expense")
+          .eq("date", today)
+          .is("deleted_at", null)
+          .order("inserted_at", { ascending: false })
+          .limit(3);
+        if (historyError) {
+          failed += 1;
+          console.error("[DAILY SUMMARY HISTORY ERROR]", { userId, phone, error: historyError });
+          continue;
+        }
+        const historyRows = (historyData ?? []) as ExpenseTransaction[];
+        console.log("[DAILY SUMMARY HISTORY]", historyRows);
+
+        const historyLines: string[] = [];
+        if (historyRows.length > 0) {
+          historyLines.push("📚 History Terakhir");
+          historyRows.forEach((row, index) => {
+            const categoryName = row.category_id ? (categoryMap.get(row.category_id) ?? "-") : "-";
+            const title = (row.title ?? "").trim() || categoryName;
+            historyLines.push(`${index + 1}. ${categoryName} - ${title}`);
+            historyLines.push(`   ${formatIDR(Number(row.amount ?? 0))}`);
+          });
+        }
+
         console.log("[DAILY SUMMARY STEP] get balance");
         let balanceText = [
           "💰 Saldo Saat Ini",
-          "Gagal mengambil saldo.",
+          "Saldo gagal diambil.",
         ];
         try {
           const balanceSummary = await getBalanceSummary(userId);
+          console.log("[DAILY SUMMARY BALANCE]", balanceSummary);
           balanceText = [
             "💰 Saldo Saat Ini",
             `Cash: ${formatIDR(balanceSummary.cash)}`,
@@ -381,9 +422,8 @@ Deno.serve(async (req: Request) => {
           "🔥 Transaksi Terbesar",
           `${largestTransaction.title} — ${formatIDR(largestTransaction.amount)}`,
           "",
-          "📊 Rata-rata Transaksi",
-          formatIDR(averageTransaction),
-          "",
+          ...historyLines,
+          ...(historyLines.length > 0 ? [""] : []),
           ...balanceText,
           "",
           "💡 Insight",


### PR DESCRIPTION
### Motivation
- Fix incorrect saldo shown in daily WhatsApp summary by ensuring the summary uses the same `get_account_type_balances` RPC and handles multiple RPC return shapes. 
- Replace the removed average transaction section with a 3-item recent-history block to surface last expenses. 
- Improve observability so `history` command routing and balance RPC responses are easier to debug.

### Description
- Implemented a robust `getBalanceSummary(userId)` that logs raw RPC output with `console.log("[DAILY SUMMARY RPC BALANCE RAW]", data)` and supports summary-shaped rows (`cash_balance`, `non_cash_balance`, `total_balance`) and row-based shapes (`type`/`account_type` with `balance|total|amount`) to compute `cash`, `nonCash`, and `total` with proper fallbacks. 
- Added retrieval of the last 3 expense transactions for today using the query on `transactions` with filters `user_id`, `type=expense`, `date=today`, `deleted_at is null`, `order('inserted_at', { ascending: false })`, `limit(3)`, and format them into the new `📚 History Terakhir` section where empty title falls back to category name. 
- Removed the `Rata-rata Transaksi` section and deleted its calculation so average is no longer shown. 
- Added debug logs `console.log("[DAILY SUMMARY HISTORY]", historyRows)` and `console.log("[DAILY SUMMARY BALANCE]", balanceSummary)` and changed the saldo-failure fallback line to `Saldo gagal diambil.` without crashing the summary flow. 
- Added `inserted_at` to `ExpenseTransaction` type for history query and added a `console.log("[HISTORY COMMAND]", { normalized, userId, sender: replyContextKey })` line in `supabase/functions/fonnte-webhook-v2/index.ts` to trace `history` command routing.

### Testing
- Ran `deno check supabase/functions/whatsapp-daily-summary/index.ts supabase/functions/fonnte-webhook-v2/index.ts` which failed due to missing `deno` binary in the environment (`/bin/bash: deno: command not found`).
- Verified repository state with `git status --short` and committed the changes successfully via `git commit`, the commit succeeded.
- No other automated tests were available or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15c0c4c454832db369b3924f1b10ff)