### PR TITLE
Auto-cache and retry Fonnte group IDs for webhook replies

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -229,6 +229,25 @@ function buildFonnteTargets(target: string): string[] {
   return [...new Set(targets.filter(Boolean))];
 }
 
+
+const groupIdCache = new Map<string, string>();
+
+function buildPossibleGroupTargets(groupId: string): string[] {
+  const raw = String(groupId || "").trim();
+
+  const clean = raw
+    .replace("@g.us", "")
+    .replace(/[^\d-]/g, "");
+
+  const candidates = [
+    raw,
+    clean,
+    `${clean}@g.us`,
+  ];
+
+  return [...new Set(candidates.filter(Boolean))];
+}
+
 function isGroupJid(raw: string): boolean {
   return /@g\.us$/i.test(raw.trim());
 }
@@ -706,13 +725,25 @@ function parseNaturalDateRange(rawInput: string): { startDate: string; endDate: 
 
 async function replyWhatsApp(target: string, message: string): Promise<boolean> {
   if (!FONNTE_TOKEN || !target || !message) return false;
-  const targets = buildFonnteTargets(target);
+  const isGroup = target.includes("@g.us");
+  const cached = groupIdCache.get(target);
+
+  const targets = isGroup
+    ? [...new Set([...(cached ? [cached] : []), ...buildPossibleGroupTargets(target)])]
+    : buildFonnteTargets(target);
   let lastResult = "";
+
+  if (isGroup) {
+    console.log("[GROUP TARGET TRY]", {
+      originalTarget: target,
+      candidates: targets,
+    });
+  }
 
   console.log("[SEND WHATSAPP]", {
     originalTarget: target,
     targets,
-    isGroup: target.includes("@g.us"),
+    isGroup,
   });
 
   for (const finalTarget of targets) {
@@ -743,6 +774,17 @@ async function replyWhatsApp(target: string, message: string): Promise<boolean> 
       }
 
       if (response.ok && parsed?.status === true) {
+        if (isGroup) {
+          groupIdCache.set(target, finalTarget);
+          console.log("[GROUP TARGET SUCCESS]", {
+            originalTarget: target,
+            successTarget: finalTarget,
+          });
+          console.log("[GROUP TARGET CACHED]", {
+            originalGroupId: target,
+            finalTarget,
+          });
+        }
         return true;
       }
     } catch (error) {
@@ -3151,6 +3193,9 @@ Deno.serve(async (req: Request) => {
     canReplyOnError = Boolean(chatTarget || sender);
 
     const isGroup = isGroupMessage(body);
+    if (isGroup && chatTarget) {
+      groupIdCache.set(chatTarget, chatTarget);
+    }
     console.log("[GROUP PAYLOAD KEYS]", Object.keys(body));
     console.log("[GROUP DATA KEYS]", body.data ? Object.keys(body.data) : []);
     console.log("[GROUP PAYLOAD DEBUG]", {
@@ -3757,7 +3802,7 @@ Deno.serve(async (req: Request) => {
     const replyTarget = chatTarget || sender;
     const sent = await replyWhatsApp(replyTarget, reply);
     if (!sent && isGroup && participant) {
-      await replyWhatsApp(participant, "⚠️ Bot belum bisa membalas ke grup ini. Group ID Fonnte tidak valid.");
+      await replyWhatsApp(participant, "⚠️ Bot belum bisa membalas ke grup ini karena Group ID Fonnte belum valid.");
     }
     await logMessage({
       wa_message_id: waMessageId,


### PR DESCRIPTION
### Motivation
- Incoming group webhooks sometimes provide a group id that Fonnte rejects as invalid, causing group replies to fail; the change aims to automatically discover and remember a valid Fonnte group id so the bot can reply to groups reliably.

### Description
- Added an in-memory cache `groupIdCache = new Map<string, string>()` and a helper `buildPossibleGroupTargets()` that returns candidate targets (`raw`, `clean`, ```${clean}@g.us``` ) for a given group id in `supabase/functions/fonnte-webhook-v2/index.ts`.
- Updated `replyWhatsApp()` to, when the target is a group, prefer a cached target, try multiple group-id candidates, log attempts with `[GROUP TARGET TRY]`, and detect success with `response.ok && parsed?.status === true`.
- On successful send the code caches the working `finalTarget` and logs `[GROUP TARGET SUCCESS]` and `[GROUP TARGET CACHED]`, and the incoming group handler now primes the cache with `groupIdCache.set(chatTarget, chatTarget)` when a group message arrives.
- Kept existing personal fallback behavior and adjusted the fallback message text to the requested wording; changes are limited to `supabase/functions/fonnte-webhook-v2/index.ts` and do not touch other features or DB schema.

### Testing
- Attempted `deno check supabase/functions/fonnte-webhook-v2/index.ts`, but it failed because `deno` is not available in the environment (`deno: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15c193bd50832d98e08e875cec3739)