### PR TITLE
Fix Fonnte group participant parsing to prioritize `member` field

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -17,6 +17,8 @@ type WebhookBody = {
   chat_id?: string;
   chatId?: string;
   member?: string;
+  memberlid?: string;
+  memberNumber?: string;
   pushNameNumber?: string;
   phone?: string;
   number?: string;
@@ -43,6 +45,8 @@ type WebhookBody = {
     chat_id?: string;
     chatId?: string;
     member?: string;
+    memberlid?: string;
+    memberNumber?: string;
     pushNameNumber?: string;
     phone?: string;
     number?: string;
@@ -294,20 +298,24 @@ function extractRawGroupId(body: WebhookBody): string {
 
 function extractRawParticipant(body: WebhookBody): string {
   const candidates = [
+    body.member,
+    body.memberlid,
     body.participant,
     body.author,
-    body.member,
-    body.pushNameNumber,
-    !isGroupJid(String(body.sender ?? "")) ? body.sender : "",
+    body.memberNumber,
     body.phone,
     body.number,
+    body.pushNameNumber,
+    !isGroupJid(String(body.sender ?? "")) ? body.sender : "",
+    body.data?.member,
+    body.data?.memberlid,
     body.data?.participant,
     body.data?.author,
-    body.data?.member,
-    body.data?.pushNameNumber,
-    !isGroupJid(String(body.data?.sender ?? "")) ? body.data?.sender : "",
+    body.data?.memberNumber,
     body.data?.phone,
     body.data?.number,
+    body.data?.pushNameNumber,
+    !isGroupJid(String(body.data?.sender ?? "")) ? body.data?.sender : "",
   ].map((v) => String(v ?? "").trim()).filter(Boolean);
 
   return candidates[0] ?? "";
@@ -3211,6 +3219,13 @@ Deno.serve(async (req: Request) => {
     const replyContextKey = isGroup ? `${sender}|${chatTarget}` : sender;
     const validCommand = isPotentialBotCommand(message);
     console.log("[GROUP CHAT]", { isGroup, sender, participant, chatTarget, message, validCommand });
+    if (isGroup) {
+      console.log("[GROUP MEMBER PARSE]", {
+        member: body.member,
+        memberlid: body.memberlid,
+        parsedParticipant: participant,
+      });
+    }
 
     if (isGroup && (!sender || !participant)) {
       console.log("[GROUP PAYLOAD COMPACT]", JSON.stringify(body));
@@ -3801,6 +3816,13 @@ Deno.serve(async (req: Request) => {
     }
 
     const replyTarget = chatTarget || sender;
+    if (isGroup) {
+      console.log("[GROUP REPLY FLOW]", {
+        groupTarget: chatTarget,
+        participant,
+        sender,
+      });
+    }
     const sent = await replyWhatsApp(replyTarget, reply);
     if (!sent && isGroup && participant) {
       await replyWhatsApp(participant, "⚠️ Bot belum bisa membalas ke grup ini karena Group ID Fonnte belum valid.");


### PR DESCRIPTION
### Motivation
- Fonnte webhook payloads include a `member` key that was not being prioritized, causing incorrect participant fallback and unstable group sender resolution. 
- Group replies sometimes failed because the parsed participant was missing or inaccurate, so parsing must prefer `member` and related keys. 
- Added debug logs to make group participant parsing and reply flow easier to troubleshoot. 

### Description
- Updated `WebhookBody` typing to include `memberlid` and `memberNumber` at the root and inside `data` to match observed payload keys. 
- Reworked `extractRawParticipant` ordering so group participant candidates prioritize `body.member`, then `body.memberlid`, then `body.participant`, `body.author`, `body.memberNumber`, `body.phone`, `body.number`, and finally non-group `sender`, including the same precedence for `data.*`. 
- Continued using `normalizeSenderLikeValue(extractRawParticipant(body))` in `extractParticipant` so normalized values like `628xxxx` are produced from `@s.whatsapp.net`, `@c.us`, and `@g.us` formats. 
- Added console debug logs: `[GROUP MEMBER PARSE]` (shows `member`, `memberlid`, and parsed participant) and `[GROUP REPLY FLOW]` (shows `groupTarget`, `participant`, and `sender`) and preserved reply target logic to keep replies addressed to `chatTarget || sender`. 

### Testing
- Attempted type-check with `deno check supabase/functions/fonnte-webhook-v2/index.ts`, but it failed to run because `deno` is not available in the environment. 
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15c37c67dc832d990f18d93eec06a8)