### PR TITLE
Do not fallback to private chat on failed group replies; add GROUP_REPLY_DEBUG_PRIVATE

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -153,6 +153,10 @@ const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 const FONNTE_TOKEN = Deno.env.get("FONNTE_TOKEN") ?? "";
 
+function isGroupPrivateDebugEnabled(): boolean {
+  return String(Deno.env.get("GROUP_REPLY_DEBUG_PRIVATE") ?? "false").toLowerCase() === "true";
+}
+
 const BOT_PREFIXES = ["🤖", "✅", "❌", "⚠️", "💰", "ℹ️", "📊", "📚", "🏦", "📌", "🗑️", "🧾", "🎯", "🔁", "🏓", "📋", "📆", "🗓️", "📘"];
 const MENU_COMMANDS = new Set(["menu", "help", "bantuan", ".menu"]);
 
@@ -3253,6 +3257,12 @@ Deno.serve(async (req: Request) => {
 
     const replyContextKey = isGroup ? `${sender}|${chatTarget}` : sender;
     const validCommand = isPotentialBotCommand(message);
+    console.log("[REPLY ROUTE]", {
+      isGroup,
+      chatTarget,
+      participant,
+      willReplyTo: isGroup ? "group" : "personal",
+    });
     console.log("[GROUP CHAT]", { isGroup, sender, participant, chatTarget, message, validCommand });
     if (isGroup) {
       console.log("[GROUP MEMBER PARSE]", {
@@ -3878,8 +3888,21 @@ Deno.serve(async (req: Request) => {
       memberlid: body.memberlid ?? body.data?.memberlid ?? parsedLid,
       senderlid: body.senderlid ?? body.data?.senderlid ?? parsedLid,
     });
-    if (!sent && isGroup && participant) {
-      await replyWhatsApp({ target: participant, message: "⚠️ Bot belum bisa membalas ke grup ini karena Group ID Fonnte belum valid." });
+    if (!sent && isGroup) {
+      console.error("[GROUP REPLY FAILED]", {
+        chatTarget,
+        participant,
+        message,
+      });
+
+      if (isGroupPrivateDebugEnabled() && participant) {
+        await replyWhatsApp({
+          target: participant,
+          message: "⚠️ Debug: bot belum bisa membalas grup ini karena target grup Fonnte tidak valid.",
+        });
+      }
+
+      return json({ ok: true, groupReplyFailed: true });
     }
     await logMessage({
       wa_message_id: waMessageId,


### PR DESCRIPTION
### Motivation

- Prevent the bot from sending main responses to a user's private chat when a command originates from a group and group delivery fails, to avoid spamming users.
- Provide an opt-in debug channel for private notifications while keeping the default behavior silent.

### Description

- Added `isGroupPrivateDebugEnabled()` helper which reads optional env `GROUP_REPLY_DEBUG_PRIVATE` (default `false`).
- Added a `[REPLY ROUTE]` log to record whether a message will be replied to the group or personal chat.
- Changed group reply routing so that when a group send fails the handler logs `[GROUP REPLY FAILED]`, returns `json({ ok: true, groupReplyFailed: true })`, and does not automatically send the main response to the participant's private chat.
- Kept the existing `replyWhatsApp` candidate/target strategy unchanged and added an optional private debug message only when `GROUP_REPLY_DEBUG_PRIVATE=true`.

### Testing

- Attempted to run `deno check supabase/functions/fonnte-webhook-v2/index.ts` but it failed because `deno` is not available in the execution environment, so static/type checks were not completed.
- Verified the file was updated at `supabase/functions/fonnte-webhook-v2/index.ts` and basic runtime paths where the new logs and checks occur via local inspection; no automated runtime tests were executed due to missing `deno`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15c6aebd18832daf77c67d8f67263e)