### PR TITLE
Use explicit FONNTE_DEVICE for Fonnte WhatsApp sends

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -152,6 +152,7 @@ type BudgetPeriodItem = {
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 const FONNTE_TOKEN = Deno.env.get("FONNTE_TOKEN") ?? "";
+const FONNTE_DEVICE = Deno.env.get("FONNTE_DEVICE") ?? "";
 
 function isGroupPrivateDebugEnabled(): boolean {
   return String(Deno.env.get("GROUP_REPLY_DEBUG_PRIVATE") ?? "false").toLowerCase() === "true";
@@ -755,23 +756,11 @@ async function replyWhatsApp(input: { target: string; message: string; memberlid
   const { target, message, memberlid = null, senderlid = null } = input;
   if (!FONNTE_TOKEN || !target || !message) return false;
   const isGroup = target.includes("@g.us");
-  const cached = groupIdCache.get(target);
   const normalizedMemberLid = memberlid ? String(memberlid).trim() : "";
   const normalizedSenderLid = senderlid ? String(senderlid).trim() : "";
-  const memberLidNoSuffix = normalizedMemberLid.replace(/@lid$/i, "");
-  const senderLidNoSuffix = normalizedSenderLid.replace(/@lid$/i, "");
 
   const targets = isGroup
-    ? [
-      ...new Set([
-        ...(cached ? [cached] : []),
-        ...buildPossibleGroupTargets(target),
-        normalizedMemberLid,
-        memberLidNoSuffix,
-        normalizedSenderLid,
-        senderLidNoSuffix,
-      ].filter(Boolean)),
-    ]
+    ? [target]
     : buildFonnteTargets(target);
   let lastResult = "";
 
@@ -787,6 +776,12 @@ async function replyWhatsApp(input: { target: string; message: string; memberlid
     });
   }
 
+  if (!FONNTE_DEVICE) {
+    console.warn("[FONNTE DEVICE WARNING]", {
+      message: "FONNTE_DEVICE is empty, request will continue without explicit device.",
+    });
+  }
+
   console.log("[SEND WHATSAPP]", {
     originalTarget: target,
     targets,
@@ -797,6 +792,14 @@ async function replyWhatsApp(input: { target: string; message: string; memberlid
     const form = new FormData();
     form.append("target", finalTarget);
     form.append("message", message);
+    if (FONNTE_DEVICE) {
+      form.append("device", FONNTE_DEVICE);
+    }
+
+    console.log("[FONNTE SEND CONFIG]", {
+      target: finalTarget,
+      device: FONNTE_DEVICE,
+    });
 
     try {
       const response = await fetch("https://api.fonnte.com/send", {


### PR DESCRIPTION
### Motivation
- Fix sending to valid Fonnte group IDs (e.g. `120363420123492143@g.us`) by providing the explicit device/session parameter that Fonnte may require.
- Keep behavior consistent for both personal and group messages while avoiding fallback to private sends on group failure.

### Description
- Add a new environment variable `FONNTE_DEVICE` and read it at module level as `FONNTE_DEVICE`.
- For group sends, stop trying experimental target formats and use the provided group id `target` as-is (e.g. `120363420123492143@g.us`).
- Use `FormData` for the outbound send and append `device` when `FONNTE_DEVICE` is set, and emit a debug log `[FONNTE SEND CONFIG]` with `target` and `device` before the fetch.
- Log a non-blocking warning when `FONNTE_DEVICE` is empty but continue sending without the explicit device parameter.

### Testing
- No automated tests were executed for this change; the patch is a targeted runtime behavior change confined to the Fonnte send path and was inspected in the updated file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15c89b7ce8832da0a9768af2028f8b)