### PR TITLE
Fix `hapus <nomor>` to read latest history log and persist displayedTransactions

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -2382,19 +2382,37 @@ function parseEditTransactionCommand(rawMessage: string): ParsedEditTransactionC
   return { number, field: "amount", value: amount };
 }
 
-async function getLastHistoryTransactions(userId: string, phone: string): Promise<Array<Record<string, JsonValue>>> {
-  const { data, error } = await supabase
+async function getLastHistoryLog(userId: string, phone: string): Promise<Record<string, JsonValue> | null> {
+  const { data: logs, error } = await supabase
     .from("whatsapp_message_logs")
-    .select("parsed")
+    .select("id,created_at,parsed")
     .eq("user_id", userId)
     .eq("phone", phone)
     .eq("status", "success")
-    .eq("parsed->>command", "history")
     .order("created_at", { ascending: false })
-    .limit(1)
-    .maybeSingle();
+    .limit(30);
   if (error) throw error;
-  const parsed = (data?.parsed ?? null) as Record<string, JsonValue> | null;
+
+  const historyLog = (logs ?? []).find((log) => {
+    const parsed = (log.parsed ?? null) as Record<string, JsonValue> | null;
+    return parsed?.command === "history" &&
+      Array.isArray(parsed?.displayedTransactions) &&
+      parsed.displayedTransactions.length > 0;
+  }) as Record<string, JsonValue> | undefined;
+
+  console.log("[LAST HISTORY LOG FOUND]", {
+    found: Boolean(historyLog),
+    count: Array.isArray((historyLog?.parsed as Record<string, JsonValue> | null)?.displayedTransactions)
+      ? (((historyLog?.parsed as Record<string, JsonValue>).displayedTransactions as JsonValue[]).length)
+      : 0,
+  });
+
+  return historyLog ?? null;
+}
+
+async function getLastHistoryTransactions(userId: string, phone: string): Promise<Array<Record<string, JsonValue>>> {
+  const historyLog = await getLastHistoryLog(userId, phone);
+  const parsed = (historyLog?.parsed ?? null) as Record<string, JsonValue> | null;
   return (parsed?.displayedTransactions ?? []) as Array<Record<string, JsonValue>>;
 }
 
@@ -3490,24 +3508,34 @@ Deno.serve(async (req: Request) => {
             categoryMap,
             accountMap,
           );
-          parsedLog = { command: "history_date", startDate: dateRange.startDate, endDate: dateRange.endDate, entityType, entityName, displayedTransactions };
+          console.log("[HISTORY DISPLAYED TRANSACTIONS]", {
+            count: displayedTransactions.length,
+            ids: displayedTransactions.map((x) => (x as Record<string, JsonValue>).id),
+          });
+          parsedLog = { command: "history", startDate: dateRange.startDate, endDate: dateRange.endDate, entityType, entityName, displayedTransactions };
           reply = historyReply;
         }
       }
-    } else if (/^hapus\s+\d+$/.test(normalized)) {
-      const number = Number(normalized.replace(/^hapus\s+/, "").trim());
+    } else if (/^hapus\s+(\d+)$/.test(normalized)) {
+      const deleteMatch = normalized.match(/^hapus\s+(\d+)$/);
+      const number = Number(deleteMatch?.[1] ?? 0);
+      console.log("[DELETE FROM HISTORY]", {
+        userId,
+        phone: replyContextKey,
+        number,
+      });
       parsedLog = { command: "hapus_history", number };
 
-      if (!Number.isInteger(number) || number < 1 || number > 5) {
+      if (!Number.isInteger(number) || number < 1) {
         reply = "⚠️ Nomor history tidak valid.\n\nPilih nomor dari hasil history terakhir.";
       } else {
         const displayedTransactions = await getLastHistoryTransactions(userId, replyContextKey);
         if (displayedTransactions.length === 0) {
-          reply = "⚠️ Belum ada history terakhir.\n\nKirim *history* dulu, lalu gunakan:\nhapus 3";
+          reply = "⚠️ Belum ada history terakhir.\n\nKirim history dulu, lalu gunakan:\nhapus 3";
         } else {
           const selectedTransaction = findDisplayedTransactionByNumber(displayedTransactions, number);
           if (!selectedTransaction) {
-            reply = "⚠️ Nomor history tidak ditemukan.\n\nKirim *history* dulu, lalu pilih nomor yang ingin dihapus.\nContoh: hapus 3";
+            reply = "⚠️ Nomor history tidak ditemukan.";
           } else {
             const transactionId = String(selectedTransaction.id ?? "");
             const { data: deletedTx, error: deleteError } = await supabase


### PR DESCRIPTION
### Motivation
- The `hapus 1` flow failed to find the most recent `history` because logs were filtered via JSON path and `parsed.displayedTransactions` was not reliably read. 
- The handler still used legacy command names and a narrow query which caused missing history context when deleting by number. 
- Goal is to let `hapus <nomor>` use the last visible `history` (with `displayedTransactions`) and to preserve that payload when history is replied.

### Description
- Added `getLastHistoryLog(userId, phone)` which fetches recent successful `whatsapp_message_logs` (limit 30) and manually finds the latest log with `parsed.command === "history"` and a non-empty `parsed.displayedTransactions` array. 
- Rewrote `getLastHistoryTransactions` to call `getLastHistoryLog` and return `parsed.displayedTransactions`, avoiding the unreliable `.eq("parsed->>command","history")` filter. 
- When replying to a `history` command the code now sets `parsedLog.command = "history"` and includes full `displayedTransactions`, plus a debug `console.log("[HISTORY DISPLAYED TRANSACTIONS]", ...)` with ids/count. 
- Updated `hapus <nomor>` handling to use the regex capture `/^hapus\s+(\d+)$/`, extract the number from the capture group, removed the old hard limit, added `console.log("[DELETE FROM HISTORY]", ...)`, and adjusted user-facing messages for missing history / not-found numbers.

### Testing
- Attempted `deno check supabase/functions/fonnte-webhook-v2/index.ts` but it failed in the environment because `deno` is not installed (`/bin/bash: deno: command not found`).
- The modified file was added and committed successfully with `git commit`.
- No further automated runtime tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15da4416c0832d8e077c9a967e7bba)