### PR TITLE
Fix amount suffix parsing and make debts (hutang/piutang) listing schema-safe

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -671,10 +671,23 @@ function buildHistoryMessage(
 }
 
 function parseAmount(raw: string): number {
-  const cleaned = raw.replace(/[^0-9]/g, "");
+  const input = String(raw ?? "").trim();
+  const suffixMatch = input.match(/(\d+(?:[.,]\d+)?)\s*(rb|rbu|ribu|k|jt|juta|m)\b/i);
+
+  if (suffixMatch) {
+    const numericValue = Number(suffixMatch[1].replace(",", "."));
+    const suffix = suffixMatch[2].toLowerCase();
+    const multiplier = ["rb", "rbu", "ribu", "k"].includes(suffix) ? 1000 : 1000000;
+    const amount = Number.isFinite(numericValue) && numericValue > 0 ? Math.floor(numericValue * multiplier) : 0;
+    console.log("[PARSE AMOUNT]", { input, amount });
+    return amount;
+  }
+
+  const cleaned = input.replace(/[^0-9]/g, "");
   const value = Number(cleaned);
-  if (!Number.isFinite(value) || value <= 0) return 0;
-  return Math.floor(value);
+  const amount = Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+  console.log("[PARSE AMOUNT]", { input, amount });
+  return amount;
 }
 
 function parseOptionalDateToken(raw: string): string | null {
@@ -1861,7 +1874,7 @@ async function getSubscriptionSummary(userId: string): Promise<{ monthlyCharge: 
   return { monthlyCharge, activeNames: active.map((s: Record<string, JsonValue>) => String(s.name ?? "-")) };
 }
 
-async function getDebtStatus(userId: string): Promise<Array<{ name: string; remaining: number; type: string }>> {
+async function getDebtStatusSummary(userId: string): Promise<Array<{ name: string; remaining: number; type: string }>> {
   const { data: debts, error } = await supabase
     .from("debts")
     .select("*")
@@ -1869,11 +1882,11 @@ async function getDebtStatus(userId: string): Promise<Array<{ name: string; rema
   if (error) throw error;
 
   return (debts ?? [])
-    .filter((d: Record<string, JsonValue>) => !(d.is_paid === true || String(d.status ?? "").toLowerCase() === "paid"))
+    .filter((d: Record<string, JsonValue>) => isDebtRowOpen(d))
     .map((d: Record<string, JsonValue>) => ({
-      name: String(d.name ?? d.person_name ?? d.counterparty_name ?? "-"),
+      name: getDebtName(d),
       remaining: getDebtRemainingAmount(d),
-      type: String(d.type ?? "debt"),
+      type: getDebtKind(d) || "debt",
     }));
 }
 
@@ -2180,7 +2193,7 @@ async function handleAiFinanceChat(userId: string, question: string): Promise<{ 
   }
 
   if (intent === "DEBT_STATUS") {
-    const rows = await getDebtStatus(userId);
+    const rows = await getDebtStatusSummary(userId);
     const lines = rows.length > 0 ? rows.map((r, i) => `${i + 1}. ${r.name} (${r.type}) — ${formatIDR(r.remaining)}`).join("\n") : "Tidak ada hutang/piutang aktif.";
     return { intent, reply: `🤖 *AI Finance Chat*\n\n${lines}` };
   }
@@ -2892,33 +2905,52 @@ async function handleEditLastTransactionAccount(userId: string, normalized: stri
   };
 }
 
+function isDebtRowOpen(row: Record<string, JsonValue>): boolean {
+  const status = getDebtStatus(row);
+  if (["paid", "lunas", "deleted", "hapus", "cancelled", "canceled", "closed"].includes(status)) return false;
+  if (row.is_paid === true || row.deleted_at || row.is_active === false) return false;
+  return true;
+}
+
+function rowHasDebtTypeField(row: Record<string, JsonValue>): boolean {
+  return row.type !== undefined || row.kind !== undefined || row.debt_type !== undefined;
+}
+
+function isDebtTypeRow(row: Record<string, JsonValue>, type: "hutang" | "piutang"): boolean {
+  const kind = getDebtKind(row);
+  if (type === "hutang") return kind.includes("hutang") || kind.includes("debt") || kind.includes("payable");
+  return kind.includes("piutang") || kind.includes("receivable");
+}
+
 async function getOpenDebts(userId: string): Promise<Array<Record<string, JsonValue>>> {
   const { data, error } = await supabase
     .from("debts")
     .select("*")
-    .eq("user_id", userId)
-    .eq("status", "ongoing")
-    .order("created_at", { ascending: true });
+    .eq("user_id", userId);
   if (error) throw error;
-  return (data ?? []) as Array<Record<string, JsonValue>>;
+  return ((data ?? []) as Array<Record<string, JsonValue>>).filter(isDebtRowOpen);
 }
 
 async function findOpenDebtByParty(userId: string, debtType: DebtType, partyName: string): Promise<Record<string, JsonValue> | null> {
-  const keyword = `%${partyName}%`;
   const { data, error } = await supabase
     .from("debts")
     .select("*")
-    .eq("user_id", userId)
-    .eq("status", "ongoing")
-    .or(`party_name.ilike.${keyword},name.ilike.${keyword},title.ilike.${keyword}`)
-    .order("created_at", { ascending: false })
-    .limit(20);
+    .eq("user_id", userId);
   if (error) throw error;
-  const rows = (data ?? []) as Array<Record<string, JsonValue>>;
+
+  const normalizedParty = normalizeText(partyName);
+  const rows = ((data ?? []) as Array<Record<string, JsonValue>>).filter(isDebtRowOpen);
   return rows.find((row) => {
-    const kind = getDebtKind(row);
-    if (debtType === "debt") return kind.includes("hutang") || kind.includes("debt");
-    return kind.includes("piutang") || kind.includes("receivable");
+    const hasTypeField = rowHasDebtTypeField(row);
+    if (hasTypeField && !isDebtTypeRow(row, debtType === "debt" ? "hutang" : "piutang")) return false;
+    if (!hasTypeField && debtType !== "debt") return false;
+    const names = [
+      getDebtName(row),
+      row.party_name,
+      row.person_name,
+      row.counterparty_name,
+    ].map((value) => normalizeText(String(value ?? ""))).filter(Boolean);
+    return names.some((name) => name.includes(normalizedParty) || normalizedParty.includes(name));
   }) ?? null;
 }
 
@@ -3002,14 +3034,32 @@ function getDebtKind(row: any): string {
     row.kind ??
     row.type ??
     row.debt_type ??
+    row.category ??
     "",
   ).toLowerCase();
+}
+
+function getDebtStatus(row: any): string {
+  return String(row.status ?? row.state ?? "").toLowerCase();
+}
+
+function formatDebtDateLocal(value: string): string {
+  const raw = String(value ?? "").trim();
+  const match = raw.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (match) return `${match[3]}/${match[2]}/${match[1]}`;
+
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) return raw || "-";
+  const day = String(date.getDate()).padStart(2, "0");
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const year = String(date.getFullYear());
+  return `${day}/${month}/${year}`;
 }
 
 function formatDebtDueDate(row: any): string {
   const due = getDebtDueDate(row);
   if (!due) return "-";
-  return formatDateLocal(String(due));
+  return formatDebtDateLocal(String(due));
 }
 
 async function findLastDisplayedDebtList(userId: string): Promise<Array<Record<string, JsonValue>> | null> {
@@ -3042,6 +3092,8 @@ async function updateDebtAmount(userId: string, debtId: string, amount: number):
     ? "nominal"
     : "total" in debtRow
     ? "total"
+    : "value" in debtRow
+    ? "value"
     : null;
   if (!field) throw new Error("DEBT_AMOUNT_FIELD_NOT_FOUND");
   console.log("[DEBT UPDATE FIELD]", { field, value: amount });
@@ -3073,40 +3125,30 @@ async function softDeleteDebt(userId: string, debtId: string): Promise<void> {
 }
 
 async function handleDebtCommand(userId: string, rawMessage: string, normalized: string): Promise<{ reply: string; parsedLog: Record<string, JsonValue> }> {
-  if (normalized === "hutang") {
-    const rows = await getOpenDebts(userId);
-    console.log("[DEBT ROW SAMPLE]", rows?.[0]);
-    const hasTypeField = rows.some((row) => row.type !== undefined || row.kind !== undefined || row.debt_type !== undefined);
-    const filteredRows = hasTypeField
-      ? rows.filter((row) => {
-        const kind = getDebtKind(row);
-        return kind.includes("hutang") || kind.includes("debt");
-      })
-      : rows;
-    if (filteredRows.length === 0) return { reply: "💳 *Hutang Aktif*\n\n━━━━━━━━━━━━━━\nℹ️ Belum ada hutang aktif.", parsedLog: { command: "hutang_list", displayedDebts: [] } };
-    const displayedDebts = filteredRows.map((row, i) => {
-      const totalAmount = getDebtTotalAmount(row);
-      const paidAmount = getDebtPaidAmount(row);
-      const remainingAmount = getDebtRemainingAmount(row);
-      const dueDate = formatDebtDueDate(row);
-      console.log("[DEBT SCHEMA SAFE]", { totalAmount, paidAmount, remainingAmount, dueDate });
-      return { no: i + 1, id: String(row.id ?? ""), name: getDebtName(row), totalAmount, paidAmount, remainingAmount, dueDate };
-    });
-    const lines = displayedDebts.map((item) => `${item.no}. *${item.name}*\n💰 Total: *${formatIDR(item.totalAmount)}*\n💸 Dibayar: *${formatIDR(item.paidAmount)}*\n🧾 Sisa: *${formatIDR(item.remainingAmount)}*\n📅 Jatuh Tempo: *${item.dueDate}*`);
-    return { reply: `💳 *Hutang Aktif*\n\n━━━━━━━━━━━━━━\n${lines.join("\n\n")}\n\n━━━━━━━━━━━━━━\n✏️ Edit:\n• edit hutang 1 200rb\n• edit hutang 2 500000\n\n🗑️ Hapus:\n• hapus hutang 1`, parsedLog: { command: "hutang_list", displayedDebts } };
-  }
-
-  if (normalized === "piutang") {
-    const rows = await getOpenDebts(userId);
-    const hasTypeField = rows.some((row) => row.type !== undefined || row.kind !== undefined || row.debt_type !== undefined);
-    if (!hasTypeField) {
-      return { reply: "📒 *Piutang Aktif*\n\n━━━━━━━━━━━━━━\nℹ️ Belum ada piutang aktif.", parsedLog: { command: "piutang_list", displayedDebts: [] } };
+  if (normalized === "hutang" || normalized === "piutang") {
+    const type = normalized === "hutang" ? "hutang" : "piutang";
+    let rows: Array<Record<string, JsonValue>> = [];
+    try {
+      rows = await getOpenDebts(userId);
+    } catch (error) {
+      console.error("[DEBT QUERY ERROR]", error);
+      const message = error instanceof Error ? error.message : String(error);
+      return { reply: `❌ *Gagal Mengambil Hutang*\n${message}`, parsedLog: { command: `${type}_list`, status: "query_error", error: message } };
     }
-    const filteredRows = rows.filter((row) => {
-      const kind = getDebtKind(row);
-      return kind.includes("piutang") || kind.includes("receivable");
-    });
-    if (filteredRows.length === 0) return { reply: "📒 *Piutang Aktif*\n\n━━━━━━━━━━━━━━\nℹ️ Belum ada piutang aktif.", parsedLog: { command: "piutang_list", displayedDebts: [] } };
+
+    console.log("[DEBT ROW SAMPLE]", rows?.[0]);
+    const hasTypeField = rows.some(rowHasDebtTypeField);
+    const filteredRows = type === "hutang"
+      ? hasTypeField ? rows.filter((row) => isDebtTypeRow(row, "hutang")) : rows
+      : hasTypeField ? rows.filter((row) => isDebtTypeRow(row, "piutang")) : [];
+
+    console.log("[DEBT LIST BUILT]", { type, count: filteredRows.length });
+
+    const title = type === "hutang" ? "💳 *Hutang Aktif*" : "📒 *Piutang Aktif*";
+    const emptyText = type === "hutang" ? "ℹ️ Belum ada hutang aktif." : "ℹ️ Belum ada piutang aktif.";
+    const command = type === "hutang" ? "hutang_list" : "piutang_list";
+    if (filteredRows.length === 0) return { reply: `${title}\n\n━━━━━━━━━━━━━━\n${emptyText}`, parsedLog: { command, displayedDebts: [] } };
+
     const displayedDebts = filteredRows.map((row, i) => {
       const totalAmount = getDebtTotalAmount(row);
       const paidAmount = getDebtPaidAmount(row);
@@ -3116,13 +3158,14 @@ async function handleDebtCommand(userId: string, rawMessage: string, normalized:
       return { no: i + 1, id: String(row.id ?? ""), name: getDebtName(row), totalAmount, paidAmount, remainingAmount, dueDate };
     });
     const lines = displayedDebts.map((item) => `${item.no}. *${item.name}*\n💰 Total: *${formatIDR(item.totalAmount)}*\n💸 Dibayar: *${formatIDR(item.paidAmount)}*\n🧾 Sisa: *${formatIDR(item.remainingAmount)}*\n📅 Jatuh Tempo: *${item.dueDate}*`);
-    return { reply: `📒 *Piutang Aktif*\n\n━━━━━━━━━━━━━━\n${lines.join("\n\n")}`, parsedLog: { command: "piutang_list", displayedDebts } };
+    const editHint = type === "hutang" ? `\n\n━━━━━━━━━━━━━━\n✏️ Edit:\n• edit hutang 1 200rb\n• edit hutang 2 500000\n\n🗑️ Hapus:\n• hapus hutang 1` : "";
+    return { reply: `${title}\n\n━━━━━━━━━━━━━━\n${lines.join("\n\n")}${editHint}`, parsedLog: { command, displayedDebts } };
   }
 
   const editMatch = normalized.match(/^edit\s+hutang\s+(\d+)\s+(.+)$/);
   if (editMatch) {
     const number = Number(editMatch[1]);
-    const amount = parseIDRAmount(editMatch[2]);
+    const amount = parseAmount(editMatch[2]);
     console.log("[EDIT DEBT]", { number, amount });
     if (!Number.isFinite(amount) || amount <= 0) return { reply: "⚠️ Nominal tidak valid.", parsedLog: { command: "edit_hutang", status: "invalid_amount" } };
     const displayedDebts = await findLastDisplayedDebtList(userId);
@@ -3133,7 +3176,7 @@ async function handleDebtCommand(userId: string, rawMessage: string, normalized:
       await updateDebtAmount(userId, String(selected.id ?? ""), amount);
     } catch (error) {
       if (error instanceof Error && error.message === "DEBT_AMOUNT_FIELD_NOT_FOUND") {
-        return { reply: "❌ Kolom nominal hutang tidak ditemukan di schema.", parsedLog: { command: "edit_hutang", status: "field_not_found", number } };
+        return { reply: "❌ Kolom nominal hutang tidak ditemukan.", parsedLog: { command: "edit_hutang", status: "field_not_found", number } };
       }
       throw error;
     }
@@ -3166,6 +3209,7 @@ async function handleDebtCommand(userId: string, rawMessage: string, normalized:
       parsedLog: { command: "debt", action: "invalid" },
     };
   }
+
 
   const account = await findAccount(userId, parsed.accountName);
   if (!account) {
@@ -3264,7 +3308,9 @@ async function handleDebtCommand(userId: string, rawMessage: string, normalized:
     return { reply: "❌ Kolom pembayaran hutang tidak ditemukan di schema.", parsedLog: { command: "debt", action: "bayar", status: "payment_field_not_found" } };
   }
   console.log("[DEBT UPDATE FIELD]", { field: paidField, value: newPaidTotal });
-  const { error: updateDebtErr } = await supabase.from("debts").update({ [paidField]: newPaidTotal, status: nextStatus }).eq("id", String(debt.id)).eq("user_id", userId);
+  const debtUpdate: Record<string, JsonValue> = { [paidField]: newPaidTotal };
+  if ("status" in debt) debtUpdate.status = nextStatus;
+  const { error: updateDebtErr } = await supabase.from("debts").update(debtUpdate).eq("id", String(debt.id)).eq("user_id", userId);
   if (updateDebtErr) throw updateDebtErr;
 
   const isDebt = parsed.debtType === "debt";
@@ -3281,7 +3327,6 @@ async function handleDebtCommand(userId: string, rawMessage: string, normalized:
     parsedLog: { command: "debt", action: "bayar", debtType: parsed.debtType, partyName: parsed.partyName, amount: parsed.amount, accountName: parsed.accountName },
   };
 }
-
 async function getMonthlyBudgetInfo(userId: string, categoryName: string, date?: string): Promise<BudgetInfo | null> {
   const category = await findCategory(userId, categoryName);
   if (!category) return null;


### PR DESCRIPTION
### Motivation
- Fix incorrect parsing of shorthand nominal like `4rb` which was interpreted as `Rp4` instead of `Rp4.000` and restore correct behaviour for decimals like `4,5rb` and `1.5jt`.
- Prevent crashes and empty responses for the `hutang`/`piutang` commands caused by server-side queries that assumed specific debt schema fields and by brittle filtering logic.

### Description
- Replace `parseAmount` with a suffix-aware parser that supports `rb|rbu|ribu|k` → *1000* and `jt|juta|m` → *1_000_000*, handles decimal `.` and `,`, and logs `console.log("[PARSE AMOUNT]", { input, amount })` for debugging.
- Make all `.from("debts")` reads use `.select("*")` and move type/status filtering to JS with safe helpers so debt queries are schema-agnostic and won't crash when columns are missing.
- Add/adjust debt helpers and utilities: `isDebtRowOpen`, `rowHasDebtTypeField`, `isDebtTypeRow`, `getDebtStatus`, `formatDebtDateLocal`, and reuse existing fallback helpers (`getDebtName`, `getDebtTotalAmount`, `getDebtPaidAmount`, `getDebtRemainingAmount`, `getDebtDueDate`, `getDebtKind`), and log debt samples/lists with `console.log` as requested.
- Unify `hutang`/`piutang` list handling into a single flow that catches query errors and replies with `❌ *Gagal Mengambil Hutang*` on failure, builds displayed lists safely, stores `displayedDebts` in parsed logs, and shows the requested formatted output; change `edit hutang` to use the shared `parseAmount` and add `value` as a fallback nominal field in `updateDebtAmount`.

### Testing
- Ran a small parse suite under `node` that validated cases including `4000`, `4.000`, `4rb`, `4,5rb`, `4.5rb`, `20k`, `1jt`, `1.5jt`, `2m`, and `jajan es budeh 4rb cash`, and all cases passed.
- Executed a TypeScript transpile check via `ts.transpileModule` on the modified file which completed without diagnostics for the changed blocks.
- Ran `tsc --noEmit ... supabase/functions/fonnte-webhook-v2/index.ts` and observed that existing repository-wide type/import issues remain unrelated to these changes while the modified debt/helper blocks produced no new diagnostics.
- Ran `git diff --check` to ensure no whitespace/errors from the edit and validated the working changes; `deno check` was not performed in this environment since `deno` was unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18d032305c832d9ad3a09562f0dcad)