### PR TITLE
Improve calculator detection to ignore transaction date patterns

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -765,12 +765,30 @@ function getCalculatorExpressionText(text: string): string {
   return String(text ?? "").trim().replace(/^(calc|hitung)\s+/i, "").trim();
 }
 
+function containsDateOnlyPattern(text: string): boolean {
+  const raw = String(text ?? "").trim();
+  if (!raw) return false;
+
+  const datePattern = /\b\d{1,2}[\/-]\d{1,2}(?:[\/-]\d{2,4})?\b/g;
+  if (!datePattern.test(raw)) return false;
+
+  const withoutDates = raw.replace(datePattern, " ");
+  return !/[+*x×/:]/i.test(withoutDates) && !/(^|\s)-(?!\s*$)/.test(withoutDates);
+}
+
 function isCalculatorExpression(text: string): boolean {
   const raw = String(text ?? "").trim();
   if (!raw) return false;
   if (/^(calc|hitung)(\s+|$)/i.test(raw)) return true;
-  if (isDateToken(raw)) return false;
-  return /\d/.test(raw) && /[+\-*x×/:]/i.test(raw);
+
+  const nominalAmountPattern = /\d+(?:[.,]\d+)?\s*(?:rb|rbu|ribu|k|jt|juta|m)\b/gi;
+  const withoutNominalAmounts = raw.replace(nominalAmountPattern, "1");
+  if (/[a-zA-Z]{2,}/.test(withoutNominalAmounts)) return false;
+  if (containsDateOnlyPattern(raw)) return false;
+  if (!/[+\-*x×/:]/i.test(raw)) return false;
+
+  const normalizedAmounts = raw.replace(nominalAmountPattern, "1");
+  return /^[0-9\s+\-*x×/:().,]+$/i.test(normalizedAmounts);
 }
 
 function normalizeCalculatorExpression(text: string): string | null {


### PR DESCRIPTION
### Motivation
- Calculator routing was incorrectly treating date-like tokens such as `01/06` as division expressions and blocking normal transaction messages with dates. 
- The intent is to only trigger the calculator when the message is clearly a math expression or when forced by `calc`/`hitung`, so transaction messages with dates continue to be parsed as transactions.

### Description
- Added a new helper `containsDateOnlyPattern(text: string): boolean` to detect date patterns like `DD/MM`, `D/M`, `DD-MM`, and optional year variants and to ensure the rest of the text contains no math operators. 
- Tightened `isCalculatorExpression(text: string)` so that `calc`/`hitung` still force calculator mode, but unprefixed messages are only treated as calculator when they contain at least one math operator, consist only of allowed math characters (numbers, operators, parentheses, separators, and nominal suffixes), do not contain ordinary words (except nominal suffixes), and are not date-only per `containsDateOnlyPattern`. 
- Kept existing normalization and calculation code paths intact and only adjusted detection logic in `supabase/functions/fonnte-webhook-v2/index.ts`.

### Testing
- Ran a Node-based smoke script covering required examples (transaction messages with dates and calculator examples), and all cases passed (transactions with dates returned false for calculator and math examples returned true). 
- Performed a TypeScript transpile check via `typescript.transpileModule` with no diagnostics returned. 
- Ran `npx eslint` which reported the file is ignored by the ESLint configuration (warning only). 
- attempted `deno check` but the `deno` binary was not available in the environment, so that check could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19b8a5cd1c832d843e73809d51039d)