### PR TITLE
Fix Indonesian thousand separators in calculator

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -791,16 +791,35 @@ function isCalculatorExpression(text: string): boolean {
   return /^[0-9\s+\-*x×/:().,]+$/i.test(normalizedAmounts);
 }
 
+function normalizeNumberToken(token: string): string {
+  const input = String(token ?? "").toLowerCase().trim();
+  if (!input) return input;
+
+  if (/^\d{1,3}([.,]\d{3})+$/.test(input)) {
+    return input.replace(/[.,]/g, "");
+  }
+
+  if (/^\d+(?:[.,]\d+)?\s*(?:rb|rbu|ribu|k|jt|juta|m)\b$/i.test(input)) {
+    const amount = parseAmount(input);
+    return amount > 0 ? String(amount) : input;
+  }
+
+  if (/^\d+(?:[.,]\d+)*$/.test(input)) {
+    return input.replace(/\d{1,3}([.,]\d{3})+/g, (match) => match.replace(/[.,]/g, ""));
+  }
+
+  return input;
+}
+
 function normalizeCalculatorExpression(text: string): string | null {
   const expression = getCalculatorExpressionText(text);
   if (!expression) return null;
 
-  const normalizedAmounts = expression.replace(/\d+(?:[.,]\d+)?\s*(?:rb|rbu|ribu|k|jt|juta|m)\b/gi, (match) => {
-    const amount = parseAmount(match);
-    return amount > 0 ? String(amount) : "INVALID_AMOUNT";
+  const normalizedNumbers = expression.replace(/\d+(?:[.,]\d+)*(?:\s*(?:rb|rbu|ribu|k|jt|juta|m)\b)?/gi, (match) => {
+    return normalizeNumberToken(match);
   });
 
-  const normalizedOperators = normalizedAmounts
+  const normalizedOperators = normalizedNumbers
     .replace(/[x×]/gi, "*")
     .replace(/:/g, "/");
 


### PR DESCRIPTION
### Motivation

- The calculator rejected Indonesian thousand-separated numbers like `3.114.534` as invalid, breaking common user inputs. 
- The goal is to support a variety of user formats (dot/comma thousand separators and `rb`/`jt` suffix decimals) without changing unrelated features.

### Description

- Add helper `normalizeNumberToken(token: string): string` to normalize numeric tokens by removing dot/comma thousand separators and delegating suffix parsing to `parseAmount` for `rb`/`jt` variants. 
- Update `normalizeCalculatorExpression` to normalize full numeric tokens using `normalizeNumberToken` so expressions such as `3.114.534 - 1.239.150` become `3114534 - 1239150` before operator validation. 
- Preserve existing suffix parsing semantics so inputs like `1.5jt`, `1,5jt`, `4.5rb` still convert to integer values via `parseAmount`. 
- Keep operator normalization (`x/× -> *`, `:` -> `/`) and expression validation unchanged otherwise so other routes are unaffected.

### Testing

- Ran the executable test script that normalizes and evaluates representative expressions via Node: `node /tmp/run-calc-tests.mjs`, and all positive and negative cases passed (examples tested: `3.114.534 - 1.239.150`, `3114534 - 1239150`, `3,114,534 - 1,239,150`, `20rb + 15rb`, `4.5rb + 500`, `1,5jt / 3`, `(3.114.534 - 1.239.150) / 2`, and negative cases with dates like `belanja alpukat 10rb seabank 01/06`). 
- Performed a TypeScript transpile/syntax check (transpile step) and it passed basic syntax verification; a full `tsc --noEmit` shows pre-existing type issues related to Deno/remote imports and project-wide types but these are unrelated to the calculator changes. 
- Ran `git diff --check` and code formatting/lint checks used during the rollout showed no new diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19bbccf984832dbf83d73de4f8611a)