### PR TITLE
Do not create transactions when adding hutang/piutang; add debug log and update success replies

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -5677,8 +5677,9 @@ function buildMissingDebtDueDateReply(): string {
 }
 
 function buildAddDebtSuccessReply(input: { debtType: DebtType; name: string; amount: number; dueDate: string; accountName: string | null }): string {
-  const debtLabel = input.debtType === "debt" ? "Hutang" : "Piutang";
-  return [
+  const isDebt = input.debtType === "debt";
+  const debtLabel = isDebt ? "Hutang" : "Piutang";
+  const lines = [
     `✅ *${debtLabel} Berhasil Dicatat*`,
     "",
     "━━━━━━━━━━━━━━",
@@ -5690,10 +5691,21 @@ function buildAddDebtSuccessReply(input: { debtType: DebtType; name: string; amo
     "",
     "📅 Jatuh Tempo:",
     `*${formatEditDateForReply(input.dueDate)}*`,
+  ];
+
+  if (isDebt) {
+    lines.push("", "🏦 Akun:", `*${input.accountName ? toTitleCase(input.accountName) : "-"}*`);
+  }
+
+  lines.push(
     "",
-    "🏦 Akun:",
-    `*${input.accountName ? toTitleCase(input.accountName) : "-"}*`,
-  ].join("\n");
+    "Catatan:",
+    isDebt
+      ? "_Hutang tidak dihitung sebagai pengeluaran sampai kamu membayarnya._"
+      : "_Piutang tidak dihitung sebagai pemasukan sampai dibayar._",
+  );
+
+  return lines.join("\n");
 }
 
 async function findLastDisplayedDebtList(userId: string, debtType?: DebtType): Promise<Array<Record<string, JsonValue>> | null> {
@@ -6170,6 +6182,14 @@ async function handleDebtCommand(userId: string, rawMessage: string, normalized:
       dueDate: parsed.dueDate,
       accountId: account?.id ?? null,
       rawMessage,
+    });
+
+    console.log("[ADD DEBT NO TRANSACTION]", {
+      debtType: parsed.debtType,
+      name: parsed.partyName,
+      amount: parsed.amount,
+      dueDate: parsed.dueDate,
+      accountName: account?.name ?? parsed.accountName ?? null,
     });
 
     return {


### PR DESCRIPTION
### Motivation
- Prevent newly added hutang/piutang from being recorded as ordinary transactions so they don't affect daily income/expense summaries.
- Provide a clear debug log when a debt/receivable is created without a corresponding transaction.
- Improve the user-facing success message to explicitly state that debts/piutang are not counted as expense/income until paid and show account only for hutang.

### Description
- Ensured the add-debt/add-piutang flow only inserts into the `debts` table via `insertDebtSchemaSafe` and does not create any `transactions` rows in that path. (file: `supabase/functions/fonnte-webhook-v2/index.ts`)
- Added `console.log("[ADD DEBT NO TRANSACTION]", { debtType, name, amount, dueDate, accountName })` immediately after a successful debt insertion to aid debugging. (file: `supabase/functions/fonnte-webhook-v2/index.ts`)
- Updated `buildAddDebtSuccessReply` to: render account line only for hutang (show `-` when account missing) and append a note clarifying that hutang/piutang are not counted as expense/income until paid. (file: `supabase/functions/fonnte-webhook-v2/index.ts`)
- Left the debt payment flow unchanged so that `bayar hutang` / `bayar piutang` still create `transactions` with the appropriate category and update debt payment records.

### Testing
- Ran a static check script that verifies the add-debt flow contains no `transactions` insert while `debts` insert remains and payment transaction insertion is preserved; this check succeeded.  
- Ran `npm run lint` which failed due to unrelated frontend lint issues in `src/` (these are pre-existing and not related to the function change).  
- Ran `npx eslint supabase/functions/fonnte-webhook-v2/index.ts` which reported the file is ignored by the current ESLint configuration (informational, unrelated to logic change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a219396c0cc832dbb9784e657750397)