### PR TITLE
Update summary: include today's expense history

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -7493,6 +7493,7 @@ function buildMenuMessage(): string {
     "",
     "📊 *Laporan*",
     "• summary",
+    "• history hari ini",
     "• pengeluaran harian",
     "• budget",
     "",
@@ -7632,6 +7633,8 @@ function buildExampleMessage(): string {
     "• akun cash",
     "",
     "📊 *Laporan*",
+    "• summary",
+    "• history hari ini",
     "• pengeluaran harian",
     "• pengeluaran per hari",
     "",
@@ -7991,6 +7994,22 @@ Deno.serve(async (req: Request) => {
       summaryQuery = await applyTransactionNotDeleted(summaryQuery);
       const { data: txs, error } = await summaryQuery;
       if (error) throw error;
+
+      let historyQuery = supabase
+        .from("transactions")
+        .select("id,title,amount,category_id,account_id,date,inserted_at", { count: "exact" })
+        .eq("user_id", userId)
+        .eq("type", "expense")
+        .eq("date", today)
+        .order("inserted_at", { ascending: false })
+        .limit(10);
+      historyQuery = await applyTransactionNotDeleted(historyQuery);
+      const { data: historyRowsRaw, error: historyError, count: expenseHistoryCount } = await historyQuery;
+      if (historyError) throw historyError;
+      const historyRows = (historyRowsRaw ?? []) as Array<Record<string, JsonValue>>;
+      const historyCount = expenseHistoryCount ?? historyRows.length;
+      const { categoryMap: historyCategoryMap, accountMap: historyAccountMap } = await getHistoryDisplayMaps(historyRows);
+
       let income = 0;
       let expense = 0;
       const catMap = new Map<string, number>();
@@ -8004,12 +8023,34 @@ Deno.serve(async (req: Request) => {
           if (cid) catMap.set(cid, (catMap.get(cid) ?? 0) + amount);
         }
       }
+      console.log("[SUMMARY HISTORY]", {
+        count: historyCount,
+        totalExpense: expense,
+      });
+
       let biggestCategory = "-";
       if (catMap.size > 0) {
         const [topId] = [...catMap.entries()].sort((a, b) => b[1] - a[1])[0];
         const { data: cat } = await supabase.from("categories").select("name").eq("id", topId).maybeSingle();
         biggestCategory = cat?.name ?? "-";
       }
+      const biggestCategoryAmount = catMap.size > 0 ? Math.max(...catMap.values()) : 0;
+      const historyLines = historyRows.length > 0
+        ? historyRows.map((tx, index) => {
+          const categoryName = historyCategoryMap.get(String(tx.category_id ?? "")) ?? "-";
+          const title = String(tx.title ?? "-").trim() || "-";
+          const accountName = historyAccountMap.get(String(tx.account_id ?? "")) ?? "-";
+          return `${index + 1}. ${categoryName} — ${title}
+   ${money(Number(tx.amount ?? 0))} • ${bold(accountName)}`;
+        })
+        : ["ℹ️ Belum ada pengeluaran hari ini."];
+      if (historyCount > historyRows.length) {
+        historyLines.push("", italic(`+${historyCount - historyRows.length} transaksi lainnya. Ketik *history hari ini* untuk detail.`));
+      }
+
+      const activeWarnings = expense > 0
+        ? await buildSmartWarnings({ userId, date: today, amount: 0, categoryName: biggestCategory === "-" ? "Lainnya" : biggestCategory })
+        : [];
       const summaryLines = [
         "📊 *Summary Hari Ini*",
         "",
@@ -8019,15 +8060,20 @@ Deno.serve(async (req: Request) => {
         `🧾 Transaksi: ${bold(`${(txs ?? []).length} data`)}`,
         "",
         "🏆 *Kategori Terbesar*",
-        `${biggestCategory} — ${money(catMap.size > 0 ? Math.max(...catMap.values()) : 0)}`,
+        `${biggestCategory} — ${money(biggestCategoryAmount)}`,
         "",
+        line(),
+        "📚 *History Pengeluaran Hari Ini*",
+        "",
+        ...historyLines,
+        "",
+        line(),
         "💡 *Insight*",
         expense > income ? "Pengeluaran hari ini perlu dijaga." : "Pengeluaran hari ini masih terkontrol.",
+        "",
+        "⚠️ *Warning Aktif*",
+        ...(activeWarnings.length > 0 ? activeWarnings.map((w) => `• ${w}`) : ["ℹ️ Tidak ada warning aktif."]),
       ];
-      if (expense > 0) {
-        const activeWarnings = await buildSmartWarnings({ userId, date: today, amount: 0, categoryName: biggestCategory === "-" ? "Lainnya" : biggestCategory });
-        if (activeWarnings.length > 0) summaryLines.push("", "⚠️ Warning Aktif", ...activeWarnings.map((w) => `• ${w}`));
-      }
       reply = summaryLines.join("\n");
     } else if (normalized.startsWith("harian ")) {
       console.log("[ROUTE MATCH]", { route: "category_daily_report", normalized, isGroup, contextKey });


### PR DESCRIPTION
### Motivation
- Make the `summary` command display a clear, compact history of today's expense transactions alongside the existing totals, top category, insights, and active warnings.

### Description
- Fetch up to 10 newest `expense` transactions for `date = today` (Jakarta) from `transactions`, filtered by `user_id` and `deleted_at` handling, ordered by `inserted_at` descending and limited to 10.
- Render a new section `📚 *History Pengeluaran Hari Ini*` in the `summary` output with numbered entries showing `category — title`, amount and account, newest first, and show `ℹ️ Belum ada pengeluaran hari ini.` when empty.
- Add overflow hint `_+N transaksi lainnya. Ketik *history hari ini* untuk detail._` when total expense count exceeds 10 and include debug log `console.log("[SUMMARY HISTORY]", { count, totalExpense })`.
- Update menu/example listings to include `history hari ini` and preserve existing summary items (`total pengeluaran`, `pemasukan`, `jumlah transaksi`, `kategori terbesar`, `insight`, `warning aktif`).

### Testing
- `node` TypeScript transpile check using `typescript` API succeeded (`TypeScript transpile syntax check passed`).
- `deno check` could not be run in this environment because `deno` is not installed (skipped). 
- `pnpm exec eslint supabase/functions/fonnte-webhook-v2/index.ts` ran and reported the file is ignored by ESLint config (warning only). 
- `git diff --check` reported no problems and the changes were committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25878bed40832d98ae36c316df8c89)