### PR TITLE
Restrict WhatsApp webhook to registered numbers

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -398,12 +398,16 @@ function isAISuggestionNumber(text: string): boolean {
   return /^(10|[1-9])$/.test(text.trim());
 }
 
-function normalizePhone(raw: string): string {
-  const trimmed = raw.trim();
-  const noPlus = trimmed.startsWith("+62") ? trimmed.slice(1) : trimmed;
-  const digits = noPlus.replace(/[^0-9]/g, "");
+function normalizePhoneForLookup(phone: string): string {
+  const digits = String(phone ?? "").replace(/[^0-9]/g, "");
   if (digits.startsWith("0")) return `62${digits.slice(1)}`;
+  if (digits.startsWith("8")) return `62${digits}`;
+  if (digits.startsWith("62")) return digits;
   return digits;
+}
+
+function normalizePhone(raw: string): string {
+  return normalizePhoneForLookup(raw);
 }
 
 function buildFonnteTargets(target: string): string[] {
@@ -2047,14 +2051,26 @@ async function logMessage(input: {
   if (error) console.error("[LOG_MESSAGE_ERROR]", error);
 }
 
+async function getRegisteredWaUser(phone: string): Promise<{ user_id: string; phone: string } | null> {
+  const rawPhone = String(phone ?? "").trim();
+  const normalizedPhone = normalizePhoneForLookup(rawPhone);
+  const lookupPhones = [...new Set([rawPhone, normalizedPhone].filter(Boolean))];
+
+  for (const lookupPhone of lookupPhones) {
+    const { data, error } = await supabase
+      .from("whatsapp_users")
+      .select("user_id,phone")
+      .eq("phone", lookupPhone)
+      .maybeSingle();
+    if (error) throw error;
+    if (data) return data;
+  }
+
+  return null;
+}
+
 async function getWaUser(phone: string): Promise<{ user_id: string } | null> {
-  const { data, error } = await supabase
-    .from("whatsapp_users")
-    .select("user_id")
-    .eq("phone", phone)
-    .maybeSingle();
-  if (error) throw error;
-  return data;
+  return await getRegisteredWaUser(phone);
 }
 
 async function findCategory(userId: string, name: string): Promise<{ id: string; name: string; type: string } | null> {
@@ -8250,6 +8266,28 @@ Deno.serve(async (req: Request) => {
     });
 
     const contextKey = getMessageContextKey({ isGroup, sender, chatTarget });
+    const rawSenderForLookup = isGroup ? extractRawParticipant(body) : String(body.sender ?? body.from ?? body.phone ?? body.number ?? body.data?.sender ?? body.data?.phone ?? body.data?.number ?? "").trim();
+    const normalizedPhoneForLookup = normalizePhoneForLookup(sender);
+
+    const waUser = await getRegisteredWaUser(sender);
+    if (!waUser) {
+      console.log("[WA USER NOT REGISTERED]", {
+        rawSender: rawSenderForLookup,
+        normalizedPhone: normalizedPhoneForLookup,
+        isGroup,
+        chatTarget,
+      });
+      return json({ ok: true, ignored: true, reason: "unregistered_phone" });
+    }
+
+    console.log("[WA USER REGISTERED]", {
+      phone: waUser.phone,
+      userId: waUser.user_id,
+      isGroup,
+    });
+
+    userId = waUser.user_id;
+
     const validCommand = isPotentialBotCommand(message);
     console.log("[REPLY ROUTE]", {
       isGroup,
@@ -8288,22 +8326,6 @@ Deno.serve(async (req: Request) => {
     if (duplicateError) throw duplicateError;
     if (duplicate) return json({ ok: true, duplicate: true });
 
-    const waUser = await getWaUser(sender);
-    if (!waUser) {
-      await logMessage({
-        wa_message_id: waMessageId,
-        phone: contextKey,
-        user_id: null,
-        raw_text: message,
-        parsed: { command: "unknown" },
-        status: "failed",
-        error_message: "WA user not found",
-      });
-      await replyWhatsApp({ target: chatTarget || sender, message: "❌ Nomor belum terdaftar di HematWoi." });
-      return json({ ok: true, handled: true, reason: "user not found" });
-    }
-
-    userId = waUser.user_id;
     const normalized = normalizeText(message);
 
     let reply = "";


### PR DESCRIPTION
### Motivation

- Ensure the webhook only processes and replies to WhatsApp numbers that are registered in the `whatsapp_users` table to tighten bot access control.
- Normalize incoming phone formats (0/8/62 and variants) so lookups are consistent and robust.
- Silence and log messages for unregistered senders/participants instead of sending visible replies.

### Description

- Added `normalizePhoneForLookup()` to normalize phone inputs by removing non-digits and converting leading `0` or `8` to the `62` format, and kept `normalizePhone()` delegating to it.
- Added `getRegisteredWaUser()` which attempts lookup against `whatsapp_users` using both raw and normalized variants and updated `getWaUser()` to call it.
- Added an early access check in the main `Deno.serve` handler that logs unregistered attempts with `console.log("[WA USER NOT REGISTERED]", ...)` and returns `json({ ok: true, ignored: true, reason: "unregistered_phone" })` without sending WhatsApp replies.
- Logged successful lookups with `console.log("[WA USER REGISTERED]", ...)`, and removed the previous outgoing reply for unregistered numbers so the bot is silent on unknown phones.

### Testing

- Ran `git diff --check` to validate no whitespace or diff issues and it succeeded.
- Ran `rg -n "Nomor belum terhubung ke HematWoi|Nomor belum terdaftar di HematWoi" supabase/functions/fonnte-webhook-v2/index.ts` to ensure the old visible-reply strings were removed and it returned no matches.
- Attempted `deno fmt supabase/functions/fonnte-webhook-v2/index.ts` but formatting could not be run in this environment because `deno` is not installed (warning reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a311ce45114832db1c9a787317654d3)