### PR TITLE
Update `summary` to show latest 10 transactions (expense/income/transfer)

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -8477,17 +8477,16 @@ Deno.serve(async (req: Request) => {
 
       let historyQuery = supabase
         .from("transactions")
-        .select("id,title,amount,category_id,account_id,date,inserted_at", { count: "exact" })
+        .select("id,title,amount,type,category_id,account_id,to_account_id,date,inserted_at", { count: "exact" })
         .eq("user_id", userId)
-        .eq("type", "expense")
         .eq("date", today)
         .order("inserted_at", { ascending: false })
         .limit(10);
       historyQuery = await applyTransactionNotDeleted(historyQuery);
-      const { data: historyRowsRaw, error: historyError, count: expenseHistoryCount } = await historyQuery;
+      const { data: historyRowsRaw, error: historyError, count: totalTodayTransactions } = await historyQuery;
       if (historyError) throw historyError;
       const historyRows = (historyRowsRaw ?? []) as Array<Record<string, JsonValue>>;
-      const historyCount = expenseHistoryCount ?? historyRows.length;
+      const historyCount = totalTodayTransactions ?? historyRows.length;
       const { categoryMap: historyCategoryMap, accountMap: historyAccountMap } = await getHistoryDisplayMaps(historyRows);
 
       let income = 0;
@@ -8503,9 +8502,9 @@ Deno.serve(async (req: Request) => {
           if (cid) catMap.set(cid, (catMap.get(cid) ?? 0) + amount);
         }
       }
-      console.log("[SUMMARY HISTORY]", {
-        count: historyCount,
-        totalExpense: expense,
+      console.log("[SUMMARY LAST TRANSACTIONS]", {
+        count: historyRows.length,
+        totalTodayTransactions: historyCount,
       });
 
       let biggestCategory = "-";
@@ -8517,13 +8516,21 @@ Deno.serve(async (req: Request) => {
       const biggestCategoryAmount = catMap.size > 0 ? Math.max(...catMap.values()) : 0;
       const historyLines = historyRows.length > 0
         ? historyRows.map((tx, index) => {
+          const type = String(tx.type ?? "expense");
+          const amount = Number(tx.amount ?? 0);
           const categoryName = historyCategoryMap.get(String(tx.category_id ?? "")) ?? "-";
           const title = String(tx.title ?? "-").trim() || "-";
           const accountName = historyAccountMap.get(String(tx.account_id ?? "")) ?? "-";
+          const toAccountName = historyAccountMap.get(String(tx.to_account_id ?? "")) ?? "-";
+          if (type === "transfer") {
+            return `${index + 1}. Transfer ${accountName} → ${toAccountName}
+   ↔ ${money(amount)} • ${bold(`${accountName} → ${toAccountName}`)}`;
+          }
+          const sign = type === "income" ? "+" : "-";
           return `${index + 1}. ${categoryName} — ${title}
-   ${money(Number(tx.amount ?? 0))} • ${bold(accountName)}`;
+   ${sign} ${money(amount)} • ${bold(accountName)}`;
         })
-        : ["ℹ️ Belum ada pengeluaran hari ini."];
+        : ["ℹ️ Belum ada transaksi hari ini."];
       if (historyCount > historyRows.length) {
         historyLines.push("", italic(`+${historyCount - historyRows.length} transaksi lainnya. Ketik *history hari ini* untuk detail.`));
       }
@@ -8543,7 +8550,7 @@ Deno.serve(async (req: Request) => {
         `${biggestCategory} — ${money(biggestCategoryAmount)}`,
         "",
         line(),
-        "📚 *History Pengeluaran Hari Ini*",
+        "📚 *Transaksi Terakhir Hari Ini*",
         "",
         ...historyLines,
         "",


### PR DESCRIPTION
### Motivation
- Make the `summary` command show the most recent transactions for today across `expense`, `income`, and `transfer` types so users can quickly see last activity without running `history`.
- Provide clear per-transaction formatting for expense, income, and transfer rows and a concise empty-state message to match the requested UX.
- Add a debug log to help trace how many transactions are displayed versus total today.

### Description
- Updated the summary query to select `type` and `to_account_id` and removed the `type = expense` filter so it fetches expense, income, and transfer rows for `date = today` ordered by `inserted_at` desc and limited to 10 using `count` as `totalTodayTransactions`.
- Built `historyLines` that render each row according to transaction `type`, formatting expense as `- Rp... • Account`, income as `+ Rp... • Account`, and transfer as `Transfer A → B` with `↔ Rp... • A → B` and kept the items ordered newest-first.
- Replaced the section title with `📚 *Transaksi Terakhir Hari Ini*` and changed the empty-state text to `ℹ️ Belum ada transaksi hari ini.`.
- Added a debug `console.log("[SUMMARY LAST TRANSACTIONS]", { count: historyRows.length, totalTodayTransactions: historyCount })` and preserved the existing totals, top-category, insight, and active warning sections.

### Testing
- Ran `npx eslint supabase/functions/fonnte-webhook-v2/index.ts` which completed but reported the file is ignored by the current ESLint configuration.
- Ran TypeScript check with `npx tsc --noEmit ... supabase/functions/fonnte-webhook-v2/index.ts` which failed due to existing Deno/remote-import type resolution and unrelated pre-existing TS errors in the project.
- Attempted `deno check` locally but `deno` is not available in the environment so the Deno runtime check could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e96fe4e40832d9086b8612ae4c117)