### PR TITLE
Fix calculator parser: normalize operators, add simple-regex parser, and prioritize calculator routing

### DIFF
--- a/supabase/functions/fonnte-webhook-v2/index.ts
+++ b/supabase/functions/fonnte-webhook-v2/index.ts
@@ -1362,6 +1362,85 @@ function parseAmount(raw: string): number {
 }
 
 
+const SIMPLE_CALCULATOR_PATTERN =
+  /^\s*(-?\d+(?:[.,]\d+)?)\s*([+\-*/x×÷])\s*(-?\d+(?:[.,]\d+)?)(%)?\s*$/i;
+
+type SimpleCalculatorParseResult = {
+  originalInput: string;
+  normalizedInput: string;
+  regexMatch: boolean;
+  left: number;
+  operator: string;
+  right: number;
+  rightIsPercent: boolean;
+};
+
+function normalizeSimpleCalculatorInput(text: string): string {
+  return String(text ?? "")
+    .trim()
+    .replace(/\s+/g, " ")
+    .replace(/×/g, "*")
+    .replace(/÷/g, "/")
+    .replace(/x/gi, "*");
+}
+
+function parseSimpleCalculatorExpression(text: string): SimpleCalculatorParseResult | null {
+  const originalInput = String(text ?? "");
+  const expression = getCalculatorExpressionText(originalInput);
+  const normalizedInput = normalizeSimpleCalculatorInput(expression);
+  const match = normalizedInput.match(SIMPLE_CALCULATOR_PATTERN);
+  if (!match) {
+    console.log("[CALCULATOR PARSER FAILED]", {
+      originalInput,
+      normalizedInput,
+      regexMatch: false,
+      parser: "simple_calculator",
+    });
+    return null;
+  }
+
+  const left = Number(match[1].replace(",", "."));
+  const operator = match[2];
+  const right = Number(match[3].replace(",", "."));
+  if (!Number.isFinite(left) || !Number.isFinite(right)) {
+    console.log("[CALCULATOR PARSER FAILED]", {
+      originalInput,
+      normalizedInput,
+      regexMatch: true,
+      parser: "simple_calculator",
+    });
+    return null;
+  }
+
+  return {
+    originalInput,
+    normalizedInput,
+    regexMatch: true,
+    left,
+    operator,
+    right,
+    rightIsPercent: match[4] === "%",
+  };
+}
+
+
+function calculateSimpleExpressionSafe(parsed: SimpleCalculatorParseResult): number {
+  const percentValue = parsed.left * (parsed.right / 100);
+  const right = parsed.rightIsPercent
+    ? (parsed.operator === "+" || parsed.operator === "-" ? percentValue : parsed.right / 100)
+    : parsed.right;
+
+  if (parsed.operator === "+") return parsed.left + right;
+  if (parsed.operator === "-") return parsed.left - right;
+  if (parsed.operator === "*") return parsed.left * right;
+  if (parsed.operator === "/") {
+    if (right === 0) throw new Error("DIVISION_BY_ZERO");
+    return parsed.left / right;
+  }
+
+  throw new Error("INVALID_OPERATOR");
+}
+
 type CalculatorToken = { type: "number"; value: number } | { type: "operator" | "paren"; value: string };
 
 function getCalculatorExpressionText(text: string): string {
@@ -1391,6 +1470,7 @@ function containsDateOnlyPattern(text: string): boolean {
 function isCalculatorExpression(text: string): boolean {
   const raw = String(text ?? "").trim();
   if (!raw) return false;
+  if (parseSimpleCalculatorExpression(raw)) return true;
   if (/^(calc|hitung)(\s+|$)/i.test(raw)) return true;
 
   const nominalAmountPattern = /\d+(?:[.,]\d+)?\s*(?:rb|rbu|ribu|k|jt|juta|m)\b/gi;
@@ -1400,7 +1480,7 @@ function isCalculatorExpression(text: string): boolean {
   if (!/[+\-*x×/:÷]/i.test(raw)) return false;
 
   const normalizedAmounts = raw.replace(nominalAmountPattern, "1");
-  return /^[0-9\s+\-*x×/:÷().,]+$/i.test(normalizedAmounts);
+  return /^[0-9%\s+\-*x×/:÷().,]+$/i.test(normalizedAmounts);
 }
 
 function normalizeNumberToken(token: string): string {
@@ -8339,11 +8419,40 @@ Deno.serve(async (req: Request) => {
     let parsedLog: Record<string, JsonValue> = { command: normalized.split(" ")[0] ?? "" };
     let budgetPeriodCommand: BudgetPeriodCommand | null = null;
 
-    const pendingUpdateCommand = parsePendingTransactionUpdateCommand(normalized);
-    const pendingDebtAccountCommand = parsePendingDebtPaymentAccountCommand(normalized);
-    const dashboardNoteCommand = parseDashboardNoteCommand(message, normalized);
+    const simpleCalculatorExpression = parseSimpleCalculatorExpression(message);
+    const pendingUpdateCommand = simpleCalculatorExpression ? null : parsePendingTransactionUpdateCommand(normalized);
+    const pendingDebtAccountCommand = simpleCalculatorExpression ? null : parsePendingDebtPaymentAccountCommand(normalized);
+    const dashboardNoteCommand = simpleCalculatorExpression ? null : parseDashboardNoteCommand(message, normalized);
 
-    if (dashboardNoteCommand) {
+    if (simpleCalculatorExpression) {
+      console.log("[ROUTE MATCH]", {
+        route: "calculator",
+        normalized,
+        calculatorNormalized: simpleCalculatorExpression.normalizedInput,
+        regexMatch: simpleCalculatorExpression.regexMatch,
+        parser: "simple_calculator",
+        isGroup,
+        contextKey,
+      });
+      try {
+        const result = calculateSimpleExpressionSafe(simpleCalculatorExpression);
+        reply = buildCalculatorReply(simpleCalculatorExpression.normalizedInput, result);
+        parsedLog = {
+          ...buildCalculatorSessionLog({ result, expression: simpleCalculatorExpression.normalizedInput, contextKey }),
+          parser: "simple_calculator",
+          originalInput: simpleCalculatorExpression.originalInput,
+          normalizedInput: simpleCalculatorExpression.normalizedInput,
+          regexMatch: simpleCalculatorExpression.regexMatch,
+        };
+      } catch (error) {
+        if (error instanceof Error && error.message === "DIVISION_BY_ZERO") {
+          reply = "❌ *Tidak Bisa Dibagi 0*";
+          parsedLog = { command: "calculator", expression: simpleCalculatorExpression.normalizedInput, result: null, status: "division_by_zero", contextKey, parser: "simple_calculator" };
+        } else {
+          throw error;
+        }
+      }
+    } else if (dashboardNoteCommand) {
       console.log("[ROUTE MATCH]", { route: "dashboard_note", normalized, isGroup, contextKey });
       const noteResult = await handleDashboardNoteCommand(userId, dashboardNoteCommand);
       reply = noteResult.reply;


### PR DESCRIPTION
### Motivation
- Ensure simple math expressions are always recognized and handled consistently (e.g. `62-48`, `22-11`) regardless of prior messages or conversation state. 
- Use a single predictable regex-based parser that treats `-` as subtraction and supports decimals, percent, and multiple operator glyphs. 
- Prevent calculator-like inputs from being forwarded to transaction/command parsers by giving the calculator highest priority.

### Description
- Added a dedicated simple calculator parser with the regex `SIMPLE_CALCULATOR_PATTERN` to accept `+ - * / x × ÷`, decimals and optional `%`, and a normalization function that trims input, collapses extra spaces, and converts `×/÷/x` to `*/` while preserving numbers (`supabase/functions/fonnte-webhook-v2/index.ts`).
- Implemented `parseSimpleCalculatorExpression` and `calculateSimpleExpressionSafe` to support percent cases (e.g. `100*10%`, `100-10%`) and handle division-by-zero safely.
- Routed simple-calculator parsing before pending transaction, debt/account, dashboard-note, and other parsers so calculator inputs are consumed immediately and do not rely on session state.
- Added parser diagnostics/logging (original input, normalized input, regex match, parser name) included in `parsedLog` for easier tracing when parsing fails.

### Testing
- ✅ Ran a Node-based validation script that verified required cases passed: `62-48`, `22-11`, `100-20`, `1-1`, `50+25`, `9*9`, `9x9`, `9×9`, `100/4`, `22.5-10.5`, plus `100*10%` and `100-10%`.
- ⚠️ `npm test` executed; overall test runner ran and most suites passed but one UI-related suite failed due to missing Supabase environment variables (existing environment issue, not related to calculator changes). 
- ⚠️ `deno fmt` could not be executed in this environment and `npm run lint` surfaced unrelated lint warnings/errors in UI files; these are not introduced by the calculator changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a453347334c832d84986c1ee1b79a38)