### PR TITLE
Show up to 10 transactions in daily WhatsApp summary history

### DIFF
--- a/supabase/functions/whatsapp-daily-summary/index.ts
+++ b/supabase/functions/whatsapp-daily-summary/index.ts
@@ -360,7 +360,7 @@ Deno.serve(async (req: Request) => {
           .eq("date", today)
           .is("deleted_at", null)
           .order("inserted_at", { ascending: false })
-          .limit(3);
+          .limit(10);
         if (historyError) {
           failed += 1;
           console.error("[DAILY SUMMARY HISTORY ERROR]", { userId, phone, error: historyError });


### PR DESCRIPTION
### Motivation
- The automatic daily WhatsApp summary only showed 3 recent expense transactions but should display up to 10 latest transactions (newest-first) for the nightly summary while leaving other summaries and manual flows unchanged.

### Description
- Increase the query limit from `3` to `10` in `supabase/functions/whatsapp-daily-summary/index.ts` so the `📚 *History Terakhir*` section returns up to 10 latest expense transactions while preserving the existing `.order("inserted_at", { ascending: false })` ordering and the current message format.

### Testing
- Ran `git diff --check` with no reported issues; ran `npx eslint supabase/functions/whatsapp-daily-summary/index.ts` which emitted a configuration warning but no errors; `deno fmt --check supabase/functions/whatsapp-daily-summary/index.ts` was not run because `deno` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45339d8e3c832db651163fc0543352)