### PR TITLE
Make compact stock inputs narrower

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -276,6 +276,20 @@
     @apply form-control;
   }
 
+  .input-compact,
+  input[data-compact='true'],
+  input[name='to'],
+  input[name='stockAktual'],
+  input[name='stock_aktual'],
+  input[name='stockActual'],
+  input[name='stock_actual'],
+  input[aria-label='To'],
+  input[aria-label='Stock Aktual'] {
+    width: min(10ch, 100%);
+    min-width: 7ch;
+    max-width: 10ch;
+  }
+
   .select-no-arrow {
     -webkit-appearance: none;
     -moz-appearance: none;


### PR DESCRIPTION
### Motivation
- Inputs for short numeric fields such as `To` and `Stock Aktual` expand to full width for 5–8 digit values, which is unnecessary and wastes space.

### Description
- Add a compact input style in `src/index.css` (`.input-compact` and selectors for `input[name='to']`, `input[name='stockAktual']`, `input[name='stock_aktual']`, `input[name='stockActual']`, `input[name='stock_actual']`, `input[aria-label='To']`, `input[aria-label='Stock Aktual']`, and `input[data-compact='true']`) and constrain sizing with `width: min(10ch, 100%)`, `min-width: 7ch`, and `max-width: 10ch` so short numeric values stay compact.

### Testing
- `pnpm build` was run and completed successfully.
- `pnpm lint` was run and failed due to pre-existing lint errors in unrelated files (`src/App.jsx`, `src/context/PrivacyContext.jsx`, `src/pages/TransactionAdd.jsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a544bb50b18832da350e8187a6d73cd)